### PR TITLE
Исправление ошибки с падением плагина сонара 

### DIFF
--- a/src/main/java/com/github/_1c_syntax/mdclasses/mdo/MDObjectBase.java
+++ b/src/main/java/com/github/_1c_syntax/mdclasses/mdo/MDObjectBase.java
@@ -55,6 +55,10 @@ public class MDObjectBase {
       ) throws IOException {
 
         Map<String, List<MDObjectBase>> childObjects = new HashMap<>();
+        if (parser.getCurrentToken() != JsonToken.START_OBJECT) {
+          return childObjects;
+        }
+
         var commandKey = "Command";
         int level = 1; // текущий уровень ChildObjects
         while (parser.nextToken() != null) {


### PR DESCRIPTION
Добавил обработку ситуации с пустым тэгом ChildObjects - в некоторых версиях jackson тэг игнорируется, в некоторых нет