### PR TITLE
Добавил фильтрацию пустых подсистем

### DIFF
--- a/src/main/java/com/github/_1c_syntax/mdclasses/mdo/Subsystem.java
+++ b/src/main/java/com/github/_1c_syntax/mdclasses/mdo/Subsystem.java
@@ -34,7 +34,11 @@ import lombok.Value;
 import lombok.experimental.NonFinal;
 import lombok.experimental.SuperBuilder;
 
-import java.util.*;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 
 @Value
 @EqualsAndHashCode(callSuper = true)

--- a/src/main/java/com/github/_1c_syntax/mdclasses/mdo/Subsystem.java
+++ b/src/main/java/com/github/_1c_syntax/mdclasses/mdo/Subsystem.java
@@ -34,12 +34,7 @@ import lombok.Value;
 import lombok.experimental.NonFinal;
 import lombok.experimental.SuperBuilder;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 @Value
 @EqualsAndHashCode(callSuper = true)
@@ -127,8 +122,9 @@ public class Subsystem extends MDObjectBase {
 
       if (value != null) {
         if (value instanceof List) {
-          List<?> values = new ArrayList<>((Collection<?>) value);
-          values.forEach(subsystemName -> childrenValue.add(Either.left(subsystemName.toString())));
+          ((List<?>) value).stream()
+            .filter(Objects::nonNull)
+            .forEach(subsystemName -> childrenValue.add(Either.left(subsystemName.toString())));
         } else {
           childrenValue.add(Either.left(value.toString()));
         }

--- a/src/test/resources/metadata/original/Subsystems/ПерваяПодсистема/Subsystems/ПодчиненнаяПодсистема.xml
+++ b/src/test/resources/metadata/original/Subsystems/ПерваяПодсистема/Subsystems/ПодчиненнаяПодсистема.xml
@@ -17,6 +17,7 @@
 			<Content>
 				<xr:Item xsi:type="xr:MDObjectRef">Catalog.Справочник1</xr:Item>
 				<xr:Item xsi:type="xr:MDObjectRef">DataProcessor.Обработка1</xr:Item>
+				<xr:Item xsi:type="xr:MDObjectRef"></xr:Item>
 			</Content>
 		</Properties>
 		<ChildObjects/>


### PR DESCRIPTION
В одном из проектов в подсистемах выгружается такая строчка.
```
<xr:Item xsi:type="xr:MDObjectRef"/>
```
Скорее всего это какой-то остаток удаленного объекта и не совсем корректна, но жить в конфигураторе не мешает. По истории есть с момента начала выгрузки из хранилища - 2 года. Выгружается и загружается из файлов нормально.

При анализе падает на mdclasses с NPE:
```
09:51:29  ERROR: Unknown MDO 97a34ca4-3f83-4cd5-a5e8-46d05e5fd415
09:51:29  ERROR: Unknown MDO b9d5b42d-94ba-4cb4-8c58-5a46f07c87e1
09:51:29  ERROR: Unknown MDO ffb55e1a-d5a4-4312-9583-58d8a8fe5f22
09:51:29  ERROR: Unknown MDO f8f4a594-8d59-49a2-9772-1a1e19c4f871
09:51:29  ERROR: Unknown MDO 757a6b46-9ad4-4f41-8c53-7f4856376d86
09:51:29  ERROR: Unknown MDO 04877e77-377d-4c35-835b-2753211adb3d
09:51:29  ERROR: N/A
09:51:29   at [Source: (File); line: 57, column: 16] (through reference chain: com.github._1c_syntax.mdclasses.mdo.MetaDataObject["Subsystem"]->com.github._1c_syntax.mdclasses.mdo.Subsystem$SubsystemBuilderImpl["Properties"])
09:51:29  com.fasterxml.jackson.databind.JsonMappingException: N/A
09:51:29   at [Source: (File); line: 57, column: 16] (through reference chain: com.github._1c_syntax.mdclasses.mdo.MetaDataObject["Subsystem"]->com.github._1c_syntax.mdclasses.mdo.Subsystem$SubsystemBuilderImpl["Properties"])
09:51:29  	at com.fasterxml.jackson.databind.JsonMappingException.from(JsonMappingException.java:281)
09:51:29  	at com.fasterxml.jackson.databind.deser.SettableBeanProperty._throwAsIOE(SettableBeanProperty.java:611)
09:51:29  	at com.fasterxml.jackson.databind.deser.SettableBeanProperty._throwAsIOE(SettableBeanProperty.java:599)
09:51:29  	at com.fasterxml.jackson.databind.deser.impl.MethodProperty.deserializeSetAndReturn(MethodProperty.java:173)
09:51:29  	at com.fasterxml.jackson.databind.deser.BuilderBasedDeserializer.vanillaDeserialize(BuilderBasedDeserializer.java:269)
09:51:29  	at com.fasterxml.jackson.databind.deser.BuilderBasedDeserializer.deserialize(BuilderBasedDeserializer.java:193)
09:51:29  	at com.fasterxml.jackson.databind.deser.SettableBeanProperty.deserialize(SettableBeanProperty.java:530)
09:51:29  	at com.fasterxml.jackson.databind.deser.BeanDeserializer._deserializeWithErrorWrapping(BeanDeserializer.java:528)
09:51:29  	at com.fasterxml.jackson.databind.deser.BeanDeserializer._deserializeUsingPropertyBased(BeanDeserializer.java:417)
09:51:29  	at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.deserializeFromObjectUsingNonDefault(BeanDeserializerBase.java:1287)
09:51:29  	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserializeFromObject(BeanDeserializer.java:326)
09:51:29  	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:159)
09:51:29  	at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:4218)
09:51:29  	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3079)
09:51:29  	at com.github._1c_syntax.mdclasses.utils.MDOUtils.getMDObject(MDOUtils.java:122)
09:51:29  	at com.github._1c_syntax.mdclasses.utils.MDOUtils.lambda$computeChildren$6(MDOUtils.java:332)
09:51:29  	at java.base/java.lang.Iterable.forEach(Unknown Source)
09:51:29  	at com.github._1c_syntax.mdclasses.utils.MDOUtils.computeChildren(MDOUtils.java:327)
09:51:29  	at com.github._1c_syntax.mdclasses.utils.MDOUtils.lambda$getAllChildren$5(MDOUtils.java:307)
09:51:29  	at java.base/java.lang.Iterable.forEach(Unknown Source)
09:51:29  	at com.github._1c_syntax.mdclasses.utils.MDOUtils.getAllChildren(MDOUtils.java:307)
09:51:29  	at com.github._1c_syntax.mdclasses.metadata.Configuration.<init>(Configuration.java:104)
09:51:29  	at com.github._1c_syntax.mdclasses.metadata.Configuration.create(Configuration.java:142)
09:51:29  	at com.github._1c_syntax.bsl.languageserver.context.ServerContext.computeConfigurationMetadata(ServerContext.java:104)
09:51:29  	at com.github._1c_syntax.utils.Lazy.maybeCompute(Lazy.java:72)
09:51:29  	at com.github._1c_syntax.utils.Lazy.getOrCompute(Lazy.java:49)
09:51:29  	at com.github._1c_syntax.utils.Lazy.getOrCompute(Lazy.java:57)
09:51:29  	at com.github._1c_syntax.bsl.languageserver.context.ServerContext.getConfiguration(ServerContext.java:96)
09:51:29  	at com.github._1c_syntax.bsl.languageserver.diagnostics.DiagnosticSupplier.getDiagnosticInstances(DiagnosticSupplier.java:79)
09:51:29  	at com.github._1c_syntax.bsl.languageserver.providers.DiagnosticProvider.computeDiagnostics(DiagnosticProvider.java:74)
09:51:29  	at com.github._1c_syntax.bsl.sonar.BSLCoreSensor.processFile(BSLCoreSensor.java:194)
09:51:29  	at com.github._1c_syntax.bsl.sonar.BSLCoreSensor.lambda$execute$3(BSLCoreSensor.java:171)
09:51:29  	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(Unknown Source)
09:51:29  	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(Unknown Source)
09:51:29  	at java.base/java.util.stream.AbstractPipeline.copyInto(Unknown Source)
09:51:29  	at java.base/java.util.stream.ForEachOps$ForEachTask.compute(Unknown Source)
09:51:29  	at java.base/java.util.concurrent.CountedCompleter.exec(Unknown Source)
09:51:29  	at java.base/java.util.concurrent.ForkJoinTask.doExec(Unknown Source)
09:51:29  	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(Unknown Source)
09:51:29  	at java.base/java.util.concurrent.ForkJoinPool.scan(Unknown Source)
09:51:29  	at java.base/java.util.concurrent.ForkJoinPool.runWorker(Unknown Source)
09:51:29  	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(Unknown Source)
09:51:29  Caused by: java.lang.NullPointerException: null
09:51:29  	at com.github._1c_syntax.mdclasses.mdo.Subsystem$SubsystemBuilderImpl.lambda$childrenAdd$0(Subsystem.java:131)
09:51:29  	at java.base/java.util.ArrayList.forEach(Unknown Source)
09:51:29  	at com.github._1c_syntax.mdclasses.mdo.Subsystem$SubsystemBuilderImpl.childrenAdd(Subsystem.java:131)
09:51:29  	at com.github._1c_syntax.mdclasses.mdo.Subsystem$SubsystemBuilderImpl.properties(Subsystem.java:118)
09:51:29  	at jdk.internal.reflect.GeneratedMethodAccessor40.invoke(Unknown Source)
09:51:29  	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
09:51:29  	at java.base/java.lang.reflect.Method.invoke(Unknown Source)
09:51:29  	at com.fasterxml.jackson.databind.deser.impl.MethodProperty.deserializeSetAndReturn(MethodProperty.java:170)
09:51:29  	... 38 common frames omitted
09:51:29  
```

Думаю, что падать из-за таких строчек на NPE не должно.
Предлагаю такие строчки фильтровать.