### PR TITLE
Поддержка атрибутов регламентных заданий

### DIFF
--- a/src/main/java/com/github/_1c_syntax/mdclasses/mdo/MDScheduledJob.java
+++ b/src/main/java/com/github/_1c_syntax/mdclasses/mdo/MDScheduledJob.java
@@ -53,6 +53,19 @@ public class MDScheduledJob extends AbstractMDObjectBase {
   @XStreamAlias("methodName")
   private Handler handler;
 
+  @XStreamAlias("Description")
+  private String description;
+  @XStreamAlias("Key")
+  private String key;
+  @XStreamAlias("Use")
+  private boolean use;
+  @XStreamAlias("Predefined")
+  private boolean predefined;
+  @XStreamAlias("RestartCountOnFailure")
+  private int restartCountOnFailure;
+  @XStreamAlias("RestartIntervalOnFailure")
+  private int restartIntervalOnFailure;
+
   public MDScheduledJob(DesignerMDO designerMDO) {
     super(designerMDO);
     this.handler = new Handler(designerMDO.getProperties().getMethodName());

--- a/src/test/java/com/github/_1c_syntax/mdclasses/mdo/MDScheduledJobAttributesTest.java
+++ b/src/test/java/com/github/_1c_syntax/mdclasses/mdo/MDScheduledJobAttributesTest.java
@@ -45,6 +45,13 @@ class MDScheduledJobAttributesTest extends AbstractMDOTest {
     assertThat(handler.getMethodPath()).isEqualTo("CommonModule.ПростойОбщийМодуль.РегламентноеЗадание1");
     assertThat(handler.getMethodName()).isEqualTo("РегламентноеЗадание1");
     assertThat(handler.getModuleName()).isEqualTo("ПростойОбщийМодуль");
+
+    assertThat(mdo.getDescription()).isEqualTo("Описание Регламентное задание 1");
+    assertThat(mdo.getKey()).isEqualTo("ПроверкаАктивностиСеансаУдаленияОбъектов");
+    assertThat(mdo.isUse()).isTrue();
+    assertThat(mdo.isPredefined()).isTrue();
+    assertThat(mdo.getRestartCountOnFailure()).isEqualTo(3);
+    assertThat(mdo.getRestartIntervalOnFailure()).isEqualTo(10);
   }
 
   @Override
@@ -58,5 +65,12 @@ class MDScheduledJobAttributesTest extends AbstractMDOTest {
     assertThat(handler.getMethodPath()).isEqualTo("CommonModule.ПростойОбщийМодуль.РегламентноеЗадание1");
     assertThat(handler.getMethodName()).isEqualTo("РегламентноеЗадание1");
     assertThat(handler.getModuleName()).isEqualTo("ПростойОбщийМодуль");
+
+    assertThat(mdo.getDescription()).isEqualTo("Описание Регламентное задание 1");
+    assertThat(mdo.getKey()).isEqualTo("ПроверкаАктивностиСеансаУдаленияОбъектов");
+    assertThat(mdo.isUse()).isTrue();
+    assertThat(mdo.isPredefined()).isTrue();
+    assertThat(mdo.getRestartCountOnFailure()).isEqualTo(3);
+    assertThat(mdo.getRestartIntervalOnFailure()).isEqualTo(10);
   }
 }

--- a/src/test/resources/metadata/edt/src/ScheduledJobs/РегламентноеЗадание1/РегламентноеЗадание1.mdo
+++ b/src/test/resources/metadata/edt/src/ScheduledJobs/РегламентноеЗадание1/РегламентноеЗадание1.mdo
@@ -2,7 +2,10 @@
 <mdclass:ScheduledJob xmlns:mdclass="http://g5.1c.ru/v8/dt/metadata/mdclass" uuid="0de0c839-4427-46d9-be68-302f88ac162c">
   <name>РегламентноеЗадание1</name>
   <methodName>CommonModule.ПростойОбщийМодуль.РегламентноеЗадание1</methodName>
+  <description>Описание Регламентное задание 1</description>
+  <key>ПроверкаАктивностиСеансаУдаленияОбъектов</key>
   <use>true</use>
+  <predefined>true</predefined>
   <restartCountOnFailure>3</restartCountOnFailure>
   <restartIntervalOnFailure>10</restartIntervalOnFailure>
 </mdclass:ScheduledJob>

--- a/src/test/resources/metadata/original/ScheduledJobs/РегламентноеЗадание1.xml
+++ b/src/test/resources/metadata/original/ScheduledJobs/РегламентноеЗадание1.xml
@@ -6,10 +6,10 @@
 			<Synonym/>
 			<Comment/>
 			<MethodName>CommonModule.ПростойОбщийМодуль.РегламентноеЗадание1</MethodName>
-			<Description/>
-			<Key/>
+			<Description>Описание Регламентное задание 1</Description>
+			<Key>ПроверкаАктивностиСеансаУдаленияОбъектов</Key>
 			<Use>true</Use>
-			<Predefined>false</Predefined>
+			<Predefined>true</Predefined>
 			<RestartCountOnFailure>3</RestartCountOnFailure>
 			<RestartIntervalOnFailure>10</RestartIntervalOnFailure>
 		</Properties>


### PR DESCRIPTION
## Описание
<!--- ОБЯЗАТЕЛЬНО опишите внесенные изменения -->
Добавил следующие атрибуты регламентных заданий
```java
  @XStreamAlias("Description")
  private String description;
  @XStreamAlias("Key")
  private String key;
  @XStreamAlias("Use")
  private boolean use;
  @XStreamAlias("Predefined")
  private boolean predefined;
  @XStreamAlias("RestartCountOnFailure")
  private int restartCountOnFailure;
  @XStreamAlias("RestartIntervalOnFailure")
  private int restartIntervalOnFailure;
```
## Связанные задачи
<!--- Для каждого PR обязательно наличие связанной задачи (issue). -->
<!--- Необходимо указать ключи задач, предваряя их символом #, например -->
<!---Closes #123 -->
<!--  -->
<!-- ВНИМАНИЕ: Без ссылки на задачу пулл-реквест не будет принят! -->
<!--  -->
Closes #363

## Чеклист
<!--- Перед отправкой пройдите по списку и поставьте отметку для каждого выполненного действия -->
<!--- Если не понятно, что подразумевается - спросите в чате проекта https://t.me/bsl_language_server -->

### Общие

- [x] Ветка PR обновлена из develop
- [x] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [x] Изменения покрыты тестами
- [x] Обязательные действия перед коммитом выполнены (запускал команду `gradlew precommit`)

## Дополнительно
<!--- Различная дополнительная информация, скриншоты и т.д. -->
Связано с https://github.com/1c-syntax/bsl-language-server/pull/2862