### PR TITLE
Чтение конфигураций из файла, проверка на пустоту конфигурации

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/mdclasses/CF.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdclasses/CF.java
@@ -196,4 +196,13 @@ public interface CF extends MDClass, ConfigurationTree, CFAccess {
   default Optional<CommonModule> findCommonModule(String name) {
     return Optional.ofNullable(getCommonModulesByName().get(name));
   }
+
+  /**
+   * Возвращает признак пустоты конфигурации
+   *
+   * @return Это пустая конфигурация
+   */
+  default boolean isEmpty() {
+    return this == Configuration.EMPTY;
+  }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/reader/MDOReader.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/reader/MDOReader.java
@@ -120,15 +120,23 @@ public class MDOReader {
   private ConfigurationSource getConfigurationSourceByPath(Path rootPath) {
     var configurationSource = ConfigurationSource.EMPTY;
     if (rootPath != null) {
-      var rootPathString = rootPath.toString();
-
-      var rootConfiguration = new File(rootPathString, DesignerReader.CONFIGURATION_MDO_PATH);
-      if (rootConfiguration.exists()) {
-        configurationSource = ConfigurationSource.DESIGNER;
-      } else {
-        rootConfiguration = Paths.get(rootPathString, EDTReader.CONFIGURATION_MDO_PATH).toFile();
-        if (rootConfiguration.exists()) {
+      if (rootPath.toFile().isFile()) { // передали сам файл, а не каталог
+        var filename = rootPath.getFileName().toString();
+        if (DesignerReader.CONFIGURATION_MDO_FILE_NAME.equals(filename)) {
+          configurationSource = ConfigurationSource.DESIGNER;
+        } else if (EDTReader.CONFIGURATION_MDO_FILE_NAME.equals(filename)) {
           configurationSource = ConfigurationSource.EDT;
+        }
+      } else {
+        var rootPathString = rootPath.toString();
+        var rootConfiguration = new File(rootPathString, DesignerReader.CONFIGURATION_MDO_PATH);
+        if (rootConfiguration.exists()) {
+          configurationSource = ConfigurationSource.DESIGNER;
+        } else {
+          rootConfiguration = Paths.get(rootPathString, EDTReader.CONFIGURATION_MDO_PATH).toFile();
+          if (rootConfiguration.exists()) {
+            configurationSource = ConfigurationSource.EDT;
+          }
         }
       }
     }

--- a/src/main/java/com/github/_1c_syntax/bsl/reader/designer/DesignerReader.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/reader/designer/DesignerReader.java
@@ -67,7 +67,6 @@ import com.thoughtworks.xstream.core.util.CompositeClassLoader;
 import com.thoughtworks.xstream.io.HierarchicalStreamReader;
 import com.thoughtworks.xstream.io.xml.QNameMap;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FilenameUtils;
 
@@ -98,9 +97,15 @@ public class DesignerReader implements MDReader {
 
   public DesignerReader(Path path, boolean skipSupport) {
     xstream = createXMLMapper();
-    var file = path.toFile();
+    var normalizedPath = path.toAbsolutePath();
+    var file = normalizedPath.toFile();
     if (file.isFile() && CONFIGURATION_MDO_FILE_NAME.equals(file.getName())) { // передали сам файл, а не каталог
-      rootPath = path.getParent();
+      var parent = normalizedPath.getParent();
+      if (parent == null) {
+        throw new IllegalArgumentException(
+          "Не удалось определить каталог конфигурации для файла " + normalizedPath);
+      }
+      rootPath = parent;
     } else {
       rootPath = path;
     }
@@ -110,13 +115,11 @@ public class DesignerReader implements MDReader {
   }
 
   @Override
-  @NonNull
   public ConfigurationSource getConfigurationSource() {
     return ConfigurationSource.DESIGNER;
   }
 
   @Override
-  @NonNull
   public MDClass readConfiguration() {
     var mdc = Optional.ofNullable((MDClass) read(
       mdoPath(rootPath, MDOType.CONFIGURATION, MDOType.CONFIGURATION.nameEn())
@@ -125,7 +128,6 @@ public class DesignerReader implements MDReader {
   }
 
   @Override
-  @NonNull
   public ExternalSource readExternalSource() {
     var value = read(rootPath);
     if (value instanceof ExternalSource externalSource) {
@@ -165,7 +167,6 @@ public class DesignerReader implements MDReader {
   }
 
   @Override
-  @NonNull
   public Path moduleFolder(Path mdoPath, MDOType mdoType) {
     if (mdoType == MDOType.COMMAND) {
       return childrenFolder(mdoPath, mdoType);
@@ -177,7 +178,6 @@ public class DesignerReader implements MDReader {
   }
 
   @Override
-  @NonNull
   public Path modulePath(Path folder, String name, ModuleType moduleType) {
     var subdirectory = "Ext";
 
@@ -193,19 +193,16 @@ public class DesignerReader implements MDReader {
   }
 
   @Override
-  @NonNull
   public Path mdoTypeFolderPath(Path mdoPath) {
     return Paths.get(FilenameUtils.getFullPathNoEndSeparator(mdoPath.toString()));
   }
 
   @Override
-  @NonNull
   public String subsystemsNodeName() {
     return "Subsystem";
   }
 
   @Override
-  @NonNull
   public String configurationExtensionFilter() {
     return "(<ObjectBelonging>)";
   }

--- a/src/main/java/com/github/_1c_syntax/bsl/reader/designer/DesignerReader.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/reader/designer/DesignerReader.java
@@ -85,6 +85,11 @@ public class DesignerReader implements MDReader {
    */
   public static final String CONFIGURATION_MDO_PATH = "Configuration.xml";
 
+  /**
+   * Имя корневого файла конфигурации
+   */
+  public static final String CONFIGURATION_MDO_FILE_NAME = "Configuration.xml";
+
   @Getter
   private final ExtendXStream xstream;
 
@@ -93,7 +98,12 @@ public class DesignerReader implements MDReader {
 
   public DesignerReader(Path path, boolean skipSupport) {
     xstream = createXMLMapper();
-    rootPath = path;
+    var file = path.toFile();
+    if (file.isFile() && CONFIGURATION_MDO_FILE_NAME.equals(file.getName())) { // передали сам файл, а не каталог
+      rootPath = path.getParent();
+    } else {
+      rootPath = path;
+    }
     if (!skipSupport) {
       ParseSupportData.readSimple(parentConfigurationsPath());
     }

--- a/src/main/java/com/github/_1c_syntax/bsl/reader/designer/package-info.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/reader/designer/package-info.java
@@ -22,4 +22,10 @@
 /**
  * Содержит ридер для формата конфигуратора
  */
+@ParametersAreNonnullByDefault
+@ReturnValuesAreNonnullByDefault
 package com.github._1c_syntax.bsl.reader.designer;
+
+import edu.umd.cs.findbugs.annotations.ReturnValuesAreNonnullByDefault;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/com/github/_1c_syntax/bsl/reader/edt/EDTReader.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/reader/edt/EDTReader.java
@@ -83,6 +83,11 @@ public class EDTReader implements MDReader {
   public static final String CONFIGURATION_MDO_PATH = Paths.get("src", "Configuration", "Configuration.mdo")
     .toString();
 
+  /**
+   * Имя корневого файла конфигурации
+   */
+  public static final String CONFIGURATION_MDO_FILE_NAME = "Configuration.mdo";
+
   @Getter
   private final ExtendXStream xstream;
 
@@ -91,7 +96,12 @@ public class EDTReader implements MDReader {
 
   public EDTReader(Path path, boolean skipSupport) {
     xstream = createXMLMapper();
-    rootPath = path;
+    var file = path.toFile();
+    if (file.isFile() && CONFIGURATION_MDO_FILE_NAME.equals(file.getName())) { // передали сам файл, а не каталог
+      rootPath = path.getParent().getParent().getParent();
+    } else {
+      rootPath = path;
+    }
     if (!skipSupport) {
       ParseSupportData.readSimple(parentConfigurationsPath());
     }

--- a/src/main/java/com/github/_1c_syntax/bsl/reader/edt/package-info.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/reader/edt/package-info.java
@@ -22,4 +22,10 @@
 /**
  * Содержит ридер для формата ЕДТ
  */
+@ParametersAreNonnullByDefault
+@ReturnValuesAreNonnullByDefault
 package com.github._1c_syntax.bsl.reader.edt;
+
+import edu.umd.cs.findbugs.annotations.ReturnValuesAreNonnullByDefault;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/test/java/com/github/_1c_syntax/bsl/mdclasses/ConfigurationTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdclasses/ConfigurationTest.java
@@ -33,10 +33,12 @@ import com.github._1c_syntax.bsl.types.ConfigurationSource;
 import com.github._1c_syntax.bsl.types.MdoReference;
 import com.github._1c_syntax.bsl.types.ModuleType;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.aggregator.ArgumentsAccessor;
 import org.junit.jupiter.params.provider.CsvSource;
 
+import java.nio.file.Path;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -211,16 +213,16 @@ class ConfigurationTest {
       .isEmpty();
   }
 
-  @ParameterizedTest
-  @CsvSource(
-    {
-      "false, mdclasses_ext"
-    }
-  )
-  void testFullExt(ArgumentsAccessor argumentsAccessor) {
-    var mdc = MDTestUtils.readConfiguration(argumentsAccessor, false);
-    assertThat(mdc).isInstanceOf(ConfigurationExtension.class);
+  @Test
+  void testFullExt() {
+    var configurationPath = Path.of("src/test/resources/ext/designer/mdclasses_ext/src/cf/Configuration.xml");
+    var mdc = MDClasses.createConfiguration(configurationPath, true);
+    assertThat(mdc).isNotNull()
+      .isInstanceOf(MDClass.class)
+      .isInstanceOf(ConfigurationExtension.class);
+
     var cf = (ConfigurationExtension) mdc;
+    assertThat(cf.isEmpty()).isFalse();
     assertThat(cf.getSupportVariant()).isEqualTo(SupportVariant.NONE);
     assertThat(cf.getModules()).isEmpty();
     assertThat(cf.getAllModules())
@@ -247,16 +249,17 @@ class ConfigurationTest {
       .isEmpty();
   }
 
-  @ParameterizedTest
-  @CsvSource(
-    {
-      "true, mdclasses_ext, _edt"
-    }
-  )
-  void testFullExtEdt(ArgumentsAccessor argumentsAccessor) {
-    var mdc = MDTestUtils.readConfiguration(argumentsAccessor, false);
-    assertThat(mdc).isInstanceOf(ConfigurationExtension.class);
+  @Test
+  void testFullExtEdt() {
+    var configurationPath = Path.of(
+      "src/test/resources/ext/edt/mdclasses_ext/configuration/src/Configuration/Configuration.mdo");
+    var mdc = MDClasses.createConfiguration(configurationPath, true);
+    assertThat(mdc).isNotNull()
+      .isInstanceOf(MDClass.class)
+      .isInstanceOf(ConfigurationExtension.class);
+
     var cf = (ConfigurationExtension) mdc;
+    assertThat(cf.isEmpty()).isFalse();
 
     // проверка порядок
     checkChildrenOrder(cf);

--- a/src/test/resources/fixtures/mdclasses/Configuration.json
+++ b/src/test/resources/fixtures/mdclasses/Configuration.json
@@ -1376,6 +1376,7 @@
       }
     }
   ],
+  "empty": false,
   "enums": [
     {
       "uuid": "f11f3441-4b64-4344-b1a0-0e4b3e466e03",
@@ -1834,12 +1835,12 @@
   "modalityUseMode": "USE",
   "moduleTypes": [
     [
-      "ExternalConnectionModule",
-      "src/test/resources/ext/designer/mdclasses/src/cf/Ext/ExternalConnectionModule.bsl"
-    ],
-    [
       "SessionModule",
       "src/test/resources/ext/designer/mdclasses/src/cf/Ext/SessionModule.bsl"
+    ],
+    [
+      "ExternalConnectionModule",
+      "src/test/resources/ext/designer/mdclasses/src/cf/Ext/ExternalConnectionModule.bsl"
     ],
     [
       "ManagedApplicationModule",

--- a/src/test/resources/fixtures/mdclasses/Configuration_edt.json
+++ b/src/test/resources/fixtures/mdclasses/Configuration_edt.json
@@ -1376,6 +1376,7 @@
       }
     }
   ],
+  "empty": false,
   "enums": [
     {
       "uuid": "f11f3441-4b64-4344-b1a0-0e4b3e466e03",
@@ -1829,12 +1830,12 @@
   "modalityUseMode": "USE",
   "moduleTypes": [
     [
-      "ExternalConnectionModule",
-      "src/test/resources/ext/edt/mdclasses/configuration/src/Configuration/ExternalConnectionModule.bsl"
-    ],
-    [
       "SessionModule",
       "src/test/resources/ext/edt/mdclasses/configuration/src/Configuration/SessionModule.bsl"
+    ],
+    [
+      "ExternalConnectionModule",
+      "src/test/resources/ext/edt/mdclasses/configuration/src/Configuration/ExternalConnectionModule.bsl"
     ],
     [
       "ManagedApplicationModule",

--- a/src/test/resources/fixtures/mdclasses_3_18/Configuration.json
+++ b/src/test/resources/fixtures/mdclasses_3_18/Configuration.json
@@ -169,6 +169,7 @@
     ],
     []
   ],
+  "empty": false,
   "enums": [],
   "eventSubscriptions": [],
   "exchangePlans": [

--- a/src/test/resources/fixtures/mdclasses_3_18/Configuration_edt.json
+++ b/src/test/resources/fixtures/mdclasses_3_18/Configuration_edt.json
@@ -169,6 +169,7 @@
     ],
     []
   ],
+  "empty": false,
   "enums": [],
   "eventSubscriptions": [],
   "exchangePlans": [

--- a/src/test/resources/fixtures/mdclasses_3_24/Configuration_edt.json
+++ b/src/test/resources/fixtures/mdclasses_3_24/Configuration_edt.json
@@ -1376,6 +1376,7 @@
       }
     }
   ],
+  "empty": false,
   "enums": [
     {
       "uuid": "f11f3441-4b64-4344-b1a0-0e4b3e466e03",
@@ -1824,12 +1825,12 @@
   "modalityUseMode": "USE_WITH_WARNINGS",
   "moduleTypes": [
     [
-      "ExternalConnectionModule",
-      "src/test/resources/ext/edt/mdclasses_3_24/configuration/src/Configuration/ExternalConnectionModule.bsl"
-    ],
-    [
       "SessionModule",
       "src/test/resources/ext/edt/mdclasses_3_24/configuration/src/Configuration/SessionModule.bsl"
+    ],
+    [
+      "ExternalConnectionModule",
+      "src/test/resources/ext/edt/mdclasses_3_24/configuration/src/Configuration/ExternalConnectionModule.bsl"
     ],
     [
       "ManagedApplicationModule",

--- a/src/test/resources/fixtures/mdclasses_5_1/Configuration.json
+++ b/src/test/resources/fixtures/mdclasses_5_1/Configuration.json
@@ -169,6 +169,7 @@
     ],
     []
   ],
+  "empty": false,
   "enums": [],
   "eventSubscriptions": [],
   "exchangePlans": [

--- a/src/test/resources/fixtures/mdclasses_ext/Configuration.json
+++ b/src/test/resources/fixtures/mdclasses_ext/Configuration.json
@@ -304,6 +304,7 @@
     ],
     []
   ],
+  "empty": false,
   "enums": [
     [
       2

--- a/src/test/resources/fixtures/mdclasses_ext/Configuration_edt.json
+++ b/src/test/resources/fixtures/mdclasses_ext/Configuration_edt.json
@@ -346,6 +346,7 @@
     ],
     []
   ],
+  "empty": false,
   "enums": [
     [
       2

--- a/src/test/resources/fixtures/mdclasses_unknown/Configuration_edt.json
+++ b/src/test/resources/fixtures/mdclasses_unknown/Configuration_edt.json
@@ -49,6 +49,7 @@
   "documentJournals": [],
   "documentNumerators": [],
   "documents": [],
+  "empty": false,
   "enums": [],
   "eventSubscriptions": [],
   "exchangePlans": [],


### PR DESCRIPTION
## Описание
<!--- ОБЯЗАТЕЛЬНО опишите внесенные изменения -->

1. для конфигураций и расширений добавлен метод проверки на пустоту
2. реализовано чтение mdclass по переданному пути к файлу корня конфигурации

## Связанные задачи
<!--- Для каждого PR обязательно наличие связанной задачи (issue). -->
<!--- Необходимо указать ключи задач, предваряя их символом #, например -->
<!---Closes #123 -->
<!--  -->
<!-- ВНИМАНИЕ: Без ссылки на задачу пулл-реквест не будет принят! -->
<!--  -->
Closes

## Чеклист
<!--- Перед отправкой пройдите по списку и поставьте отметку для каждого выполненного действия -->
<!--- Если не понятно, что подразумевается - спросите в чате проекта https://t.me/bsl_language_server -->

### Общие

- [x] Ветка PR обновлена из develop
- [x] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [x] Изменения покрыты тестами
- [x] Обязательные действия перед коммитом выполнены (запускал команду `gradlew precommit`)

## Дополнительно
<!--- Различная дополнительная информация, скриншоты и т.д. -->
