### PR TITLE
fix: Улучшена обработка ошибок в RoleConverter и ExtendXStream

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/reader/common/xstream/ExtendXStream.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/reader/common/xstream/ExtendXStream.java
@@ -127,7 +127,9 @@ public class ExtendXStream extends XStream {
       } catch (CannotResolveClassException e) {
         LOGGER.debug("Can't read file '{}' - unknown class (skipped) \n", file, e);
       } catch (StreamException e) {
-        LOGGER.error("Can't read file '{}' - it's broken (skipped): {}", file, e.getCause().getMessage());
+        LOGGER.error("Can't read file '{}' - it's broken (skipped)", file, e);
+      } catch (Exception e) {
+        LOGGER.error("Can't read file '{}' - unexpected error (skipped): {}", file, e.getMessage(), e);
       }
     }
     return result;

--- a/src/main/java/com/github/_1c_syntax/bsl/reader/common/xstream/ExtendXStream.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/reader/common/xstream/ExtendXStream.java
@@ -123,13 +123,13 @@ public class ExtendXStream extends XStream {
       try {
         result = super.fromXML(file);
       } catch (ConversionException e) {
-        LOGGER.error("Can't read file '{}' - it's broken (skipped) \n", file, e);
+        LOGGER.warn("Can't read file '{}' - it's broken (skipped) \n", file, e);
       } catch (CannotResolveClassException e) {
         LOGGER.debug("Can't read file '{}' - unknown class (skipped) \n", file, e);
       } catch (StreamException e) {
-        LOGGER.error("Can't read file '{}' - it's broken (skipped)", file, e);
+        LOGGER.warn("Can't read file '{}' - it's broken (skipped)", file, e);
       } catch (Exception e) {
-        LOGGER.error("Can't read file '{}' - unexpected error (skipped): {}", file, e.getMessage(), e);
+        LOGGER.warn("Can't read file '{}' - unexpected error (skipped): {}", file, e.getMessage(), e);
       }
     }
     return result;

--- a/src/main/java/com/github/_1c_syntax/bsl/reader/designer/converter/RoleConverter.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/reader/designer/converter/RoleConverter.java
@@ -31,11 +31,21 @@ import com.thoughtworks.xstream.io.HierarchicalStreamReader;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+/**
+ * Конвертер для чтения ролей из формата конфигуратора
+ */
 @DesignerConverter
 public class RoleConverter extends AbstractReadConverter {
 
   private static final String DATA_FIELD = "data";
 
+  /**
+   * Выполняет чтение роли из XML, включая данные прав доступа из файла Rights.xml
+   *
+   * @param reader  Ридер XML потока
+   * @param context Контекст десериализации
+   * @return Прочитанный объект роли с данными прав доступа
+   */
   @Override
   public Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context) {
     var readerContext = super.read(reader, context);
@@ -57,11 +67,24 @@ public class RoleConverter extends AbstractReadConverter {
     return readerContext.build();
   }
 
+  /**
+   * Проверяет, может ли конвертер обработать указанный тип
+   *
+   * @param type Тип класса для проверки
+   * @return true, если тип является Role или его подклассом
+   */
   @Override
   public boolean canConvert(Class type) {
     return Role.class.isAssignableFrom(type);
   }
 
+  /**
+   * Формирует путь к файлу Rights.xml для роли
+   *
+   * @param path Путь к файлу описания роли
+   * @param name Имя роли
+   * @return Путь к файлу Rights.xml
+   */
   private static Path dataPath(Path path, String name) {
     return Paths.get(path.getParent().toString(), name, "Ext", "Rights.xml");
   }

--- a/src/main/java/com/github/_1c_syntax/bsl/reader/designer/converter/RoleConverter.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/reader/designer/converter/RoleConverter.java
@@ -41,7 +41,13 @@ public class RoleConverter extends AbstractReadConverter {
     var readerContext = super.read(reader, context);
     RoleData data;
     try {
-      data = (RoleData) ExtendXStream.read(reader, dataPath(readerContext.getCurrentPath(), readerContext.getName()));
+      var readResult = ExtendXStream.read(reader, dataPath(readerContext.getCurrentPath(), readerContext.getName()));
+      if (readResult instanceof RoleData roleData) {
+        data = roleData;
+      } else {
+        // файл не прочитан или прочитан некорректно
+        data = RoleData.EMPTY;
+      }
     } catch (Exception e) {
       // ничего не делаем, считаем файл битым
       data = RoleData.EMPTY;

--- a/src/main/java/com/github/_1c_syntax/bsl/reader/edt/converter/RoleConverter.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/reader/edt/converter/RoleConverter.java
@@ -40,7 +40,13 @@ public class RoleConverter extends AbstractReadConverter {
     var readerContext = super.read(reader, context);
     RoleData data;
     try {
-      data = (RoleData) ExtendXStream.read(reader, dataPath(readerContext.getCurrentPath()));
+      var readResult = ExtendXStream.read(reader, dataPath(readerContext.getCurrentPath()));
+      if (readResult instanceof RoleData roleData) {
+        data = roleData;
+      } else {
+        // файл не прочитан или прочитан некорректно
+        data = RoleData.EMPTY;
+      }
     } catch (Exception e) {
       // ничего не делаем, считаем файл битым
       data = RoleData.EMPTY;

--- a/src/main/java/com/github/_1c_syntax/bsl/reader/edt/converter/RoleConverter.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/reader/edt/converter/RoleConverter.java
@@ -30,11 +30,21 @@ import com.thoughtworks.xstream.io.HierarchicalStreamReader;
 
 import java.nio.file.Path;
 
+/**
+ * Конвертер для чтения ролей из формата ЕДТ
+ */
 @EDTConverter
 public class RoleConverter extends AbstractReadConverter {
 
   private static final String DATA_FIELD = "data";
 
+  /**
+   * Выполняет чтение роли из XML, включая данные прав доступа из файла Rights.rights
+   *
+   * @param reader  Ридер XML потока
+   * @param context Контекст десериализации
+   * @return Прочитанный объект роли с данными прав доступа
+   */
   @Override
   public Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context) {
     var readerContext = super.read(reader, context);
@@ -56,11 +66,23 @@ public class RoleConverter extends AbstractReadConverter {
     return readerContext.build();
   }
 
+  /**
+   * Проверяет, может ли конвертер обработать указанный тип
+   *
+   * @param type Тип класса для проверки
+   * @return true, если тип является Role или его подклассом
+   */
   @Override
   public boolean canConvert(Class type) {
     return Role.class.isAssignableFrom(type);
   }
 
+  /**
+   * Формирует путь к файлу Rights.rights для роли
+   *
+   * @param path Путь к файлу описания роли
+   * @return Путь к файлу Rights.rights
+   */
   private static Path dataPath(Path path) {
     return Path.of(path.getParent().toString(), "Rights.rights");
   }


### PR DESCRIPTION
## Описание

- Добавлен блок catch для неожиданных исключений в ExtendXStream, регистрирующий сообщение об ошибке.
- Обновлен RoleConverter для обработки результата ExtendXStream.read, гарантирующий присвоение значения RoleData.EMPTY, если результат чтения не является допустимым экземпляром RoleData.

## Связанные задачи

Closes #563

## Чеклист

### Общие

- [x] Ветка PR обновлена из develop
- [x] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [x] Изменения покрыты тестами
- [x] Обязательные действия перед коммитом выполнены (запускал команду `gradlew precommit`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Downgraded noisy XML parsing errors to warnings and added handling for unexpected failures to avoid crashes.
  * Improved role data conversion to safely handle unexpected or malformed input, preventing type-related failures and ensuring consistent reader context population.

* **Documentation**
  * Added and updated inline documentation describing role conversion behavior and path-resolution utilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->