### PR TITLE
fix: Update precommit task dependency from :updateLicenses to :licenseFormat in build.gradle.kts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -238,7 +238,7 @@ tasks.register("precommit") {
     description = "Run all precommit tasks"
     group = "Developer tools"
     dependsOn(":test")
-    dependsOn(":updateLicenses")
+    dependsOn(":licenseFormat")
 }
 
 jreleaser {


### PR DESCRIPTION
## Описание
Обновил плагин

### Общие

- [x] Ветка PR обновлена из develop
- [x] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [x] Изменения покрыты тестами
- [x] Обязательные действия перед коммитом выполнены (запускал команду `gradlew precommit`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This release contains internal build system updates with no user-visible changes. The precommit build task dependency was updated to use an alternative licensing tool.

* **Chores**
  * Updated build configuration dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->