### PR TITLE
feat: API записи объектов метаданных (Subsystem, Catalog, Configuration) в формате конфигуратора (JAXB)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,6 +54,10 @@ dependencies {
 
     implementation("com.thoughtworks.xstream:xstream:1.4.21")
 
+    // JAXB (Jakarta) for Designer XML write via XSD-generated classes
+    implementation("jakarta.xml.bind:jakarta.xml.bind-api:4.0.2")
+    implementation("org.glassfish.jaxb:jaxb-runtime:4.0.5")
+
     // логирование
     implementation("org.slf4j:slf4j-api:2.0.16")
 
@@ -89,11 +93,53 @@ dependencies {
     jmhAnnotationProcessor("org.openjdk.jmh:jmh-generator-annprocess:1.37")
 }
 
+val xjcOutputMDClasses = layout.buildDirectory.dir("generated/sources/xjc-mdclasses")
+val xsdV85Dir = layout.projectDirectory.dir("src/main/xsd/v8.5")
+
+val xjc by configurations.creating
+dependencies {
+    xjc("org.glassfish.jaxb:jaxb-xjc:4.0.5")
+    xjc("org.glassfish.jaxb:jaxb-runtime:4.0.5")
+}
+
+tasks.register<JavaExec>("xjcMDClasses") {
+    group = "Build"
+    description = "Generate JAXB classes from v8.5 MDClasses XSD"
+    classpath = xjc
+    mainClass = "com.sun.tools.xjc.Driver"
+    workingDir = xsdV85Dir.asFile
+    doFirst {
+        args(
+            "-extension",
+            "-catalog", "catalog.xml",
+            "-b", "bindings.xjb",
+            "-d", xjcOutputMDClasses.get().asFile.absolutePath,
+            "v8.1c.ru-8.3-MDClasses.xsd"
+        )
+    }
+    inputs.dir(xsdV85Dir)
+    outputs.dir(xjcOutputMDClasses)
+}
+
+tasks.compileJava {
+    dependsOn("xjcMDClasses")
+}
+
 java {
     sourceCompatibility = JavaVersion.VERSION_21
     targetCompatibility = JavaVersion.VERSION_21
     withSourcesJar()
     withJavadocJar()
+}
+
+sourceSets["main"].java.srcDir(xjcOutputMDClasses)
+
+tasks.named("sourcesJar") {
+    dependsOn("xjcMDClasses")
+}
+
+tasks.named("licenseMain") {
+    dependsOn("xjcMDClasses")
 }
 
 jmh {
@@ -172,6 +218,7 @@ license {
     ext["project"] = "MDClasses"
     mapping("java", "SLASHSTAR_STYLE")
     include("**/*.java")
+    exclude("**/jaxb/**")
 }
 
 

--- a/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/AccountingRegisterToJaxbConverter.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/AccountingRegisterToJaxbConverter.java
@@ -1,0 +1,83 @@
+/*
+ * This file is a part of MDClasses.
+ *
+ * Copyright (c) 2019 - 2026
+ * Tymko Oleg <olegtymko@yandex.ru>, Maximov Valery <maximovvalery@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package com.github._1c_syntax.bsl.mdclasses.jaxb.write;
+
+import com.github._1c_syntax.bsl.mdo.AccountingRegister;
+import com.github._1c_syntax.bsl.mdo.children.ObjectForm;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.AccountingRegisterChildObjects;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.AccountingRegisterProperties;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.MetaDataObject;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.ObjectFactory;
+
+import java.math.BigDecimal;
+
+/**
+ * Преобразует регистр бухгалтерии mdclasses в JAXB-DTO для записи Designer XML.
+ */
+public final class AccountingRegisterToJaxbConverter {
+
+  private static final ObjectFactory FACTORY = new ObjectFactory();
+
+  private AccountingRegisterToJaxbConverter() {
+  }
+
+  /**
+   * Собирает JAXB MetaDataObject из регистра бухгалтерии.
+   *
+   * @param ar регистр бухгалтерии из модели mdclasses
+   * @return корневой элемент для маршаллинга в Designer XML
+   */
+  public static MetaDataObject toMetaDataObject(AccountingRegister ar) {
+    MetaDataObject root = FACTORY.createMetaDataObject();
+    root.setVersion(JaxbWriteDefaults.DEFAULT_FORMAT_VERSION);
+    com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.AccountingRegister inner = FACTORY.createAccountingRegister();
+    inner.setUuid(ar.getUuid() != null ? ar.getUuid() : "");
+    inner.setProperties(buildProperties(ar));
+    inner.setChildObjects(buildChildObjects(ar));
+    root.setAccountingRegister(inner);
+    return root;
+  }
+
+  private static AccountingRegisterProperties buildProperties(AccountingRegister ar) {
+    AccountingRegisterProperties p = FACTORY.createAccountingRegisterProperties();
+    p.setName(ar.getName());
+    p.setSynonym(JaxbWriteDefaults.localStringType(JaxbWriteUtils.contentForLocalString(ar.getSynonym())));
+    p.setComment(ar.getComment() != null ? ar.getComment() : "");
+    p.setObjectBelonging(JaxbWriteDefaults.objectBelongingNative());
+    p.setUseStandardCommands(false);
+    p.setIncludeHelpInContents(false);
+    p.setHelp("");
+    p.setChartOfAccounts("");
+    p.setCorrespondence(false);
+    p.setPeriodAdjustmentLength(BigDecimal.ZERO);
+    p.setDefaultListForm("");
+    p.setAuxiliaryListForm("");
+    p.setRecordSetModule("");
+    p.setManagerModule("");
+    p.setStandardAttributes(JaxbWriteDefaults.emptyStandardAttributeDescriptions());
+    p.setDataLockControlMode(JaxbWriteDefaults.defaultDataLockControlModeAutomatic());
+    p.setEnableTotalsSplitting(false);
+    p.setFullTextSearch(JaxbWriteDefaults.fullTextSearchDontUse());
+    p.setListPresentation(JaxbWriteDefaults.localStringType(""));
+    p.setExtendedListPresentation(JaxbWriteDefaults.localStringType(""));
+    p.setExplanation(JaxbWriteDefaults.localStringType(""));
+    p.setAdditionalIndexes("");
+    return p;
+  }
+
+  private static AccountingRegisterChildObjects buildChildObjects(AccountingRegister ar) {
+    AccountingRegisterChildObjects co = FACTORY.createAccountingRegisterChildObjects();
+    if (ar.getForms() != null) {
+      for (ObjectForm form : ar.getForms()) {
+        co.getForm().add(form.getName() != null ? form.getName() : "");
+      }
+    }
+    return co;
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/AccumulationRegisterToJaxbConverter.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/AccumulationRegisterToJaxbConverter.java
@@ -1,0 +1,80 @@
+/*
+ * This file is a part of MDClasses.
+ *
+ * Copyright (c) 2019 - 2026
+ * Tymko Oleg <olegtymko@yandex.ru>, Maximov Valery <maximovvalery@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package com.github._1c_syntax.bsl.mdclasses.jaxb.write;
+
+import com.github._1c_syntax.bsl.mdo.AccumulationRegister;
+import com.github._1c_syntax.bsl.mdo.children.ObjectForm;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.AccumulationRegisterChildObjects;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.AccumulationRegisterProperties;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.MetaDataObject;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.ObjectFactory;
+
+/**
+ * Преобразует регистр накопления mdclasses в JAXB-DTO для записи Designer XML.
+ */
+public final class AccumulationRegisterToJaxbConverter {
+
+  private static final ObjectFactory FACTORY = new ObjectFactory();
+
+  private AccumulationRegisterToJaxbConverter() {
+  }
+
+  /**
+   * Собирает JAXB MetaDataObject из регистра накопления.
+   *
+   * @param ar регистр накопления из модели mdclasses
+   * @return корневой элемент для маршаллинга в Designer XML
+   */
+  public static MetaDataObject toMetaDataObject(AccumulationRegister ar) {
+    MetaDataObject root = FACTORY.createMetaDataObject();
+    root.setVersion(JaxbWriteDefaults.DEFAULT_FORMAT_VERSION);
+    com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.AccumulationRegister inner = FACTORY.createAccumulationRegister();
+    inner.setUuid(ar.getUuid() != null ? ar.getUuid() : "");
+    inner.setProperties(buildProperties(ar));
+    inner.setChildObjects(buildChildObjects(ar));
+    root.setAccumulationRegister(inner);
+    return root;
+  }
+
+  private static AccumulationRegisterProperties buildProperties(AccumulationRegister ar) {
+    AccumulationRegisterProperties p = FACTORY.createAccumulationRegisterProperties();
+    p.setName(ar.getName());
+    p.setSynonym(JaxbWriteDefaults.localStringType(JaxbWriteUtils.contentForLocalString(ar.getSynonym())));
+    p.setComment(ar.getComment() != null ? ar.getComment() : "");
+    p.setObjectBelonging(JaxbWriteDefaults.objectBelongingNative());
+    p.setUseStandardCommands(false);
+    p.setDefaultListForm("");
+    p.setAuxiliaryListForm("");
+    p.setRegisterType(JaxbWriteDefaults.accumulationRegisterTypeBalance());
+    p.setIncludeHelpInContents(false);
+    p.setHelp("");
+    p.setRecordSetModule("");
+    p.setManagerModule("");
+    p.setStandardAttributes(JaxbWriteDefaults.emptyStandardAttributeDescriptions());
+    p.setDataLockControlMode(JaxbWriteDefaults.defaultDataLockControlModeAutomatic());
+    p.setFullTextSearch(JaxbWriteDefaults.fullTextSearchDontUse());
+    p.setEnableTotalsSplitting(false);
+    p.setAggregates("");
+    p.setListPresentation(JaxbWriteDefaults.localStringType(""));
+    p.setExtendedListPresentation(JaxbWriteDefaults.localStringType(""));
+    p.setExplanation(JaxbWriteDefaults.localStringType(""));
+    p.setAdditionalIndexes("");
+    return p;
+  }
+
+  private static AccumulationRegisterChildObjects buildChildObjects(AccumulationRegister ar) {
+    AccumulationRegisterChildObjects co = FACTORY.createAccumulationRegisterChildObjects();
+    if (ar.getForms() != null) {
+      for (ObjectForm form : ar.getForms()) {
+        co.getForm().add(form.getName() != null ? form.getName() : "");
+      }
+    }
+    return co;
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/BusinessProcessToJaxbConverter.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/BusinessProcessToJaxbConverter.java
@@ -1,0 +1,62 @@
+/*
+ * This file is a part of MDClasses.
+ *
+ * Copyright (c) 2019 - 2026
+ * Tymko Oleg <olegtymko@yandex.ru>, Maximov Valery <maximovvalery@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package com.github._1c_syntax.bsl.mdclasses.jaxb.write;
+
+import com.github._1c_syntax.bsl.mdo.BusinessProcess;
+import com.github._1c_syntax.bsl.mdo.children.ObjectForm;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.MetaDataObject;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.ObjectFactory;
+
+/**
+ * Преобразует бизнес-процесс mdclasses в JAXB-DTO для записи Designer XML.
+ */
+public final class BusinessProcessToJaxbConverter {
+
+  private static final ObjectFactory FACTORY = new ObjectFactory();
+
+  private BusinessProcessToJaxbConverter() {
+  }
+
+  /**
+   * Собирает JAXB MetaDataObject из бизнес-процесса.
+   *
+   * @param bp бизнес-процесс из модели mdclasses
+   * @return корневой элемент для маршаллинга в Designer XML
+   */
+  public static MetaDataObject toMetaDataObject(BusinessProcess bp) {
+    MetaDataObject root = FACTORY.createMetaDataObject();
+    root.setVersion(JaxbWriteDefaults.DEFAULT_FORMAT_VERSION);
+    com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.BusinessProcess inner = FACTORY.createBusinessProcess();
+    inner.setUuid(bp.getUuid() != null ? bp.getUuid() : "");
+    inner.setProperties(buildProperties(bp));
+    inner.setChildObjects(buildChildObjects(bp));
+    root.setBusinessProcess(inner);
+    return root;
+  }
+
+  private static com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.BusinessProcessProperties buildProperties(BusinessProcess bp) {
+    com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.BusinessProcessProperties p =
+      FACTORY.createBusinessProcessProperties();
+    p.setName(bp.getName());
+    p.setSynonym(JaxbWriteDefaults.localStringType(JaxbWriteUtils.contentForLocalString(bp.getSynonym())));
+    p.setComment(bp.getComment() != null ? bp.getComment() : "");
+    return p;
+  }
+
+  private static com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.BusinessProcessChildObjects buildChildObjects(BusinessProcess bp) {
+    com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.BusinessProcessChildObjects childObjects =
+      FACTORY.createBusinessProcessChildObjects();
+    if (bp.getForms() != null) {
+      for (ObjectForm form : bp.getForms()) {
+        childObjects.getForm().add(form.getName() != null ? form.getName() : "");
+      }
+    }
+    return childObjects;
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/CalculationRegisterToJaxbConverter.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/CalculationRegisterToJaxbConverter.java
@@ -1,0 +1,84 @@
+/*
+ * This file is a part of MDClasses.
+ *
+ * Copyright (c) 2019 - 2026
+ * Tymko Oleg <olegtymko@yandex.ru>, Maximov Valery <maximovvalery@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package com.github._1c_syntax.bsl.mdclasses.jaxb.write;
+
+import com.github._1c_syntax.bsl.mdo.CalculationRegister;
+import com.github._1c_syntax.bsl.mdo.children.ObjectForm;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.CalculationRegisterChildObjects;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.CalculationRegisterProperties;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.MetaDataObject;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.ObjectFactory;
+
+/**
+ * Преобразует регистр расчёта mdclasses в JAXB-DTO для записи Designer XML.
+ */
+public final class CalculationRegisterToJaxbConverter {
+
+  private static final ObjectFactory FACTORY = new ObjectFactory();
+
+  private CalculationRegisterToJaxbConverter() {
+  }
+
+  /**
+   * Собирает JAXB MetaDataObject из регистра расчёта.
+   *
+   * @param cr регистр расчёта из модели mdclasses
+   * @return корневой элемент для маршаллинга в Designer XML
+   */
+  public static MetaDataObject toMetaDataObject(CalculationRegister cr) {
+    MetaDataObject root = FACTORY.createMetaDataObject();
+    root.setVersion(JaxbWriteDefaults.DEFAULT_FORMAT_VERSION);
+    com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.CalculationRegister inner = FACTORY.createCalculationRegister();
+    inner.setUuid(cr.getUuid() != null ? cr.getUuid() : "");
+    inner.setProperties(buildProperties(cr));
+    inner.setChildObjects(buildChildObjects(cr));
+    root.setCalculationRegister(inner);
+    return root;
+  }
+
+  private static CalculationRegisterProperties buildProperties(CalculationRegister cr) {
+    CalculationRegisterProperties p = FACTORY.createCalculationRegisterProperties();
+    p.setName(cr.getName());
+    p.setSynonym(JaxbWriteDefaults.localStringType(JaxbWriteUtils.contentForLocalString(cr.getSynonym())));
+    p.setComment(cr.getComment() != null ? cr.getComment() : "");
+    p.setObjectBelonging(JaxbWriteDefaults.objectBelongingNative());
+    p.setUseStandardCommands(false);
+    p.setDefaultListForm("");
+    p.setAuxiliaryListForm("");
+    p.setPeriodicity(JaxbWriteDefaults.calculationRegisterPeriodicityYear());
+    p.setActionPeriod(false);
+    p.setBasePeriod(false);
+    p.setSchedule("");
+    p.setScheduleValue("");
+    p.setScheduleDate("");
+    p.setChartOfCalculationTypes("");
+    p.setRecordSetModule("");
+    p.setManagerModule("");
+    p.setIncludeHelpInContents(false);
+    p.setHelp("");
+    p.setStandardAttributes(JaxbWriteDefaults.emptyStandardAttributeDescriptions());
+    p.setDataLockControlMode(JaxbWriteDefaults.defaultDataLockControlModeAutomatic());
+    p.setFullTextSearch(JaxbWriteDefaults.fullTextSearchDontUse());
+    p.setListPresentation(JaxbWriteDefaults.localStringType(""));
+    p.setExtendedListPresentation(JaxbWriteDefaults.localStringType(""));
+    p.setExplanation(JaxbWriteDefaults.localStringType(""));
+    p.setAdditionalIndexes("");
+    return p;
+  }
+
+  private static CalculationRegisterChildObjects buildChildObjects(CalculationRegister cr) {
+    CalculationRegisterChildObjects co = FACTORY.createCalculationRegisterChildObjects();
+    if (cr.getForms() != null) {
+      for (ObjectForm form : cr.getForms()) {
+        co.getForm().add(form.getName() != null ? form.getName() : "");
+      }
+    }
+    return co;
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/CatalogToJaxbConverter.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/CatalogToJaxbConverter.java
@@ -1,0 +1,236 @@
+/*
+ * This file is a part of MDClasses.
+ *
+ * Copyright (c) 2019 - 2026
+ * Tymko Oleg <olegtymko@yandex.ru>, Maximov Valery <maximovvalery@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package com.github._1c_syntax.bsl.mdclasses.jaxb.write;
+
+import com.github._1c_syntax.bsl.mdo.Attribute;
+import com.github._1c_syntax.bsl.mdo.Catalog;
+import com.github._1c_syntax.bsl.mdo.children.ObjectCommand;
+import com.github._1c_syntax.bsl.mdo.children.ObjectForm;
+import com.github._1c_syntax.bsl.mdo.support.CodeSeries;
+import com.github._1c_syntax.bsl.types.MdoReference;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.AttributeProperties;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.CatalogChildObjects;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.CatalogProperties;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.Command;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.CommandProperties;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.MetaDataObject;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.ObjectFactory;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.v8_1_data_core.AllowedLength;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.v8_2_managed_application_logform.ChoiceDataGetModeOnInputByString;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.v8_2_managed_application_logform.FullTextSearchOnInputByString;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.v8_2_managed_application_logform.SearchStringModeOnInputByString;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.v8_3_xcf_enums.CatalogCodeType;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.v8_3_xcf_enums.CatalogCodesSeries;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.v8_3_xcf_enums.CatalogMainPresentation;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.v8_3_xcf_enums.CreateOnInput;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.v8_3_xcf_enums.DataHistoryUse;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.v8_3_xcf_enums.EditType;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.v8_3_xcf_enums.HierarchyType;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.v8_3_xcf_enums.PredefinedDataUpdate;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.v8_3_xcf_enums.SubordinationUse;
+
+import java.math.BigDecimal;
+import java.util.Set;
+
+/**
+ * Преобразует модель справочника mdclasses в JAXB-DTO для записи Designer XML.
+ */
+public final class CatalogToJaxbConverter {
+
+  private static final ObjectFactory FACTORY = new ObjectFactory();
+
+  private static final String EMPTY_REF = "";
+
+  private static final Set<String> STANDARD_CATALOG_ATTRIBUTE_NAMES = Set.of(
+    "Code", "Description", "Ref", "DeletionMark", "IsFolder", "Owner", "Parent",
+    "PredefinedDataName", "Predefined"
+  );
+
+  private CatalogToJaxbConverter() {
+  }
+
+  /**
+   * Собирает JAXB MetaDataObject из справочника mdclasses.
+   *
+   * @param catalog справочник из модели mdclasses
+   * @return корневой элемент для маршаллинга в Designer XML
+   */
+  public static MetaDataObject toMetaDataObject(Catalog catalog) {
+    return toMetaDataObject(catalog, null);
+  }
+
+  /**
+   * Собирает JAXB MetaDataObject из справочника mdclasses с указанием группы команд по умолчанию.
+   *
+   * @param catalog справочник из модели mdclasses
+   * @param defaultCommandGroupRef MDO-ссылка группы команд (например, "CommandGroup.ГруппаКоманд1") для команд без группы
+   * @return корневой элемент для маршаллинга в Designer XML
+   */
+  public static MetaDataObject toMetaDataObject(Catalog catalog, String defaultCommandGroupRef) {
+    MetaDataObject root = FACTORY.createMetaDataObject();
+    root.setVersion(JaxbWriteDefaults.DEFAULT_FORMAT_VERSION);
+    com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.Catalog inner = FACTORY.createCatalog();
+    inner.setUuid(catalog.getUuid() != null ? catalog.getUuid() : "");
+    inner.setProperties(buildProperties(catalog));
+    inner.setChildObjects(buildChildObjects(catalog, defaultCommandGroupRef));
+    root.setCatalog(inner);
+    return root;
+  }
+
+  private static CatalogProperties buildProperties(Catalog c) {
+    CatalogProperties p = FACTORY.createCatalogProperties();
+    p.setName(c.getName());
+    p.setSynonym(JaxbWriteDefaults.localStringType(JaxbWriteUtils.contentForLocalString(c.getSynonym())));
+    p.setComment(c.getComment() != null ? c.getComment() : "");
+    p.setObjectBelonging(JaxbWriteDefaults.objectBelongingNative());
+    p.setHierarchical(false);
+    p.setHierarchyType(HierarchyType.HIERARCHY_FOLDERS_AND_ITEMS);
+    p.setLimitLevelCount(false);
+    p.setLevelCount(BigDecimal.ONE);
+    p.setFoldersOnTop(true);
+    p.setUseStandardCommands(true);
+    p.setOwners(buildOwners(c));
+    p.setSubordinationUse(SubordinationUse.TO_FOLDERS_AND_ITEMS);
+    p.setCodeLength(BigDecimal.valueOf(9));
+    p.setDescriptionLength(BigDecimal.valueOf(150));
+    p.setCodeType(CatalogCodeType.STRING);
+    p.setCodeAllowedLength(AllowedLength.VARIABLE);
+    p.setCodeSeries(codeSeriesToJaxb(c.getCodeSeries()));
+    p.setCheckUnique(c.isCheckUnique());
+    p.setAutonumbering(false);
+    p.setDefaultPresentation(CatalogMainPresentation.AS_DESCRIPTION);
+    p.setStandardAttributes(JaxbWriteDefaults.emptyStandardAttributeDescriptions());
+    p.setCharacteristics(JaxbWriteDefaults.emptyCharacteristicsDescriptions());
+    p.setPredefined("");
+    p.setPredefinedDataUpdate(PredefinedDataUpdate.DONT_AUTO_UPDATE);
+    p.setEditType(EditType.IN_LIST);
+    p.setQuickChoice(false);
+    p.setChoiceMode(JaxbWriteDefaults.choiceModeFromForm());
+    p.setInputByString(JaxbWriteDefaults.emptyFieldList());
+    p.setSearchStringModeOnInputByString(SearchStringModeOnInputByString.ANY_PART);
+    p.setFullTextSearchOnInputByString(FullTextSearchOnInputByString.USE);
+    p.setChoiceDataGetModeOnInputByString(ChoiceDataGetModeOnInputByString.DIRECTLY);
+    p.setDefaultObjectForm(EMPTY_REF);
+    p.setDefaultFolderForm(EMPTY_REF);
+    p.setDefaultListForm(EMPTY_REF);
+    p.setDefaultChoiceForm(EMPTY_REF);
+    p.setDefaultFolderChoiceForm(EMPTY_REF);
+    p.setAuxiliaryObjectForm(EMPTY_REF);
+    p.setAuxiliaryFolderForm(EMPTY_REF);
+    p.setAuxiliaryListForm(EMPTY_REF);
+    p.setAuxiliaryChoiceForm(EMPTY_REF);
+    p.setAuxiliaryFolderChoiceForm(EMPTY_REF);
+    p.setObjectModule(EMPTY_REF);
+    p.setManagerModule(EMPTY_REF);
+    p.setIncludeHelpInContents(false);
+    p.setHelp(EMPTY_REF);
+    p.setBasedOn(JaxbWriteDefaults.emptyMDListType());
+    p.setDataLockFields(JaxbWriteDefaults.emptyFieldList());
+    p.setDataLockControlMode(JaxbWriteDefaults.defaultDataLockControlModeAutomatic());
+    p.setFullTextSearch(JaxbWriteDefaults.fullTextSearchDontUse());
+    p.setObjectPresentation(JaxbWriteDefaults.localStringType(""));
+    p.setExtendedObjectPresentation(JaxbWriteDefaults.localStringType(""));
+    p.setListPresentation(JaxbWriteDefaults.localStringType(""));
+    p.setExtendedListPresentation(JaxbWriteDefaults.localStringType(""));
+    p.setExplanation(JaxbWriteDefaults.localStringType(JaxbWriteUtils.contentForLocalString(c.getExplanation())));
+    p.setCreateOnInput(CreateOnInput.DONT_USE);
+    p.setChoiceHistoryOnInput(JaxbWriteDefaults.choiceHistoryOnInputAuto());
+    p.setDataHistory(DataHistoryUse.DONT_USE);
+    p.setUpdateDataHistoryImmediatelyAfterWrite(false);
+    p.setExecuteAfterWriteDataHistoryVersionProcessing(false);
+    p.setAdditionalIndexes(EMPTY_REF);
+    return p;
+  }
+
+  private static com.github._1c_syntax.bsl.mdclasses.jaxb.v8_3_xcf_readable.MDListType buildOwners(Catalog c) {
+    com.github._1c_syntax.bsl.mdclasses.jaxb.v8_3_xcf_readable.MDListType owners =
+      new com.github._1c_syntax.bsl.mdclasses.jaxb.v8_3_xcf_readable.MDListType();
+    if (c.getOwners() != null && !c.getOwners().isEmpty()) {
+      for (MdoReference ref : c.getOwners()) {
+        owners.getItem().add(shortNameFromMdoRef(ref != null ? ref.getMdoRef() : null));
+      }
+    }
+    return owners;
+  }
+
+  private static CatalogCodesSeries codeSeriesToJaxb(CodeSeries cs) {
+    if (cs == null) {
+      return CatalogCodesSeries.WHOLE_CATALOG;
+    }
+    return switch (cs) {
+      case WITHIN_SUBORDINATION -> CatalogCodesSeries.WITHIN_SUBORDINATION;
+      case WITHIN_OWNER_SUBORDINATION -> CatalogCodesSeries.WITHIN_OWNER_SUBORDINATION;
+      default -> CatalogCodesSeries.WHOLE_CATALOG;
+    };
+  }
+
+  private static CatalogChildObjects buildChildObjects(Catalog c, String defaultCommandGroupRef) {
+    CatalogChildObjects co = FACTORY.createCatalogChildObjects();
+    addForms(co, c);
+    addCommands(co, c, defaultCommandGroupRef);
+    addAttributes(co, c);
+    return co;
+  }
+
+  private static void addForms(CatalogChildObjects co, Catalog c) {
+    if (c.getForms() == null) {
+      return;
+    }
+    for (ObjectForm form : c.getForms()) {
+      co.getForm().add(form.getName() != null ? form.getName() : "");
+    }
+  }
+
+  private static void addCommands(CatalogChildObjects co, Catalog c, String defaultCommandGroupRef) {
+    if (c.getCommands() == null) {
+      return;
+    }
+    for (ObjectCommand cmd : c.getCommands()) {
+      Command command = FACTORY.createCommand();
+      command.setUuid(cmd.getUuid() != null ? cmd.getUuid() : "");
+      CommandProperties cmdProps = FACTORY.createCommandProperties();
+      cmdProps.setName(cmd.getName());
+      cmdProps.setSynonym(JaxbWriteDefaults.localStringType(JaxbWriteUtils.contentForLocalString(cmd.getSynonym())));
+      cmdProps.setComment(cmd.getComment() != null ? cmd.getComment() : "");
+      cmdProps.setOnMainServerUnavalableBehavior(JaxbWriteDefaults.onMainServerUnavalableBehaviorAuto());
+      if (defaultCommandGroupRef != null && !defaultCommandGroupRef.isEmpty()) {
+        cmdProps.setGroup(defaultCommandGroupRef);
+      }
+      command.setProperties(cmdProps);
+      co.getCommand().add(command);
+    }
+  }
+
+  private static void addAttributes(CatalogChildObjects co, Catalog c) {
+    if (c.getAttributes() == null) {
+      return;
+    }
+    for (Attribute attr : c.getAttributes()) {
+      if (attr.getName() == null || STANDARD_CATALOG_ATTRIBUTE_NAMES.contains(attr.getName())) {
+        continue;
+      }
+      com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.Attribute attribute = FACTORY.createAttribute();
+      attribute.setUuid(attr.getUuid() != null ? attr.getUuid() : "");
+      AttributeProperties attrProps = FACTORY.createAttributeProperties();
+      attrProps.setName(attr.getName());
+      attrProps.setSynonym(JaxbWriteDefaults.localStringType(JaxbWriteUtils.contentForLocalString(attr.getSynonym())));
+      attrProps.setComment(attr.getComment() != null ? attr.getComment() : "");
+      attribute.setProperties(attrProps);
+      co.getAttribute().add(attribute);
+    }
+  }
+
+  private static String shortNameFromMdoRef(String mdoRef) {
+    if (mdoRef == null) {
+      return "";
+    }
+    int dot = mdoRef.indexOf('.');
+    return dot >= 0 ? mdoRef.substring(dot + 1) : mdoRef;
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/ChartOfAccountsToJaxbConverter.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/ChartOfAccountsToJaxbConverter.java
@@ -1,0 +1,62 @@
+/*
+ * This file is a part of MDClasses.
+ *
+ * Copyright (c) 2019 - 2026
+ * Tymko Oleg <olegtymko@yandex.ru>, Maximov Valery <maximovvalery@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package com.github._1c_syntax.bsl.mdclasses.jaxb.write;
+
+import com.github._1c_syntax.bsl.mdo.ChartOfAccounts;
+import com.github._1c_syntax.bsl.mdo.children.ObjectForm;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.ChartOfAccountsChildObjects;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.ChartOfAccountsProperties;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.MetaDataObject;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.ObjectFactory;
+
+/**
+ * Преобразует план счетов mdclasses в JAXB-DTO для записи Designer XML.
+ */
+public final class ChartOfAccountsToJaxbConverter {
+
+  private static final ObjectFactory FACTORY = new ObjectFactory();
+
+  private ChartOfAccountsToJaxbConverter() {
+  }
+
+  /**
+   * Собирает JAXB MetaDataObject из плана счетов.
+   *
+   * @param coa план счетов из модели mdclasses
+   * @return корневой элемент для маршаллинга в Designer XML
+   */
+  public static MetaDataObject toMetaDataObject(ChartOfAccounts coa) {
+    MetaDataObject root = FACTORY.createMetaDataObject();
+    root.setVersion(JaxbWriteDefaults.DEFAULT_FORMAT_VERSION);
+    com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.ChartOfAccounts inner = FACTORY.createChartOfAccounts();
+    inner.setUuid(coa.getUuid() != null ? coa.getUuid() : "");
+    inner.setProperties(buildProperties(coa));
+    inner.setChildObjects(buildChildObjects(coa));
+    root.setChartOfAccounts(inner);
+    return root;
+  }
+
+  private static ChartOfAccountsProperties buildProperties(ChartOfAccounts coa) {
+    ChartOfAccountsProperties p = FACTORY.createChartOfAccountsProperties();
+    p.setName(coa.getName());
+    p.setSynonym(JaxbWriteDefaults.localStringType(JaxbWriteUtils.contentForLocalString(coa.getSynonym())));
+    p.setComment(coa.getComment() != null ? coa.getComment() : "");
+    return p;
+  }
+
+  private static ChartOfAccountsChildObjects buildChildObjects(ChartOfAccounts chart) {
+    ChartOfAccountsChildObjects childObjects = FACTORY.createChartOfAccountsChildObjects();
+    if (chart.getForms() != null) {
+      for (ObjectForm form : chart.getForms()) {
+        childObjects.getForm().add(form.getName() != null ? form.getName() : "");
+      }
+    }
+    return childObjects;
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/ChartOfCalculationTypesToJaxbConverter.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/ChartOfCalculationTypesToJaxbConverter.java
@@ -1,0 +1,63 @@
+/*
+ * This file is a part of MDClasses.
+ *
+ * Copyright (c) 2019 - 2026
+ * Tymko Oleg <olegtymko@yandex.ru>, Maximov Valery <maximovvalery@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package com.github._1c_syntax.bsl.mdclasses.jaxb.write;
+
+import com.github._1c_syntax.bsl.mdo.ChartOfCalculationTypes;
+import com.github._1c_syntax.bsl.mdo.children.ObjectForm;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.ChartOfCalculationTypesChildObjects;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.ChartOfCalculationTypesProperties;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.MetaDataObject;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.ObjectFactory;
+
+/**
+ * Преобразует план видов расчёта mdclasses в JAXB-DTO для записи Designer XML.
+ */
+public final class ChartOfCalculationTypesToJaxbConverter {
+
+  private static final ObjectFactory FACTORY = new ObjectFactory();
+
+  private ChartOfCalculationTypesToJaxbConverter() {
+  }
+
+  /**
+   * Собирает JAXB MetaDataObject из плана видов расчёта.
+   *
+   * @param chart план видов расчёта из модели mdclasses
+   * @return корневой элемент для маршаллинга в Designer XML
+   */
+  public static MetaDataObject toMetaDataObject(ChartOfCalculationTypes chart) {
+    MetaDataObject root = FACTORY.createMetaDataObject();
+    root.setVersion(JaxbWriteDefaults.DEFAULT_FORMAT_VERSION);
+    com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.ChartOfCalculationTypes inner =
+      FACTORY.createChartOfCalculationTypes();
+    inner.setUuid(chart.getUuid() != null ? chart.getUuid() : "");
+    inner.setProperties(buildProperties(chart));
+    inner.setChildObjects(buildChildObjects(chart));
+    root.setChartOfCalculationTypes(inner);
+    return root;
+  }
+
+  private static ChartOfCalculationTypesProperties buildProperties(ChartOfCalculationTypes chart) {
+    ChartOfCalculationTypesProperties p = FACTORY.createChartOfCalculationTypesProperties();
+    p.setName(chart.getName());
+    p.setSynonym(JaxbWriteDefaults.localStringType(JaxbWriteUtils.contentForLocalString(chart.getSynonym())));
+    p.setComment(chart.getComment() != null ? chart.getComment() : "");
+    return p;
+  }
+
+  private static ChartOfCalculationTypesChildObjects buildChildObjects(ChartOfCalculationTypes chart) {
+    ChartOfCalculationTypesChildObjects childObjects = FACTORY.createChartOfCalculationTypesChildObjects();
+    if (chart.getForms() != null) {
+      for (ObjectForm form : chart.getForms()) {
+        childObjects.getForm().add(form.getName() != null ? form.getName() : "");
+      }
+    }
+    return childObjects;
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/ChartOfCharacteristicTypesToJaxbConverter.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/ChartOfCharacteristicTypesToJaxbConverter.java
@@ -1,0 +1,63 @@
+/*
+ * This file is a part of MDClasses.
+ *
+ * Copyright (c) 2019 - 2026
+ * Tymko Oleg <olegtymko@yandex.ru>, Maximov Valery <maximovvalery@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package com.github._1c_syntax.bsl.mdclasses.jaxb.write;
+
+import com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes;
+import com.github._1c_syntax.bsl.mdo.children.ObjectForm;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.ChartOfCharacteristicTypesChildObjects;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.ChartOfCharacteristicTypesProperties;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.MetaDataObject;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.ObjectFactory;
+
+/**
+ * Преобразует план видов характеристик mdclasses в JAXB-DTO для записи Designer XML.
+ */
+public final class ChartOfCharacteristicTypesToJaxbConverter {
+
+  private static final ObjectFactory FACTORY = new ObjectFactory();
+
+  private ChartOfCharacteristicTypesToJaxbConverter() {
+  }
+
+  /**
+   * Собирает JAXB MetaDataObject из плана видов характеристик.
+   *
+   * @param chart план видов характеристик из модели mdclasses
+   * @return корневой элемент для маршаллинга в Designer XML
+   */
+  public static MetaDataObject toMetaDataObject(ChartOfCharacteristicTypes chart) {
+    MetaDataObject root = FACTORY.createMetaDataObject();
+    root.setVersion(JaxbWriteDefaults.DEFAULT_FORMAT_VERSION);
+    com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.ChartOfCharacteristicTypes inner =
+      FACTORY.createChartOfCharacteristicTypes();
+    inner.setUuid(chart.getUuid() != null ? chart.getUuid() : "");
+    inner.setProperties(buildProperties(chart));
+    inner.setChildObjects(buildChildObjects(chart));
+    root.setChartOfCharacteristicTypes(inner);
+    return root;
+  }
+
+  private static ChartOfCharacteristicTypesProperties buildProperties(ChartOfCharacteristicTypes chart) {
+    ChartOfCharacteristicTypesProperties p = FACTORY.createChartOfCharacteristicTypesProperties();
+    p.setName(chart.getName());
+    p.setSynonym(JaxbWriteDefaults.localStringType(JaxbWriteUtils.contentForLocalString(chart.getSynonym())));
+    p.setComment(chart.getComment() != null ? chart.getComment() : "");
+    return p;
+  }
+
+  private static ChartOfCharacteristicTypesChildObjects buildChildObjects(ChartOfCharacteristicTypes chart) {
+    ChartOfCharacteristicTypesChildObjects childObjects = FACTORY.createChartOfCharacteristicTypesChildObjects();
+    if (chart.getForms() != null) {
+      for (ObjectForm form : chart.getForms()) {
+        childObjects.getForm().add(form.getName() != null ? form.getName() : "");
+      }
+    }
+    return childObjects;
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/CommandGroupToJaxbConverter.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/CommandGroupToJaxbConverter.java
@@ -1,0 +1,56 @@
+/*
+ * This file is a part of MDClasses.
+ *
+ * Copyright (c) 2019 - 2026
+ * Tymko Oleg <olegtymko@yandex.ru>, Maximov Valery <maximovvalery@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package com.github._1c_syntax.bsl.mdclasses.jaxb.write;
+
+import com.github._1c_syntax.bsl.mdo.CommandGroup;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.CommandGroupProperties;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.MetaDataObject;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.ObjectFactory;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.v8_2_managed_application_core.CommandGroupCategory;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.v8_2_managed_application_logform.ButtonRepresentation;
+
+/**
+ * Преобразует группу команд mdclasses в JAXB-DTO для записи Designer XML.
+ */
+public final class CommandGroupToJaxbConverter {
+
+  private static final ObjectFactory FACTORY = new ObjectFactory();
+
+  private CommandGroupToJaxbConverter() {
+  }
+
+  /**
+   * Собирает JAXB MetaDataObject из группы команд.
+   *
+   * @param commandGroup группа команд из модели mdclasses
+   * @return корневой элемент для маршаллинга в Designer XML
+   */
+  public static MetaDataObject toMetaDataObject(CommandGroup commandGroup) {
+    MetaDataObject root = FACTORY.createMetaDataObject();
+    root.setVersion(JaxbWriteDefaults.DEFAULT_FORMAT_VERSION);
+    com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.CommandGroup inner = FACTORY.createCommandGroup();
+    inner.setUuid(commandGroup.getUuid() != null ? commandGroup.getUuid() : "");
+    inner.setProperties(buildProperties(commandGroup));
+    root.setCommandGroup(inner);
+    return root;
+  }
+
+  private static CommandGroupProperties buildProperties(CommandGroup g) {
+    CommandGroupProperties p = FACTORY.createCommandGroupProperties();
+    p.setName(g.getName() != null ? g.getName() : "");
+    p.setSynonym(JaxbWriteDefaults.localStringType(JaxbWriteUtils.contentForLocalString(g.getSynonym())));
+    p.setComment(g.getComment() != null ? g.getComment() : "");
+    p.setObjectBelonging(JaxbWriteDefaults.objectBelongingNative());
+    p.setRepresentation(ButtonRepresentation.AUTO);
+    p.setToolTip(JaxbWriteDefaults.localStringType(""));
+    p.setPicture(JaxbWriteDefaults.emptyPicture());
+    p.setCategory(CommandGroupCategory.NAVIGATION_PANEL);
+    return p;
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/CommonModuleToJaxbConverter.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/CommonModuleToJaxbConverter.java
@@ -1,0 +1,61 @@
+/*
+ * This file is a part of MDClasses.
+ *
+ * Copyright (c) 2019 - 2026
+ * Tymko Oleg <olegtymko@yandex.ru>, Maximov Valery <maximovvalery@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package com.github._1c_syntax.bsl.mdclasses.jaxb.write;
+
+import com.github._1c_syntax.bsl.mdo.CommonModule;
+import com.github._1c_syntax.bsl.mdo.support.ReturnValueReuse;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.CommonModuleProperties;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.MetaDataObject;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.ObjectFactory;
+
+/**
+ * Преобразует модель общего модуля mdclasses в JAXB-DTO для записи Designer XML.
+ */
+public final class CommonModuleToJaxbConverter {
+
+  private static final ObjectFactory FACTORY = new ObjectFactory();
+
+  private CommonModuleToJaxbConverter() {
+  }
+
+  /**
+   * Собирает JAXB MetaDataObject из общего модуля mdclasses.
+   *
+   * @param commonModule общий модуль из модели mdclasses
+   * @return корневой элемент для маршаллинга в Designer XML
+   */
+  public static MetaDataObject toMetaDataObject(CommonModule commonModule) {
+    MetaDataObject root = FACTORY.createMetaDataObject();
+    root.setVersion(JaxbWriteDefaults.DEFAULT_FORMAT_VERSION);
+    com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.CommonModule inner = FACTORY.createCommonModule();
+    inner.setUuid(commonModule.getUuid() != null ? commonModule.getUuid() : "");
+    inner.setProperties(buildProperties(commonModule));
+    root.setCommonModule(inner);
+    return root;
+  }
+
+  private static CommonModuleProperties buildProperties(CommonModule c) {
+    CommonModuleProperties p = FACTORY.createCommonModuleProperties();
+    p.setName(c.getName());
+    p.setSynonym(JaxbWriteDefaults.localStringType(JaxbWriteUtils.contentForLocalString(c.getSynonym())));
+    p.setComment(c.getComment() != null ? c.getComment() : "");
+    p.setGlobal(c.isGlobal());
+    p.setServer(c.isServer());
+    p.setClientManagedApplication(c.isClientManagedApplication());
+    p.setClientOrdinaryApplication(c.isClientOrdinaryApplication());
+    p.setExternalConnection(c.isExternalConnection());
+    p.setServerCall(c.isServerCall());
+    p.setPrivileged(c.isPrivileged());
+    ReturnValueReuse rvr = c.getReturnValuesReuse();
+    if (rvr != null && rvr != ReturnValueReuse.UNKNOWN && rvr.fullName() != null) {
+      p.setReturnValuesReuse(com.github._1c_syntax.bsl.mdclasses.jaxb.v8_3_xcf_enums.ReturnValuesReuse.fromValue(rvr.fullName().getEn()));
+    }
+    return p;
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/ConfigurationToJaxbConverter.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/ConfigurationToJaxbConverter.java
@@ -1,0 +1,201 @@
+/*
+ * This file is a part of MDClasses.
+ *
+ * Copyright (c) 2019 - 2026
+ * Tymko Oleg <olegtymko@yandex.ru>, Maximov Valery <maximovvalery@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package com.github._1c_syntax.bsl.mdclasses.jaxb.write;
+
+import com.github._1c_syntax.bsl.mdclasses.CF;
+import com.github._1c_syntax.bsl.mdclasses.Configuration;
+import com.github._1c_syntax.bsl.mdo.MD;
+import com.github._1c_syntax.bsl.mdo.support.ApplicationRunMode;
+import com.github._1c_syntax.bsl.support.CompatibilityMode;
+import com.github._1c_syntax.bsl.mdo.support.InterfaceCompatibilityMode;
+import com.github._1c_syntax.bsl.types.ScriptVariant;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.ConfigurationChildObjects;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.ConfigurationProperties;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.MetaDataObject;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.ObjectFactory;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.v8_2_managed_application_core.ClientRunMode;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Преобразует корневую конфигурацию (CF) в JAXB-DTO для записи Designer XML.
+ */
+public final class ConfigurationToJaxbConverter {
+
+  private static final ObjectFactory FACTORY = new ObjectFactory();
+
+  private ConfigurationToJaxbConverter() {
+  }
+
+  /**
+   * Собирает JAXB MetaDataObject из конфигурации mdclasses.
+   *
+   * @param configuration конфигурация
+   * @return корневой элемент для маршаллинга в Designer XML
+   */
+  public static MetaDataObject toMetaDataObject(Configuration configuration) {
+    CF cf = configuration;
+    MetaDataObject root = FACTORY.createMetaDataObject();
+    root.setVersion(JaxbWriteDefaults.DEFAULT_FORMAT_VERSION);
+    com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.Configuration inner = FACTORY.createConfiguration();
+    inner.setUuid(nonEmptyUuid(cf.getUuid()));
+    inner.setFormatVersion(JaxbWriteDefaults.DEFAULT_FORMAT_VERSION);
+    inner.setProperties(buildProperties(cf));
+    inner.setChildObjects(buildChildObjects(cf));
+    root.setConfiguration(inner);
+    return root;
+  }
+
+  private static String nonEmptyUuid(String uuid) {
+    String value = (uuid != null && !uuid.isBlank()) ? uuid : UUID.randomUUID().toString();
+    return value.toLowerCase();
+  }
+
+  private static ConfigurationProperties buildProperties(CF c) {
+    ConfigurationProperties p = FACTORY.createConfigurationProperties();
+    p.setName(c.getName());
+    p.setSynonym(JaxbWriteDefaults.localStringType(JaxbWriteUtils.contentForLocalString(c.getSynonym())));
+    p.setComment(c.getComment() != null ? c.getComment() : "");
+    p.setVendor(c.getVendor() != null ? c.getVendor() : "");
+    p.setVersion(c.getVersion() != null ? c.getVersion() : "");
+    ApplicationRunMode runMode = c.getDefaultRunMode();
+    if (runMode == ApplicationRunMode.MANAGED_APPLICATION) {
+      p.setDefaultRunMode(ClientRunMode.MANAGED_APPLICATION);
+    } else if (runMode == ApplicationRunMode.ORDINARY_APPLICATION) {
+      p.setDefaultRunMode(ClientRunMode.ORDINARY_APPLICATION);
+    }
+    ScriptVariant scriptVariant = c.getScriptVariant();
+    if (scriptVariant != null) {
+      p.setScriptVariant(safeScriptVariant(scriptVariant.name()));
+    }
+    if (c.getDefaultLanguage() != null && c.getDefaultLanguage().getMdoRef() != null && !c.getDefaultLanguage().getMdoRef().isEmpty()) {
+      p.setDefaultLanguage(c.getDefaultLanguage().getMdoRef());
+    }
+    InterfaceCompatibilityMode ifMode = c.getInterfaceCompatibilityMode();
+    if (ifMode != null && ifMode.fullName() != null) {
+      p.setInterfaceCompatibilityMode(safeInterfaceCompatibilityMode(ifMode.fullName().getEn()));
+    }
+    CompatibilityMode compatMode = c.getCompatibilityMode();
+    if (compatMode != null) {
+      p.setCompatibilityMode(safeCompatibilityMode(compatMode.toString()));
+    }
+    CompatibilityMode extCompatMode = c.getConfigurationExtensionCompatibilityMode();
+    if (extCompatMode != null) {
+      p.setConfigurationExtensionCompatibilityMode(safeCompatibilityMode(extCompatMode.toString()));
+    }
+    return p;
+  }
+
+  private static com.github._1c_syntax.bsl.mdclasses.jaxb.v8_3_xcf_enums.InterfaceCompatibilityMode safeInterfaceCompatibilityMode(String value) {
+    if (value == null || value.isEmpty()) {
+      return com.github._1c_syntax.bsl.mdclasses.jaxb.v8_3_xcf_enums.InterfaceCompatibilityMode.VERSION_8_2;
+    }
+    try {
+      return com.github._1c_syntax.bsl.mdclasses.jaxb.v8_3_xcf_enums.InterfaceCompatibilityMode.fromValue(value);
+    } catch (IllegalArgumentException e) {
+      return com.github._1c_syntax.bsl.mdclasses.jaxb.v8_3_xcf_enums.InterfaceCompatibilityMode.VERSION_8_2;
+    }
+  }
+
+  private static com.github._1c_syntax.bsl.mdclasses.jaxb.v8_3_xcf_enums.CompatibilityMode safeCompatibilityMode(String value) {
+    if (value == null || value.isEmpty()) {
+      return com.github._1c_syntax.bsl.mdclasses.jaxb.v8_3_xcf_enums.CompatibilityMode.values()[0];
+    }
+    try {
+      return com.github._1c_syntax.bsl.mdclasses.jaxb.v8_3_xcf_enums.CompatibilityMode.fromValue(value);
+    } catch (IllegalArgumentException e) {
+      return com.github._1c_syntax.bsl.mdclasses.jaxb.v8_3_xcf_enums.CompatibilityMode.values()[0];
+    }
+  }
+
+  private static com.github._1c_syntax.bsl.mdclasses.jaxb.v8_3_xcf_enums.ScriptVariant safeScriptVariant(String value) {
+    if (value == null || value.isEmpty()) {
+      return com.github._1c_syntax.bsl.mdclasses.jaxb.v8_3_xcf_enums.ScriptVariant.values()[0];
+    }
+    try {
+      return com.github._1c_syntax.bsl.mdclasses.jaxb.v8_3_xcf_enums.ScriptVariant.valueOf(value);
+    } catch (IllegalArgumentException e) {
+      return com.github._1c_syntax.bsl.mdclasses.jaxb.v8_3_xcf_enums.ScriptVariant.values()[0];
+    }
+  }
+
+  private static String shortNameFromMdoRef(String mdoRef) {
+    if (mdoRef == null) {
+      return "";
+    }
+    int dot = mdoRef.indexOf('.');
+    return dot >= 0 ? mdoRef.substring(dot + 1) : mdoRef;
+  }
+
+  private static ConfigurationChildObjects buildChildObjects(CF c) {
+    ConfigurationChildObjects co = FACTORY.createConfigurationChildObjects();
+    addChildNames(c.getLanguages(), co.getLanguage(), MD::getName);
+    addChildNames(c.getSubsystems(), co.getSubsystem(), MD::getName);
+    addChildNames(c.getStyleItems(), co.getStyleItem(), MD::getName);
+    addChildNames(c.getStyles(), co.getStyle(), MD::getName);
+    addChildNames(c.getCommonPictures(), co.getCommonPicture(), MD::getName);
+    addChildNames(c.getInterfaces(), co.getInterface(), MD::getName);
+    addChildNames(c.getSessionParameters(), co.getSessionParameter(), MD::getName);
+    addChildNames(c.getRoles(), co.getRole(), MD::getName);
+    addChildNames(c.getCommonTemplates(), co.getCommonTemplate(), MD::getName);
+    addChildNames(c.getFilterCriteria(), co.getFilterCriterion(), MD::getName);
+    addChildNames(c.getCommonModules(), co.getCommonModule(), MD::getName);
+    addChildNames(c.getCommonAttributes(), co.getCommonAttribute(), MD::getName);
+    addChildNames(c.getExchangePlans(), co.getExchangePlan(), md -> shortNameFromMdoRef(md.getMdoRef()));
+    addChildNames(c.getXDTOPackages(), co.getXDTOPackage(), MD::getName);
+    addChildNames(c.getWebServices(), co.getWebService(), MD::getName);
+    addChildNames(c.getHttpServices(), co.getHTTPService(), MD::getName);
+    addChildNames(c.getWsReferences(), co.getWSReference(), md -> shortNameFromMdoRef(md.getMdoRef()));
+    addChildNames(c.getEventSubscriptions(), co.getEventSubscription(), MD::getName);
+    addChildNames(c.getScheduledJobs(), co.getScheduledJob(), MD::getName);
+    addChildNames(c.getSettingsStorages(), co.getSettingsStorage(), MD::getName);
+    addChildNames(c.getFunctionalOptions(), co.getFunctionalOption(), MD::getName);
+    addChildNames(c.getFunctionalOptionsParameters(), co.getFunctionalOptionsParameter(), MD::getName);
+    addChildNames(c.getDefinedTypes(), co.getDefinedType(), MD::getName);
+    addChildNames(c.getCommonCommands(), co.getCommonCommand(), MD::getName);
+    addChildNames(c.getCommandGroups(), co.getCommandGroup(), g -> shortNameFromMdoRef(g.getMdoRef()));
+    addChildNames(c.getConstants(), co.getConstant(), MD::getName);
+    addChildNames(c.getCommonForms(), co.getCommonForm(), MD::getName);
+    addChildNames(c.getCatalogs(), co.getCatalog(), MD::getName);
+    addChildNames(c.getDocuments(), co.getDocument(), MD::getName);
+    addChildNames(c.getDocumentNumerators(), co.getDocumentNumerator(), MD::getName);
+    addChildNames(c.getSequences(), co.getSequence(), MD::getName);
+    addChildNames(c.getDocumentJournals(), co.getDocumentJournal(), MD::getName);
+    addChildNames(c.getEnums(), co.getEnum(), MD::getName);
+    addChildNames(c.getReports(), co.getReport(), MD::getName);
+    addChildNames(c.getDataProcessors(), co.getDataProcessor(), MD::getName);
+    addChildNames(c.getInformationRegisters(), co.getInformationRegister(), MD::getName);
+    addChildNames(c.getAccumulationRegisters(), co.getAccumulationRegister(), MD::getName);
+    addChildNames(c.getChartsOfCharacteristicTypes(), co.getChartOfCharacteristicTypes(), MD::getName);
+    addChildNames(c.getChartsOfAccounts(), co.getChartOfAccounts(), MD::getName);
+    addChildNames(c.getAccountingRegisters(), co.getAccountingRegister(), MD::getName);
+    addChildNames(c.getChartsOfCalculationTypes(), co.getChartOfCalculationTypes(), MD::getName);
+    addChildNames(c.getCalculationRegisters(), co.getCalculationRegister(), MD::getName);
+    addChildNames(c.getBusinessProcesses(), co.getBusinessProcess(), MD::getName);
+    addChildNames(c.getTasks(), co.getTask(), MD::getName);
+    addChildNames(c.getExternalDataSources(), co.getExternalDataSource(), MD::getName);
+    addChildNames(c.getIntegrationServices(), co.getIntegrationService(), MD::getName);
+    addChildNames(c.getBots(), co.getBot(), MD::getName);
+    addChildNames(c.getWebSocketClients(), co.getWebSocketClient(), MD::getName);
+    return co;
+  }
+
+  private static <T> void addChildNames(List<T> list, List<String> target, java.util.function.Function<T, String> nameFn) {
+    if (list == null) {
+      return;
+    }
+    for (T md : list) {
+      String name = nameFn.apply(md);
+      if (name != null) {
+        target.add(name);
+      }
+    }
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/DataProcessorToJaxbConverter.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/DataProcessorToJaxbConverter.java
@@ -1,0 +1,62 @@
+/*
+ * This file is a part of MDClasses.
+ *
+ * Copyright (c) 2019 - 2026
+ * Tymko Oleg <olegtymko@yandex.ru>, Maximov Valery <maximovvalery@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package com.github._1c_syntax.bsl.mdclasses.jaxb.write;
+
+import com.github._1c_syntax.bsl.mdo.DataProcessor;
+import com.github._1c_syntax.bsl.mdo.children.ObjectForm;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.DataProcessorChildObjects;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.DataProcessorProperties;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.MetaDataObject;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.ObjectFactory;
+
+/**
+ * Преобразует обработку mdclasses в JAXB-DTO для записи Designer XML.
+ */
+public final class DataProcessorToJaxbConverter {
+
+  private static final ObjectFactory FACTORY = new ObjectFactory();
+
+  private DataProcessorToJaxbConverter() {
+  }
+
+  /**
+   * Собирает JAXB MetaDataObject из обработки.
+   *
+   * @param dp обработка из модели mdclasses
+   * @return корневой элемент для маршаллинга в Designer XML
+   */
+  public static MetaDataObject toMetaDataObject(DataProcessor dp) {
+    MetaDataObject root = FACTORY.createMetaDataObject();
+    root.setVersion(JaxbWriteDefaults.DEFAULT_FORMAT_VERSION);
+    com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.DataProcessor inner = FACTORY.createDataProcessor();
+    inner.setUuid(dp.getUuid() != null ? dp.getUuid() : "");
+    inner.setProperties(buildProperties(dp));
+    inner.setChildObjects(buildChildObjects(dp));
+    root.setDataProcessor(inner);
+    return root;
+  }
+
+  private static DataProcessorProperties buildProperties(DataProcessor dp) {
+    DataProcessorProperties p = FACTORY.createDataProcessorProperties();
+    p.setName(dp.getName());
+    p.setSynonym(JaxbWriteDefaults.localStringType(JaxbWriteUtils.contentForLocalString(dp.getSynonym())));
+    p.setComment(dp.getComment() != null ? dp.getComment() : "");
+    return p;
+  }
+
+  private static DataProcessorChildObjects buildChildObjects(DataProcessor dp) {
+    DataProcessorChildObjects co = FACTORY.createDataProcessorChildObjects();
+    if (dp.getForms() != null) {
+      for (ObjectForm form : dp.getForms()) {
+        co.getForm().add(form.getName() != null ? form.getName() : "");
+      }
+    }
+    return co;
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/DesignerJaxbWriter.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/DesignerJaxbWriter.java
@@ -1,0 +1,188 @@
+/*
+ * This file is a part of MDClasses.
+ *
+ * Copyright (c) 2019 - 2026
+ * Tymko Oleg <olegtymko@yandex.ru>, Maximov Valery <maximovvalery@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package com.github._1c_syntax.bsl.mdclasses.jaxb.write;
+
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.MetaDataObject;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.ObjectFactory;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Marshaller;
+
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Сериализация JAXB MetaDataObject в XML-файл в формате Designer.
+ */
+public final class DesignerJaxbWriter {
+
+  private static final JAXBContext JAXB_CONTEXT;
+
+  static {
+    try {
+      JAXB_CONTEXT = JAXBContext.newInstance(MetaDataObject.class);
+    } catch (JAXBException e) {
+      throw new ExceptionInInitializerError(e);
+    }
+  }
+
+  private DesignerJaxbWriter() {
+  }
+
+  private static final String NS_MDCLASSES = "http://v8.1c.ru/8.3/MDClasses";
+  private static final String NS_XCF_READABLE = "http://v8.1c.ru/8.3/xcf/readable";
+
+  /**
+   * InternalInfo для Configuration: 7 ContainedObject (Конфигуратор 1С требует ровно 7).
+   * ClassId — константы платформы (тип внутреннего объекта), одинаковы во всех выгрузках.
+   * ObjectId — уникальный идентификатор экземпляра; в каждой конфигурации свои, генерируем при записи.
+   */
+  private static String buildConfigurationInternalInfoBlock() {
+    return """
+        <InternalInfo>
+            <xr:ContainedObject>
+                <xr:ClassId>9cd510cd-abfc-11d4-9434-004095e12fc7</xr:ClassId>
+                <xr:ObjectId>%s</xr:ObjectId>
+            </xr:ContainedObject>
+            <xr:ContainedObject>
+                <xr:ClassId>9fcd25a0-4822-11d4-9414-008048da11f9</xr:ClassId>
+                <xr:ObjectId>%s</xr:ObjectId>
+            </xr:ContainedObject>
+            <xr:ContainedObject>
+                <xr:ClassId>e3687481-0a87-462c-a166-9f34594f9bba</xr:ClassId>
+                <xr:ObjectId>%s</xr:ObjectId>
+            </xr:ContainedObject>
+            <xr:ContainedObject>
+                <xr:ClassId>9de14907-ec23-4a07-96f0-85521cb6b53b</xr:ClassId>
+                <xr:ObjectId>%s</xr:ObjectId>
+            </xr:ContainedObject>
+            <xr:ContainedObject>
+                <xr:ClassId>51f2d5d8-ea4d-4064-8892-82951750031e</xr:ClassId>
+                <xr:ObjectId>%s</xr:ObjectId>
+            </xr:ContainedObject>
+            <xr:ContainedObject>
+                <xr:ClassId>e68182ea-4237-4383-967f-90c1e3370bc7</xr:ClassId>
+                <xr:ObjectId>%s</xr:ObjectId>
+            </xr:ContainedObject>
+            <xr:ContainedObject>
+                <xr:ClassId>fb282519-d103-4dd3-bc12-cb271d631dfc</xr:ClassId>
+                <xr:ObjectId>%s</xr:ObjectId>
+            </xr:ContainedObject>
+        </InternalInfo>""".formatted(
+        UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(),
+        UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
+  }
+
+  /** Плейсхолдер имени справочника (без $, чтобы не интерпретировался в replaceFirst как группа). */
+  private static final String CATALOG_NAME_PLACEHOLDER = "\u0000CatalogName\u0000";
+
+  private static final Pattern NAME_TAG = Pattern.compile("<Name>([^<]+)</Name>");
+
+  /**
+   * InternalInfo для справочника: xr:GeneratedType (Object, Ref, Selection, List, Manager),
+   * как в фикстурах. Имя подставляется из плейсхолдера после вставки (из первого тега &lt;Name&gt;).
+   */
+  private static String buildCatalogInternalInfoBlock() {
+    String n = CATALOG_NAME_PLACEHOLDER;
+    UUID u1 = UUID.randomUUID();
+    UUID u2 = UUID.randomUUID();
+    UUID u3 = UUID.randomUUID();
+    UUID u4 = UUID.randomUUID();
+    UUID u5 = UUID.randomUUID();
+    UUID u6 = UUID.randomUUID();
+    UUID u7 = UUID.randomUUID();
+    UUID u8 = UUID.randomUUID();
+    UUID u9 = UUID.randomUUID();
+    UUID u10 = UUID.randomUUID();
+    return """
+        <InternalInfo>
+            <xr:GeneratedType name="CatalogObject.%s" category="Object">
+                <xr:TypeId>%s</xr:TypeId>
+                <xr:ValueId>%s</xr:ValueId>
+            </xr:GeneratedType>
+            <xr:GeneratedType name="CatalogRef.%s" category="Ref">
+                <xr:TypeId>%s</xr:TypeId>
+                <xr:ValueId>%s</xr:ValueId>
+            </xr:GeneratedType>
+            <xr:GeneratedType name="CatalogSelection.%s" category="Selection">
+                <xr:TypeId>%s</xr:TypeId>
+                <xr:ValueId>%s</xr:ValueId>
+            </xr:GeneratedType>
+            <xr:GeneratedType name="CatalogList.%s" category="List">
+                <xr:TypeId>%s</xr:TypeId>
+                <xr:ValueId>%s</xr:ValueId>
+            </xr:GeneratedType>
+            <xr:GeneratedType name="CatalogManager.%s" category="Manager">
+                <xr:TypeId>%s</xr:TypeId>
+                <xr:ValueId>%s</xr:ValueId>
+            </xr:GeneratedType>
+        </InternalInfo>""".formatted(n, u1, u2, n, u3, u4, n, u5, u6, n, u7, u8, n, u9, u10);
+  }
+
+  /**
+   * Сериализует MetaDataObject в XML и записывает в файл.
+   *
+   * @param path   путь к .xml файлу
+   * @param object корневой JAXB MetaDataObject (подсистема, справочник, конфигурация и т.д.)
+   * @throws JAXBException       при ошибке маршаллинга
+   * @throws java.io.IOException при ошибке записи файла
+   */
+  public static void write(Path path, MetaDataObject object)
+    throws JAXBException, java.io.IOException {
+    Marshaller m = JAXB_CONTEXT.createMarshaller();
+    m.setProperty(Marshaller.JAXB_ENCODING, StandardCharsets.UTF_8.name());
+    m.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
+    m.setProperty("org.glassfish.jaxb.namespacePrefixMapper", new DesignerNamespacePrefixMapper());
+    JAXBElement<MetaDataObject> root = new ObjectFactory().createMetaDataObject(object);
+    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    m.marshal(root, buffer);
+    String xml = buffer.toString(StandardCharsets.UTF_8);
+    xml = makeMDClassesDefaultNamespace(xml);
+    try (OutputStream out = Files.newOutputStream(path)) {
+      out.write(xml.getBytes(StandardCharsets.UTF_8));
+    }
+  }
+
+  /**
+   * Приводит XML к виду выгрузки платформы 1С: дефолтный неймспейс MDClasses, без ns2,
+   * у Configuration только uuid (без formatVersion), первым дочерним — InternalInfo.
+   */
+  private static String makeMDClassesDefaultNamespace(String xml) {
+    xml = xml.replace("xmlns=\"" + NS_XCF_READABLE + "\"", "xmlns:xr=\"" + NS_XCF_READABLE + "\"");
+    xml = xml.replace("xmlns:ns2=\"" + NS_MDCLASSES + "\"", "xmlns=\"" + NS_MDCLASSES + "\"");
+    xml = xml.replace("<ns2:", "<");
+    xml = xml.replace("</ns2:", "</");
+    // Как в фикстурах: у Configuration только uuid, без formatVersion
+    xml = xml.replace(" formatVersion=\"2.20\"", "");
+    // Configuration: InternalInfo с ContainedObject (как в фикстурах платформы)
+    xml = xml.replaceFirst(
+        "(<Configuration uuid=\"[^\"]+\">)\\s*\\n\\s*<Properties>",
+        "$1\n        " + buildConfigurationInternalInfoBlock() + "\n        <Properties>");
+    // Catalog: InternalInfo с GeneratedType (Object, Ref, Selection, List, Manager)
+    xml = xml.replaceFirst(
+        "(<Catalog uuid=\"[^\"]+\">)\\s*\\n\\s*<Properties>",
+        "$1\n        " + buildCatalogInternalInfoBlock() + "\n        <Properties>");
+    // Подставить имя справочника из первого тега <Name>
+    if (xml.contains(CATALOG_NAME_PLACEHOLDER)) {
+      Matcher m = NAME_TAG.matcher(xml);
+      if (m.find()) {
+        xml = xml.replace(CATALOG_NAME_PLACEHOLDER, m.group(1));
+      }
+    }
+    return xml;
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/DesignerNamespacePrefixMapper.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/DesignerNamespacePrefixMapper.java
@@ -1,0 +1,27 @@
+/*
+ * This file is a part of MDClasses.
+ *
+ * Copyright (c) 2019 - 2026
+ * Tymko Oleg <olegtymko@yandex.ru>, Maximov Valery <maximovvalery@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package com.github._1c_syntax.bsl.mdclasses.jaxb.write;
+
+import org.glassfish.jaxb.runtime.marshaller.NamespacePrefixMapper;
+
+/**
+ * Задаёт префиксы неймспейсов при маршалинге Designer XML (дефолтный неймспейс MDClasses без префикса).
+ */
+public final class DesignerNamespacePrefixMapper extends NamespacePrefixMapper {
+
+  private static final String MDCLASSES_NS = "http://v8.1c.ru/8.3/MDClasses";
+
+  @Override
+  public String getPreferredPrefix(String namespaceUri, String suggestion, boolean requirePrefix) {
+    if (MDCLASSES_NS.equals(namespaceUri)) {
+      return requirePrefix ? "v8" : "";
+    }
+    return suggestion != null ? suggestion : null;
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/DesignerPathResolver.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/DesignerPathResolver.java
@@ -1,0 +1,80 @@
+/*
+ * This file is a part of MDClasses.
+ *
+ * Copyright (c) 2019 - 2026
+ * Tymko Oleg <olegtymko@yandex.ru>, Maximov Valery <maximovvalery@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package com.github._1c_syntax.bsl.mdclasses.jaxb.write;
+
+import com.github._1c_syntax.bsl.mdo.MD;
+import com.github._1c_syntax.bsl.reader.designer.DesignerReader;
+import com.github._1c_syntax.bsl.types.MDOType;
+import org.apache.commons.io.FilenameUtils;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Разрешение путей к XML-файлам объектов метаданных в формате Designer.
+ */
+public final class DesignerPathResolver {
+
+  private DesignerPathResolver() {
+  }
+
+  /**
+   * Путь к файлу Configuration.xml в корне выгрузки.
+   *
+   * @param rootPath корень выгрузки (каталог, в котором лежит Configuration.xml)
+   * @return путь к Configuration.xml
+   */
+  public static Path configurationPath(Path rootPath) {
+    return rootPath.resolve(DesignerReader.CONFIGURATION_MDO_PATH);
+  }
+
+  /**
+   * Путь к XML-файлу объекта. Для вложенной подсистемы задаётся путь к .xml родителя.
+   *
+   * @param rootPath             корень выгрузки
+   * @param md                   объект метаданных
+   * @param parentSubsystemPath  путь к .xml родительской подсистемы или null
+   * @return путь к .xml файлу
+   */
+  public static Path pathForObject(Path rootPath, MD md, Path parentSubsystemPath) {
+    MDOType type = md.getMdoType();
+    String name = md.getName();
+    if (type == MDOType.SUBSYSTEM && parentSubsystemPath != null) {
+      Path parentDir = Paths.get(
+        FilenameUtils.getFullPathNoEndSeparator(parentSubsystemPath.toString()),
+        FilenameUtils.getBaseName(parentSubsystemPath.toString()));
+      return parentDir.resolve(type.groupName()).resolve(name + ".xml");
+    }
+    return rootPath.resolve(type.groupName()).resolve(name + ".xml");
+  }
+
+  /**
+   * Путь к XML-файлу объекта верхнего уровня.
+   *
+   * @param rootPath корень выгрузки
+   * @param md      объект метаданных
+   * @return путь к .xml файлу
+   */
+  public static Path pathForObject(Path rootPath, MD md) {
+    return pathForObject(rootPath, md, null);
+  }
+
+  /**
+   * Путь к XML-файлу формы (например Catalogs/Имя/Forms/ИмяФормы.xml).
+   *
+   * @param rootPath   корень выгрузки
+   * @param ownerGroup группа владельца (Catalogs, Documents и т.д.)
+   * @param ownerName  имя владельца
+   * @param formName   имя формы
+   * @return путь к .xml файлу формы
+   */
+  public static Path pathForForm(Path rootPath, String ownerGroup, String ownerName, String formName) {
+    return rootPath.resolve(ownerGroup).resolve(ownerName).resolve("Forms").resolve(formName + ".xml");
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/DocumentJournalToJaxbConverter.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/DocumentJournalToJaxbConverter.java
@@ -1,0 +1,62 @@
+/*
+ * This file is a part of MDClasses.
+ *
+ * Copyright (c) 2019 - 2026
+ * Tymko Oleg <olegtymko@yandex.ru>, Maximov Valery <maximovvalery@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package com.github._1c_syntax.bsl.mdclasses.jaxb.write;
+
+import com.github._1c_syntax.bsl.mdo.DocumentJournal;
+import com.github._1c_syntax.bsl.mdo.children.ObjectForm;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.DocumentJournalChildObjects;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.DocumentJournalProperties;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.MetaDataObject;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.ObjectFactory;
+
+/**
+ * Преобразует журнал документов mdclasses в JAXB-DTO для записи Designer XML.
+ */
+public final class DocumentJournalToJaxbConverter {
+
+  private static final ObjectFactory FACTORY = new ObjectFactory();
+
+  private DocumentJournalToJaxbConverter() {
+  }
+
+  /**
+   * Собирает JAXB MetaDataObject из журнала документов.
+   *
+   * @param dj журнал документов из модели mdclasses
+   * @return корневой элемент для маршаллинга в Designer XML
+   */
+  public static MetaDataObject toMetaDataObject(DocumentJournal dj) {
+    MetaDataObject root = FACTORY.createMetaDataObject();
+    root.setVersion(JaxbWriteDefaults.DEFAULT_FORMAT_VERSION);
+    com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.DocumentJournal inner = FACTORY.createDocumentJournal();
+    inner.setUuid(dj.getUuid() != null ? dj.getUuid() : "");
+    inner.setProperties(buildProperties(dj));
+    inner.setChildObjects(buildChildObjects(dj));
+    root.setDocumentJournal(inner);
+    return root;
+  }
+
+  private static DocumentJournalProperties buildProperties(DocumentJournal dj) {
+    DocumentJournalProperties p = FACTORY.createDocumentJournalProperties();
+    p.setName(dj.getName());
+    p.setSynonym(JaxbWriteDefaults.localStringType(JaxbWriteUtils.contentForLocalString(dj.getSynonym())));
+    p.setComment(dj.getComment() != null ? dj.getComment() : "");
+    return p;
+  }
+
+  private static DocumentJournalChildObjects buildChildObjects(DocumentJournal dj) {
+    DocumentJournalChildObjects co = FACTORY.createDocumentJournalChildObjects();
+    if (dj.getForms() != null) {
+      for (ObjectForm form : dj.getForms()) {
+        co.getForm().add(form.getName() != null ? form.getName() : "");
+      }
+    }
+    return co;
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/DocumentToJaxbConverter.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/DocumentToJaxbConverter.java
@@ -1,0 +1,62 @@
+/*
+ * This file is a part of MDClasses.
+ *
+ * Copyright (c) 2019 - 2026
+ * Tymko Oleg <olegtymko@yandex.ru>, Maximov Valery <maximovvalery@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package com.github._1c_syntax.bsl.mdclasses.jaxb.write;
+
+import com.github._1c_syntax.bsl.mdo.Document;
+import com.github._1c_syntax.bsl.mdo.children.ObjectForm;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.DocumentChildObjects;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.DocumentProperties;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.MetaDataObject;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.ObjectFactory;
+
+/**
+ * Преобразует модель документа mdclasses в JAXB-DTO для записи Designer XML.
+ */
+public final class DocumentToJaxbConverter {
+
+  private static final ObjectFactory FACTORY = new ObjectFactory();
+
+  private DocumentToJaxbConverter() {
+  }
+
+  /**
+   * Собирает JAXB MetaDataObject из документа mdclasses.
+   *
+   * @param document документ из модели mdclasses
+   * @return корневой элемент для маршаллинга в Designer XML
+   */
+  public static MetaDataObject toMetaDataObject(Document document) {
+    MetaDataObject root = FACTORY.createMetaDataObject();
+    root.setVersion(JaxbWriteDefaults.DEFAULT_FORMAT_VERSION);
+    com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.Document inner = FACTORY.createDocument();
+    inner.setUuid(document.getUuid() != null ? document.getUuid() : "");
+    inner.setProperties(buildProperties(document));
+    inner.setChildObjects(buildChildObjects(document));
+    root.setDocument(inner);
+    return root;
+  }
+
+  private static DocumentProperties buildProperties(Document d) {
+    DocumentProperties p = FACTORY.createDocumentProperties();
+    p.setName(d.getName());
+    p.setSynonym(JaxbWriteDefaults.localStringType(JaxbWriteUtils.contentForLocalString(d.getSynonym())));
+    p.setComment(d.getComment() != null ? d.getComment() : "");
+    return p;
+  }
+
+  private static DocumentChildObjects buildChildObjects(Document d) {
+    DocumentChildObjects co = FACTORY.createDocumentChildObjects();
+    if (d.getForms() != null) {
+      for (ObjectForm form : d.getForms()) {
+        co.getForm().add(form.getName() != null ? form.getName() : "");
+      }
+    }
+    return co;
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/EnumToJaxbConverter.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/EnumToJaxbConverter.java
@@ -1,0 +1,91 @@
+/*
+ * This file is a part of MDClasses.
+ *
+ * Copyright (c) 2019 - 2026
+ * Tymko Oleg <olegtymko@yandex.ru>, Maximov Valery <maximovvalery@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package com.github._1c_syntax.bsl.mdclasses.jaxb.write;
+
+import com.github._1c_syntax.bsl.mdo.children.EnumValue;
+import com.github._1c_syntax.bsl.mdo.children.ObjectForm;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.EnumChildObjects;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.EnumProperties;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.EnumValueProperties;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.MetaDataObject;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.ObjectFactory;
+
+/**
+ * Преобразует модель перечисления mdclasses в JAXB-DTO для записи Designer XML.
+ */
+public final class EnumToJaxbConverter {
+
+  private static final ObjectFactory FACTORY = new ObjectFactory();
+
+  private EnumToJaxbConverter() {
+  }
+
+  /**
+   * Собирает JAXB MetaDataObject из перечисления mdclasses.
+   *
+   * @param anEnum перечисление из модели mdclasses (mdo.Enum)
+   * @return корневой элемент для маршаллинга в Designer XML
+   */
+  public static MetaDataObject toMetaDataObject(com.github._1c_syntax.bsl.mdo.Enum anEnum) {
+    MetaDataObject root = FACTORY.createMetaDataObject();
+    root.setVersion(JaxbWriteDefaults.DEFAULT_FORMAT_VERSION);
+    com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.Enum inner = FACTORY.createEnum();
+    inner.setUuid(anEnum.getUuid() != null ? anEnum.getUuid() : "");
+    inner.setProperties(buildProperties(anEnum));
+    inner.setChildObjects(buildChildObjects(anEnum));
+    root.setEnum(inner);
+    return root;
+  }
+
+  private static EnumProperties buildProperties(com.github._1c_syntax.bsl.mdo.Enum e) {
+    EnumProperties p = FACTORY.createEnumProperties();
+    p.setName(e.getName());
+    p.setSynonym(JaxbWriteDefaults.localStringType(JaxbWriteUtils.contentForLocalString(e.getSynonym())));
+    p.setComment(e.getComment() != null ? e.getComment() : "");
+    p.setObjectBelonging(JaxbWriteDefaults.objectBelongingNative());
+    p.setUseStandardCommands(false);
+    p.setStandardAttributes(JaxbWriteDefaults.emptyStandardAttributeDescriptions());
+    p.setCharacteristics(JaxbWriteDefaults.emptyCharacteristicsDescriptions());
+    p.setQuickChoice(false);
+    p.setChoiceMode(JaxbWriteDefaults.choiceModeFromForm());
+    p.setDefaultListForm("");
+    p.setDefaultChoiceForm("");
+    p.setAuxiliaryListForm("");
+    p.setAuxiliaryChoiceForm("");
+    p.setManagerModule("");
+    p.setListPresentation(JaxbWriteDefaults.localStringType(""));
+    p.setExtendedListPresentation(JaxbWriteDefaults.localStringType(""));
+    p.setExplanation(JaxbWriteDefaults.localStringType(JaxbWriteUtils.contentForLocalString(e.getExplanation())));
+    p.setChoiceHistoryOnInput(JaxbWriteDefaults.choiceHistoryOnInputAuto());
+    return p;
+  }
+
+  private static EnumChildObjects buildChildObjects(com.github._1c_syntax.bsl.mdo.Enum e) {
+    EnumChildObjects co = FACTORY.createEnumChildObjects();
+    if (e.getEnumValues() != null) {
+      for (EnumValue ev : e.getEnumValues()) {
+        com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.EnumValue jaxbEv = FACTORY.createEnumValue();
+        jaxbEv.setUuid(ev.getUuid() != null ? ev.getUuid() : "");
+        EnumValueProperties evProps = FACTORY.createEnumValueProperties();
+        evProps.setName(ev.getName());
+        evProps.setSynonym(JaxbWriteDefaults.localStringType(JaxbWriteUtils.contentForLocalString(ev.getSynonym())));
+        evProps.setComment(ev.getComment() != null ? ev.getComment() : "");
+        evProps.setObjectBelonging(JaxbWriteDefaults.objectBelongingNative());
+        jaxbEv.setProperties(evProps);
+        co.getEnumValue().add(jaxbEv);
+      }
+    }
+    if (e.getForms() != null) {
+      for (ObjectForm form : e.getForms()) {
+        co.getForm().add(form.getName() != null ? form.getName() : "");
+      }
+    }
+    return co;
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/ExchangePlanToJaxbConverter.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/ExchangePlanToJaxbConverter.java
@@ -1,0 +1,62 @@
+/*
+ * This file is a part of MDClasses.
+ *
+ * Copyright (c) 2019 - 2026
+ * Tymko Oleg <olegtymko@yandex.ru>, Maximov Valery <maximovvalery@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package com.github._1c_syntax.bsl.mdclasses.jaxb.write;
+
+import com.github._1c_syntax.bsl.mdo.ExchangePlan;
+import com.github._1c_syntax.bsl.mdo.children.ObjectForm;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.ExchangePlanChildObjects;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.ExchangePlanProperties;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.MetaDataObject;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.ObjectFactory;
+
+/**
+ * Преобразует план обмена mdclasses в JAXB-DTO для записи Designer XML.
+ */
+public final class ExchangePlanToJaxbConverter {
+
+  private static final ObjectFactory FACTORY = new ObjectFactory();
+
+  private ExchangePlanToJaxbConverter() {
+  }
+
+  /**
+   * Собирает JAXB MetaDataObject из плана обмена.
+   *
+   * @param ep план обмена из модели mdclasses
+   * @return корневой элемент для маршаллинга в Designer XML
+   */
+  public static MetaDataObject toMetaDataObject(ExchangePlan ep) {
+    MetaDataObject root = FACTORY.createMetaDataObject();
+    root.setVersion(JaxbWriteDefaults.DEFAULT_FORMAT_VERSION);
+    com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.ExchangePlan inner = FACTORY.createExchangePlan();
+    inner.setUuid(ep.getUuid() != null ? ep.getUuid() : "");
+    inner.setProperties(buildProperties(ep));
+    inner.setChildObjects(buildChildObjects(ep));
+    root.setExchangePlan(inner);
+    return root;
+  }
+
+  private static ExchangePlanProperties buildProperties(ExchangePlan ep) {
+    ExchangePlanProperties p = FACTORY.createExchangePlanProperties();
+    p.setName(ep.getName());
+    p.setSynonym(JaxbWriteDefaults.localStringType(JaxbWriteUtils.contentForLocalString(ep.getSynonym())));
+    p.setComment(ep.getComment() != null ? ep.getComment() : "");
+    return p;
+  }
+
+  private static ExchangePlanChildObjects buildChildObjects(ExchangePlan ep) {
+    ExchangePlanChildObjects co = FACTORY.createExchangePlanChildObjects();
+    if (ep.getForms() != null) {
+      for (ObjectForm form : ep.getForms()) {
+        co.getForm().add(form.getName() != null ? form.getName() : "");
+      }
+    }
+    return co;
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/FilterCriterionToJaxbConverter.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/FilterCriterionToJaxbConverter.java
@@ -1,0 +1,62 @@
+/*
+ * This file is a part of MDClasses.
+ *
+ * Copyright (c) 2019 - 2026
+ * Tymko Oleg <olegtymko@yandex.ru>, Maximov Valery <maximovvalery@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package com.github._1c_syntax.bsl.mdclasses.jaxb.write;
+
+import com.github._1c_syntax.bsl.mdo.FilterCriterion;
+import com.github._1c_syntax.bsl.mdo.children.ObjectForm;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.FilterCriterionChildObjects;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.FilterCriterionProperties;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.MetaDataObject;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.ObjectFactory;
+
+/**
+ * Преобразует критерий отбора mdclasses в JAXB-DTO для записи Designer XML.
+ */
+public final class FilterCriterionToJaxbConverter {
+
+  private static final ObjectFactory FACTORY = new ObjectFactory();
+
+  private FilterCriterionToJaxbConverter() {
+  }
+
+  /**
+   * Собирает JAXB MetaDataObject из критерия отбора.
+   *
+   * @param fc критерий отбора из модели mdclasses
+   * @return корневой элемент для маршаллинга в Designer XML
+   */
+  public static MetaDataObject toMetaDataObject(FilterCriterion fc) {
+    MetaDataObject root = FACTORY.createMetaDataObject();
+    root.setVersion(JaxbWriteDefaults.DEFAULT_FORMAT_VERSION);
+    com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.FilterCriterion inner = FACTORY.createFilterCriterion();
+    inner.setUuid(fc.getUuid() != null ? fc.getUuid() : "");
+    inner.setProperties(buildProperties(fc));
+    inner.setChildObjects(buildChildObjects(fc));
+    root.setFilterCriterion(inner);
+    return root;
+  }
+
+  private static FilterCriterionProperties buildProperties(FilterCriterion fc) {
+    FilterCriterionProperties p = FACTORY.createFilterCriterionProperties();
+    p.setName(fc.getName());
+    p.setSynonym(JaxbWriteDefaults.localStringType(JaxbWriteUtils.contentForLocalString(fc.getSynonym())));
+    p.setComment(fc.getComment() != null ? fc.getComment() : "");
+    return p;
+  }
+
+  private static FilterCriterionChildObjects buildChildObjects(FilterCriterion fc) {
+    FilterCriterionChildObjects co = FACTORY.createFilterCriterionChildObjects();
+    if (fc.getForms() != null) {
+      for (ObjectForm form : fc.getForms()) {
+        co.getForm().add(form.getName() != null ? form.getName() : "");
+      }
+    }
+    return co;
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/FormToJaxbConverter.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/FormToJaxbConverter.java
@@ -1,0 +1,63 @@
+/*
+ * This file is a part of MDClasses.
+ *
+ * Copyright (c) 2019 - 2026
+ * Tymko Oleg <olegtymko@yandex.ru>, Maximov Valery <maximovvalery@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package com.github._1c_syntax.bsl.mdclasses.jaxb.write;
+
+import com.github._1c_syntax.bsl.mdo.children.ObjectForm;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.Form;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.FormProperties;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.MetaDataObject;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.ObjectFactory;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.v8_3_xcf_enums.FormType;
+
+/**
+ * Преобразует форму объекта (ObjectForm) в JAXB MetaDataObject с Form для записи в отдельный XML-файл.
+ */
+public final class FormToJaxbConverter {
+
+  private static final ObjectFactory FACTORY = new ObjectFactory();
+
+  private FormToJaxbConverter() {
+  }
+
+  /**
+   * Собирает JAXB MetaDataObject с одной формой для записи в Catalogs/Имя/Forms/ИмяФормы.xml и т.д.
+   *
+   * @param form форма из модели mdclasses (справочник, документ и т.д.)
+   * @return корневой MetaDataObject для маршаллинга
+   */
+  public static MetaDataObject toMetaDataObject(ObjectForm form) {
+    MetaDataObject root = FACTORY.createMetaDataObject();
+    root.setVersion(JaxbWriteDefaults.DEFAULT_FORMAT_VERSION);
+    Form inner = FACTORY.createForm();
+    inner.setUuid(form.getUuid() != null && !form.getUuid().isEmpty()
+        ? form.getUuid()
+        : java.util.UUID.randomUUID().toString().toLowerCase());
+    inner.setProperties(buildProperties(form));
+    root.setForm(inner);
+    return root;
+  }
+
+  private static FormProperties buildProperties(ObjectForm f) {
+    FormProperties p = FACTORY.createFormProperties();
+    p.setName(f.getName() != null ? f.getName() : "");
+    p.setSynonym(JaxbWriteDefaults.localStringType(JaxbWriteUtils.contentForLocalString(f.getSynonym())));
+    p.setComment(f.getComment() != null ? f.getComment() : "");
+    p.setObjectBelonging(JaxbWriteDefaults.objectBelongingNative());
+    p.setFormType(formTypeToJaxb(f.getFormType()));
+    p.setIncludeHelpInContents(Boolean.FALSE);
+    return p;
+  }
+
+  private static FormType formTypeToJaxb(com.github._1c_syntax.bsl.mdo.support.FormType ft) {
+    if (ft == null) {
+      return FormType.MANAGED;
+    }
+    return ft == com.github._1c_syntax.bsl.mdo.support.FormType.ORDINARY ? FormType.ORDINARY : FormType.MANAGED;
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/InformationRegisterToJaxbConverter.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/InformationRegisterToJaxbConverter.java
@@ -1,0 +1,62 @@
+/*
+ * This file is a part of MDClasses.
+ *
+ * Copyright (c) 2019 - 2026
+ * Tymko Oleg <olegtymko@yandex.ru>, Maximov Valery <maximovvalery@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package com.github._1c_syntax.bsl.mdclasses.jaxb.write;
+
+import com.github._1c_syntax.bsl.mdo.InformationRegister;
+import com.github._1c_syntax.bsl.mdo.children.ObjectForm;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.InformationRegisterChildObjects;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.InformationRegisterProperties;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.MetaDataObject;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.ObjectFactory;
+
+/**
+ * Преобразует регистр сведений mdclasses в JAXB-DTO для записи Designer XML.
+ */
+public final class InformationRegisterToJaxbConverter {
+
+  private static final ObjectFactory FACTORY = new ObjectFactory();
+
+  private InformationRegisterToJaxbConverter() {
+  }
+
+  /**
+   * Собирает JAXB MetaDataObject из регистра сведений.
+   *
+   * @param ir регистр сведений из модели mdclasses
+   * @return корневой элемент для маршаллинга в Designer XML
+   */
+  public static MetaDataObject toMetaDataObject(InformationRegister ir) {
+    MetaDataObject root = FACTORY.createMetaDataObject();
+    root.setVersion(JaxbWriteDefaults.DEFAULT_FORMAT_VERSION);
+    com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.InformationRegister inner = FACTORY.createInformationRegister();
+    inner.setUuid(ir.getUuid() != null ? ir.getUuid() : "");
+    inner.setProperties(buildProperties(ir));
+    inner.setChildObjects(buildChildObjects(ir));
+    root.setInformationRegister(inner);
+    return root;
+  }
+
+  private static InformationRegisterProperties buildProperties(InformationRegister ir) {
+    InformationRegisterProperties p = FACTORY.createInformationRegisterProperties();
+    p.setName(ir.getName());
+    p.setSynonym(JaxbWriteDefaults.localStringType(JaxbWriteUtils.contentForLocalString(ir.getSynonym())));
+    p.setComment(ir.getComment() != null ? ir.getComment() : "");
+    return p;
+  }
+
+  private static InformationRegisterChildObjects buildChildObjects(InformationRegister ir) {
+    InformationRegisterChildObjects co = FACTORY.createInformationRegisterChildObjects();
+    if (ir.getForms() != null) {
+      for (ObjectForm form : ir.getForms()) {
+        co.getForm().add(form.getName() != null ? form.getName() : "");
+      }
+    }
+    return co;
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/JaxbWriteDefaults.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/JaxbWriteDefaults.java
@@ -1,0 +1,114 @@
+/*
+ * This file is a part of MDClasses.
+ *
+ * Copyright (c) 2019 - 2026
+ * Tymko Oleg <olegtymko@yandex.ru>, Maximov Valery <maximovvalery@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package com.github._1c_syntax.bsl.mdclasses.jaxb.write;
+
+import com.github._1c_syntax.bsl.mdclasses.jaxb.v8_1_data_core.LocalStringItemType;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.v8_1_data_core.LocalStringType;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.v8_2_managed_application_logform.ChoiceHistoryOnInput;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.v8_2_managed_application_logform.OnMainServerUnavalableBehavior;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.v8_3_xcf_enums.AccumulationRegisterType;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.v8_3_xcf_enums.CalculationRegisterPeriodicity;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.v8_3_xcf_enums.ChoiceMode;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.v8_3_xcf_enums.DefaultDataLockControlMode;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.v8_3_xcf_enums.FullTextSearchUsing;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.v8_3_xcf_enums.ObjectBelonging;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.v8_3_xcf_readable.CharacteristicsDescriptions;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.v8_3_xcf_readable.FieldList;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.v8_3_xcf_readable.MDListType;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.v8_3_xcf_readable.Picture;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.v8_3_xcf_readable.StandardAttributeDescriptions;
+
+/**
+ * Значения по умолчанию для JAXB-типов при записи Designer XML.
+ */
+public final class JaxbWriteDefaults {
+
+  /** Версия формата выгрузки Designer XML (атрибут version в MetaDataObject). */
+  public static final String DEFAULT_FORMAT_VERSION = "2.20";
+
+  private static final String DEFAULT_LANG = "ru";
+
+  private JaxbWriteDefaults() {
+  }
+
+  /** LocalStringType с одним элементом (язык ru). */
+  public static LocalStringType localStringType(String content) {
+    LocalStringType t = new LocalStringType();
+    LocalStringItemType item = new LocalStringItemType();
+    item.setLang(DEFAULT_LANG);
+    item.setContent(content != null ? content : "");
+    t.getItem().add(item);
+    return t;
+  }
+
+  /** Пустой MDListType. */
+  public static MDListType emptyMDListType() {
+    return new MDListType();
+  }
+
+  /** Пустая картинка (все поля null/false). */
+  public static Picture emptyPicture() {
+    return new Picture();
+  }
+
+  /** ObjectBelonging = Native. */
+  public static ObjectBelonging objectBelongingNative() {
+    return ObjectBelonging.NATIVE;
+  }
+
+  /** Пустое описание стандартных реквизитов. */
+  public static StandardAttributeDescriptions emptyStandardAttributeDescriptions() {
+    return new StandardAttributeDescriptions();
+  }
+
+  /** Пустое описание характеристик. */
+  public static CharacteristicsDescriptions emptyCharacteristicsDescriptions() {
+    return new CharacteristicsDescriptions();
+  }
+
+  /** ChoiceMode = FromForm. */
+  public static ChoiceMode choiceModeFromForm() {
+    return ChoiceMode.FROM_FORM;
+  }
+
+  /** ChoiceHistoryOnInput = Auto. */
+  public static ChoiceHistoryOnInput choiceHistoryOnInputAuto() {
+    return ChoiceHistoryOnInput.AUTO;
+  }
+
+  /** DefaultDataLockControlMode = Automatic. */
+  public static DefaultDataLockControlMode defaultDataLockControlModeAutomatic() {
+    return DefaultDataLockControlMode.AUTOMATIC;
+  }
+
+  /** FullTextSearchUsing = DontUse. */
+  public static FullTextSearchUsing fullTextSearchDontUse() {
+    return FullTextSearchUsing.DONT_USE;
+  }
+
+  /** AccumulationRegisterType = Balance. */
+  public static AccumulationRegisterType accumulationRegisterTypeBalance() {
+    return AccumulationRegisterType.BALANCE;
+  }
+
+  /** CalculationRegisterPeriodicity = Year. */
+  public static CalculationRegisterPeriodicity calculationRegisterPeriodicityYear() {
+    return CalculationRegisterPeriodicity.YEAR;
+  }
+
+  /** Пустой FieldList. */
+  public static FieldList emptyFieldList() {
+    return new FieldList();
+  }
+
+  /** OnMainServerUnavalableBehavior = Auto (для команд). */
+  public static OnMainServerUnavalableBehavior onMainServerUnavalableBehaviorAuto() {
+    return OnMainServerUnavalableBehavior.AUTO;
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/JaxbWriteUtils.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/JaxbWriteUtils.java
@@ -1,0 +1,40 @@
+/*
+ * This file is a part of MDClasses.
+ *
+ * Copyright (c) 2019 - 2026
+ * Tymko Oleg <olegtymko@yandex.ru>, Maximov Valery <maximovvalery@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package com.github._1c_syntax.bsl.mdclasses.jaxb.write;
+
+import com.github._1c_syntax.bsl.types.MultiLanguageString;
+
+/**
+ * Вспомогательные методы для записи JAXB в формате Designer XML.
+ */
+public final class JaxbWriteUtils {
+
+  private static final String DEFAULT_LANG = "ru";
+
+  private JaxbWriteUtils() {
+  }
+
+  /**
+   * Возвращает текст для поля v8:content в LocalStringType: значение для языка {@value #DEFAULT_LANG},
+   * при отсутствии — первое доступное через {@link MultiLanguageString#getAny()}.
+   *
+   * @param ml многоязычная строка (синоним, пояснение и т.д.)
+   * @return текст для v8:content или пустая строка
+   */
+  public static String contentForLocalString(MultiLanguageString ml) {
+    if (ml == null || ml.isEmpty()) {
+      return "";
+    }
+    String forLang = ml.get(DEFAULT_LANG);
+    if (forLang != null && !forLang.isEmpty()) {
+      return forLang;
+    }
+    return ml.getAny();
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/LanguageToJaxbConverter.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/LanguageToJaxbConverter.java
@@ -1,0 +1,51 @@
+/*
+ * This file is a part of MDClasses.
+ *
+ * Copyright (c) 2019 - 2026
+ * Tymko Oleg <olegtymko@yandex.ru>, Maximov Valery <maximovvalery@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package com.github._1c_syntax.bsl.mdclasses.jaxb.write;
+
+import com.github._1c_syntax.bsl.mdo.Language;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.LanguageProperties;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.MetaDataObject;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.ObjectFactory;
+
+/**
+ * Преобразует язык mdclasses в JAXB-DTO для записи Designer XML.
+ */
+public final class LanguageToJaxbConverter {
+
+  private static final ObjectFactory FACTORY = new ObjectFactory();
+
+  private LanguageToJaxbConverter() {
+  }
+
+  /**
+   * Собирает JAXB MetaDataObject из языка.
+   *
+   * @param language язык из модели mdclasses
+   * @return корневой элемент для маршаллинга в Designer XML
+   */
+  public static MetaDataObject toMetaDataObject(Language language) {
+    MetaDataObject root = FACTORY.createMetaDataObject();
+    root.setVersion(JaxbWriteDefaults.DEFAULT_FORMAT_VERSION);
+    com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.Language inner = FACTORY.createLanguage();
+    inner.setUuid(language.getUuid() != null ? language.getUuid() : "");
+    inner.setProperties(buildProperties(language));
+    root.setLanguage(inner);
+    return root;
+  }
+
+  private static LanguageProperties buildProperties(Language l) {
+    LanguageProperties p = FACTORY.createLanguageProperties();
+    p.setName(l.getName());
+    p.setSynonym(JaxbWriteDefaults.localStringType(JaxbWriteUtils.contentForLocalString(l.getSynonym())));
+    p.setComment(l.getComment() != null ? l.getComment() : "");
+    p.setObjectBelonging(JaxbWriteDefaults.objectBelongingNative());
+    p.setLanguageCode(l.getLanguageCode() != null ? l.getLanguageCode() : "");
+    return p;
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/MDClassesJaxbWriter.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/MDClassesJaxbWriter.java
@@ -1,0 +1,291 @@
+/*
+ * This file is a part of MDClasses.
+ *
+ * Copyright (c) 2019 - 2026
+ * Tymko Oleg <olegtymko@yandex.ru>, Maximov Valery <maximovvalery@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package com.github._1c_syntax.bsl.mdclasses.jaxb.write;
+
+import com.github._1c_syntax.bsl.mdo.AccumulationRegister;
+import com.github._1c_syntax.bsl.mdo.AccountingRegister;
+import com.github._1c_syntax.bsl.mdo.BusinessProcess;
+import com.github._1c_syntax.bsl.mdo.CalculationRegister;
+import com.github._1c_syntax.bsl.mdo.Catalog;
+import com.github._1c_syntax.bsl.mdo.children.ObjectForm;
+import com.github._1c_syntax.bsl.mdo.ChartOfAccounts;
+import com.github._1c_syntax.bsl.mdo.CommandGroup;
+import com.github._1c_syntax.bsl.mdo.ChartOfCalculationTypes;
+import com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes;
+import com.github._1c_syntax.bsl.mdo.CommonModule;
+import com.github._1c_syntax.bsl.mdo.DataProcessor;
+import com.github._1c_syntax.bsl.mdo.Document;
+import com.github._1c_syntax.bsl.mdo.DocumentJournal;
+import com.github._1c_syntax.bsl.mdo.ExchangePlan;
+import com.github._1c_syntax.bsl.mdo.FilterCriterion;
+import com.github._1c_syntax.bsl.mdo.InformationRegister;
+import com.github._1c_syntax.bsl.mdo.Language;
+import com.github._1c_syntax.bsl.mdo.MD;
+import com.github._1c_syntax.bsl.mdo.Report;
+import com.github._1c_syntax.bsl.mdo.Role;
+import com.github._1c_syntax.bsl.mdo.SettingsStorage;
+import com.github._1c_syntax.bsl.mdo.Subsystem;
+import com.github._1c_syntax.bsl.mdo.Task;
+import com.github._1c_syntax.bsl.types.MDOType;
+import com.github._1c_syntax.bsl.mdclasses.Configuration;
+
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.MetaDataObject;
+
+import jakarta.xml.bind.JAXBException;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+/**
+ * Запись объектов метаданных конфигурации 1С в Designer XML через JAXB.
+ */
+public final class MDClassesJaxbWriter {
+
+  private record TypeWriter(MDOType type, Function<Configuration, List<? extends MD>> getList) {}
+
+  private static final List<TypeWriter> LIST_TYPE_WRITERS = List.of(
+    new TypeWriter(MDOType.LANGUAGE, Configuration::getLanguages),
+    new TypeWriter(MDOType.COMMAND_GROUP, Configuration::getCommandGroups),
+    new TypeWriter(MDOType.ROLE, Configuration::getRoles),
+    new TypeWriter(MDOType.REPORT, Configuration::getReports),
+    new TypeWriter(MDOType.TASK, Configuration::getTasks),
+    new TypeWriter(MDOType.FILTER_CRITERION, Configuration::getFilterCriteria),
+    new TypeWriter(MDOType.DATA_PROCESSOR, Configuration::getDataProcessors),
+    new TypeWriter(MDOType.INFORMATION_REGISTER, Configuration::getInformationRegisters),
+    new TypeWriter(MDOType.ACCOUNTING_REGISTER, Configuration::getAccountingRegisters),
+    new TypeWriter(MDOType.ACCUMULATION_REGISTER, Configuration::getAccumulationRegisters),
+    new TypeWriter(MDOType.CALCULATION_REGISTER, Configuration::getCalculationRegisters),
+    new TypeWriter(MDOType.DOCUMENT_JOURNAL, Configuration::getDocumentJournals),
+    new TypeWriter(MDOType.EXCHANGE_PLAN, Configuration::getExchangePlans),
+    new TypeWriter(MDOType.CHART_OF_ACCOUNTS, Configuration::getChartsOfAccounts),
+    new TypeWriter(MDOType.CHART_OF_CHARACTERISTIC_TYPES, Configuration::getChartsOfCharacteristicTypes),
+    new TypeWriter(MDOType.CHART_OF_CALCULATION_TYPES, Configuration::getChartsOfCalculationTypes),
+    new TypeWriter(MDOType.SETTINGS_STORAGE, Configuration::getSettingsStorages),
+    new TypeWriter(MDOType.BUSINESS_PROCESS, Configuration::getBusinessProcesses),
+    new TypeWriter(MDOType.DOCUMENT, Configuration::getDocuments),
+    new TypeWriter(MDOType.ENUM, Configuration::getEnums),
+    new TypeWriter(MDOType.COMMON_MODULE, Configuration::getCommonModules)
+  );
+
+  private static final Map<MDOType, BiFunction<MD, Configuration, MetaDataObject>> CONVERTERS = new HashMap<>();
+
+  static {
+    CONVERTERS.put(MDOType.SUBSYSTEM, (md, cfg) -> SubsystemToJaxbConverter.toMetaDataObject((Subsystem) md));
+    CONVERTERS.put(MDOType.CATALOG, (md, cfg) ->
+      CatalogToJaxbConverter.toMetaDataObject((Catalog) md, defaultCommandGroupRef(cfg)));
+    CONVERTERS.put(MDOType.ENUM, (md, cfg) -> EnumToJaxbConverter.toMetaDataObject((com.github._1c_syntax.bsl.mdo.Enum) md));
+    CONVERTERS.put(MDOType.COMMON_MODULE, (md, cfg) -> CommonModuleToJaxbConverter.toMetaDataObject((CommonModule) md));
+    CONVERTERS.put(MDOType.DOCUMENT, (md, cfg) -> DocumentToJaxbConverter.toMetaDataObject((Document) md));
+    CONVERTERS.put(MDOType.ROLE, (md, cfg) -> RoleToJaxbConverter.toMetaDataObject((Role) md));
+    CONVERTERS.put(MDOType.LANGUAGE, (md, cfg) -> LanguageToJaxbConverter.toMetaDataObject((Language) md));
+    CONVERTERS.put(MDOType.COMMAND_GROUP, (md, cfg) -> CommandGroupToJaxbConverter.toMetaDataObject((CommandGroup) md));
+    CONVERTERS.put(MDOType.REPORT, (md, cfg) -> ReportToJaxbConverter.toMetaDataObject((Report) md));
+    CONVERTERS.put(MDOType.TASK, (md, cfg) -> TaskToJaxbConverter.toMetaDataObject((Task) md));
+    CONVERTERS.put(MDOType.FILTER_CRITERION, (md, cfg) -> FilterCriterionToJaxbConverter.toMetaDataObject((FilterCriterion) md));
+    CONVERTERS.put(MDOType.DATA_PROCESSOR, (md, cfg) -> DataProcessorToJaxbConverter.toMetaDataObject((DataProcessor) md));
+    CONVERTERS.put(MDOType.INFORMATION_REGISTER, (md, cfg) -> InformationRegisterToJaxbConverter.toMetaDataObject((InformationRegister) md));
+    CONVERTERS.put(MDOType.ACCOUNTING_REGISTER, (md, cfg) -> AccountingRegisterToJaxbConverter.toMetaDataObject((AccountingRegister) md));
+    CONVERTERS.put(MDOType.ACCUMULATION_REGISTER, (md, cfg) -> AccumulationRegisterToJaxbConverter.toMetaDataObject((AccumulationRegister) md));
+    CONVERTERS.put(MDOType.CALCULATION_REGISTER, (md, cfg) -> CalculationRegisterToJaxbConverter.toMetaDataObject((CalculationRegister) md));
+    CONVERTERS.put(MDOType.DOCUMENT_JOURNAL, (md, cfg) -> DocumentJournalToJaxbConverter.toMetaDataObject((DocumentJournal) md));
+    CONVERTERS.put(MDOType.EXCHANGE_PLAN, (md, cfg) -> ExchangePlanToJaxbConverter.toMetaDataObject((ExchangePlan) md));
+    CONVERTERS.put(MDOType.CHART_OF_ACCOUNTS, (md, cfg) -> ChartOfAccountsToJaxbConverter.toMetaDataObject((ChartOfAccounts) md));
+    CONVERTERS.put(MDOType.CHART_OF_CHARACTERISTIC_TYPES, (md, cfg) ->
+      ChartOfCharacteristicTypesToJaxbConverter.toMetaDataObject((ChartOfCharacteristicTypes) md));
+    CONVERTERS.put(MDOType.CHART_OF_CALCULATION_TYPES, (md, cfg) ->
+      ChartOfCalculationTypesToJaxbConverter.toMetaDataObject((ChartOfCalculationTypes) md));
+    CONVERTERS.put(MDOType.SETTINGS_STORAGE, (md, cfg) -> SettingsStorageToJaxbConverter.toMetaDataObject((SettingsStorage) md));
+    CONVERTERS.put(MDOType.BUSINESS_PROCESS, (md, cfg) -> BusinessProcessToJaxbConverter.toMetaDataObject((BusinessProcess) md));
+  }
+
+  private static String defaultCommandGroupRef(Configuration c) {
+    if (c == null || c.getCommandGroups() == null || c.getCommandGroups().isEmpty()) {
+      return null;
+    }
+    return c.getCommandGroups().get(0).getMdoRef();
+  }
+
+  private MDClassesJaxbWriter() {
+  }
+
+  /**
+   * Записывает объект метаданных в XML-файл в формате Designer.
+   *
+   * @param path путь к .xml файлу
+   * @param md   объект метаданных
+   * @throws IllegalArgumentException если тип объекта не поддерживается
+   * @throws JAXBException            при ошибке сериализации
+   * @throws IOException              при ошибке записи файла
+   */
+  public static void writeObjectJaxb(Path path, MD md) throws JAXBException, IOException {
+    writeObjectJaxb(path, md, null);
+  }
+
+  /**
+   * Записывает объект метаданных в XML. Для справочников при передаче конфигурации
+   * используется первая группа команд как группа по умолчанию для команд.
+   *
+   * @param path          путь к .xml файлу
+   * @param md            объект метаданных
+   * @param configuration конфигурация или null
+   */
+  public static void writeObjectJaxb(Path path, MD md, Configuration configuration) throws JAXBException, IOException {
+    var converter = CONVERTERS.get(md.getMdoType());
+    if (converter == null) {
+      throw new IllegalArgumentException("JAXB writer does not support type: " + md.getMdoType());
+    }
+    DesignerJaxbWriter.write(path, converter.apply(md, configuration));
+  }
+
+  /**
+   * Записывает корневую конфигурацию в Configuration.xml.
+   *
+   * @param path          путь к файлу (например Configuration.xml)
+   * @param configuration конфигурация
+   */
+  public static void writeConfigurationJaxb(Path path, Configuration configuration)
+    throws JAXBException, IOException {
+    var jaxb = ConfigurationToJaxbConverter.toMetaDataObject(configuration);
+    DesignerJaxbWriter.write(path, jaxb);
+  }
+
+  /**
+   * Возвращает путь к XML-файлу объекта в дереве Designer.
+   *
+   * @param rootPath корень выгрузки
+   * @param md      объект метаданных
+   * @return путь к .xml файлу
+   */
+  public static Path getPathForObject(Path rootPath, MD md) {
+    return DesignerPathResolver.pathForObject(rootPath, md);
+  }
+
+  /**
+   * Возвращает путь к XML-файлу объекта с учётом родительской подсистемы (для вложенных подсистем).
+   *
+   * @param rootPath            корень выгрузки
+   * @param md                  объект метаданных
+   * @param parentSubsystemPath путь к .xml родительской подсистемы или null
+   * @return путь к .xml файлу
+   */
+  public static Path getPathForObject(Path rootPath, MD md, Path parentSubsystemPath) {
+    return DesignerPathResolver.pathForObject(rootPath, md, parentSubsystemPath);
+  }
+
+  /**
+   * Записывает конфигурацию в папку в формате Designer (Configuration.xml и дочерние объекты).
+   *
+   * @param rootPath       корень выгрузки
+   * @param configuration конфигурация для записи
+   */
+  public static void writeConfigurationToFolder(Path rootPath, Configuration configuration)
+    throws JAXBException, IOException {
+    writeConfigurationToFolder(rootPath, configuration, WriteOptions.defaults());
+  }
+
+  /**
+   * Записывает конфигурацию в папку с заданными опциями.
+   *
+   * @param rootPath       корень выгрузки
+   * @param configuration конфигурация для записи
+   * @param options        опции (фильтр типов и т.д.) или null для записи всего
+   */
+  public static void writeConfigurationToFolder(Path rootPath, Configuration configuration,
+    WriteOptions options) throws JAXBException, IOException {
+    Path configPath = DesignerPathResolver.configurationPath(rootPath);
+    Files.createDirectories(configPath.getParent());
+    writeConfigurationJaxb(configPath, configuration);
+
+    Set<MDOType> filter = options != null ? options.getTypeFilter() : null;
+
+    writeSubsystemsIfAllowed(rootPath, configuration, filter);
+    writeCatalogsIfAllowed(rootPath, configuration, filter);
+
+    for (TypeWriter tw : LIST_TYPE_WRITERS) {
+      if (shouldWriteType(filter, tw.type())) {
+        writeList(rootPath, tw.getList().apply(configuration));
+      }
+    }
+  }
+
+  private static boolean shouldWriteType(Set<MDOType> filter, MDOType type) {
+    return filter == null || filter.contains(type);
+  }
+
+  private static void writeSubsystemsIfAllowed(Path rootPath, Configuration configuration, Set<MDOType> filter)
+    throws JAXBException, IOException {
+    if (configuration.getSubsystems() == null || !shouldWriteType(filter, MDOType.SUBSYSTEM)) {
+      return;
+    }
+    for (Subsystem s : configuration.getSubsystems()) {
+      writeSubsystemRecursive(rootPath, s, null);
+    }
+  }
+
+  private static void writeCatalogsIfAllowed(Path rootPath, Configuration configuration, Set<MDOType> filter)
+    throws JAXBException, IOException {
+    if (configuration.getCatalogs() == null || !shouldWriteType(filter, MDOType.CATALOG)) {
+      return;
+    }
+    for (Catalog c : configuration.getCatalogs()) {
+      Path path = DesignerPathResolver.pathForObject(rootPath, c);
+      Files.createDirectories(path.getParent());
+      writeObjectJaxb(path, c, configuration);
+      writeCatalogForms(rootPath, c);
+    }
+  }
+
+  private static void writeList(Path rootPath, List<? extends MD> list) throws JAXBException, IOException {
+    if (list == null) {
+      return;
+    }
+    for (MD md : list) {
+      Path path = DesignerPathResolver.pathForObject(rootPath, md);
+      Files.createDirectories(path.getParent());
+      writeObjectJaxb(path, md);
+    }
+  }
+
+  private static void writeCatalogForms(Path rootPath, Catalog catalog) throws JAXBException, IOException {
+    if (catalog.getForms() == null) {
+      return;
+    }
+    for (ObjectForm form : catalog.getForms()) {
+      String formName = form.getName();
+      if (formName == null || formName.isEmpty()) {
+        continue;
+      }
+      Path formPath = DesignerPathResolver.pathForForm(rootPath, "Catalogs", catalog.getName(), formName);
+      Files.createDirectories(formPath.getParent());
+      var jaxb = FormToJaxbConverter.toMetaDataObject(form);
+      DesignerJaxbWriter.write(formPath, jaxb);
+    }
+  }
+
+  private static void writeSubsystemRecursive(Path rootPath, Subsystem subsystem, Path parentSubsystemPath)
+    throws JAXBException, IOException {
+    Path path = DesignerPathResolver.pathForObject(rootPath, subsystem, parentSubsystemPath);
+    Files.createDirectories(path.getParent());
+    writeObjectJaxb(path, subsystem);
+
+    List<Subsystem> children = subsystem.getSubsystems();
+    if (children != null && !children.isEmpty()) {
+      for (Subsystem child : children) {
+        writeSubsystemRecursive(rootPath, child, path);
+      }
+    }
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/ReportToJaxbConverter.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/ReportToJaxbConverter.java
@@ -1,0 +1,62 @@
+/*
+ * This file is a part of MDClasses.
+ *
+ * Copyright (c) 2019 - 2026
+ * Tymko Oleg <olegtymko@yandex.ru>, Maximov Valery <maximovvalery@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package com.github._1c_syntax.bsl.mdclasses.jaxb.write;
+
+import com.github._1c_syntax.bsl.mdo.Report;
+import com.github._1c_syntax.bsl.mdo.children.ObjectForm;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.MetaDataObject;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.ObjectFactory;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.ReportChildObjects;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.ReportProperties;
+
+/**
+ * Преобразует отчёт mdclasses в JAXB-DTO для записи Designer XML.
+ */
+public final class ReportToJaxbConverter {
+
+  private static final ObjectFactory FACTORY = new ObjectFactory();
+
+  private ReportToJaxbConverter() {
+  }
+
+  /**
+   * Собирает JAXB MetaDataObject из отчёта.
+   *
+   * @param report отчёт из модели mdclasses
+   * @return корневой элемент для маршаллинга в Designer XML
+   */
+  public static MetaDataObject toMetaDataObject(Report report) {
+    MetaDataObject root = FACTORY.createMetaDataObject();
+    root.setVersion(JaxbWriteDefaults.DEFAULT_FORMAT_VERSION);
+    com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.Report inner = FACTORY.createReport();
+    inner.setUuid(report.getUuid() != null ? report.getUuid() : "");
+    inner.setProperties(buildProperties(report));
+    inner.setChildObjects(buildChildObjects(report));
+    root.setReport(inner);
+    return root;
+  }
+
+  private static ReportProperties buildProperties(Report r) {
+    ReportProperties p = FACTORY.createReportProperties();
+    p.setName(r.getName());
+    p.setSynonym(JaxbWriteDefaults.localStringType(JaxbWriteUtils.contentForLocalString(r.getSynonym())));
+    p.setComment(r.getComment() != null ? r.getComment() : "");
+    return p;
+  }
+
+  private static ReportChildObjects buildChildObjects(Report r) {
+    ReportChildObjects co = FACTORY.createReportChildObjects();
+    if (r.getForms() != null) {
+      for (ObjectForm form : r.getForms()) {
+        co.getForm().add(form.getName() != null ? form.getName() : "");
+      }
+    }
+    return co;
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/RoleToJaxbConverter.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/RoleToJaxbConverter.java
@@ -1,0 +1,51 @@
+/*
+ * This file is a part of MDClasses.
+ *
+ * Copyright (c) 2019 - 2026
+ * Tymko Oleg <olegtymko@yandex.ru>, Maximov Valery <maximovvalery@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package com.github._1c_syntax.bsl.mdclasses.jaxb.write;
+
+import com.github._1c_syntax.bsl.mdo.Role;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.MetaDataObject;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.ObjectFactory;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.RoleProperties;
+
+/**
+ * Преобразует роль mdclasses в JAXB-DTO для записи Designer XML.
+ */
+public final class RoleToJaxbConverter {
+
+  private static final ObjectFactory FACTORY = new ObjectFactory();
+
+  private RoleToJaxbConverter() {
+  }
+
+  /**
+   * Собирает JAXB MetaDataObject из роли.
+   *
+   * @param role роль из модели mdclasses
+   * @return корневой элемент для маршаллинга в Designer XML
+   */
+  public static MetaDataObject toMetaDataObject(Role role) {
+    MetaDataObject root = FACTORY.createMetaDataObject();
+    root.setVersion(JaxbWriteDefaults.DEFAULT_FORMAT_VERSION);
+    com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.Role inner = FACTORY.createRole();
+    inner.setUuid(role.getUuid() != null ? role.getUuid() : "");
+    inner.setProperties(buildProperties(role));
+    root.setRole(inner);
+    return root;
+  }
+
+  private static RoleProperties buildProperties(Role r) {
+    RoleProperties p = FACTORY.createRoleProperties();
+    p.setName(r.getName());
+    p.setSynonym(JaxbWriteDefaults.localStringType(JaxbWriteUtils.contentForLocalString(r.getSynonym())));
+    p.setComment(r.getComment() != null ? r.getComment() : "");
+    p.setObjectBelonging(JaxbWriteDefaults.objectBelongingNative());
+    p.setRights("");
+    return p;
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/SettingsStorageToJaxbConverter.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/SettingsStorageToJaxbConverter.java
@@ -1,0 +1,50 @@
+/*
+ * This file is a part of MDClasses.
+ *
+ * Copyright (c) 2019 - 2026
+ * Tymko Oleg <olegtymko@yandex.ru>, Maximov Valery <maximovvalery@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package com.github._1c_syntax.bsl.mdclasses.jaxb.write;
+
+import com.github._1c_syntax.bsl.mdo.SettingsStorage;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.MetaDataObject;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.ObjectFactory;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.SettingsStorageProperties;
+
+/**
+ * Преобразует хранилище настроек mdclasses в JAXB-DTO для записи Designer XML.
+ */
+public final class SettingsStorageToJaxbConverter {
+
+  private static final ObjectFactory FACTORY = new ObjectFactory();
+
+  private SettingsStorageToJaxbConverter() {
+  }
+
+  /**
+   * Собирает JAXB MetaDataObject из хранилища настроек.
+   *
+   * @param ss хранилище настроек из модели mdclasses
+   * @return корневой элемент для маршаллинга в Designer XML
+   */
+  public static MetaDataObject toMetaDataObject(SettingsStorage ss) {
+    MetaDataObject root = FACTORY.createMetaDataObject();
+    root.setVersion(JaxbWriteDefaults.DEFAULT_FORMAT_VERSION);
+    com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.SettingsStorage inner = FACTORY.createSettingsStorage();
+    inner.setUuid(ss.getUuid() != null ? ss.getUuid() : "");
+    inner.setProperties(buildProperties(ss));
+    inner.setChildObjects(FACTORY.createSettingsStorageChildObjects());
+    root.setSettingsStorage(inner);
+    return root;
+  }
+
+  private static SettingsStorageProperties buildProperties(SettingsStorage ss) {
+    SettingsStorageProperties p = FACTORY.createSettingsStorageProperties();
+    p.setName(ss.getName());
+    p.setSynonym(JaxbWriteDefaults.localStringType(JaxbWriteUtils.contentForLocalString(ss.getSynonym())));
+    p.setComment(ss.getComment() != null ? ss.getComment() : "");
+    return p;
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/SubsystemToJaxbConverter.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/SubsystemToJaxbConverter.java
@@ -1,0 +1,85 @@
+/*
+ * This file is a part of MDClasses.
+ *
+ * Copyright (c) 2019 - 2026
+ * Tymko Oleg <olegtymko@yandex.ru>, Maximov Valery <maximovvalery@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package com.github._1c_syntax.bsl.mdclasses.jaxb.write;
+
+import com.github._1c_syntax.bsl.mdo.Subsystem;
+import com.github._1c_syntax.bsl.types.MdoReference;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.MetaDataObject;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.ObjectFactory;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.SubsystemChildObjects;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.SubsystemProperties;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.v8_3_xcf_readable.MDListType;
+
+/**
+ * Преобразует модель подсистемы mdclasses в JAXB-DTO для записи Designer XML.
+ */
+public final class SubsystemToJaxbConverter {
+
+  private static final ObjectFactory FACTORY = new ObjectFactory();
+
+  private SubsystemToJaxbConverter() {
+  }
+
+  /**
+   * Собирает JAXB MetaDataObject из подсистемы mdclasses.
+   *
+   * @param subsystem подсистема из модели mdclasses
+   * @return корневой элемент для маршаллинга в Designer XML
+   */
+  public static MetaDataObject toMetaDataObject(Subsystem subsystem) {
+    MetaDataObject root = FACTORY.createMetaDataObject();
+    root.setVersion(JaxbWriteDefaults.DEFAULT_FORMAT_VERSION);
+    com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.Subsystem inner = FACTORY.createSubsystem();
+    inner.setUuid(subsystem.getUuid() != null ? subsystem.getUuid() : "");
+    inner.setProperties(buildProperties(subsystem));
+    inner.setChildObjects(buildChildObjects(subsystem));
+    root.setSubsystem(inner);
+    return root;
+  }
+
+  private static SubsystemChildObjects buildChildObjects(Subsystem s) {
+    SubsystemChildObjects co = new SubsystemChildObjects();
+    if (s.getSubsystems() != null) {
+      for (Subsystem child : s.getSubsystems()) {
+        co.getSubsystem().add(child.getName());
+      }
+    }
+    return co;
+  }
+
+  private static SubsystemProperties buildProperties(Subsystem s) {
+    SubsystemProperties p = new SubsystemProperties();
+    p.setName(s.getName());
+    p.setSynonym(JaxbWriteDefaults.localStringType(JaxbWriteUtils.contentForLocalString(s.getSynonym())));
+    p.setComment(s.getComment() != null ? s.getComment() : "");
+    p.setObjectBelonging(JaxbWriteDefaults.objectBelongingNative());
+    p.setIncludeHelpInContents(s.isIncludeHelpInContents());
+    p.setHelp("");
+    p.setIncludeInCommandInterface(s.isIncludeInCommandInterface());
+    p.setCommandInterface("");
+    p.setExplanation(JaxbWriteDefaults.localStringType(JaxbWriteUtils.contentForLocalString(s.getExplanation())));
+    p.setPicture(JaxbWriteDefaults.emptyPicture());
+    MDListType content = JaxbWriteDefaults.emptyMDListType();
+    if (s.getContent() != null && !s.getContent().isEmpty()) {
+      for (MdoReference ref : s.getContent()) {
+        content.getItem().add(shortNameFromMdoRef(ref.getMdoRef()));
+      }
+    }
+    p.setContent(content);
+    return p;
+  }
+
+  private static String shortNameFromMdoRef(String mdoRef) {
+    if (mdoRef == null) {
+      return "";
+    }
+    int dot = mdoRef.indexOf('.');
+    return dot >= 0 ? mdoRef.substring(dot + 1) : mdoRef;
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/TaskToJaxbConverter.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/TaskToJaxbConverter.java
@@ -1,0 +1,62 @@
+/*
+ * This file is a part of MDClasses.
+ *
+ * Copyright (c) 2019 - 2026
+ * Tymko Oleg <olegtymko@yandex.ru>, Maximov Valery <maximovvalery@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package com.github._1c_syntax.bsl.mdclasses.jaxb.write;
+
+import com.github._1c_syntax.bsl.mdo.Task;
+import com.github._1c_syntax.bsl.mdo.children.ObjectForm;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.MetaDataObject;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.ObjectFactory;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.TaskChildObjects;
+import com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.TaskProperties;
+
+/**
+ * Преобразует задачу mdclasses в JAXB-DTO для записи Designer XML.
+ */
+public final class TaskToJaxbConverter {
+
+  private static final ObjectFactory FACTORY = new ObjectFactory();
+
+  private TaskToJaxbConverter() {
+  }
+
+  /**
+   * Собирает JAXB MetaDataObject из задачи.
+   *
+   * @param task задача из модели mdclasses
+   * @return корневой элемент для маршаллинга в Designer XML
+   */
+  public static MetaDataObject toMetaDataObject(Task task) {
+    MetaDataObject root = FACTORY.createMetaDataObject();
+    root.setVersion(JaxbWriteDefaults.DEFAULT_FORMAT_VERSION);
+    com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses.Task inner = FACTORY.createTask();
+    inner.setUuid(task.getUuid() != null ? task.getUuid() : "");
+    inner.setProperties(buildProperties(task));
+    inner.setChildObjects(buildChildObjects(task));
+    root.setTask(inner);
+    return root;
+  }
+
+  private static TaskProperties buildProperties(Task t) {
+    TaskProperties p = FACTORY.createTaskProperties();
+    p.setName(t.getName());
+    p.setSynonym(JaxbWriteDefaults.localStringType(JaxbWriteUtils.contentForLocalString(t.getSynonym())));
+    p.setComment(t.getComment() != null ? t.getComment() : "");
+    return p;
+  }
+
+  private static TaskChildObjects buildChildObjects(Task t) {
+    TaskChildObjects co = FACTORY.createTaskChildObjects();
+    if (t.getForms() != null) {
+      for (ObjectForm form : t.getForms()) {
+        co.getForm().add(form.getName() != null ? form.getName() : "");
+      }
+    }
+    return co;
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/WriteOptions.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/WriteOptions.java
@@ -1,0 +1,95 @@
+/*
+ * This file is a part of MDClasses.
+ *
+ * Copyright (c) 2019 - 2026
+ * Tymko Oleg <olegtymko@yandex.ru>, Maximov Valery <maximovvalery@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package com.github._1c_syntax.bsl.mdclasses.jaxb.write;
+
+import com.github._1c_syntax.bsl.types.MDOType;
+
+import java.util.Set;
+
+/**
+ * Опции записи конфигурации в формате Designer.
+ */
+public final class WriteOptions {
+
+  private final boolean useShortNamesInChildObjects;
+  private final String version;
+  private final Set<MDOType> typeFilter;
+
+  private WriteOptions(Builder builder) {
+    this.useShortNamesInChildObjects = builder.useShortNamesInChildObjects;
+    this.version = builder.version;
+    this.typeFilter = builder.typeFilter;
+  }
+
+  /**
+   * Использовать короткие имена (имя объекта) в ChildObjects вместо полной MDO-ссылки.
+   * По умолчанию true (как в выгрузке платформы).
+   */
+  public boolean isUseShortNamesInChildObjects() {
+    return useShortNamesInChildObjects;
+  }
+
+  /**
+   * Версия формата выгрузки в атрибуте version корневого MetaDataObject (например "2.20", "2.27").
+   * Не путать с версией платформы (8.3). По умолчанию {@link JaxbWriteDefaults#DEFAULT_FORMAT_VERSION}.
+   */
+  public String getVersion() {
+    return version;
+  }
+
+  /**
+   * Фильтр типов метаданных для записи в папку. Если null — записываются все поддерживаемые типы.
+   * Позволяет выгружать только выбранные типы (например, только Catalogs и Documents).
+   */
+  public Set<MDOType> getTypeFilter() {
+    return typeFilter;
+  }
+
+  /** Создаёт построитель опций записи. */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * Опции по умолчанию: короткие имена, версия формата выгрузки по умолчанию, без фильтра типов.
+   */
+  public static WriteOptions defaults() {
+    return builder().build();
+  }
+
+  /** Построитель опций записи конфигурации. */
+  public static final class Builder {
+    private boolean useShortNamesInChildObjects = true;
+    private String version = JaxbWriteDefaults.DEFAULT_FORMAT_VERSION;
+    private Set<MDOType> typeFilter = null;
+
+    public Builder useShortNamesInChildObjects(boolean useShortNamesInChildObjects) {
+      this.useShortNamesInChildObjects = useShortNamesInChildObjects;
+      return this;
+    }
+
+    /**
+     * Версия формата выгрузки (2.20, 2.27 и т.д.). Если null — используется {@link JaxbWriteDefaults#DEFAULT_FORMAT_VERSION}.
+     */
+    public Builder version(String version) {
+      this.version = version != null ? version : JaxbWriteDefaults.DEFAULT_FORMAT_VERSION;
+      return this;
+    }
+
+    public Builder typeFilter(Set<MDOType> typeFilter) {
+      this.typeFilter = typeFilter;
+      return this;
+    }
+
+    /** Создаёт опции записи. */
+    public WriteOptions build() {
+      return new WriteOptions(this);
+    }
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/package-info.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/package-info.java
@@ -1,0 +1,13 @@
+/*
+ * This file is a part of MDClasses.
+ *
+ * Copyright (c) 2019 - 2026
+ * Tymko Oleg <olegtymko@yandex.ru>, Maximov Valery <maximovvalery@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+/**
+ * Запись метаданных конфигурации 1С в формат Designer XML через JAXB-модель (XSD).
+ */
+package com.github._1c_syntax.bsl.mdclasses.jaxb.write;

--- a/src/main/xsd/v8.3.27/catalog.xml
+++ b/src/main/xsd/v8.3.27/catalog.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+  <uri name="http://v8.1c.ru/8.1/data/core" uri="v8.1c.ru-8.1-data-core.xsd"/>
+  <uri name="http://v8.1c.ru/8.1/data/enterprise" uri="v8.1c.ru-8.1-data-enterprise.xsd"/>
+  <uri name="http://v8.1c.ru/8.1/data/ui" uri="v8.1c.ru-8.1-data-ui.xsd"/>
+  <uri name="http://v8.1c.ru/8.2/managed-application/core" uri="v8.1c.ru-8.2-managed-application-core.xsd"/>
+  <uri name="http://v8.1c.ru/8.2/managed-application/cmi" uri="v8.1c.ru-8.2-managed-application-cmi.xsd"/>
+  <uri name="http://v8.1c.ru/8.2/managed-application/logform" uri="v8.1c.ru-8.2-managed-application-logform.xsd"/>
+  <uri name="http://v8.1c.ru/8.3/xcf/enums" uri="v8.1c.ru-8.3-xcf-enums.xsd"/>
+  <uri name="http://v8.1c.ru/8.3/xcf/readable" uri="v8.1c.ru-8.3-xcf-readable.xsd"/>
+  <uri name="http://v8.1c.ru/8.3/xcf/predef" uri="v8.1c.ru-8.3-xcf-predef.xsd"/>
+  <uri name="http://v8.1c.ru/8.2/data/spreadsheet" uri="v8.1c.ru-8.2-data-spreadsheet.xsd"/>
+  <uri name="http://v8.1c.ru/8.2/data/bsl" uri="v8.1c.ru-8.2-data-bsl.xsd"/>
+  <uri name="http://v8.1c.ru/8.2/managed-application/modules" uri="v8.1c.ru-8.2-managed-application-modules.xsd"/>
+  <uri name="http://v8.1c.ru/8.2/uobjects" uri="v8.1c.ru-8.2-uobjects.xsd"/>
+</catalog>

--- a/src/main/xsd/v8.3.27/v8.1c.ru-8.1-data-core.xsd
+++ b/src/main/xsd/v8.3.27/v8.1c.ru-8.1-data-core.xsd
@@ -1,0 +1,398 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:tns="http://v8.1c.ru/8.1/data/core" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://v8.1c.ru/8.1/data/core" attributeFormDefault="unqualified" elementFormDefault="qualified">
+	<xs:simpleType name="AllowedLength">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Fixed"/>
+			<xs:enumeration value="Variable"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="AllowedSign">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Any"/>
+			<xs:enumeration value="Nonnegative"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CompositeID">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="-?[0-9]+(:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DateFractions">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Date"/>
+			<xs:enumeration value="Time"/>
+			<xs:enumeration value="DateTime"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ErrorCategory">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="AccessViolation"/>
+			<xs:enumeration value="LocalFileAccessError"/>
+			<xs:enumeration value="NetworkError"/>
+			<xs:enumeration value="PrinterError"/>
+			<xs:enumeration value="ScriptCompileError"/>
+			<xs:enumeration value="ScriptRuntimeError"/>
+			<xs:enumeration value="ScriptUseError"/>
+			<xs:enumeration value="ExceptionRaisedFromScript"/>
+			<xs:enumeration value="CollaborationSystemError"/>
+			<xs:enumeration value="DataCompositionSettingsError"/>
+			<xs:enumeration value="SessionError"/>
+			<xs:enumeration value="StoredDataError"/>
+			<xs:enumeration value="FullTextSearchError"/>
+			<xs:enumeration value="ExternalDataSourceError"/>
+			<xs:enumeration value="GotoURLError"/>
+			<xs:enumeration value="DatabaseCopyError"/>
+			<xs:enumeration value="NoPermissionToUseFunctionality"/>
+			<xs:enumeration value="MultimediaToolsError"/>
+			<xs:enumeration value="DocumentConversionError"/>
+			<xs:enumeration value="InvalidPassword"/>
+			<xs:enumeration value="SignatureVerificationError"/>
+			<xs:enumeration value="ConfigurationError"/>
+			<xs:enumeration value="DatabaseTablespaceError"/>
+			<xs:enumeration value="SpeechProcessingError"/>
+			<xs:enumeration value="ForcedShutdown"/>
+			<xs:enumeration value="UnsupportedFormat"/>
+			<xs:enumeration value="OtherError"/>
+			<xs:enumeration value="AllErrors"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FileDragMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="AsFile"/>
+			<xs:enumeration value="AsFileRef"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FillCheckErrorStatus">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Error"/>
+			<xs:enumeration value="Warning"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FillChecking">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="DontCheck"/>
+			<xs:enumeration value="ShowError"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="MainClientApplicationWindowMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Normal"/>
+			<xs:enumeration value="Workplace"/>
+			<xs:enumeration value="FullscreenWorkplace"/>
+			<xs:enumeration value="Kiosk"/>
+			<xs:enumeration value="EmbeddedWorkplace"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Null">
+		<xs:restriction base="xs:string">
+			<xs:length value="0"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ObjectVersion">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[0-9a-fA-F]{40}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="StandardBeginningDateVariant">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Custom"/>
+			<xs:enumeration value="BeginningOfThisDay"/>
+			<xs:enumeration value="BeginningOfThisWeek"/>
+			<xs:enumeration value="BeginningOfThisTenDays"/>
+			<xs:enumeration value="BeginningOfThisMonth"/>
+			<xs:enumeration value="BeginningOfThisQuarter"/>
+			<xs:enumeration value="BeginningOfThisHalfYear"/>
+			<xs:enumeration value="BeginningOfThisYear"/>
+			<xs:enumeration value="BeginningOfLastDay"/>
+			<xs:enumeration value="BeginningOfLastWeek"/>
+			<xs:enumeration value="BeginningOfLastTenDays"/>
+			<xs:enumeration value="BeginningOfLastMonth"/>
+			<xs:enumeration value="BeginningOfLastQuarter"/>
+			<xs:enumeration value="BeginningOfLastHalfYear"/>
+			<xs:enumeration value="BeginningOfLastYear"/>
+			<xs:enumeration value="BeginningOfNextDay"/>
+			<xs:enumeration value="BeginningOfNextWeek"/>
+			<xs:enumeration value="BeginningOfNextTenDays"/>
+			<xs:enumeration value="BeginningOfNextMonth"/>
+			<xs:enumeration value="BeginningOfNextQuarter"/>
+			<xs:enumeration value="BeginningOfNextHalfYear"/>
+			<xs:enumeration value="BeginningOfNextYear"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="StandardPeriodVariant">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Custom"/>
+			<xs:enumeration value="Today"/>
+			<xs:enumeration value="ThisWeek"/>
+			<xs:enumeration value="ThisTenDays"/>
+			<xs:enumeration value="ThisMonth"/>
+			<xs:enumeration value="ThisQuarter"/>
+			<xs:enumeration value="ThisHalfYear"/>
+			<xs:enumeration value="ThisYear"/>
+			<xs:enumeration value="FromBeginningOfThisWeek"/>
+			<xs:enumeration value="FromBeginningOfThisTenDays"/>
+			<xs:enumeration value="FromBeginningOfThisMonth"/>
+			<xs:enumeration value="FromBeginningOfThisQuarter"/>
+			<xs:enumeration value="FromBeginningOfThisHalfYear"/>
+			<xs:enumeration value="FromBeginningOfThisYear"/>
+			<xs:enumeration value="Yesterday"/>
+			<xs:enumeration value="LastWeek"/>
+			<xs:enumeration value="LastTenDays"/>
+			<xs:enumeration value="LastMonth"/>
+			<xs:enumeration value="LastQuarter"/>
+			<xs:enumeration value="LastHalfYear"/>
+			<xs:enumeration value="LastYear"/>
+			<xs:enumeration value="LastWeekTillSameWeekDay"/>
+			<xs:enumeration value="LastTenDaysTillSameDayNumber"/>
+			<xs:enumeration value="LastMonthTillSameDate"/>
+			<xs:enumeration value="LastQuarterTillSameDate"/>
+			<xs:enumeration value="LastHalfYearTillSameDate"/>
+			<xs:enumeration value="LastYearTillSameDate"/>
+			<xs:enumeration value="Tomorrow"/>
+			<xs:enumeration value="NextWeek"/>
+			<xs:enumeration value="NextTenDays"/>
+			<xs:enumeration value="NextMonth"/>
+			<xs:enumeration value="NextQuarter"/>
+			<xs:enumeration value="NextHalfYear"/>
+			<xs:enumeration value="NextYear"/>
+			<xs:enumeration value="NextWeekTillSameWeekDay"/>
+			<xs:enumeration value="NextTenDaysTillSameDayNumber"/>
+			<xs:enumeration value="NextMonthTillSameDate"/>
+			<xs:enumeration value="NextQuarterTillSameDate"/>
+			<xs:enumeration value="NextHalfYearTillSameDate"/>
+			<xs:enumeration value="NextYearTillSameDate"/>
+			<xs:enumeration value="TillEndOfThisWeek"/>
+			<xs:enumeration value="TillEndOfThisTenDays"/>
+			<xs:enumeration value="TillEndOfThisMonth"/>
+			<xs:enumeration value="TillEndOfThisQuarter"/>
+			<xs:enumeration value="TillEndOfThisHalfYear"/>
+			<xs:enumeration value="TillEndOfThisYear"/>
+			<xs:enumeration value="Last7Days"/>
+			<xs:enumeration value="Next7Days"/>
+			<xs:enumeration value="Month"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Type">
+		<xs:restriction base="xs:QName"/>
+	</xs:simpleType>
+	<xs:simpleType name="UUID">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ValueStorage">
+		<xs:restriction base="xs:base64Binary"/>
+	</xs:simpleType>
+	<xs:complexType name="Array">
+		<xs:sequence>
+			<xs:element name="Value" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="BinaryDataQualifiers">
+		<xs:sequence>
+			<xs:element name="Length" type="xs:decimal"/>
+			<xs:element name="AllowedLength" type="tns:AllowedLength"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DataFillError">
+		<xs:sequence>
+			<xs:element name="Data" type="xs:string"/>
+			<xs:element name="DataDescr" type="xs:string"/>
+			<xs:element name="Text" type="xs:string"/>
+			<xs:element name="Status" type="tns:FillCheckErrorStatus"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DataFillErrors">
+		<xs:sequence>
+			<xs:element name="item" type="tns:DataFillError" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DateQualifiers">
+		<xs:sequence>
+			<xs:element name="DateFractions" type="tns:DateFractions"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Exception">
+		<xs:complexContent>
+			<xs:extension base="tns:GenericException">
+				<xs:sequence>
+					<xs:element name="data" type="xs:base64Binary" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="FixedArray">
+		<xs:sequence>
+			<xs:element name="Value" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="FixedMap">
+		<xs:sequence>
+			<xs:element name="pair" type="tns:KeyAndValue" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="FixedStructure">
+		<xs:sequence>
+			<xs:element name="Property" minOccurs="0" maxOccurs="unbounded">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="Value" nillable="true"/>
+					</xs:sequence>
+					<xs:attribute name="name" type="xs:NMTOKEN" use="required"/>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="GenericException" abstract="true">
+		<xs:sequence>
+			<xs:element name="descr" type="xs:string"/>
+			<xs:element name="inner" type="tns:GenericException" minOccurs="0"/>
+			<xs:element name="category" type="xs:string" minOccurs="0"/>
+			<xs:element name="uiHelperUUID" type="tns:UUID" minOccurs="0"/>
+			<xs:element name="creationStack" type="xs:string" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="clsid" type="tns:UUID" use="required"/>
+		<xs:attribute name="encoded" type="xs:boolean" default="false"/>
+	</xs:complexType>
+	<xs:complexType name="KeyAndValue">
+		<xs:sequence>
+			<xs:element name="Key"/>
+			<xs:element name="Value" nillable="true"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="LocalStringItemType">
+		<xs:sequence>
+			<xs:element name="lang" type="xs:NMTOKEN"/>
+			<xs:element name="content" type="xs:string"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="LocalStringType">
+		<xs:sequence>
+			<xs:element name="item" type="tns:LocalStringItemType" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Map">
+		<xs:sequence>
+			<xs:element name="pair" type="tns:KeyAndValue" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="NumberQualifiers">
+		<xs:sequence>
+			<xs:element name="Digits" type="xs:decimal"/>
+			<xs:element name="FractionDigits" type="xs:decimal"/>
+			<xs:element name="AllowedSign" type="tns:AllowedSign"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="StandardBeginningDate">
+		<xs:sequence>
+			<xs:element name="variant"/>
+			<xs:element name="date" type="xs:dateTime" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="StandardPeriod">
+		<xs:sequence>
+			<xs:element name="variant"/>
+			<xs:element name="startDate" type="xs:dateTime" minOccurs="0"/>
+			<xs:element name="endDate" type="xs:dateTime" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="StringQualifiers">
+		<xs:sequence>
+			<xs:element name="Length" type="xs:decimal"/>
+			<xs:element name="AllowedLength" type="tns:AllowedLength"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Structure">
+		<xs:sequence>
+			<xs:element name="Property" minOccurs="0" maxOccurs="unbounded">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="Value" nillable="true"/>
+					</xs:sequence>
+					<xs:attribute name="name" type="xs:NMTOKEN" use="required"/>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TypeDescription">
+		<xs:sequence>
+			<xs:element name="Type" type="xs:QName" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="TypeSet" type="xs:QName" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="TypeId" type="tns:UUID" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="NumberQualifiers" type="tns:NumberQualifiers" minOccurs="0"/>
+			<xs:element name="StringQualifiers" type="tns:StringQualifiers" minOccurs="0"/>
+			<xs:element name="DateQualifiers" type="tns:DateQualifiers" minOccurs="0"/>
+			<xs:element name="BinaryDataQualifiers" type="tns:BinaryDataQualifiers" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ValueListItemType">
+		<xs:sequence>
+			<xs:element name="value" nillable="true"/>
+			<xs:element name="presentation" type="xs:string" minOccurs="0"/>
+			<xs:element name="checkState" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="picture" minOccurs="0"/>
+			<xs:element name="id" type="xs:long" minOccurs="0"/>
+			<xs:element name="formatPresentationSpecified" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="formatPresentation" type="xs:string" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ValueListType">
+		<xs:choice>
+			<xs:element name="valueType" type="tns:TypeDescription"/>
+			<xs:element name="availableValues" type="tns:ValueListType" minOccurs="0"/>
+			<xs:element name="lastId" type="xs:long" minOccurs="0"/>
+			<xs:element name="item" type="tns:ValueListItemType" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="ValueTable">
+		<xs:sequence>
+			<xs:element name="column" type="tns:ValueTableColumn" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="index" type="tns:ValueTableIndex" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="row" type="tns:ValueTableRow" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ValueTableColumn">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:NMTOKEN" minOccurs="0"/>
+			<xs:element name="ValueType" type="tns:TypeDescription" minOccurs="0"/>
+			<xs:element name="Title" type="xs:string" minOccurs="0"/>
+			<xs:element name="Width" type="xs:nonNegativeInteger" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ValueTableIndex">
+		<xs:sequence>
+			<xs:element name="column" type="xs:NMTOKEN" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ValueTableRow">
+		<xs:sequence>
+			<xs:element name="Value" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ValueTree">
+		<xs:sequence>
+			<xs:element name="column" type="tns:ValueTreeColumn" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="row" type="tns:ValueTreeRow" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ValueTreeColumn">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:NMTOKEN" minOccurs="0"/>
+			<xs:element name="ValueType" type="tns:TypeDescription" minOccurs="0"/>
+			<xs:element name="Title" type="xs:string" minOccurs="0"/>
+			<xs:element name="Width" type="xs:nonNegativeInteger" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ValueTreeRow">
+		<xs:sequence>
+			<xs:element name="row" type="tns:ValueTreeRow" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Value" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="LocalFormattedStringType">
+		<xs:sequence>
+			<xs:element name="lws" type="tns:LocalStringType" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="formatted" type="xs:boolean" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+</xs:schema>

--- a/src/main/xsd/v8.3.27/v8.1c.ru-8.1-data-enterprise.xsd
+++ b/src/main/xsd/v8.3.27/v8.1c.ru-8.1-data-enterprise.xsd
@@ -1,0 +1,390 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:ns1="http://v8.1c.ru/8.1/data/core" xmlns:tns="http://v8.1c.ru/8.1/data/enterprise" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://v8.1c.ru/8.1/data/enterprise" attributeFormDefault="unqualified" elementFormDefault="qualified">
+	<xs:import namespace="http://v8.1c.ru/8.1/data/core"/>
+	<xs:simpleType name="AccountType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Active"/>
+			<xs:enumeration value="Passive"/>
+			<xs:enumeration value="ActivePassive"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="AccountingRecordType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Debit"/>
+			<xs:enumeration value="Credit"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="AccumulationRecordType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Receipt"/>
+			<xs:enumeration value="Expense"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="AccumulationRegisterAggregatePeriodicity">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Nonperiodical"/>
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Day"/>
+			<xs:enumeration value="Month"/>
+			<xs:enumeration value="Quarter"/>
+			<xs:enumeration value="HalfYear"/>
+			<xs:enumeration value="Year"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="AccumulationRegisterAggregateUse">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Always"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="AnyDBRef">
+		<xs:restriction base="tns:AnyRef"/>
+	</xs:simpleType>
+	<xs:simpleType name="AnyIBRef">
+		<xs:union memberTypes="tns:AnyDBRef tns:AnyMDEnum"/>
+	</xs:simpleType>
+	<xs:simpleType name="AnyMDEnum">
+		<xs:restriction base="xs:NCName"/>
+	</xs:simpleType>
+	<xs:simpleType name="AnyRef">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="AutoShowStateMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="DontShow"/>
+			<xs:enumeration value="Show"/>
+			<xs:enumeration value="ShowOnComposition"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="AutoTimeMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="DontUse"/>
+			<xs:enumeration value="Last"/>
+			<xs:enumeration value="First"/>
+			<xs:enumeration value="CurrentOrLast"/>
+			<xs:enumeration value="CurrentOrFirst"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CalculationRegisterPeriodType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="RegistrationPeriod"/>
+			<xs:enumeration value="ActionPeriod"/>
+			<xs:enumeration value="ActualActionPeriod"/>
+			<xs:enumeration value="BasePeriod"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ClientApplicationBaseFontVariant">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Normal"/>
+			<xs:enumeration value="Large"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ClientApplicationFormScaleVariant">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Normal"/>
+			<xs:enumeration value="Compact"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ClientApplicationInterfaceVariant">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Version8_2"/>
+			<xs:enumeration value="Taxi"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ClientApplicationType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="ThickClient"/>
+			<xs:enumeration value="ThinClient"/>
+			<xs:enumeration value="WebClient"/>
+			<xs:enumeration value="MobileClient"/>
+			<xs:enumeration value="MobileAppClient"/>
+			<xs:enumeration value="ExternalConnection"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ClientConnectionSpeed">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Normal"/>
+			<xs:enumeration value="Low"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ComparisonType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Equal"/>
+			<xs:enumeration value="NotEqual"/>
+			<xs:enumeration value="Less"/>
+			<xs:enumeration value="LessOrEqual"/>
+			<xs:enumeration value="Greater"/>
+			<xs:enumeration value="GreaterOrEqual"/>
+			<xs:enumeration value="Interval"/>
+			<xs:enumeration value="IntervalIncludingBounds"/>
+			<xs:enumeration value="IntervalIncludingLowerBound"/>
+			<xs:enumeration value="IntervalIncludingUpperBound"/>
+			<xs:enumeration value="Contains"/>
+			<xs:enumeration value="InList"/>
+			<xs:enumeration value="InListByHierarchy"/>
+			<xs:enumeration value="NotInList"/>
+			<xs:enumeration value="NotInListByHierarchy"/>
+			<xs:enumeration value="InHierarchy"/>
+			<xs:enumeration value="NotInHierarchy"/>
+			<xs:enumeration value="NotContains"/>
+			<xs:enumeration value="BeginsWith"/>
+			<xs:enumeration value="NotBeginsWith"/>
+			<xs:enumeration value="Like"/>
+			<xs:enumeration value="NotLike"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DataChangeType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Create"/>
+			<xs:enumeration value="Update"/>
+			<xs:enumeration value="Delete"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DataLineChangeType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Add"/>
+			<xs:enumeration value="Update"/>
+			<xs:enumeration value="Delete"/>
+			<xs:enumeration value="Move"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DatabaseCopiesUse">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="UseCopiesOnly"/>
+			<xs:enumeration value="PreferUseCopies"/>
+			<xs:enumeration value="DontUseCopies"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DocumentPostingMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Regular"/>
+			<xs:enumeration value="RealTime"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DocumentWriteMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Write"/>
+			<xs:enumeration value="Posting"/>
+			<xs:enumeration value="UndoPosting"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FoldersAndItemsUse">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Items"/>
+			<xs:enumeration value="Folders"/>
+			<xs:enumeration value="FoldersAndItems"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="JobScheduleMonths">
+		<xs:list itemType="xs:decimal"/>
+	</xs:simpleType>
+	<xs:simpleType name="JobScheduleWeekDays">
+		<xs:list itemType="xs:decimal"/>
+	</xs:simpleType>
+	<xs:simpleType name="LinkedValueChangeMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Clear"/>
+			<xs:enumeration value="DontChange"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="MessageStatus">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="WithoutStatus"/>
+			<xs:enumeration value="Ordinary"/>
+			<xs:enumeration value="Information"/>
+			<xs:enumeration value="Attention"/>
+			<xs:enumeration value="Important"/>
+			<xs:enumeration value="VeryImportant"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ModalityUseMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Use"/>
+			<xs:enumeration value="UseWithWarnings"/>
+			<xs:enumeration value="DontUse"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="PostingModeUse">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Regular"/>
+			<xs:enumeration value="RealTime"/>
+			<xs:enumeration value="Ask"/>
+			<xs:enumeration value="Auto"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="PredefinedDataUpdate">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="AutoUpdate"/>
+			<xs:enumeration value="DontAutoUpdate"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ReplacementMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Append"/>
+			<xs:enumeration value="Replace"/>
+			<xs:enumeration value="Merge"/>
+			<xs:enumeration value="Delete"/>
+			<xs:enumeration value="Update"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ReportResultViewMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Default"/>
+			<xs:enumeration value="Compact"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="RequiredDataRelevance">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Relevant"/>
+			<xs:enumeration value="Any"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ResultCompositionMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Background"/>
+			<xs:enumeration value="Directly"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SliceUse">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="DontUse"/>
+			<xs:enumeration value="First"/>
+			<xs:enumeration value="Last"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SortDirection">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Asc"/>
+			<xs:enumeration value="Desc"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TransactionsIsolationLevel">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="ReadUncommitted"/>
+			<xs:enumeration value="ReadCommitted"/>
+			<xs:enumeration value="RepeatableRead"/>
+			<xs:enumeration value="Serializable"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="UpdateOnDataChange">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="DontUpdate"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ViewModeApplicationOnSetReportResult">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Apply"/>
+			<xs:enumeration value="DontApply"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="Aggregate">
+		<xs:sequence>
+			<xs:element name="use" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="periodicity" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="beginOfPeriod" type="xs:dateTime" minOccurs="0"/>
+			<xs:element name="endOfPeriod" type="xs:dateTime" minOccurs="0"/>
+			<xs:element name="size" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="dimension" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="AggregateList">
+		<xs:sequence>
+			<xs:element name="buildDate" type="xs:dateTime" minOccurs="0"/>
+			<xs:element name="sizeLimit" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="size" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="effect" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="aggregate" type="tns:Aggregate" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Bound">
+		<xs:sequence>
+			<xs:element name="value" nillable="true"/>
+			<xs:element name="kind" type="xs:decimal"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Filter">
+		<xs:sequence>
+			<xs:element name="FilterItem" type="tns:FilterItem" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="FilterItem">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:NCName"/>
+			<xs:element name="Usage" type="xs:boolean" default="true" minOccurs="0"/>
+			<xs:element name="ComparisonType" type="tns:ComparisonType" default="Equal" minOccurs="0"/>
+			<xs:element name="Value" nillable="true" minOccurs="0"/>
+			<xs:element name="ValueFrom" nillable="true" minOccurs="0"/>
+			<xs:element name="ValueTo" nillable="true" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="JobSchedule">
+		<xs:sequence>
+			<xs:element name="WeekDays" type="tns:JobScheduleWeekDays"/>
+			<xs:element name="Months" type="tns:JobScheduleMonths"/>
+			<xs:element name="DetailedDailySchedules" type="tns:JobSchedule" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="BeginDate" type="xs:date"/>
+		<xs:attribute name="EndDate" type="xs:date"/>
+		<xs:attribute name="BeginTime" type="xs:time"/>
+		<xs:attribute name="EndTime" type="xs:time"/>
+		<xs:attribute name="CompletionTime" type="xs:time"/>
+		<xs:attribute name="CompletionInterval" type="xs:decimal"/>
+		<xs:attribute name="RepeatPeriodInDay" type="xs:decimal"/>
+		<xs:attribute name="RepeatPause" type="xs:decimal"/>
+		<xs:attribute name="WeekDayInMonth" type="xs:decimal"/>
+		<xs:attribute name="DayInMonth" type="xs:decimal"/>
+		<xs:attribute name="WeeksPeriod" type="xs:decimal"/>
+		<xs:attribute name="DaysRepeatPeriod" type="xs:decimal"/>
+	</xs:complexType>
+	<xs:complexType name="ObjectDeletion">
+		<xs:sequence>
+			<xs:element name="Ref" type="tns:AnyRef"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PointOfTime">
+		<xs:sequence>
+			<xs:element name="date" type="xs:dateTime"/>
+			<xs:element name="reference" type="tns:AnyRef" nillable="true"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PointOfTimeWithPeriodAdjustment">
+		<xs:sequence>
+			<xs:element name="date" type="xs:dateTime"/>
+			<xs:element name="dateAdjustment" type="xs:decimal"/>
+			<xs:element name="reference" type="tns:AnyRef" nillable="true"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="UserMessage">
+		<xs:sequence>
+			<xs:element name="Text" type="xs:string" minOccurs="0"/>
+			<xs:element name="Ref" type="tns:AnyRef" nillable="true"/>
+			<xs:element name="pic" minOccurs="0"/>
+			<xs:element name="details" type="xs:string" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="MessageMarker" type="xs:decimal"/>
+		<xs:attribute name="DataPath" type="xs:string"/>
+		<xs:attribute name="FormAttributePath" type="xs:string"/>
+		<xs:attribute name="FormID" type="ns1:UUID"/>
+		<xs:attribute name="notification" type="xs:boolean"/>
+		<xs:attribute name="caption" type="xs:string"/>
+		<xs:attribute name="url" type="xs:string"/>
+		<xs:attribute name="tag" type="xs:string"/>
+	</xs:complexType>
+	<xs:complexType name="UserMessages">
+		<xs:sequence>
+			<xs:element name="message" type="tns:UserMessage" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+</xs:schema>

--- a/src/main/xsd/v8.3.27/v8.1c.ru-8.1-data-ui.xsd
+++ b/src/main/xsd/v8.3.27/v8.1c.ru-8.1-data-ui.xsd
@@ -1,0 +1,424 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:ns1="http://v8.1c.ru/8.1/data/core" xmlns:tns="http://v8.1c.ru/8.1/data/ui" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://v8.1c.ru/8.1/data/ui" attributeFormDefault="unqualified" elementFormDefault="qualified">
+	<xs:import namespace="http://v8.1c.ru/8.1/data/core"/>
+	<xs:simpleType name="AbsoluteColor">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="#[0-9a-fA-F]{6}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="AbstractRef">
+		<xs:union memberTypes="ns1:CompositeID xs:QName"/>
+	</xs:simpleType>
+	<xs:simpleType name="AutoColor">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="auto"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="AutoSeriesSeparation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="None"/>
+			<xs:enumeration value="All"/>
+			<xs:enumeration value="Maximum"/>
+			<xs:enumeration value="Minimum"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="BorderType">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="ChartColorPalette">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Palette8"/>
+			<xs:enumeration value="Palette32"/>
+			<xs:enumeration value="Pastel"/>
+			<xs:enumeration value="Bright"/>
+			<xs:enumeration value="Soft"/>
+			<xs:enumeration value="Warm"/>
+			<xs:enumeration value="Cold"/>
+			<xs:enumeration value="Blue"/>
+			<xs:enumeration value="Orange"/>
+			<xs:enumeration value="Green"/>
+			<xs:enumeration value="Yellow"/>
+			<xs:enumeration value="Gray"/>
+			<xs:enumeration value="Custom"/>
+			<xs:enumeration value="Gradient"/>
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="SoftAdaptive"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ChartLabelType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="None"/>
+			<xs:enumeration value="Series"/>
+			<xs:enumeration value="Value"/>
+			<xs:enumeration value="Percent"/>
+			<xs:enumeration value="SeriesPercent"/>
+			<xs:enumeration value="SeriesValue"/>
+			<xs:enumeration value="SeriesValuePercent"/>
+			<xs:enumeration value="ValuePercent"/>
+			<xs:enumeration value="Point"/>
+			<xs:enumeration value="PointPercent"/>
+			<xs:enumeration value="PointValue"/>
+			<xs:enumeration value="PointValuePercent"/>
+			<xs:enumeration value="SeriesPoint"/>
+			<xs:enumeration value="SeriesPointPercent"/>
+			<xs:enumeration value="SeriesPointValue"/>
+			<xs:enumeration value="SeriesPointValuePercent"/>
+			<xs:enumeration value="ValueSize"/>
+			<xs:enumeration value="SeriesSize"/>
+			<xs:enumeration value="SeriesValueSize"/>
+			<xs:enumeration value="SeriesPointSize"/>
+			<xs:enumeration value="SeriesPointValueSize"/>
+			<xs:enumeration value="PointSize"/>
+			<xs:enumeration value="PointValueSize"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ChartLabelsOrientation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Horizontal"/>
+			<xs:enumeration value="Vertical"/>
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="CustomAngle"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ChartLineType">
+		<xs:restriction base="tns:LineType">
+			<xs:enumeration value="None"/>
+			<xs:enumeration value="Solid"/>
+			<xs:enumeration value="Dotted"/>
+			<xs:enumeration value="Dashed"/>
+			<xs:enumeration value="DashDotted"/>
+			<xs:enumeration value="DashDottedDotted"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ChartType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Line"/>
+			<xs:enumeration value="Step"/>
+			<xs:enumeration value="StackedLine"/>
+			<xs:enumeration value="Area"/>
+			<xs:enumeration value="StackedArea"/>
+			<xs:enumeration value="NormalizedArea"/>
+			<xs:enumeration value="Column"/>
+			<xs:enumeration value="StackedColumn"/>
+			<xs:enumeration value="NormalizedColumn"/>
+			<xs:enumeration value="Column3D"/>
+			<xs:enumeration value="StackedColumn3D"/>
+			<xs:enumeration value="NormalizedColumn3D"/>
+			<xs:enumeration value="Bar"/>
+			<xs:enumeration value="StackedBar"/>
+			<xs:enumeration value="NormalizedBar"/>
+			<xs:enumeration value="Bar3D"/>
+			<xs:enumeration value="StackedBar3D"/>
+			<xs:enumeration value="NormalizedBar3D"/>
+			<xs:enumeration value="Pie"/>
+			<xs:enumeration value="Pie3D"/>
+			<xs:enumeration value="Stock"/>
+			<xs:enumeration value="OpenHighLowClose"/>
+			<xs:enumeration value="BarGraph"/>
+			<xs:enumeration value="CeilGraph"/>
+			<xs:enumeration value="TapeGraph"/>
+			<xs:enumeration value="PyramidGraph"/>
+			<xs:enumeration value="Waterfall"/>
+			<xs:enumeration value="WireframeSurface"/>
+			<xs:enumeration value="Honeycomb"/>
+			<xs:enumeration value="Surface"/>
+			<xs:enumeration value="ConvexSurface"/>
+			<xs:enumeration value="ConcaveSurface"/>
+			<xs:enumeration value="ShadedSurface"/>
+			<xs:enumeration value="RadarLine"/>
+			<xs:enumeration value="RadarArea"/>
+			<xs:enumeration value="RadarStackedLine"/>
+			<xs:enumeration value="RadarStackedArea"/>
+			<xs:enumeration value="RadarNormalizedArea"/>
+			<xs:enumeration value="Gauge"/>
+			<xs:enumeration value="Funnel"/>
+			<xs:enumeration value="Funnel3D"/>
+			<xs:enumeration value="NormalizedFunnel"/>
+			<xs:enumeration value="NormalizedFunnel3D"/>
+			<xs:enumeration value="Scatter"/>
+			<xs:enumeration value="Bubble"/>
+			<xs:enumeration value="Donut"/>
+			<xs:enumeration value="Donut3D"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Color">
+		<xs:union memberTypes="tns:AbsoluteColor tns:AutoColor ns1:CompositeID xs:QName"/>
+	</xs:simpleType>
+	<xs:simpleType name="ControlBorderType">
+		<xs:restriction base="tns:BorderType">
+			<xs:enumeration value="WithoutBorder"/>
+			<xs:enumeration value="Single"/>
+			<xs:enumeration value="Double"/>
+			<xs:enumeration value="Embossed"/>
+			<xs:enumeration value="Indented"/>
+			<xs:enumeration value="Underline"/>
+			<xs:enumeration value="DoubleUnderline"/>
+			<xs:enumeration value="Rounded"/>
+			<xs:enumeration value="Overline"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FontType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Absolute"/>
+			<xs:enumeration value="WindowsFont"/>
+			<xs:enumeration value="StyleItem"/>
+			<xs:enumeration value="AutoFont"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FormattedString">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="GeographicalSchemeLineType">
+		<xs:restriction base="tns:LineType">
+			<xs:enumeration value="None"/>
+			<xs:enumeration value="Solid"/>
+			<xs:enumeration value="Dotted"/>
+			<xs:enumeration value="Dashed"/>
+			<xs:enumeration value="DashDotted"/>
+			<xs:enumeration value="DashDottedDotted"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="HorizontalAlign">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Left"/>
+			<xs:enumeration value="Center"/>
+			<xs:enumeration value="Right"/>
+			<xs:enumeration value="Justify"/>
+			<xs:enumeration value="Auto"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Key">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="None"/>
+			<xs:enumeration value="BackSpace"/>
+			<xs:enumeration value="Space"/>
+			<xs:enumeration value="PageUp"/>
+			<xs:enumeration value="PageDown"/>
+			<xs:enumeration value="Home"/>
+			<xs:enumeration value="End"/>
+			<xs:enumeration value="Left"/>
+			<xs:enumeration value="Up"/>
+			<xs:enumeration value="Right"/>
+			<xs:enumeration value="Down"/>
+			<xs:enumeration value="Ins"/>
+			<xs:enumeration value="Del"/>
+			<xs:enumeration value="Tab"/>
+			<xs:enumeration value="Enter"/>
+			<xs:enumeration value="Esc"/>
+			<xs:enumeration value="_0"/>
+			<xs:enumeration value="_1"/>
+			<xs:enumeration value="_2"/>
+			<xs:enumeration value="_3"/>
+			<xs:enumeration value="_4"/>
+			<xs:enumeration value="_5"/>
+			<xs:enumeration value="_6"/>
+			<xs:enumeration value="_7"/>
+			<xs:enumeration value="_8"/>
+			<xs:enumeration value="_9"/>
+			<xs:enumeration value="A"/>
+			<xs:enumeration value="B"/>
+			<xs:enumeration value="C"/>
+			<xs:enumeration value="D"/>
+			<xs:enumeration value="E"/>
+			<xs:enumeration value="F"/>
+			<xs:enumeration value="G"/>
+			<xs:enumeration value="H"/>
+			<xs:enumeration value="I"/>
+			<xs:enumeration value="J"/>
+			<xs:enumeration value="K"/>
+			<xs:enumeration value="L"/>
+			<xs:enumeration value="M"/>
+			<xs:enumeration value="N"/>
+			<xs:enumeration value="O"/>
+			<xs:enumeration value="P"/>
+			<xs:enumeration value="Q"/>
+			<xs:enumeration value="R"/>
+			<xs:enumeration value="S"/>
+			<xs:enumeration value="T"/>
+			<xs:enumeration value="U"/>
+			<xs:enumeration value="V"/>
+			<xs:enumeration value="W"/>
+			<xs:enumeration value="X"/>
+			<xs:enumeration value="Y"/>
+			<xs:enumeration value="Z"/>
+			<xs:enumeration value="Num0"/>
+			<xs:enumeration value="Num1"/>
+			<xs:enumeration value="Num2"/>
+			<xs:enumeration value="Num3"/>
+			<xs:enumeration value="Num4"/>
+			<xs:enumeration value="Num5"/>
+			<xs:enumeration value="Num6"/>
+			<xs:enumeration value="Num7"/>
+			<xs:enumeration value="Num8"/>
+			<xs:enumeration value="Num9"/>
+			<xs:enumeration value="NumMultiply"/>
+			<xs:enumeration value="NumAdd"/>
+			<xs:enumeration value="NumSubtract"/>
+			<xs:enumeration value="NumDecimal"/>
+			<xs:enumeration value="NumDivide"/>
+			<xs:enumeration value="F1"/>
+			<xs:enumeration value="F2"/>
+			<xs:enumeration value="F3"/>
+			<xs:enumeration value="F4"/>
+			<xs:enumeration value="F5"/>
+			<xs:enumeration value="F6"/>
+			<xs:enumeration value="F7"/>
+			<xs:enumeration value="F8"/>
+			<xs:enumeration value="F9"/>
+			<xs:enumeration value="F10"/>
+			<xs:enumeration value="F11"/>
+			<xs:enumeration value="F12"/>
+			<xs:enumeration value="Break"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="LineType">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="PictureFormat">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="BMP"/>
+			<xs:enumeration value="EMF"/>
+			<xs:enumeration value="GIF"/>
+			<xs:enumeration value="Icon"/>
+			<xs:enumeration value="JPEG"/>
+			<xs:enumeration value="PNG"/>
+			<xs:enumeration value="TIFF"/>
+			<xs:enumeration value="WMF"/>
+			<xs:enumeration value="UnknownFormat"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="PictureRef">
+		<xs:union memberTypes="ns1:CompositeID xs:QName"/>
+	</xs:simpleType>
+	<xs:simpleType name="PivotChartType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Column"/>
+			<xs:enumeration value="Column3D"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SizeChangeMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Normal"/>
+			<xs:enumeration value="QuickChange"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SpreadsheetDocumentCellLineType">
+		<xs:restriction base="tns:LineType">
+			<xs:enumeration value="None"/>
+			<xs:enumeration value="Solid"/>
+			<xs:enumeration value="Dotted"/>
+			<xs:enumeration value="Double"/>
+			<xs:enumeration value="ThinDashed"/>
+			<xs:enumeration value="ThickDashed"/>
+			<xs:enumeration value="LargeDashed"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SpreadsheetDocumentDrawingLineType">
+		<xs:restriction base="tns:LineType">
+			<xs:enumeration value="None"/>
+			<xs:enumeration value="Solid"/>
+			<xs:enumeration value="Dashed"/>
+			<xs:enumeration value="Dotted"/>
+			<xs:enumeration value="DashDotted"/>
+			<xs:enumeration value="DashDottedDotted"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="StyleRef">
+		<xs:union memberTypes="ns1:CompositeID xs:QName"/>
+	</xs:simpleType>
+	<xs:simpleType name="TextDirection">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="LeftToRight"/>
+			<xs:enumeration value="RightToLeft"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TextEncoding">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="UTF16"/>
+			<xs:enumeration value="UTF8"/>
+			<xs:enumeration value="ANSI"/>
+			<xs:enumeration value="OEM"/>
+			<xs:enumeration value="System"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="UseOutput">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Enable"/>
+			<xs:enumeration value="Disable"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="VerticalAlign">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Top"/>
+			<xs:enumeration value="Center"/>
+			<xs:enumeration value="Bottom"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="Border">
+		<xs:sequence>
+			<xs:element name="style" type="tns:BorderType" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="ref" type="tns:StyleRef"/>
+		<xs:attribute name="width" type="xs:unsignedInt"/>
+	</xs:complexType>
+	<xs:complexType name="Font">
+		<xs:attribute name="ref" type="tns:StyleRef"/>
+		<xs:attribute name="faceName" type="xs:string"/>
+		<xs:attribute name="height" type="xs:decimal"/>
+		<xs:attribute name="bold" type="xs:boolean" default="false"/>
+		<xs:attribute name="italic" type="xs:boolean" default="false"/>
+		<xs:attribute name="underline" type="xs:boolean" default="false"/>
+		<xs:attribute name="strikeout" type="xs:boolean" default="false"/>
+		<xs:attribute name="kind" type="tns:FontType"/>
+		<xs:attribute name="scale" type="xs:decimal"/>
+	</xs:complexType>
+	<xs:complexType name="GaugeChartQualityBand">
+		<xs:sequence>
+			<xs:element name="begin" type="xs:decimal"/>
+			<xs:element name="end" type="xs:decimal"/>
+			<xs:element name="backColor" type="tns:Color"/>
+			<xs:element name="text" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="tooltip" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="textStr" type="xs:string" minOccurs="0"/>
+			<xs:element name="tooltipStr" type="xs:string" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="GaugeChartQualityBands">
+		<xs:sequence>
+			<xs:element name="item" type="tns:GaugeChartQualityBand" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="useTextStr" type="xs:boolean"/>
+		<xs:attribute name="useTooltipStr" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="Line">
+		<xs:sequence>
+			<xs:element name="style" type="tns:LineType" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="width" type="xs:unsignedInt"/>
+		<xs:attribute name="gap" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="Picture">
+		<xs:simpleContent>
+			<xs:extension base="xs:base64Binary">
+				<xs:attribute name="url" type="xs:string"/>
+				<xs:attribute name="ref" type="tns:PictureRef"/>
+				<xs:attribute name="t" type="xs:boolean"/>
+				<xs:attribute name="tx" type="xs:decimal"/>
+				<xs:attribute name="ty" type="xs:decimal"/>
+				<xs:attribute name="gx" type="xs:decimal"/>
+				<xs:attribute name="gy" type="xs:decimal"/>
+				<xs:attribute name="gw" type="xs:decimal"/>
+				<xs:attribute name="gh" type="xs:decimal"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:complexType name="ShortCutType">
+		<xs:sequence>
+			<xs:element name="Key" type="tns:Key"/>
+		</xs:sequence>
+		<xs:attribute name="Alt" type="xs:boolean"/>
+		<xs:attribute name="Ctrl" type="xs:boolean"/>
+		<xs:attribute name="Shift" type="xs:boolean"/>
+	</xs:complexType>
+</xs:schema>

--- a/src/main/xsd/v8.3.27/v8.1c.ru-8.2-data-bsl.xsd
+++ b/src/main/xsd/v8.3.27/v8.1c.ru-8.2-data-bsl.xsd
@@ -1,0 +1,56 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:tns="http://v8.1c.ru/8.2/data/bsl" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://v8.1c.ru/8.2/data/bsl" attributeFormDefault="unqualified" elementFormDefault="qualified">
+	<xs:complexType name="BSLAnnotation">
+		<xs:sequence>
+			<xs:element name="attribute" type="tns:BSLAnnotationAttribute" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="name" type="xs:string"/>
+	</xs:complexType>
+	<xs:complexType name="BSLAnnotationAttribute">
+		<xs:attribute name="name" type="xs:string"/>
+		<xs:attribute name="value" type="xs:string"/>
+	</xs:complexType>
+	<xs:complexType name="BSLLabel">
+		<xs:attribute name="name" type="xs:string"/>
+		<xs:attribute name="addr" type="xs:unsignedInt"/>
+	</xs:complexType>
+	<xs:complexType name="BSLModuleImage">
+		<xs:sequence>
+			<xs:element name="cmdOpCode" type="xs:string"/>
+			<xs:element name="cmdOperand" type="xs:string"/>
+			<xs:element name="constant" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="variable" type="tns:BSLVariableImage" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="label" type="tns:BSLLabel" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="procedure" type="tns:BSLProcedureImage" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="version" type="xs:unsignedInt"/>
+		<xs:attribute name="startAddr" type="xs:unsignedInt" default="4294967295"/>
+	</xs:complexType>
+	<xs:complexType name="BSLProcedureImage">
+		<xs:sequence>
+			<xs:element name="label" type="tns:BSLLabel" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="variable" type="tns:BSLVariableImage" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="paramsDefValue" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="annotation" type="tns:BSLAnnotation" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="isAsync" type="xs:boolean" default="false"/>
+		<xs:attribute name="name" type="xs:string"/>
+		<xs:attribute name="isFunction" type="xs:boolean" default="false"/>
+		<xs:attribute name="isExported" type="xs:boolean" default="false"/>
+		<xs:attribute name="isExternal" type="xs:boolean" default="false"/>
+		<xs:attribute name="parametersCount" type="xs:unsignedInt" default="0"/>
+		<xs:attribute name="startAddr" type="xs:unsignedInt"/>
+	</xs:complexType>
+	<xs:complexType name="BSLVariableImage">
+		<xs:sequence>
+			<xs:element name="annotation" type="tns:BSLAnnotation" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="name" type="xs:string"/>
+		<xs:attribute name="isLocal" type="xs:boolean" default="false"/>
+		<xs:attribute name="isExternal" type="xs:boolean" default="false"/>
+		<xs:attribute name="isParam" type="xs:boolean" default="false"/>
+		<xs:attribute name="isByValue" type="xs:boolean" default="false"/>
+		<xs:attribute name="isExported" type="xs:boolean" default="false"/>
+		<xs:attribute name="initConstPos" type="xs:int" default="-1"/>
+	</xs:complexType>
+</xs:schema>

--- a/src/main/xsd/v8.3.27/v8.1c.ru-8.2-data-spreadsheet.xsd
+++ b/src/main/xsd/v8.3.27/v8.1c.ru-8.2-data-spreadsheet.xsd
@@ -1,0 +1,693 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:ns1="http://v8.1c.ru/8.1/data/core" xmlns:ns2="http://v8.1c.ru/8.1/data/ui" xmlns:tns="http://v8.1c.ru/8.2/data/spreadsheet" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://v8.1c.ru/8.2/data/spreadsheet" attributeFormDefault="unqualified" elementFormDefault="qualified">
+	<xs:import namespace="http://v8.1c.ru/8.1/data/core"/>
+	<xs:import namespace="http://v8.1c.ru/8.1/data/ui"/>
+	<xs:element name="document" type="tns:SpreadsheetDocument"/>
+	<xs:simpleType name="DimensionAttributePlacementType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="WithDimensions"/>
+			<xs:enumeration value="Separately"/>
+			<xs:enumeration value="Together"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DimensionPlacementType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Together"/>
+			<xs:enumeration value="Separately"/>
+			<xs:enumeration value="SeparatelyAndInTotalsOnly"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DuplexPrintingType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="None"/>
+			<xs:enumeration value="FlipPagesLeft"/>
+			<xs:enumeration value="FlipPagesUp"/>
+			<xs:enumeration value="UsePrinterSettings"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="NamedItemType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Cells"/>
+			<xs:enumeration value="Drawing"/>
+			<xs:enumeration value="EmbeddedTable"/>
+			<xs:enumeration value="DataSource"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="PageOrientation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Portrait"/>
+			<xs:enumeration value="Landscape"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="PagePlacementAlternation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="DontUse"/>
+			<xs:enumeration value="MirrorOnLeft"/>
+			<xs:enumeration value="MirrorOnTop"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="PictureSize">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="RealSize"/>
+			<xs:enumeration value="Stretch"/>
+			<xs:enumeration value="Proportionally"/>
+			<xs:enumeration value="Tile"/>
+			<xs:enumeration value="AutoSize"/>
+			<xs:enumeration value="RealSizeIgnoreScale"/>
+			<xs:enumeration value="AutoSizeIgnoreScale"/>
+			<xs:enumeration value="ByFontSize"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="PivotTableLinesShowType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Always"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="PrintAccuracy">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Accurate"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SpreadsheetDocumentAreaFillType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Text"/>
+			<xs:enumeration value="Parameter"/>
+			<xs:enumeration value="Template"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SpreadsheetDocumentCellAreaType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Table"/>
+			<xs:enumeration value="Rows"/>
+			<xs:enumeration value="Columns"/>
+			<xs:enumeration value="Rectangle"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SpreadsheetDocumentDetailUse">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Cell"/>
+			<xs:enumeration value="Row"/>
+			<xs:enumeration value="WithoutProcessing"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SpreadsheetDocumentDrawingType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Line"/>
+			<xs:enumeration value="Rectangle"/>
+			<xs:enumeration value="Text"/>
+			<xs:enumeration value="Ellipse"/>
+			<xs:enumeration value="Picture"/>
+			<xs:enumeration value="Object"/>
+			<xs:enumeration value="Group"/>
+			<xs:enumeration value="Chart"/>
+			<xs:enumeration value="GanttChart"/>
+			<xs:enumeration value="PivotChart"/>
+			<xs:enumeration value="Dendrogram"/>
+			<xs:enumeration value="GeographicalSchema"/>
+			<xs:enumeration value="Control"/>
+			<xs:enumeration value="Comment"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SpreadsheetDocumentExtensionAlgorithm">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Replace"/>
+			<xs:enumeration value="Merge"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SpreadsheetDocumentFileType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="MXL"/>
+			<xs:enumeration value="XLS"/>
+			<xs:enumeration value="HTML"/>
+			<xs:enumeration value="TXT"/>
+			<xs:enumeration value="MXL7"/>
+			<xs:enumeration value="HTML3"/>
+			<xs:enumeration value="HTML4"/>
+			<xs:enumeration value="HTML5"/>
+			<xs:enumeration value="XLS95"/>
+			<xs:enumeration value="XLS97"/>
+			<xs:enumeration value="ANSITXT"/>
+			<xs:enumeration value="DOCX"/>
+			<xs:enumeration value="XLSX"/>
+			<xs:enumeration value="ODS"/>
+			<xs:enumeration value="PDF"/>
+			<xs:enumeration value="PDF_A_1"/>
+			<xs:enumeration value="PDF_A_2"/>
+			<xs:enumeration value="PDF_A_3"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SpreadsheetDocumentGroupHeaderPlacement">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Begin"/>
+			<xs:enumeration value="End"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SpreadsheetDocumentPatternType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="WithoutPattern"/>
+			<xs:enumeration value="Solid"/>
+			<xs:enumeration value="Pattern1"/>
+			<xs:enumeration value="Pattern2"/>
+			<xs:enumeration value="Pattern3"/>
+			<xs:enumeration value="Pattern4"/>
+			<xs:enumeration value="Pattern5"/>
+			<xs:enumeration value="Pattern6"/>
+			<xs:enumeration value="Pattern7"/>
+			<xs:enumeration value="Pattern8"/>
+			<xs:enumeration value="Pattern9"/>
+			<xs:enumeration value="Pattern10"/>
+			<xs:enumeration value="Pattern11"/>
+			<xs:enumeration value="Pattern12"/>
+			<xs:enumeration value="Pattern13"/>
+			<xs:enumeration value="Pattern14"/>
+			<xs:enumeration value="Pattern15"/>
+			<xs:enumeration value="Pattern16"/>
+			<xs:enumeration value="Pattern17"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SpreadsheetDocumentPointerType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Special"/>
+			<xs:enumeration value="Regular"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SpreadsheetDocumentSavedPicturesDensity">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Original"/>
+			<xs:enumeration value="High"/>
+			<xs:enumeration value="Medium"/>
+			<xs:enumeration value="Low"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SpreadsheetDocumentStepDirectionType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="ByRows"/>
+			<xs:enumeration value="ByColumns"/>
+			<xs:enumeration value="WithoutMove"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SpreadsheetDocumentTextPlacementType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Cut"/>
+			<xs:enumeration value="Block"/>
+			<xs:enumeration value="Wrap"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="StandardAppearance">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="None"/>
+			<xs:enumeration value="Stone"/>
+			<xs:enumeration value="Classic"/>
+			<xs:enumeration value="Classic2"/>
+			<xs:enumeration value="Classic3"/>
+			<xs:enumeration value="Spring"/>
+			<xs:enumeration value="Summer"/>
+			<xs:enumeration value="Autumn"/>
+			<xs:enumeration value="Winter"/>
+			<xs:enumeration value="Asphalt"/>
+			<xs:enumeration value="Copper"/>
+			<xs:enumeration value="Bronze"/>
+			<xs:enumeration value="Platinum"/>
+			<xs:enumeration value="Silver"/>
+			<xs:enumeration value="Turquoise"/>
+			<xs:enumeration value="Sand"/>
+			<xs:enumeration value="Grass"/>
+			<xs:enumeration value="Ice"/>
+			<xs:enumeration value="Orange"/>
+			<xs:enumeration value="Textile"/>
+			<xs:enumeration value="Wood"/>
+			<xs:enumeration value="Interface"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TextPositionRelativeToPicture">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Left"/>
+			<xs:enumeration value="Right"/>
+			<xs:enumeration value="Top"/>
+			<xs:enumeration value="Bottom"/>
+			<xs:enumeration value="OnTop"/>
+			<xs:enumeration value="Auto"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="Area">
+		<xs:sequence>
+			<xs:element name="type" type="tns:SpreadsheetDocumentCellAreaType"/>
+			<xs:element name="beginRow" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="endRow" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="beginColumn" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="endColumn" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="columnsID" type="ns1:UUID" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Cell">
+		<xs:sequence>
+			<xs:element name="f" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="tl" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="t" type="xs:string" minOccurs="0"/>
+			<xs:element name="tfl" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="tf" type="xs:string" minOccurs="0"/>
+			<xs:element name="parameter" type="xs:string" minOccurs="0"/>
+			<xs:element name="v" minOccurs="0"/>
+			<xs:element name="detailParameter" type="xs:string" minOccurs="0"/>
+			<xs:element name="d" minOccurs="0"/>
+			<xs:element name="r" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="note" type="tns:Drawing" minOccurs="0"/>
+			<xs:element name="control" type="xs:base64Binary" minOccurs="0"/>
+			<xs:element name="pictureParameter" type="xs:string" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ChangedCell">
+		<xs:sequence>
+			<xs:element name="NewElement" type="xs:string"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ChangedCellItem">
+		<xs:sequence>
+			<xs:element name="i" type="xs:decimal"/>
+			<xs:element name="c" type="tns:Cell"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ChangedRow">
+		<xs:sequence>
+			<xs:element name="c" type="tns:ChangedCellItem" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ChangedRowItem">
+		<xs:sequence>
+			<xs:element name="index" type="xs:decimal"/>
+			<xs:element name="row" type="tns:ChangedRow"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Changes">
+		<xs:sequence>
+			<xs:element name="commonPart" type="tns:SpreadsheetDocument" minOccurs="0"/>
+			<xs:element name="fullDocument" type="tns:SpreadsheetDocument" minOccurs="0"/>
+			<xs:element name="fullDocumentWithoutContent" type="tns:SpreadsheetDocument" minOccurs="0"/>
+			<xs:element name="row" type="tns:ChangedRowItem" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="vg" type="tns:Group" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Column">
+		<xs:sequence>
+			<xs:element name="formatIndex" type="xs:decimal" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Columns">
+		<xs:sequence>
+			<xs:element name="id" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="formatIndex" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="size" type="xs:decimal"/>
+			<xs:element name="columnsItem" type="tns:ColumnsItem" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ColumnsItem">
+		<xs:sequence>
+			<xs:element name="index" type="xs:decimal"/>
+			<xs:element name="column" type="tns:Column"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Drawing">
+		<xs:sequence>
+			<xs:element name="drawingType" type="tns:SpreadsheetDocumentDrawingType"/>
+			<xs:element name="id" type="xs:decimal"/>
+			<xs:element name="formatIndex" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="text" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="textString" type="xs:string" minOccurs="0"/>
+			<xs:element name="tfl" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="tf" type="xs:string" minOccurs="0"/>
+			<xs:element name="parameter" type="xs:string" minOccurs="0"/>
+			<xs:element name="value" minOccurs="0"/>
+			<xs:element name="detailParameter" type="xs:string" minOccurs="0"/>
+			<xs:element name="detailValue" minOccurs="0"/>
+			<xs:element name="beginRow" type="xs:decimal"/>
+			<xs:element name="beginRowOffset" type="xs:decimal"/>
+			<xs:element name="endRow" type="xs:decimal"/>
+			<xs:element name="endRowOffset" type="xs:decimal"/>
+			<xs:element name="beginColumn" type="xs:decimal"/>
+			<xs:element name="beginColumnOffset" type="xs:decimal"/>
+			<xs:element name="endColumn" type="xs:decimal"/>
+			<xs:element name="endColumnOffset" type="xs:decimal"/>
+			<xs:element name="autoSize" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="pictureSize" type="tns:PictureSize" minOccurs="0"/>
+			<xs:element name="zOrder" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="nestedDrawing" type="tns:Drawing" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="object" minOccurs="0"/>
+			<xs:element name="pictureIndex" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="picture" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DrawingsDataSource">
+		<xs:sequence>
+			<xs:element name="drawingID" type="xs:decimal"/>
+			<xs:element name="area" type="tns:Area"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="EmbeddedTableItem">
+		<xs:sequence>
+			<xs:element name="id" type="xs:decimal"/>
+			<xs:element name="table"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Format">
+		<xs:sequence>
+			<xs:element name="font" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="border" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="leftBorder" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="rightBorder" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="topBorder" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="bottomBorder" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="borderColor" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="height" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="width" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="autoWidthCalculation" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="widthWeightFactor" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="horizontalAlignment" type="ns2:HorizontalAlign" minOccurs="0"/>
+			<xs:element name="verticalAlignment" type="ns2:VerticalAlign" minOccurs="0"/>
+			<xs:element name="textColor" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="backColor" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="patternColor" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="pattern" type="tns:SpreadsheetDocumentPatternType" minOccurs="0"/>
+			<xs:element name="textPlacement" type="tns:SpreadsheetDocumentTextPlacementType" minOccurs="0"/>
+			<xs:element name="fillType" type="tns:SpreadsheetDocumentAreaFillType" minOccurs="0"/>
+			<xs:element name="protection" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="hidden" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="textOrientation" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="detailsUse" type="tns:SpreadsheetDocumentDetailUse" minOccurs="0"/>
+			<xs:element name="bySelectedColumns" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="markNegatives" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="containsValue" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="valueType" type="ns1:TypeDescription" minOccurs="0"/>
+			<xs:element name="format" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="controlType" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="hyperLink" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="quickDrag" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="autoMarkIncomplete" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="markIncomplete" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="indent" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="autoIndent" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="editFormat" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="columnSizeChange" type="ns2:SizeChangeMode" minOccurs="0"/>
+			<xs:element name="print" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="drawingBorder" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="drawingHaveLeftBorder" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="drawingHaveTopBorder" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="drawingHaveRightBorder" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="drawingHaveBottomBorder" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="mask" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="picIndex" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="pictureSizeMode" type="tns:PictureSize" minOccurs="0"/>
+			<xs:element name="picHorizontalAlignment" type="ns2:HorizontalAlign" minOccurs="0"/>
+			<xs:element name="picVerticalAlignment" type="ns2:VerticalAlign" minOccurs="0"/>
+			<xs:element name="textPosition" type="tns:TextPositionRelativeToPicture" minOccurs="0"/>
+			<xs:element name="leftMargin" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="topMargin" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="rightMargin" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="bottomMargin" type="xs:decimal" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Group">
+		<xs:sequence>
+			<xs:element name="columnsID" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="b" type="xs:decimal"/>
+			<xs:element name="e" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="t" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="o" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="g" type="tns:SpreadsheetDocumentGroupHeaderPlacement" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Merge">
+		<xs:sequence>
+			<xs:element name="r" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="c" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="h" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="w" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="columnsID" type="ns1:UUID" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="MoxelImageMap">
+		<xs:sequence>
+			<xs:element name="mi" type="tns:MoxelImageMapItem" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="MoxelImageMapItem">
+		<xs:sequence>
+			<xs:element name="p" type="xs:decimal" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="d" minOccurs="0"/>
+			<xs:element name="r" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="t" type="xs:string" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="NamedItem">
+		<xs:sequence>
+			<xs:element name="name" type="xs:string"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="NamedItemCells">
+		<xs:complexContent>
+			<xs:extension base="tns:NamedItem">
+				<xs:sequence>
+					<xs:element name="area" type="tns:Area" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="NamedItemDataSource">
+		<xs:complexContent>
+			<xs:extension base="tns:NamedItem">
+				<xs:sequence>
+					<xs:element name="area" type="tns:Area" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="NamedItemDrawing">
+		<xs:complexContent>
+			<xs:extension base="tns:NamedItem">
+				<xs:sequence>
+					<xs:element name="drawingID" type="xs:decimal" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="NamedItemEmbeddedTable">
+		<xs:complexContent>
+			<xs:extension base="tns:NamedItem">
+				<xs:sequence>
+					<xs:element name="area" type="tns:Area" minOccurs="0"/>
+					<xs:element name="embeddedTableID" type="xs:decimal" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="NewComplexType"/>
+	<xs:complexType name="PageBreak">
+		<xs:sequence>
+			<xs:element name="position" type="xs:decimal"/>
+			<xs:element name="columnsID" type="ns1:UUID" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Picture">
+		<xs:sequence>
+			<xs:element name="index" type="xs:decimal"/>
+			<xs:element name="picture"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PivotTable">
+		<xs:sequence>
+			<xs:element name="showFields" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="measuresAxis" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="horizontalRows" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="verticalRows" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="horizontalColumns" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="verticalColumns" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="horizontalOveralls" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="verticalOveralls" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="horizontalFullSize" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="verticalFullSize" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="horizontalFieldsArea" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="verticalFieldsArea" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="horizontalEmptyArea" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="verticalEmptyArea" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="autoFixation" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="rowsGroupping" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="columnsGroupping" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="totalRowsOnTop" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="totalColumnsOnLeft" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="dimensionAttributePlacementInRows" type="tns:DimensionAttributePlacementType" minOccurs="0"/>
+			<xs:element name="dimensionAttributePlacementInColumns" type="tns:DimensionAttributePlacementType" minOccurs="0"/>
+			<xs:element name="dimensionsPlacementOnRows" type="tns:DimensionPlacementType" minOccurs="0"/>
+			<xs:element name="dimensionsPlacementOnColumns" type="tns:DimensionPlacementType" minOccurs="0"/>
+			<xs:element name="standardAppearance" type="tns:StandardAppearance" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="notStandardAppearance" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="horizontalAdditionalSize" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="verticalAdditionalSize" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="showLines" type="tns:PivotTableLinesShowType" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PrintSettings">
+		<xs:sequence>
+			<xs:element name="pageOrientation" type="tns:PageOrientation" minOccurs="0"/>
+			<xs:element name="scale" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="collate" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="copies" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="perPage" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="topMargin" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="leftMargin" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="bottomMargin" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="rightMargin" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="headerSize" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="footerSize" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="fitToPage" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="blackAndWhite" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="printerName" type="xs:string" minOccurs="0"/>
+			<xs:element name="paper" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="pageSize" type="xs:string" minOccurs="0"/>
+			<xs:element name="paperSource" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="pageWidth" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="pageHeight" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="printAccuracy" type="tns:PrintAccuracy" minOccurs="0"/>
+			<xs:element name="duplexType" type="tns:DuplexPrintingType" minOccurs="0"/>
+			<xs:element name="pagePlacementAlternation" type="tns:PagePlacementAlternation" minOccurs="0"/>
+			<xs:element name="firstPageNumber" type="xs:decimal" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Row">
+		<xs:sequence>
+			<xs:element name="columnsID" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="formatIndex" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="empty" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="c" type="tns:RowCellsItem" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="RowCellsItem">
+		<xs:sequence>
+			<xs:element name="i" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="c" type="tns:Cell"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Rows">
+		<xs:sequence>
+			<xs:element name="index" type="xs:decimal"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="RowsItem">
+		<xs:sequence>
+			<xs:element name="index" type="xs:decimal"/>
+			<xs:element name="indexTo" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="row" type="tns:Row"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="SpreadsheetDocument">
+		<xs:choice>
+			<xs:element name="distributedKey" type="xs:string" minOccurs="0"/>
+			<xs:element name="languageSettings" minOccurs="0">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="currentLanguage" type="xs:string"/>
+						<xs:element name="defaultLanguage" type="xs:string"/>
+						<xs:element name="languageInfo" minOccurs="0" maxOccurs="unbounded">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="id" type="xs:string"/>
+									<xs:element name="code" type="xs:string"/>
+									<xs:element name="description" type="xs:string" minOccurs="0"/>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="languageCode" type="xs:string" minOccurs="0"/>
+			<xs:element name="columns" type="tns:Columns" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="rowsItem" type="tns:RowsItem" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="drawing" type="tns:Drawing" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="backPicture" minOccurs="0"/>
+			<xs:element name="fixedBackground" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="leftHeader" type="tns:Cell" minOccurs="0"/>
+			<xs:element name="centerHeader" type="tns:Cell" minOccurs="0"/>
+			<xs:element name="rightHeader" type="tns:Cell" minOccurs="0"/>
+			<xs:element name="leftFooter" type="tns:Cell" minOccurs="0"/>
+			<xs:element name="centerFooter" type="tns:Cell" minOccurs="0"/>
+			<xs:element name="rightFooter" type="tns:Cell" minOccurs="0"/>
+			<xs:element name="templateMode" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="stepDirection" type="tns:SpreadsheetDocumentStepDirectionType" minOccurs="0"/>
+			<xs:element name="totalsRight" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="totalsBelow" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="defaultFormatIndex" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="height" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="vgLevels" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="vgRows" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="vg" type="tns:Group" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="hg" type="tns:Group" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="verticalPageBreak" type="tns:PageBreak" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="horizontalPageBreak" type="tns:PageBreak" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="merge" type="tns:Merge" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="verticalUnmerge" type="tns:Merge" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="horizontalUnmerge" type="tns:Merge" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="namedItem" type="tns:NamedItem" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="printSettingsName" type="xs:string" minOccurs="0"/>
+			<xs:element name="printSettings" type="tns:PrintSettings" minOccurs="0"/>
+			<xs:element name="printArea" type="tns:Area" minOccurs="0"/>
+			<xs:element name="repeatRows" type="tns:Area" minOccurs="0"/>
+			<xs:element name="repeatColumns" type="tns:Area" minOccurs="0"/>
+			<xs:element name="drawingDataSource" type="tns:DrawingsDataSource" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="groupsBackColor" type="ns2:Color" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="groupsColor" type="ns2:Color" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="headersBackColor" type="ns2:Color" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="headersColor" type="ns2:Color" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="saveViewSettings" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="viewSettings" type="tns:ViewSettings" minOccurs="0"/>
+			<xs:element name="embeddedTable" type="tns:EmbeddedTableItem" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="line" type="ns2:Line" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="font" type="ns2:Font" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="format" type="tns:Format" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="picture" type="tns:Picture" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="usedFileName" type="xs:string" minOccurs="0"/>
+			<xs:element name="output" type="ns2:UseOutput" minOccurs="0"/>
+			<xs:element name="nextInsertionRow" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="nextInsertionCol" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="readOnly" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="protection" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="baseSheet" type="tns:SpreadsheetDocument" minOccurs="0"/>
+			<xs:element name="extensionMethod" type="tns:SpreadsheetDocumentExtensionAlgorithm" minOccurs="0"/>
+			<xs:element name="isCompactMode" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="originalSheet" type="tns:SpreadsheetDocument" minOccurs="0"/>
+			<xs:element name="textDirection" type="ns2:TextDirection" minOccurs="0"/>
+			<xs:element name="savedPicturesDensity" type="tns:SpreadsheetDocumentSavedPicturesDensity" minOccurs="0"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="ViewSettings">
+		<xs:sequence>
+			<xs:element name="currentColumn" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="currentRow" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="scale" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="showGrid" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="showHeaders" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="showNames" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="showGroups" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="showGroupsText" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="showPageBreaks" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="blackAndWhite" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="fixedColumn" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="fixedColumnRow" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="fixedRow" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="fixationPointColumn" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="fixationPointRow" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="topFixationPointColumn" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="topFixationPointRow" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="screenBeginPointColumn" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="screenBeginPointRow" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="showNamedRowsAndColumns" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="showNamedRowsAndColumnsText" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="currentLanguage" type="xs:string" minOccurs="0"/>
+			<xs:element name="showComments" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="selection" type="tns:Area" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="selectedDrawing" type="xs:decimal" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+</xs:schema>

--- a/src/main/xsd/v8.3.27/v8.1c.ru-8.2-managed-application-cmi.xsd
+++ b/src/main/xsd/v8.3.27/v8.1c.ru-8.2-managed-application-cmi.xsd
@@ -1,0 +1,275 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:ns1="http://v8.1c.ru/8.1/data/core" xmlns:ns2="http://v8.1c.ru/8.1/data/ui" xmlns:ns3="http://v8.1c.ru/8.2/uobjects" xmlns:ns4="http://v8.1c.ru/8.2/managed-application/logform" xmlns:ns5="http://v8.1c.ru/8.2/managed-application/modules" xmlns:ns6="http://v8.1c.ru/8.2/managed-application/core" xmlns:ns7="http://v8.1c.ru/8.2/data/bsl" xmlns:tns="http://v8.1c.ru/8.2/managed-application/cmi" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://v8.1c.ru/8.2/managed-application/cmi" attributeFormDefault="unqualified" elementFormDefault="qualified">
+	<xs:import namespace="http://v8.1c.ru/8.1/data/core"/>
+	<xs:import namespace="http://v8.1c.ru/8.1/data/ui"/>
+	<xs:import namespace="http://v8.1c.ru/8.2/uobjects"/>
+	<xs:import namespace="http://v8.1c.ru/8.2/managed-application/logform"/>
+	<xs:import namespace="http://v8.1c.ru/8.2/managed-application/modules"/>
+	<xs:import namespace="http://v8.1c.ru/8.2/managed-application/core"/>
+	<xs:import namespace="http://v8.1c.ru/8.2/data/bsl"/>
+	<xs:element name="command" type="tns:Command"/>
+	<xs:element name="group" type="tns:Group"/>
+	<xs:element name="section" type="tns:Section"/>
+	<xs:simpleType name="CommandParameterUseMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Single"/>
+			<xs:enumeration value="Multiple"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FuncMenuGroupType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Simple"/>
+			<xs:enumeration value="SubSystem"/>
+			<xs:enumeration value="Section"/>
+			<xs:enumeration value="Group"/>
+			<xs:enumeration value="Actions"/>
+			<xs:enumeration value="SeeAlso"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="GroupCategories">
+		<xs:list itemType="tns:GroupCategory"/>
+	</xs:simpleType>
+	<xs:simpleType name="GroupCategory">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="undefined"/>
+			<xs:enumeration value="navigator"/>
+			<xs:enumeration value="form"/>
+			<xs:enumeration value="panel"/>
+			<xs:enumeration value="toolbar"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="ClientCMIStartUpDataType">
+		<xs:sequence>
+			<xs:element name="defaultNPHandleInfo" type="tns:HandlerInfo" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="toplevelSubsystems" type="tns:Fragment" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="urls" type="tns:URLsByNavigationPoints" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="panels" type="tns:Fragment" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="commandsWithShortCuts" type="tns:CommansShortCutInfoVector" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ClientCMIUpdateInterfaceDataType">
+		<xs:sequence>
+			<xs:element name="foVer" type="xs:string" minOccurs="0"/>
+			<xs:element name="defaultNP" type="ns6:NavigationPoint" minOccurs="0"/>
+			<xs:element name="currentNPUrl" type="xs:string" minOccurs="0"/>
+			<xs:element name="startUpData" type="tns:ClientCMIStartUpDataType" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Command">
+		<xs:complexContent>
+			<xs:extension base="tns:CommandInfo">
+				<xs:attribute name="include" type="xs:boolean" default="true"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="CommandIDs">
+		<xs:sequence>
+			<xs:element name="id" type="ns1:CompositeID" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CommandInfo">
+		<xs:choice>
+			<xs:element name="text" type="xs:string" minOccurs="0"/>
+			<xs:element name="tooltip" type="xs:string" minOccurs="0"/>
+			<xs:element name="pic" type="ns2:Picture" minOccurs="0"/>
+			<xs:element name="picSizeCX" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="picSizeCY" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="shortcut" type="ns2:ShortCutType" minOccurs="0"/>
+			<xs:element name="param" type="ns1:TypeDescription" minOccurs="0"/>
+		</xs:choice>
+		<xs:attribute name="id" type="ns1:CompositeID" use="required"/>
+		<xs:attribute name="nameInt" type="xs:string" use="required"/>
+		<xs:attribute name="nameRus" type="xs:string" use="required"/>
+		<xs:attribute name="md" type="xs:string" use="required"/>
+		<xs:attribute name="kind" type="ns4:ButtonRepresentation"/>
+		<xs:attribute name="helpTopic" type="xs:string" use="required"/>
+		<xs:attribute name="url" type="xs:string" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="CommandInterfaceItems">
+		<xs:sequence>
+			<xs:element name="uitems" type="ns3:FormDataTree" minOccurs="0"/>
+			<xs:element name="present" type="ns6:SectionPanelRepresentation" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CommandPath">
+		<xs:sequence>
+			<xs:element name="cmd" type="tns:CommandInfo" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CommandsInfo">
+		<xs:sequence>
+			<xs:element name="info" type="tns:CommandInfo" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CommansShortCutInfo">
+		<xs:sequence>
+			<xs:element name="shortCut" type="ns2:ShortCutType"/>
+			<xs:element name="fragments" type="tns:SubsystemAndPanel" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="commandId" type="ns1:CompositeID"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CommansShortCutInfoVector">
+		<xs:sequence>
+			<xs:element name="info" type="tns:CommansShortCutInfo" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Fragment">
+		<xs:choice>
+			<xs:element ref="tns:command" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element ref="tns:group" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element ref="tns:section" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:choice>
+		<xs:attribute name="kind" type="ns6:SectionPanelRepresentation"/>
+	</xs:complexType>
+	<xs:complexType name="FuncMenuCommand">
+		<xs:sequence>
+			<xs:element name="id" type="ns1:CompositeID" minOccurs="0"/>
+			<xs:element name="url" type="xs:string" minOccurs="0"/>
+			<xs:element name="text" type="xs:string" minOccurs="0"/>
+			<xs:element name="tooltip" type="xs:string" minOccurs="0"/>
+			<xs:element name="picture" type="ns2:Picture" minOccurs="0"/>
+			<xs:element name="shortCut" type="ns2:ShortCutType" minOccurs="0"/>
+			<xs:element name="important" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="highlight" type="tns:FuncMenuHighlight"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="FuncMenuGroup">
+		<xs:sequence>
+			<xs:element name="type" type="tns:FuncMenuGroupType" minOccurs="0"/>
+			<xs:element name="id" type="ns1:CompositeID" minOccurs="0"/>
+			<xs:element name="text" type="xs:string" minOccurs="0"/>
+			<xs:element name="picture" type="ns2:Picture" minOccurs="0"/>
+			<xs:element name="newColumn" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="command" type="tns:FuncMenuCommand" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="group" type="tns:FuncMenuGroup" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="highlight" type="tns:FuncMenuHighlight"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="FuncMenuHighlight">
+		<xs:attribute name="position" type="xs:decimal"/>
+		<xs:attribute name="length" type="xs:decimal"/>
+	</xs:complexType>
+	<xs:complexType name="Group">
+		<xs:complexContent>
+			<xs:extension base="tns:GroupInfo">
+				<xs:choice>
+					<xs:element ref="tns:command" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element ref="tns:group" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element ref="tns:section" minOccurs="0" maxOccurs="unbounded"/>
+				</xs:choice>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="GroupInfo">
+		<xs:choice>
+			<xs:element name="text" type="xs:string" minOccurs="0"/>
+			<xs:element name="tooltip" type="xs:string" minOccurs="0"/>
+			<xs:element name="pic" type="ns2:Picture" minOccurs="0"/>
+			<xs:element name="picSizeCX" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="picSizeCY" type="xs:decimal" minOccurs="0"/>
+		</xs:choice>
+		<xs:attribute name="id" type="ns1:UUID" use="required"/>
+		<xs:attribute name="cat" type="tns:GroupCategory"/>
+		<xs:attribute name="order" type="xs:decimal"/>
+		<xs:attribute name="kind" type="ns4:ButtonRepresentation"/>
+	</xs:complexType>
+	<xs:complexType name="HandlerInfo">
+		<xs:sequence>
+			<xs:element name="formId" type="ns1:CompositeID"/>
+			<xs:element name="formName" type="xs:string" minOccurs="0"/>
+			<xs:element name="moduleInfo" type="tns:ModuleInfo" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="name" type="xs:string" minOccurs="0"/>
+			<xs:element name="nameRu" type="xs:string" minOccurs="0"/>
+			<xs:element name="listFilter" type="xs:boolean"/>
+			<xs:element name="param" type="xs:string" minOccurs="0"/>
+			<xs:element name="usageMode" type="tns:CommandParameterUseMode"/>
+			<xs:element name="modifiesData" type="xs:boolean"/>
+			<xs:element name="createGroupCommand" type="xs:boolean"/>
+		</xs:sequence>
+		<xs:attribute name="theme" type="xs:boolean"/>
+		<xs:attribute name="subTheme" type="xs:boolean"/>
+		<xs:attribute name="standard" type="xs:boolean"/>
+		<xs:attribute name="defGroupCat" type="tns:GroupCategory"/>
+	</xs:complexType>
+	<xs:complexType name="HandlerInfoByID">
+		<xs:sequence>
+			<xs:element name="id" type="ns1:CompositeID"/>
+			<xs:element name="handleInfo" type="tns:HandlerInfo" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="HandlerInfoEx">
+		<xs:complexContent>
+			<xs:extension base="tns:HandlerInfo">
+				<xs:sequence>
+					<xs:element name="moduleInfoEx" type="tns:ModuleInfoEx" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="url" type="xs:string" minOccurs="0"/>
+					<xs:element name="presentation" type="xs:string" minOccurs="0"/>
+					<xs:element name="shortPresentation" type="xs:string" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="HandlersInfosVector">
+		<xs:sequence>
+			<xs:element name="item" type="tns:HandlerInfoByID" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ModuleInfo">
+		<xs:sequence>
+			<xs:element name="securityInfo" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="moduleId" type="xs:string"/>
+		<xs:attribute name="moduleName" type="xs:string"/>
+	</xs:complexType>
+	<xs:complexType name="ModuleInfoEx">
+		<xs:sequence>
+			<xs:element name="clnModule" type="xs:string" minOccurs="0"/>
+			<xs:element name="mtd" type="ns5:MethodDefs" minOccurs="0"/>
+			<xs:element name="moduleImage" type="ns7:BSLModuleImage" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Section">
+		<xs:complexContent>
+			<xs:extension base="tns:SectionInfo">
+				<xs:choice>
+					<xs:element ref="tns:command" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element ref="tns:group" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element ref="tns:section" minOccurs="0" maxOccurs="unbounded"/>
+				</xs:choice>
+				<xs:attribute name="include" type="xs:boolean" default="true"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="SectionInfo">
+		<xs:choice>
+			<xs:element name="text" type="xs:string" minOccurs="0"/>
+			<xs:element name="tooltip" type="xs:string" minOccurs="0"/>
+			<xs:element name="pic" type="ns2:Picture" minOccurs="0"/>
+			<xs:element name="picSizeCX" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="picSizeCY" type="xs:decimal" minOccurs="0"/>
+		</xs:choice>
+		<xs:attribute name="id" type="ns1:UUID" use="required"/>
+		<xs:attribute name="name" type="xs:string" use="required"/>
+		<xs:attribute name="helpTopic" type="xs:string" use="required"/>
+		<xs:attribute name="oneCommandSubsystem" type="xs:boolean" default="false"/>
+	</xs:complexType>
+	<xs:complexType name="SubsystemAndPanel">
+		<xs:sequence>
+			<xs:element name="subsystem" type="ns1:UUID"/>
+			<xs:element name="panel" type="xs:decimal"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="URLByNavigationPoint">
+		<xs:sequence>
+			<xs:element name="np" type="ns6:NavigationPoint"/>
+			<xs:element name="url" type="xs:string"/>
+			<xs:element name="presentation" type="xs:string"/>
+			<xs:element name="shortPresentation" type="xs:string"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="URLsByNavigationPoints">
+		<xs:sequence>
+			<xs:element name="data" type="tns:URLByNavigationPoint" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+</xs:schema>

--- a/src/main/xsd/v8.3.27/v8.1c.ru-8.2-managed-application-core.xsd
+++ b/src/main/xsd/v8.3.27/v8.1c.ru-8.2-managed-application-core.xsd
@@ -1,0 +1,1109 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:ns1="http://v8.1c.ru/8.1/data/core" xmlns:ns2="http://v8.1c.ru/8.1/data/ui" xmlns:ns3="http://v8.1c.ru/8.1/data/enterprise" xmlns:ns4="http://v8.1c.ru/8.2/data/bsl" xmlns:tns="http://v8.1c.ru/8.2/managed-application/core" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://v8.1c.ru/8.2/managed-application/core" attributeFormDefault="unqualified" elementFormDefault="qualified">
+	<xs:import namespace="http://v8.1c.ru/8.1/data/core"/>
+	<xs:import namespace="http://v8.1c.ru/8.1/data/ui"/>
+	<xs:import namespace="http://v8.1c.ru/8.1/data/enterprise"/>
+	<xs:import namespace="http://v8.1c.ru/8.2/data/bsl"/>
+	<xs:element name="ClientApplicationInterface" type="tns:InterfaceLayouter"/>
+	<xs:simpleType name="Alias">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="en"/>
+			<xs:enumeration value="ru"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ApplicationUsePurpose">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="PlatformApplication"/>
+			<xs:enumeration value="MobilePlatformApplication"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ClientRunMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="ManagedApplication"/>
+			<xs:enumeration value="OrdinaryApplication"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CommandGroupCategory">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="NavigationPanel"/>
+			<xs:enumeration value="ActionsPanel"/>
+			<xs:enumeration value="FormNavigationPanel"/>
+			<xs:enumeration value="FormCommandBar"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ErrorMessageDisplayVariant">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="ErrorMessageForUser"/>
+			<xs:enumeration value="BriefErrorDescription"/>
+			<xs:enumeration value="DetailErrorDescription"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ErrorReportingMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="DontSend"/>
+			<xs:enumeration value="AskUser"/>
+			<xs:enumeration value="Send"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="MainWindowMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Normal"/>
+			<xs:enumeration value="Workplace"/>
+			<xs:enumeration value="FullscreenWorkplace"/>
+			<xs:enumeration value="Kiosk"/>
+			<xs:enumeration value="EmbeddedWorkplace"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="MobileApplicationFunctionalities">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Biometrics"/>
+			<xs:enumeration value="Location"/>
+			<xs:enumeration value="BackgroundLocation"/>
+			<xs:enumeration value="BluetoothPrinters"/>
+			<xs:enumeration value="WiFiPrinters"/>
+			<xs:enumeration value="Contacts"/>
+			<xs:enumeration value="Calendars"/>
+			<xs:enumeration value="PushNotifications"/>
+			<xs:enumeration value="LocalNotifications"/>
+			<xs:enumeration value="InAppPurchases"/>
+			<xs:enumeration value="PersonalComputerFileExchange"/>
+			<xs:enumeration value="Ads"/>
+			<xs:enumeration value="NumberDialing"/>
+			<xs:enumeration value="CallProcessing"/>
+			<xs:enumeration value="CallLog"/>
+			<xs:enumeration value="AutoSendSMS"/>
+			<xs:enumeration value="ReceiveSMS"/>
+			<xs:enumeration value="SMSLog"/>
+			<xs:enumeration value="Camera"/>
+			<xs:enumeration value="Microphone"/>
+			<xs:enumeration value="MusicLibrary"/>
+			<xs:enumeration value="PictureAndVideoLibraries"/>
+			<xs:enumeration value="AudioPlaybackAndVibration"/>
+			<xs:enumeration value="BackgroundAudioPlaybackAndVibration"/>
+			<xs:enumeration value="InstallPackages"/>
+			<xs:enumeration value="OSBackup"/>
+			<xs:enumeration value="ApplicationUsageStatistics"/>
+			<xs:enumeration value="BarcodeScanning"/>
+			<xs:enumeration value="BackgroundAudioRecording"/>
+			<xs:enumeration value="AllFilesAccess"/>
+			<xs:enumeration value="Videoconferences"/>
+			<xs:enumeration value="NFC"/>
+			<xs:enumeration value="DocumentScanning"/>
+			<xs:enumeration value="Geofences"/>
+			<xs:enumeration value="IncomingShareRequests"/>
+			<xs:enumeration value="AllIncomingShareRequestsTypesProcessing"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="RequiredMobileApplicationPermissionMessages">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Biometrics"/>
+			<xs:enumeration value="Location"/>
+			<xs:enumeration value="BackgroundLocation"/>
+			<xs:enumeration value="BluetoothPrinters"/>
+			<xs:enumeration value="Contacts"/>
+			<xs:enumeration value="Calendars"/>
+			<xs:enumeration value="NumberDialing"/>
+			<xs:enumeration value="CallProcessing"/>
+			<xs:enumeration value="CallLog"/>
+			<xs:enumeration value="AutoSendSMS"/>
+			<xs:enumeration value="ReceiveSMS"/>
+			<xs:enumeration value="SMSLog"/>
+			<xs:enumeration value="Camera"/>
+			<xs:enumeration value="Microphone"/>
+			<xs:enumeration value="MusicLibrary"/>
+			<xs:enumeration value="PictureAndVideoLibraries"/>
+			<xs:enumeration value="AudioPlaybackAndVibration"/>
+			<xs:enumeration value="PermissionGroupPhone"/>
+			<xs:enumeration value="PermissionGroupCallLog"/>
+			<xs:enumeration value="PermissionGroupSMS"/>
+			<xs:enumeration value="PostNotifications"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="RequiredMobileApplicationPermissions">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Multimedia"/>
+			<xs:enumeration value="Location"/>
+			<xs:enumeration value="Contacts"/>
+			<xs:enumeration value="Calendars"/>
+			<xs:enumeration value="Telephony"/>
+			<xs:enumeration value="PushNotification"/>
+			<xs:enumeration value="LocalNotification"/>
+			<xs:enumeration value="Print"/>
+			<xs:enumeration value="InAppPurchases"/>
+			<xs:enumeration value="Ads"/>
+			<xs:enumeration value="BackgroundLocation"/>
+			<xs:enumeration value="BackgroundAudioPlayback"/>
+			<xs:enumeration value="FileExchangeWithPersonalComputer"/>
+			<xs:enumeration value="CallPhone"/>
+			<xs:enumeration value="HandlePhoneCalls"/>
+			<xs:enumeration value="CallLog"/>
+			<xs:enumeration value="SendSMS"/>
+			<xs:enumeration value="ReceiveSMS"/>
+			<xs:enumeration value="SMSLog"/>
+			<xs:enumeration value="Camera"/>
+			<xs:enumeration value="Microphone"/>
+			<xs:enumeration value="MusicLibrary"/>
+			<xs:enumeration value="PicturesAndVideoLibraries"/>
+			<xs:enumeration value="AudioAndVibrationPlayback"/>
+			<xs:enumeration value="PermissionGroupPhone"/>
+			<xs:enumeration value="PermissionGroupCallLog"/>
+			<xs:enumeration value="PermissionGroupSMS"/>
+			<xs:enumeration value="InstallPackages"/>
+			<xs:enumeration value="AllowOSBackup"/>
+			<xs:enumeration value="Biometrics"/>
+			<xs:enumeration value="BluetoothPrinters"/>
+			<xs:enumeration value="WiFiPrinters"/>
+			<xs:enumeration value="AllFilesAccess"/>
+			<xs:enumeration value="Videoconferences"/>
+			<xs:enumeration value="NFC"/>
+			<xs:enumeration value="PostNotifications"/>
+			<xs:enumeration value="Geofences"/>
+			<xs:enumeration value="IncomingShareRequests"/>
+			<xs:enumeration value="AllIncomingShareRequestsTypesProcessing"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SectionPanelRepresentation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Picture"/>
+			<xs:enumeration value="PictureAndText"/>
+			<xs:enumeration value="Text"/>
+			<xs:enumeration value="PictureOnTopAndText"/>
+			<xs:enumeration value="PictureOnLeftAndText"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="StandardGlobalSearchType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="UserWorkFavorites"/>
+			<xs:enumeration value="UserWorkHistory"/>
+			<xs:enumeration value="FunctionsMenu"/>
+			<xs:enumeration value="CollaborationSystemConversations"/>
+			<xs:enumeration value="CollaborationSystemMessages"/>
+			<xs:enumeration value="Data"/>
+			<xs:enumeration value="Help"/>
+			<xs:enumeration value="Expression"/>
+			<xs:enumeration value="URL"/>
+			<xs:enumeration value="FunctionsForTechnicalSpecialist"/>
+			<xs:enumeration value="GlobalStandardCommands"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="StyleEntryKind">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="color"/>
+			<xs:enumeration value="font"/>
+			<xs:enumeration value="border"/>
+			<xs:enumeration value="line"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="AboutInfo">
+		<xs:sequence>
+			<xs:element name="title" type="xs:string"/>
+			<xs:element name="user" type="xs:string"/>
+			<xs:element name="config" type="xs:string"/>
+			<xs:element name="logo" type="ns2:Picture" minOccurs="0"/>
+			<xs:element name="presentation" type="xs:string"/>
+			<xs:element name="runMode" type="xs:string" minOccurs="0"/>
+			<xs:element name="compress" type="xs:string" minOccurs="0"/>
+			<xs:element name="configLicenseInfo" type="xs:string"/>
+			<xs:element name="version" type="xs:string" minOccurs="0"/>
+			<xs:element name="developerInfo" type="xs:string" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="AllowedIncomingShareRequestType">
+		<xs:sequence>
+			<xs:element name="mime" type="xs:string"/>
+			<xs:element name="uti" type="xs:string"/>
+			<xs:element name="ext" type="xs:string"/>
+			<xs:element name="processingVariant" type="xs:integer"/>
+			<xs:element name="isCustom" type="xs:boolean"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="AllowedIncomingShareRequestTypes">
+		<xs:sequence>
+			<xs:element name="allowedIncomingShareRequestType" type="tns:AllowedIncomingShareRequestType" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ApplicationInfo">
+		<xs:sequence>
+			<xs:element name="infoBaseInstanceID" type="ns1:UUID"/>
+			<xs:element name="infoBaseAlias" type="xs:string"/>
+			<xs:element name="locale" type="tns:LocaleInfo" minOccurs="0"/>
+			<xs:element name="langs" type="tns:LangSettings"/>
+			<xs:element name="config" type="ns1:ObjectVersion"/>
+			<xs:element name="types" type="xs:string"/>
+			<xs:element name="user" type="ns1:UUID"/>
+			<xs:element name="rolesID" type="xs:decimal"/>
+			<xs:element name="seance" type="ns1:UUID"/>
+			<xs:element name="seanceNo" type="xs:decimal"/>
+			<xs:element name="userRunMode" type="xs:decimal"/>
+			<xs:element name="configRunMode" type="xs:decimal"/>
+			<xs:element name="splash" type="tns:SplashInfo" minOccurs="0"/>
+			<xs:element name="fullLocale" type="tns:MngLocale" minOccurs="0"/>
+			<xs:element name="compatibilityMode" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="compatibilityModeLive" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="userSeparatorsEmpty" type="xs:boolean"/>
+			<xs:element name="training" type="xs:boolean"/>
+			<xs:element name="modalityUseMode" type="xs:decimal"/>
+			<xs:element name="rigthClientsStart" type="xs:decimal"/>
+			<xs:element name="syncCallsUseMode" type="xs:decimal"/>
+			<xs:element name="assemblyVersion" type="ns1:ObjectVersion"/>
+			<xs:element name="interactiveSecurity" type="xs:boolean"/>
+			<xs:element name="defaultPaperWidth" type="xs:decimal"/>
+			<xs:element name="defaultPaperHeight" type="xs:decimal"/>
+			<xs:element name="serverVersion" type="xs:string" minOccurs="0"/>
+			<xs:element name="beginningOfCentury" type="xs:decimal"/>
+			<xs:element name="authMessage" type="xs:string" minOccurs="0"/>
+			<xs:element name="infoBaseInFileMode" type="xs:boolean"/>
+			<xs:element name="countryUA" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="objectFileExtensionChrome" type="xs:string"/>
+			<xs:element name="objectFileExtensionFirefox" type="xs:string"/>
+			<xs:element name="objectFileExtensionIE" type="xs:string"/>
+			<xs:element name="objectFileExtensionSafari" type="xs:string"/>
+			<xs:element name="objectFileExtensionAnyChromiumBased" type="xs:string"/>
+			<xs:element name="objectFileExtensionChromiumGost" type="xs:string"/>
+			<xs:element name="objectFileExtensionYandex" type="xs:string"/>
+			<xs:element name="objectFileExtensionEdge" type="xs:string"/>
+			<xs:element name="objectCryptoExtensionChrome" type="xs:string"/>
+			<xs:element name="objectCryptoExtensionFirefox" type="xs:string"/>
+			<xs:element name="objectCryptoExtensionIE" type="xs:string"/>
+			<xs:element name="objectCryptoExtensionSafari" type="xs:string"/>
+			<xs:element name="objectCryptoExtensionAnyChromiumBased" type="xs:string"/>
+			<xs:element name="objectCryptoExtensionChromiumGost" type="xs:string"/>
+			<xs:element name="objectCryptoExtensionYandex" type="xs:string"/>
+			<xs:element name="objectCryptoExtensionEdge" type="xs:string"/>
+			<xs:element name="objectAgentExtensionChrome" type="xs:string"/>
+			<xs:element name="objectAgentExtensionFirefox" type="xs:string"/>
+			<xs:element name="objectAgentExtensionIE" type="xs:string"/>
+			<xs:element name="objectAgentExtensionSafari" type="xs:string"/>
+			<xs:element name="objectAgentExtensionAnyChromiumBased" type="xs:string"/>
+			<xs:element name="objectAgentExtensionChromiumGost" type="xs:string"/>
+			<xs:element name="objectAgentExtensionYandex" type="xs:string"/>
+			<xs:element name="objectAgentExtensionEdge" type="xs:string"/>
+			<xs:element name="objectCompInfoExtensionChrome" type="xs:string"/>
+			<xs:element name="objectCompInfoExtensionFirefox" type="xs:string"/>
+			<xs:element name="objectCompInfoExtensionIE" type="xs:string"/>
+			<xs:element name="objectCompInfoExtensionSafari" type="xs:string"/>
+			<xs:element name="objectCompInfoExtensionAnyChromiumBased" type="xs:string"/>
+			<xs:element name="objectCompInfoExtensionChromiumGost" type="xs:string"/>
+			<xs:element name="objectCompInfoExtensionYandex" type="xs:string"/>
+			<xs:element name="objectCompInfoExtensionEdge" type="xs:string"/>
+			<xs:element name="credAns4" type="xs:string" minOccurs="0"/>
+			<xs:element name="credAns6" type="xs:string" minOccurs="0"/>
+			<xs:element name="passwordRequirementsComplianceStatus" type="xs:decimal"/>
+			<xs:element name="passwordExpirationTicksLeft" type="xs:decimal"/>
+			<xs:element name="passwordMinLength" type="xs:decimal"/>
+			<xs:element name="cannotChangePassword" type="xs:boolean"/>
+			<xs:element name="seanceLicenseInfoPrs" type="xs:string" minOccurs="0"/>
+			<xs:element name="passwordExpirationStatus" type="xs:decimal"/>
+		</xs:sequence>
+		<xs:attribute name="confNotSaved" type="xs:boolean"/>
+		<xs:attribute name="noFontsOnServer" type="xs:boolean"/>
+		<xs:attribute name="noFontConfigOnServer" type="xs:boolean"/>
+		<xs:attribute name="needUpdateMCSignature" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="BinaryDataQualifiers">
+		<xs:attribute name="length" type="xs:decimal" default="0"/>
+		<xs:attribute name="varying" type="xs:boolean" default="true"/>
+	</xs:complexType>
+	<xs:complexType name="BoolFormat">
+		<xs:attribute name="true" type="xs:string"/>
+		<xs:attribute name="false" type="xs:string"/>
+	</xs:complexType>
+	<xs:complexType name="ChoiceParameter">
+		<xs:sequence>
+			<xs:element name="name" type="xs:string"/>
+			<xs:element name="mode" type="ns3:LinkedValueChangeMode"/>
+			<xs:element name="pathItem" type="ns1:CompositeID" maxOccurs="unbounded"/>
+			<xs:element name="webDataPath" type="xs:string" minOccurs="0"/>
+			<xs:element name="strPath" type="xs:string" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ChoiceParameterItem">
+		<xs:sequence>
+			<xs:element name="value"/>
+		</xs:sequence>
+		<xs:attribute name="name" type="xs:string"/>
+	</xs:complexType>
+	<xs:complexType name="ChoiceParameterLink">
+		<xs:sequence>
+			<xs:element name="dataPath" type="xs:string"/>
+		</xs:sequence>
+		<xs:attribute name="name" type="xs:string"/>
+		<xs:attribute name="mode" type="ns3:LinkedValueChangeMode"/>
+	</xs:complexType>
+	<xs:complexType name="ChoiceParameterLinks">
+		<xs:sequence>
+			<xs:element name="item" type="tns:ChoiceParameter" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ChoiceParameters">
+		<xs:sequence>
+			<xs:element name="item" type="tns:ChoiceParameterItem" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ClientDisplayInformation">
+		<xs:attribute name="x" type="xs:decimal"/>
+		<xs:attribute name="y" type="xs:decimal"/>
+		<xs:attribute name="dpi" type="xs:decimal"/>
+	</xs:complexType>
+	<xs:complexType name="ConstValueKey">
+		<xs:complexContent>
+			<xs:extension base="tns:Type">
+				<xs:sequence>
+					<xs:element name="sep" type="tns:ConstValueKeySep"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="ConstValueKeySep">
+		<xs:attribute name="name" type="xs:NCName"/>
+		<xs:attribute name="type" type="xs:QName"/>
+	</xs:complexType>
+	<xs:complexType name="ConstValueKeyTypeSet">
+		<xs:complexContent>
+			<xs:extension base="tns:TypeSetDef">
+				<xs:sequence>
+					<xs:element name="type" type="tns:ConstValueKey" minOccurs="0" maxOccurs="unbounded"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="DateFormat">
+		<xs:attribute name="shortDate" type="xs:string"/>
+		<xs:attribute name="time" type="xs:string"/>
+	</xs:complexType>
+	<xs:complexType name="DateQualifiers">
+		<xs:attribute name="fractions" type="ns1:DateFractions" default="DateTime"/>
+	</xs:complexType>
+	<xs:complexType name="DesktopFormInfo">
+		<xs:attribute name="id" type="xs:string"/>
+		<xs:attribute name="height" type="xs:decimal"/>
+		<xs:attribute name="visible" type="xs:boolean" default="true"/>
+		<xs:attribute name="title" type="xs:string"/>
+	</xs:complexType>
+	<xs:complexType name="DesktopInfo">
+		<xs:sequence>
+			<xs:element name="left" type="tns:DesktopFormInfo" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="right" type="tns:DesktopFormInfo" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="state" type="xs:decimal"/>
+		<xs:attribute name="commandInterfaceDisplays" type="xs:decimal"/>
+	</xs:complexType>
+	<xs:complexType name="Enum">
+		<xs:complexContent>
+			<xs:extension base="tns:Type">
+				<xs:sequence>
+					<xs:element name="val" type="tns:EnumValue" maxOccurs="unbounded"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="EnumPresentations">
+		<xs:sequence>
+			<xs:element name="val" type="xs:string" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="EnumTypeSet">
+		<xs:complexContent>
+			<xs:extension base="tns:TypeSetDef">
+				<xs:sequence>
+					<xs:element name="type" type="tns:Enum" minOccurs="0" maxOccurs="unbounded"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="EnumVal">
+		<xs:attribute name="uuid" type="ns1:UUID"/>
+		<xs:attribute name="code" type="xs:string"/>
+		<xs:attribute name="presentation" type="xs:string"/>
+	</xs:complexType>
+	<xs:complexType name="EnumVals">
+		<xs:sequence>
+			<xs:element name="enumVals" type="tns:EnumVal" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="EnumValue">
+		<xs:attribute name="uuid" type="ns1:UUID" use="required"/>
+		<xs:attribute name="code" type="xs:string"/>
+	</xs:complexType>
+	<xs:complexType name="ErrorMessageTemplatesCollectionItem">
+		<xs:sequence>
+			<xs:element name="category" type="ns1:ErrorCategory"/>
+			<xs:element name="messageTemplate" type="tns:ErrorMessageTexts"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ErrorMessageTexts">
+		<xs:sequence>
+			<xs:element name="templateNotRequiresRestartFormatted" type="xs:boolean"/>
+			<xs:element name="templateNotRequiresRestart" type="xs:string"/>
+			<xs:element name="templateRequiresRestartFormatted" type="xs:boolean"/>
+			<xs:element name="templateRequiresRestart" type="xs:string"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ErrorMessagesTexts">
+		<xs:sequence>
+			<xs:element name="item" type="tns:ErrorMessageTemplatesCollectionItem" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ErrorOnStartupProcessingSettings">
+		<xs:sequence>
+			<xs:element name="helpTextFormatted" type="xs:boolean"/>
+			<xs:element name="helpText" type="xs:string"/>
+			<xs:element name="helpUrl" type="xs:string" minOccurs="0"/>
+			<xs:element name="serviceUrl" type="xs:string" minOccurs="0"/>
+			<xs:element name="additionalInfo" type="xs:string" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ErrorProcessingSettings">
+		<xs:sequence>
+			<xs:element name="descriptionLevel" type="tns:ErrorMessageDisplayVariant" minOccurs="0"/>
+			<xs:element name="serverUrl" type="xs:string" minOccurs="0"/>
+			<xs:element name="createReportMode" type="tns:ErrorReportingMode" minOccurs="0"/>
+			<xs:element name="createCrashReport" type="tns:ErrorReportingMode" minOccurs="0"/>
+			<xs:element name="addUserName" type="tns:ErrorReportingMode" minOccurs="0"/>
+			<xs:element name="addSystemInfo" type="tns:ErrorReportingMode" minOccurs="0"/>
+			<xs:element name="addScreenshot" type="tns:ErrorReportingMode" minOccurs="0"/>
+			<xs:element name="addErrorFullDescription" type="tns:ErrorReportingMode" minOccurs="0"/>
+			<xs:element name="addConfigInfo" type="tns:ErrorReportingMode" minOccurs="0"/>
+			<xs:element name="sendCrashReportTo1C" type="tns:ErrorReportingMode" minOccurs="0"/>
+			<xs:element name="additionalInfo" type="xs:string" minOccurs="0"/>
+			<xs:element name="messageTemplates" type="tns:ErrorMessagesTexts" minOccurs="0"/>
+			<xs:element name="createReportModeOnServer" type="tns:ErrorReportingMode" minOccurs="0"/>
+			<xs:element name="createCrashReportOnServer" type="tns:ErrorReportingMode" minOccurs="0"/>
+			<xs:element name="sendCrashReportOnServerTo1C" type="tns:ErrorReportingMode" minOccurs="0"/>
+			<xs:element name="addUserNameOnServer" type="tns:ErrorReportingMode" minOccurs="0"/>
+			<xs:element name="addErrorFullDescriptionOnServer" type="tns:ErrorReportingMode" minOccurs="0"/>
+			<xs:element name="addConfigInfoOnServer" type="tns:ErrorReportingMode" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ExtKey">
+		<xs:complexContent>
+			<xs:extension base="tns:Type">
+				<xs:sequence>
+					<xs:element name="key" type="tns:ExtKeyKey"/>
+				</xs:sequence>
+				<xs:attribute name="present" type="xs:string"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="ExtKeyKey">
+		<xs:attribute name="name" type="xs:NCName"/>
+		<xs:attribute name="type" type="xs:QName"/>
+	</xs:complexType>
+	<xs:complexType name="ExtKeyTypeSet">
+		<xs:sequence>
+			<xs:element name="type" type="tns:ExtKey" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="en" type="xs:NCName"/>
+		<xs:attribute name="ru" type="xs:NCName"/>
+	</xs:complexType>
+	<xs:complexType name="ExtRefTypeSet">
+		<xs:sequence>
+			<xs:element name="type" type="tns:ExtReference" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="en" type="xs:NCName"/>
+		<xs:attribute name="ru" type="xs:NCName"/>
+	</xs:complexType>
+	<xs:complexType name="ExtReference">
+		<xs:complexContent>
+			<xs:extension base="tns:Type">
+				<xs:sequence>
+					<xs:element name="tdp" type="ns1:TypeDescription" minOccurs="0"/>
+				</xs:sequence>
+				<xs:attribute name="valueType" type="xs:QName"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="GlobalSearchFetch">
+		<xs:sequence>
+			<xs:element name="id" type="ns1:UUID"/>
+		</xs:sequence>
+		<xs:attribute name="cancel" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="GlobalSearchHistory">
+		<xs:sequence>
+			<xs:element name="item" type="tns:GlobalSearchHistoryItem" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="GlobalSearchHistoryItem">
+		<xs:sequence>
+			<xs:element name="searchString" type="xs:string"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="GlobalSearchQuery">
+		<xs:sequence>
+			<xs:element name="id" type="ns1:UUID"/>
+			<xs:element name="item" type="tns:GlobalSearchQueryItem" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="pattern" type="xs:string" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="GlobalSearchQueryItem">
+		<xs:sequence>
+			<xs:element name="params"/>
+		</xs:sequence>
+		<xs:attribute name="type" type="tns:StandardGlobalSearchType"/>
+		<xs:attribute name="module" type="xs:string"/>
+		<xs:attribute name="method" type="xs:string"/>
+		<xs:attribute name="requestId" type="xs:decimal"/>
+		<xs:attribute name="async" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="GlobalSearchResult">
+		<xs:sequence>
+			<xs:element name="item" type="tns:GlobalSearchResultItem" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="more" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="GlobalSearchResultItem">
+		<xs:sequence>
+			<xs:element name="presentation" type="xs:string" minOccurs="0"/>
+			<xs:element name="presentationFmt" type="xs:string" minOccurs="0"/>
+			<xs:element name="description" type="xs:string" minOccurs="0"/>
+			<xs:element name="descriptionFmt" type="xs:string" minOccurs="0"/>
+			<xs:element name="value"/>
+			<xs:element name="picture" type="ns2:Picture"/>
+			<xs:element name="actions" type="tns:GlobalSearchResultItemActionCollection"/>
+		</xs:sequence>
+		<xs:attribute name="type" type="tns:StandardGlobalSearchType"/>
+		<xs:attribute name="typeStr" type="xs:string"/>
+		<xs:attribute name="requestId" type="xs:decimal"/>
+	</xs:complexType>
+	<xs:complexType name="GlobalSearchResultItemAction">
+		<xs:sequence>
+			<xs:element name="value"/>
+			<xs:element name="text" type="xs:string" minOccurs="0"/>
+			<xs:element name="formatted" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="picture" type="ns2:Picture"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="GlobalSearchResultItemActionCollection">
+		<xs:sequence>
+			<xs:element name="item" type="tns:GlobalSearchResultItemAction" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="InfoRegKey">
+		<xs:complexContent>
+			<xs:extension base="tns:Type">
+				<xs:sequence>
+					<xs:element name="dim" type="tns:InfoRegKeyDim"/>
+					<xs:element name="sep" type="tns:InfoRegKeyDim"/>
+				</xs:sequence>
+				<xs:attribute name="recorder" type="xs:QName"/>
+				<xs:attribute name="period" type="xs:boolean"/>
+				<xs:attribute name="present" type="xs:string"/>
+				<xs:attribute name="timePeriodicity" type="xs:boolean"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="InfoRegKeyDim">
+		<xs:attribute name="name" type="xs:NCName"/>
+		<xs:attribute name="type" type="xs:QName"/>
+	</xs:complexType>
+	<xs:complexType name="InfoRegKeyTypeSet">
+		<xs:complexContent>
+			<xs:extension base="tns:TypeSetDef">
+				<xs:sequence>
+					<xs:element name="type" type="tns:InfoRegKey" minOccurs="0" maxOccurs="unbounded"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="InterfaceLayouter">
+		<xs:sequence>
+			<xs:element name="top" type="tns:PanelLayouter" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="left" type="tns:PanelLayouter" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="right" type="tns:PanelLayouter" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="bottom" type="tns:PanelLayouter" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="panelDef" type="tns:PanelDef" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="LFEFChoiceHistory">
+		<xs:sequence>
+			<xs:element name="group" type="tns:LFEFChoiceHistoryGroup"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="LFEFChoiceHistoryGroup">
+		<xs:sequence>
+			<xs:element name="choiceParams" type="tns:ChoiceParameters" minOccurs="0"/>
+			<xs:element name="usage" type="ns3:FoldersAndItemsUse" minOccurs="0"/>
+			<xs:element name="items" type="tns:LFEFChoiceHistoryItems" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="LFEFChoiceHistoryItem">
+		<xs:sequence>
+			<xs:element name="value" nillable="true"/>
+			<xs:element name="presentation" type="xs:string" minOccurs="0"/>
+			<xs:element name="score" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="lastHitDate" type="xs:dateTime" minOccurs="0"/>
+			<xs:element name="sample" type="tns:LFEFChoiceHistorySample"/>
+			<xs:element name="deleted" type="xs:boolean" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="LFEFChoiceHistoryItems">
+		<xs:sequence>
+			<xs:element name="item" type="tns:LFEFChoiceHistoryItem" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="LFEFChoiceHistorySample">
+		<xs:attribute name="date" type="xs:dateTime"/>
+		<xs:attribute name="hits" type="xs:decimal"/>
+	</xs:complexType>
+	<xs:complexType name="LangSettings">
+		<xs:sequence>
+			<xs:element name="lang" type="tns:LanguageInfo"/>
+		</xs:sequence>
+		<xs:attribute name="current" type="xs:string"/>
+		<xs:attribute name="default" type="xs:string"/>
+		<xs:attribute name="alias" type="tns:Alias"/>
+	</xs:complexType>
+	<xs:complexType name="LanguageInfo">
+		<xs:simpleContent>
+			<xs:extension base="xs:string">
+				<xs:attribute name="code" type="xs:string"/>
+				<xs:attribute name="id" type="xs:string"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:complexType name="LocaleBoolFormat">
+		<xs:attribute name="falseName" type="xs:string"/>
+		<xs:attribute name="trueName" type="xs:string"/>
+	</xs:complexType>
+	<xs:complexType name="LocaleDateFormat">
+		<xs:choice>
+			<xs:element name="longDayNames" type="xs:string" minOccurs="7" maxOccurs="7"/>
+			<xs:element name="shortDayNames" type="xs:string" minOccurs="7" maxOccurs="7"/>
+			<xs:element name="longMonthNames" type="xs:string" minOccurs="12" maxOccurs="12"/>
+			<xs:element name="shortMonthNames" type="xs:string" minOccurs="12" maxOccurs="12"/>
+			<xs:element name="longAloneMonthNames" type="xs:string" minOccurs="12" maxOccurs="12"/>
+			<xs:element name="shortAloneMonthNames" type="xs:string" minOccurs="12" maxOccurs="12"/>
+		</xs:choice>
+		<xs:attribute name="fullDatePattern" type="xs:string"/>
+		<xs:attribute name="longDatePattern" type="xs:string"/>
+		<xs:attribute name="shortDatePattern" type="xs:string"/>
+		<xs:attribute name="timePattern" type="xs:string"/>
+		<xs:attribute name="shortTimePattern" type="xs:string"/>
+		<xs:attribute name="longDateTimePattern" type="xs:string"/>
+		<xs:attribute name="shortDateTimePattern" type="xs:string"/>
+		<xs:attribute name="amPmMarkers" type="xs:string"/>
+	</xs:complexType>
+	<xs:complexType name="LocaleInfo">
+		<xs:sequence>
+			<xs:element name="bool" type="tns:BoolFormat" minOccurs="0"/>
+			<xs:element name="date" type="tns:DateFormat" minOccurs="0"/>
+			<xs:element name="numeric" type="tns:NumericFormat" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="name" type="xs:string"/>
+		<xs:attribute name="useSeanceFormats" type="xs:boolean"/>
+		<xs:attribute name="firstDayOfWeek" type="xs:int" default="0"/>
+	</xs:complexType>
+	<xs:complexType name="LocaleNumericFormat">
+		<xs:attribute name="decimalSeparator" type="xs:string"/>
+		<xs:attribute name="groupingSeparator" type="xs:string"/>
+		<xs:attribute name="groupingSize" type="xs:decimal"/>
+		<xs:attribute name="secondaryGroupingSize" type="xs:decimal"/>
+		<xs:attribute name="negativePrefix" type="xs:string"/>
+		<xs:attribute name="negativeSuffix" type="xs:string"/>
+		<xs:attribute name="positivePrefix" type="xs:string"/>
+		<xs:attribute name="positiveSuffix" type="xs:string"/>
+		<xs:attribute name="digitSymbols" type="xs:string"/>
+	</xs:complexType>
+	<xs:complexType name="LocaleWeekInfo">
+		<xs:attribute name="firstDayOfWeek" type="xs:int"/>
+		<xs:attribute name="weekendOnSet" type="xs:int"/>
+		<xs:attribute name="weekendCease" type="xs:int"/>
+	</xs:complexType>
+	<xs:complexType name="MCDigestDeltaItem">
+		<xs:sequence>
+			<xs:element name="add" type="tns:MCDigestItem" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="ch" type="tns:MCDigestItem" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="del" type="ns1:UUID" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="MCDigestItem">
+		<xs:attribute name="uuid" type="ns1:UUID"/>
+		<xs:attribute name="name" type="xs:NCName"/>
+	</xs:complexType>
+	<xs:complexType name="MngLocale">
+		<xs:sequence>
+			<xs:element name="boolFormat" type="tns:LocaleBoolFormat"/>
+			<xs:element name="numericFormat" type="tns:LocaleNumericFormat"/>
+			<xs:element name="dateFormat" type="tns:LocaleDateFormat"/>
+			<xs:element name="weekInfo" type="tns:LocaleWeekInfo"/>
+		</xs:sequence>
+		<xs:attribute name="localeCode" type="xs:string"/>
+		<xs:attribute name="displayName" type="xs:string"/>
+		<xs:attribute name="cdisplayName" type="xs:string"/>
+		<xs:attribute name="localeName" type="xs:string"/>
+		<xs:attribute name="sessionLocaleCode" type="xs:string"/>
+		<xs:attribute name="resourceLocaleCode" type="xs:string"/>
+	</xs:complexType>
+	<xs:complexType name="MobileApplicationURL">
+		<xs:sequence>
+			<xs:element name="baseUrl" type="xs:string"/>
+			<xs:element name="useAndroid" type="xs:boolean"/>
+			<xs:element name="useIOS" type="xs:boolean"/>
+			<xs:element name="useWindows" type="xs:boolean"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="MobileApplicationURLs">
+		<xs:sequence>
+			<xs:element name="url" type="tns:MobileApplicationURL" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="NavigationPoint">
+		<xs:attribute name="fragment" type="ns1:UUID"/>
+		<xs:attribute name="subTheme" type="ns1:CompositeID"/>
+	</xs:complexType>
+	<xs:complexType name="NumberQualifiers">
+		<xs:attribute name="length" type="xs:decimal" default="0"/>
+		<xs:attribute name="precision" type="xs:decimal" default="0"/>
+		<xs:attribute name="positive" type="xs:boolean" default="false"/>
+	</xs:complexType>
+	<xs:complexType name="NumericFormat">
+		<xs:attribute name="decimal" type="xs:string"/>
+		<xs:attribute name="group" type="xs:string"/>
+		<xs:attribute name="grouping" type="xs:string"/>
+		<xs:attribute name="negative" type="xs:decimal"/>
+	</xs:complexType>
+	<xs:complexType name="Panel">
+		<xs:choice>
+			<xs:element name="uuid" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="name" type="xs:string" minOccurs="0"/>
+			<xs:element name="height" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="kind" type="tns:SectionPanelRepresentation" minOccurs="0"/>
+		</xs:choice>
+		<xs:attribute name="id" type="ns1:UUID"/>
+	</xs:complexType>
+	<xs:complexType name="PanelDef">
+		<xs:sequence>
+			<xs:element name="name" type="xs:string" minOccurs="0"/>
+			<xs:element name="spr" type="tns:SectionPanelRepresentation" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="id" type="ns1:UUID"/>
+	</xs:complexType>
+	<xs:complexType name="PanelGroup">
+		<xs:sequence>
+			<xs:element name="group" type="tns:PanelLayouter" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="id" type="ns1:UUID"/>
+	</xs:complexType>
+	<xs:complexType name="PanelLayouter">
+		<xs:choice>
+			<xs:element name="panel" type="tns:Panel" minOccurs="0"/>
+			<xs:element name="group" type="tns:PanelGroup" minOccurs="0"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="RefTypeSet">
+		<xs:complexContent>
+			<xs:extension base="tns:TypeSetDef">
+				<xs:sequence>
+					<xs:element name="type" type="tns:Reference" minOccurs="0" maxOccurs="unbounded"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="Reference">
+		<xs:complexContent>
+			<xs:extension base="tns:Type">
+				<xs:attribute name="bppoint" type="xs:boolean"/>
+				<xs:attribute name="hasAccess" type="xs:boolean"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="RegKey">
+		<xs:complexContent>
+			<xs:extension base="tns:Type">
+				<xs:attribute name="recorder" type="xs:QName"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="RegKeyTypeSet">
+		<xs:complexContent>
+			<xs:extension base="tns:TypeSetDef">
+				<xs:sequence>
+					<xs:element name="type" type="tns:RegKey" minOccurs="0" maxOccurs="unbounded"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="RequiredPermission">
+		<xs:sequence>
+			<xs:element name="permission" type="tns:RequiredMobileApplicationPermissions"/>
+			<xs:element name="use" type="xs:boolean"/>
+			<xs:element name="description" type="ns1:LocalStringType"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="RequiredPermissionMessage">
+		<xs:sequence>
+			<xs:element name="permission" type="tns:RequiredMobileApplicationPermissionMessages"/>
+			<xs:element name="description" type="ns1:LocalStringType"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="RequiredPermissions">
+		<xs:sequence>
+			<xs:element name="permission" type="tns:RequiredPermission" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ResourceString">
+		<xs:sequence>
+			<xs:element name="resName" type="xs:string"/>
+			<xs:element name="resString" type="xs:string"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ResourceStrings">
+		<xs:sequence>
+			<xs:element name="content" type="tns:ResourceString" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="SearchBlock">
+		<xs:sequence>
+			<xs:element name="value"/>
+		</xs:sequence>
+		<xs:attribute name="fieldName" type="xs:string"/>
+		<xs:attribute name="compareType" type="xs:decimal"/>
+	</xs:complexType>
+	<xs:complexType name="SettingsChoice">
+		<xs:sequence>
+			<xs:element name="settingsKey"/>
+			<xs:element name="additionalProperties" type="ns1:Structure" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="SplashInfo">
+		<xs:sequence>
+			<xs:element name="copyright" type="xs:string" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="exist" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="StartInfo">
+		<xs:sequence>
+			<xs:element name="navStartPoint" type="tns:NavigationPoint"/>
+			<xs:element name="subsystemVer" type="tns:SubsystemVerInfo" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="desktop" type="tns:DesktopInfo"/>
+			<xs:element name="styleEntries" type="tns:StyleEntriesInfo"/>
+			<xs:element name="fullConfName" type="xs:string"/>
+			<xs:element name="extName" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="disabledExtName" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="extIssue" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="compress" type="xs:string"/>
+			<xs:element name="panels" type="tns:InterfaceLayouter" minOccurs="0"/>
+			<xs:element name="choiceHistory" type="tns:LFEFChoiceHistory" minOccurs="0"/>
+			<xs:element name="favs" type="tns:UserFavorites" minOccurs="0"/>
+			<xs:element name="userName" type="xs:string"/>
+			<xs:element name="fullUserName" type="xs:string"/>
+			<xs:element name="externalResourceMode" type="xs:string"/>
+			<xs:element name="deploymentType" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="errorProcessingSettings" type="tns:ErrorProcessingSettings" minOccurs="0"/>
+			<xs:element name="configHash" type="xs:string" minOccurs="0"/>
+			<xs:element name="configCode" type="xs:string" minOccurs="0"/>
+			<xs:element name="configVersion" type="xs:string" minOccurs="0"/>
+			<xs:element name="dataZoneString" type="xs:string" minOccurs="0"/>
+			<xs:element name="configChangeEnabled" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="extensionVersion" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="serverVersion" type="xs:string" minOccurs="0"/>
+			<xs:element name="serverType" type="xs:string" minOccurs="0"/>
+			<xs:element name="serverDBMS" type="xs:string" minOccurs="0"/>
+			<xs:element name="serverNeedFunctionalities" type="xs:string" minOccurs="0"/>
+			<xs:element name="urlExtDataSupport" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="startupErrorProcessingSettings" type="tns:ErrorOnStartupProcessingSettings" minOccurs="0"/>
+			<xs:element name="appVariant" type="xs:string" minOccurs="0"/>
+			<xs:element name="dataZoneStringExclCondOff" type="xs:string" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="agentVersion" type="xs:string"/>
+		<xs:attribute name="hasConfigExt" type="xs:boolean"/>
+		<xs:attribute name="mainWindowMode" type="tns:MainWindowMode"/>
+		<xs:attribute name="infoBaseInstanceID" type="ns1:UUID"/>
+		<xs:attribute name="confName" type="xs:string"/>
+		<xs:attribute name="subsystemsPanelVer" type="ns1:UUID"/>
+		<xs:attribute name="foVer" type="ns1:UUID"/>
+		<xs:attribute name="mainWindowOptionsVer" type="ns1:UUID"/>
+		<xs:attribute name="desktopSpliterPosVer" type="ns1:UUID"/>
+		<xs:attribute name="notifyWindowOptionsVer" type="ns1:UUID"/>
+		<xs:attribute name="stateWindowOptionsVer" type="ns1:UUID"/>
+		<xs:attribute name="commConfName" type="xs:string"/>
+		<xs:attribute name="commConfURL" type="xs:string"/>
+		<xs:attribute name="commProvName" type="xs:string"/>
+		<xs:attribute name="commProvURL" type="xs:string"/>
+		<xs:attribute name="desktopFormsWindowSettingsVerHash" type="xs:string"/>
+		<xs:attribute name="enableOutput" type="xs:boolean"/>
+		<xs:attribute name="allowAllFunctionsMode" type="xs:boolean"/>
+		<xs:attribute name="allowSaveUserData" type="xs:boolean"/>
+		<xs:attribute name="clientSettings" type="xs:decimal"/>
+		<xs:attribute name="debugServerHTTP" type="xs:string"/>
+		<xs:attribute name="allowFullTextSearch" type="xs:boolean"/>
+		<xs:attribute name="taxi" type="xs:boolean"/>
+		<xs:attribute name="sdi" type="xs:boolean"/>
+		<xs:attribute name="enableChoiceInterface" type="xs:boolean"/>
+		<xs:attribute name="newInterfaceByDefault" type="xs:boolean"/>
+		<xs:attribute name="largeFont" type="xs:boolean"/>
+		<xs:attribute name="rtl" type="xs:boolean"/>
+		<xs:attribute name="ecsServer" type="xs:string"/>
+		<xs:attribute name="ecsClientId" type="xs:string"/>
+		<xs:attribute name="ecsAdmin" type="xs:boolean"/>
+		<xs:attribute name="ecsUserChoiceForm" type="xs:string"/>
+		<xs:attribute name="searchFormPresent" type="xs:boolean"/>
+		<xs:attribute name="allowMWMNormal" type="xs:boolean"/>
+		<xs:attribute name="allowMWMWorkplace" type="xs:boolean"/>
+		<xs:attribute name="allowMWMEmbeddedWorkplace" type="xs:boolean"/>
+		<xs:attribute name="allowMWMFullscreenWorkplace" type="xs:boolean"/>
+		<xs:attribute name="allowMWMKiosk" type="xs:boolean"/>
+		<xs:attribute name="allowOpenAnalytics" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="StringQualifiers">
+		<xs:attribute name="length" type="xs:decimal" default="0"/>
+		<xs:attribute name="varying" type="xs:boolean" default="true"/>
+	</xs:complexType>
+	<xs:complexType name="StyleEntriesInfo">
+		<xs:sequence>
+			<xs:element name="styleEntries" type="tns:StyleEntryInfo" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="StyleEntryInfo">
+		<xs:sequence>
+			<xs:element name="value"/>
+		</xs:sequence>
+		<xs:attribute name="uuid" type="ns1:CompositeID"/>
+		<xs:attribute name="code" type="xs:string"/>
+		<xs:attribute name="description" type="xs:string"/>
+		<xs:attribute name="kind" type="tns:StyleEntryKind"/>
+	</xs:complexType>
+	<xs:complexType name="SubsystemVerInfo">
+		<xs:attribute name="id" type="ns1:UUID"/>
+		<xs:attribute name="actionPanelVer" type="ns1:UUID"/>
+		<xs:attribute name="navPanelVer" type="ns1:UUID"/>
+	</xs:complexType>
+	<xs:complexType name="SysEnum">
+		<xs:sequence>
+			<xs:element name="values" type="tns:SysEnumValue" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="factoryClsid" type="ns1:UUID"/>
+		<xs:attribute name="clsid" type="ns1:UUID"/>
+		<xs:attribute name="enumName" type="xs:string"/>
+		<xs:attribute name="enumName2" type="xs:string"/>
+		<xs:attribute name="enumName3" type="xs:string"/>
+		<xs:attribute name="enumName4" type="xs:string"/>
+		<xs:attribute name="xmlName" type="xs:string"/>
+		<xs:attribute name="namespace" type="xs:anyURI"/>
+		<xs:attribute name="defValue" type="xs:string"/>
+	</xs:complexType>
+	<xs:complexType name="SysEnumValue">
+		<xs:attribute name="name" type="xs:string"/>
+		<xs:attribute name="name2" type="xs:string"/>
+		<xs:attribute name="name3" type="xs:string"/>
+		<xs:attribute name="name4" type="xs:string"/>
+		<xs:attribute name="presentation" type="xs:string"/>
+	</xs:complexType>
+	<xs:complexType name="SysEnums">
+		<xs:sequence>
+			<xs:element name="sysEnums" type="tns:SysEnum" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Type" abstract="true">
+		<xs:attribute name="clsid" type="ns1:UUID" use="required"/>
+		<xs:attribute name="table" type="xs:decimal" use="required"/>
+		<xs:attribute name="code" type="xs:NCName"/>
+		<xs:attribute name="extension" type="xs:boolean" default="false"/>
+	</xs:complexType>
+	<xs:complexType name="TypeIDList">
+		<xs:sequence>
+			<xs:element name="type" type="ns1:UUID" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TypeLink">
+		<xs:sequence>
+			<xs:element name="pathItem" type="ns1:CompositeID" maxOccurs="unbounded"/>
+			<xs:element name="linkItem" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="webDataPath" type="xs:string" minOccurs="0"/>
+			<xs:element name="strPath" type="xs:string" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TypePresentation">
+		<xs:attribute name="clsid" type="ns1:UUID" use="required"/>
+		<xs:attribute name="view" type="xs:string" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TypePresentations">
+		<xs:sequence>
+			<xs:element name="type" type="tns:TypePresentation"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TypeSet">
+		<xs:sequence>
+			<xs:element name="type" type="ns1:UUID" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="string" type="tns:StringQualifiers" minOccurs="0"/>
+			<xs:element name="number" type="tns:NumberQualifiers" minOccurs="0"/>
+			<xs:element name="date" type="tns:DateQualifiers" minOccurs="0"/>
+			<xs:element name="binary" type="tns:BinaryDataQualifiers" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="clsid" type="ns1:UUID"/>
+		<xs:attribute name="name" type="xs:QName"/>
+	</xs:complexType>
+	<xs:complexType name="TypeSetDef">
+		<xs:attribute name="clsid" type="ns1:UUID"/>
+		<xs:attribute name="en" type="xs:NCName"/>
+		<xs:attribute name="ru" type="xs:NCName"/>
+		<xs:attribute name="name" type="xs:QName"/>
+	</xs:complexType>
+	<xs:complexType name="TypeSystem">
+		<xs:choice>
+			<xs:element name="enums" type="tns:EnumTypeSet" minOccurs="0"/>
+			<xs:element name="refs" type="tns:RefTypeSet" minOccurs="0"/>
+			<xs:element name="regs" type="tns:RegKeyTypeSet" minOccurs="0"/>
+			<xs:element name="infoRegs" type="tns:InfoRegKeyTypeSet" minOccurs="0"/>
+			<xs:element name="typeSet" type="tns:TypeSet" minOccurs="0"/>
+			<xs:element name="extRef" type="tns:ExtRefTypeSet" minOccurs="0"/>
+			<xs:element name="extKey" type="tns:ExtKeyTypeSet" minOccurs="0"/>
+			<xs:element name="constValueKeys" type="tns:ConstValueKeyTypeSet" minOccurs="0"/>
+			<xs:element name="mcDigitalSignature" type="xs:string" minOccurs="0"/>
+			<xs:element name="mcTaskName" type="xs:Name" minOccurs="0"/>
+			<xs:element name="mcTaskSynonym" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="mcTaskSynonym2" type="xs:Name" minOccurs="0"/>
+			<xs:element name="mcDSAKey" type="xs:Name" minOccurs="0"/>
+			<xs:element name="mcAppName" type="xs:Name" minOccurs="0"/>
+			<xs:element name="mcAppURL" type="xs:Name" minOccurs="0"/>
+			<xs:element name="mcdEnums" type="tns:MCDigestDeltaItem" minOccurs="0"/>
+			<xs:element name="mcdRefs" type="tns:MCDigestDeltaItem" minOccurs="0"/>
+			<xs:element name="mcdRegKeys" type="tns:MCDigestDeltaItem" minOccurs="0"/>
+			<xs:element name="mcdInfoRegKeys" type="tns:MCDigestDeltaItem" minOccurs="0"/>
+		</xs:choice>
+		<xs:attribute name="namespace" type="xs:anyURI"/>
+	</xs:complexType>
+	<xs:complexType name="UUIDAndStringsVectorType">
+		<xs:sequence>
+			<xs:element name="UUID" type="ns1:UUID"/>
+			<xs:element name="item" type="tns:UserFavoriteItem" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="UpdateInfo">
+		<xs:attribute name="date" type="xs:dateTime"/>
+		<xs:attribute name="version" type="xs:string"/>
+		<xs:attribute name="win32" type="xs:string"/>
+		<xs:attribute name="win64" type="xs:string"/>
+		<xs:attribute name="lin32" type="xs:string"/>
+		<xs:attribute name="lin64" type="xs:string"/>
+		<xs:attribute name="mac64" type="xs:string"/>
+	</xs:complexType>
+	<xs:complexType name="UsedFunctionality">
+		<xs:sequence>
+			<xs:element name="functionality" type="tns:UsedFunctionalityFlag" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="permissionMessage" type="tns:RequiredPermissionMessage" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="UsedFunctionalityFlag">
+		<xs:sequence>
+			<xs:element name="functionality" type="tns:MobileApplicationFunctionalities"/>
+			<xs:element name="use" type="xs:boolean"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="UserFavoriteItem">
+		<xs:sequence>
+			<xs:element name="url" type="xs:string"/>
+			<xs:element name="pres" type="xs:string" minOccurs="0"/>
+			<xs:element name="darling" type="xs:boolean" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="UserFavorites">
+		<xs:sequence>
+			<xs:element name="item" type="tns:UserFavoriteItem" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+</xs:schema>

--- a/src/main/xsd/v8.3.27/v8.1c.ru-8.2-managed-application-logform.xsd
+++ b/src/main/xsd/v8.3.27/v8.1c.ru-8.2-managed-application-logform.xsd
@@ -1,0 +1,2023 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:ns1="http://v8.1c.ru/8.1/data/core" xmlns:ns2="http://v8.1c.ru/8.1/data/ui" xmlns:ns3="http://v8.1c.ru/8.2/managed-application/core" xmlns:ns4="http://v8.1c.ru/8.2/uobjects" xmlns:ns5="http://v8.1c.ru/8.1/data/enterprise" xmlns:ns6="http://v8.1c.ru/8.2/data/spreadsheet" xmlns:tns="http://v8.1c.ru/8.2/managed-application/logform" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://v8.1c.ru/8.2/managed-application/logform" attributeFormDefault="unqualified" elementFormDefault="qualified">
+	<xs:import namespace="http://v8.1c.ru/8.1/data/core"/>
+	<xs:import namespace="http://v8.1c.ru/8.1/data/ui"/>
+	<xs:import namespace="http://v8.1c.ru/8.2/managed-application/core"/>
+	<xs:import namespace="http://v8.1c.ru/8.2/uobjects"/>
+	<xs:import namespace="http://v8.1c.ru/8.1/data/enterprise"/>
+	<xs:import namespace="http://v8.1c.ru/8.2/data/spreadsheet"/>
+	<xs:simpleType name="AutoCapitalizationOnTextInput">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="None"/>
+			<xs:enumeration value="Words"/>
+			<xs:enumeration value="Sentences"/>
+			<xs:enumeration value="AllCharacters"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="AutoCorrectionOnTextInput">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Use"/>
+			<xs:enumeration value="DontUse"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="AutoSaveFormDataInSettings">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="DontUse"/>
+			<xs:enumeration value="Use"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="AutoShowClearButtonMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Always"/>
+			<xs:enumeration value="FilledOnly"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="AutoShowOpenButtonMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Always"/>
+			<xs:enumeration value="FilledOnly"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="AutofillHint">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="DontUse"/>
+			<xs:enumeration value="FullName"/>
+			<xs:enumeration value="GivenName"/>
+			<xs:enumeration value="FamilyName"/>
+			<xs:enumeration value="MiddleName"/>
+			<xs:enumeration value="NamePrefix"/>
+			<xs:enumeration value="NameSuffix"/>
+			<xs:enumeration value="Street"/>
+			<xs:enumeration value="City"/>
+			<xs:enumeration value="Region"/>
+			<xs:enumeration value="Country"/>
+			<xs:enumeration value="PostalCode"/>
+			<xs:enumeration value="UserName"/>
+			<xs:enumeration value="Password"/>
+			<xs:enumeration value="NewPassword"/>
+			<xs:enumeration value="OneTimeCode"/>
+			<xs:enumeration value="Email"/>
+			<xs:enumeration value="PhoneNumber"/>
+			<xs:enumeration value="CreditCardNumber"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="BWAValue">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="true"/>
+			<xs:enumeration value="false"/>
+			<xs:enumeration value="auto"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ButtonGroupRepresentation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Usual"/>
+			<xs:enumeration value="Compact"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ButtonLocationInCommandBar">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="InAdditionalSubmenu"/>
+			<xs:enumeration value="InCommandBar"/>
+			<xs:enumeration value="InCommandBarAndInAdditionalSubmenu"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ButtonRepresentation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Text"/>
+			<xs:enumeration value="Picture"/>
+			<xs:enumeration value="PictureAndText"/>
+			<xs:enumeration value="Auto"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ButtonShape">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Usual"/>
+			<xs:enumeration value="Oval"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ButtonShapeRepresentation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Always"/>
+			<xs:enumeration value="WhenActive"/>
+			<xs:enumeration value="None"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CheckBoxType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="CheckBox"/>
+			<xs:enumeration value="Tumbler"/>
+			<xs:enumeration value="Switcher"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ChoiceButtonRepresentation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="ShowInDropList"/>
+			<xs:enumeration value="ShowInDropListAndInInputField"/>
+			<xs:enumeration value="ShowInInputField"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ChoiceDataGetModeOnInputByString">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Directly"/>
+			<xs:enumeration value="Background"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ChoiceHistoryOnInput">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="DontUse"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CollapseFormItemsByImportance">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Use"/>
+			<xs:enumeration value="DontUse"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ColumnsGroup">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Horizontal"/>
+			<xs:enumeration value="Vertical"/>
+			<xs:enumeration value="InCell"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CurrentRowUse">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Use"/>
+			<xs:enumeration value="DontUse"/>
+			<xs:enumeration value="Auto"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DisplayImportance">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="VeryHigh"/>
+			<xs:enumeration value="High"/>
+			<xs:enumeration value="Usual"/>
+			<xs:enumeration value="Low"/>
+			<xs:enumeration value="VeryLow"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DrawingSelectionShowMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Show"/>
+			<xs:enumeration value="DontShow"/>
+			<xs:enumeration value="Auto"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="EditTextUpdate">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="DontUse"/>
+			<xs:enumeration value="OnValueChange"/>
+			<xs:enumeration value="Always"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="EventHandlerCallType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Before"/>
+			<xs:enumeration value="After"/>
+			<xs:enumeration value="Override"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FileDragMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="AsFile"/>
+			<xs:enumeration value="AsFileRef"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FoldersAndItems">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Items"/>
+			<xs:enumeration value="Folders"/>
+			<xs:enumeration value="FoldersAndItems"/>
+			<xs:enumeration value="Auto"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FormBaseFontVariant">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Normal"/>
+			<xs:enumeration value="Compact"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FormButtonPictureLocation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Left"/>
+			<xs:enumeration value="Right"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FormChildrenAlign">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="None"/>
+			<xs:enumeration value="ItemsLeftTitlesLeft"/>
+			<xs:enumeration value="ItemsRightTitlesLeft"/>
+			<xs:enumeration value="ItemsLeftTitlesRight"/>
+			<xs:enumeration value="ItemsRightTitlesRight"/>
+			<xs:enumeration value="TitlesLeftDataLeft"/>
+			<xs:enumeration value="TitlesLeftDataRight"/>
+			<xs:enumeration value="TitlesRightDataLeft"/>
+			<xs:enumeration value="TitlesRightDataRight"/>
+			<xs:enumeration value="TitlesLeftDataAuto"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FormChildrenGroup">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Horizontal"/>
+			<xs:enumeration value="Vertical"/>
+			<xs:enumeration value="HorizontalIfPossible"/>
+			<xs:enumeration value="AlwaysHorizontal"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FormChildrenWidth">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Equal"/>
+			<xs:enumeration value="LeftWide"/>
+			<xs:enumeration value="LeftWidest"/>
+			<xs:enumeration value="LeftNarrow"/>
+			<xs:enumeration value="LeftNarrowest"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FormDateSelectionMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Single"/>
+			<xs:enumeration value="Multiple"/>
+			<xs:enumeration value="Interval"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FormElementCommandBarLocation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="None"/>
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Top"/>
+			<xs:enumeration value="Bottom"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FormElementOrientation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Horizontal"/>
+			<xs:enumeration value="Vertical"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FormElementOrigin">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Source"/>
+			<xs:enumeration value="AutoGenerated"/>
+			<xs:enumeration value="AddedFromContext"/>
+			<xs:enumeration value="AddedFromMainConf"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FormElementTitleLocation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="None"/>
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Left"/>
+			<xs:enumeration value="Top"/>
+			<xs:enumeration value="Right"/>
+			<xs:enumeration value="Bottom"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FormEnterKeyBehavior">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="ControlNavigation"/>
+			<xs:enumeration value="DefaultButton"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FormFixedInTable">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="None"/>
+			<xs:enumeration value="Left"/>
+			<xs:enumeration value="Right"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FormItemSpacing">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="None"/>
+			<xs:enumeration value="Half"/>
+			<xs:enumeration value="Single"/>
+			<xs:enumeration value="OneAndHalf"/>
+			<xs:enumeration value="Double"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FormPagesRepresentation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="None"/>
+			<xs:enumeration value="TabsOnTop"/>
+			<xs:enumeration value="TabsOnBottom"/>
+			<xs:enumeration value="TabsOnLeftHorizontal"/>
+			<xs:enumeration value="TabsOnRightHorizontal"/>
+			<xs:enumeration value="Swipe"/>
+			<xs:enumeration value="Auto"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FormPagesState">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="TitlesAndCurrentPage"/>
+			<xs:enumeration value="Titles"/>
+			<xs:enumeration value="CurrentPage"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FormProgressBarRepresentation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Smooth"/>
+			<xs:enumeration value="Broken"/>
+			<xs:enumeration value="BrokenTilt"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FormStandardURLVariant">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Object"/>
+			<xs:enumeration value="Record"/>
+			<xs:enumeration value="Report"/>
+			<xs:enumeration value="ReportVariant"/>
+			<xs:enumeration value="ReportWithCurrentSettings"/>
+			<xs:enumeration value="List"/>
+			<xs:enumeration value="ListWithCurrentSettings"/>
+			<xs:enumeration value="ListWithCurrentSettingsAndRow"/>
+			<xs:enumeration value="ListCurrentRowObject"/>
+			<xs:enumeration value="ListCurrentRowRecord"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FormWindowOpeningMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Independent"/>
+			<xs:enumeration value="LockOwnerWindow"/>
+			<xs:enumeration value="LockWholeInterface"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FullTextSearchOnInputByString">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Use"/>
+			<xs:enumeration value="DontUse"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="GanttChartIntervalsSelectionMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Multiple"/>
+			<xs:enumeration value="Single"/>
+			<xs:enumeration value="None"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="GanttChartTableLocation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Left"/>
+			<xs:enumeration value="Right"/>
+			<xs:enumeration value="None"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="GanttChartValuesSelectionMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Multiple"/>
+			<xs:enumeration value="Single"/>
+			<xs:enumeration value="None"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="HeightControlVariant">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="UseHeightInFormRows"/>
+			<xs:enumeration value="UseContentHeight"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="IncompleteItemChoiceMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="OnEnterPressed"/>
+			<xs:enumeration value="OnActivate"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="InputFieldMultipleValuePictureShape">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Rect"/>
+			<xs:enumeration value="Circle"/>
+			<xs:enumeration value="Square"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="InputFieldMultipleValuePictureSize">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Small"/>
+			<xs:enumeration value="Medium"/>
+			<xs:enumeration value="Large"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ItemHorizontalAlignment">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Left"/>
+			<xs:enumeration value="Center"/>
+			<xs:enumeration value="Right"/>
+			<xs:enumeration value="Auto"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ItemVerticalAlignment">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Top"/>
+			<xs:enumeration value="Center"/>
+			<xs:enumeration value="Bottom"/>
+			<xs:enumeration value="Auto"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="LFTableListEditingMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="None"/>
+			<xs:enumeration value="MultipleSelection"/>
+			<xs:enumeration value="LinesRearrangement"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="LogFormElementAdditionKind">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="SearchStringRepresentation"/>
+			<xs:enumeration value="ViewStatusRepresentation"/>
+			<xs:enumeration value="SearchControl"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="LogFormScrollMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="auto"/>
+			<xs:enumeration value="use"/>
+			<xs:enumeration value="useIfNecessary"/>
+			<xs:enumeration value="useWithoutStretch"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="LogFormShowConversations">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Show"/>
+			<xs:enumeration value="DontShow"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ManagedFormButtonType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="CommandBarButton"/>
+			<xs:enumeration value="UsualButton"/>
+			<xs:enumeration value="Hyperlink"/>
+			<xs:enumeration value="CommandBarHyperlink"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ManagedFormDecorationType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Label"/>
+			<xs:enumeration value="Picture"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ManagedFormFieldType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Default"/>
+			<xs:enumeration value="LabelField"/>
+			<xs:enumeration value="InputField"/>
+			<xs:enumeration value="CheckBoxField"/>
+			<xs:enumeration value="PictureField"/>
+			<xs:enumeration value="RadioButtonField"/>
+			<xs:enumeration value="SpreadsheetDocumentField"/>
+			<xs:enumeration value="TextDocumentField"/>
+			<xs:enumeration value="FormattedDocumentField"/>
+			<xs:enumeration value="PlannerField"/>
+			<xs:enumeration value="CalendarField"/>
+			<xs:enumeration value="PeriodField"/>
+			<xs:enumeration value="ProgressBarField"/>
+			<xs:enumeration value="TrackBarField"/>
+			<xs:enumeration value="ChartField"/>
+			<xs:enumeration value="GanttChartField"/>
+			<xs:enumeration value="DendrogramField"/>
+			<xs:enumeration value="GraphicalSchemaField"/>
+			<xs:enumeration value="HTMLDocumentField"/>
+			<xs:enumeration value="GeographicalSchemaField"/>
+			<xs:enumeration value="PDFDocumentField"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ManagedFormGroupType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="CommandBar"/>
+			<xs:enumeration value="Popup"/>
+			<xs:enumeration value="ColumnGroup"/>
+			<xs:enumeration value="Pages"/>
+			<xs:enumeration value="Page"/>
+			<xs:enumeration value="UsualGroup"/>
+			<xs:enumeration value="ButtonGroup"/>
+			<xs:enumeration value="ContextMenu"/>
+			<xs:enumeration value="AutoCommandBar"/>
+			<xs:enumeration value="Navigator"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="MarkingStyle">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="DontShow"/>
+			<xs:enumeration value="TopLeft"/>
+			<xs:enumeration value="BottomRight"/>
+			<xs:enumeration value="BothSides"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="MenuElementPlacementArea">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="mainCmdsLeft"/>
+			<xs:enumeration value="autoCmds"/>
+			<xs:enumeration value="userCmds"/>
+			<xs:enumeration value="mainCmdsRight"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="OnMainServerUnavalableBehavior">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="MakeDisable"/>
+			<xs:enumeration value="DontChangeBehavior"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="OnScreenKeyboardReturnKeyText">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Return"/>
+			<xs:enumeration value="Go"/>
+			<xs:enumeration value="Join"/>
+			<xs:enumeration value="Next"/>
+			<xs:enumeration value="Search"/>
+			<xs:enumeration value="Send"/>
+			<xs:enumeration value="Done"/>
+			<xs:enumeration value="Continue"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="PictureSize">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="RealSize"/>
+			<xs:enumeration value="Stretch"/>
+			<xs:enumeration value="Proportionally"/>
+			<xs:enumeration value="Tile"/>
+			<xs:enumeration value="AutoSize"/>
+			<xs:enumeration value="RealSizeIgnoreScale"/>
+			<xs:enumeration value="AutoSizeIgnoreScale"/>
+			<xs:enumeration value="ByFontSize"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="RadioButtonType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="RadioButtons"/>
+			<xs:enumeration value="Tumbler"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="RefreshRequestMethod">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="None"/>
+			<xs:enumeration value="PullFromTop"/>
+			<xs:enumeration value="PullFromBottom"/>
+			<xs:enumeration value="PullFromTopOrBottom"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ReportFormType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Main"/>
+			<xs:enumeration value="Settings"/>
+			<xs:enumeration value="Variant"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="RepresentationInContextMenu">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="None"/>
+			<xs:enumeration value="AdditionalInContextMenu"/>
+			<xs:enumeration value="OnlyInContextMenu"/>
+			<xs:enumeration value="Auto"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SaveFormDataInSettings">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="DontUse"/>
+			<xs:enumeration value="UseList"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SearchControlLocation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="None"/>
+			<xs:enumeration value="CommandBar"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SearchOnInput">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Use"/>
+			<xs:enumeration value="DontUse"/>
+			<xs:enumeration value="Auto"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SearchStringLocation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="None"/>
+			<xs:enumeration value="CommandBar"/>
+			<xs:enumeration value="Top"/>
+			<xs:enumeration value="Bottom"/>
+			<xs:enumeration value="FormCaption"/>
+			<xs:enumeration value="PullFromTop"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SearchStringModeOnInputByString">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Begin"/>
+			<xs:enumeration value="AnyPart"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SelectionShowMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="WhenActive"/>
+			<xs:enumeration value="Always"/>
+			<xs:enumeration value="DontShow"/>
+			<xs:enumeration value="WhenMultipleCellsSelected"/>
+			<xs:enumeration value="WhenMultipleCellsSelectedWhenActive"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SpecialTextInputMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="None"/>
+			<xs:enumeration value="DigitsAndPunctuation"/>
+			<xs:enumeration value="URL"/>
+			<xs:enumeration value="Email"/>
+			<xs:enumeration value="PhoneNumber"/>
+			<xs:enumeration value="Digits"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SpellCheckingOnTextInput">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Use"/>
+			<xs:enumeration value="DontUse"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SpreadSheetDocumentScrollBarUse">
+		<xs:union memberTypes="tns:TableScrollBarUse xs:boolean"/>
+	</xs:simpleType>
+	<xs:simpleType name="TableBehaviorOnHorizontalCompression">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="HideItemsByImportance"/>
+			<xs:enumeration value="MoveItemsByImportance"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TableCurrentRowUse">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Choice"/>
+			<xs:enumeration value="SelectionPresentation"/>
+			<xs:enumeration value="SelectionPresentationAndChoice"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TableFieldEditMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Directly"/>
+			<xs:enumeration value="Enter"/>
+			<xs:enumeration value="EnterOnInput"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TableHeightControlVariant">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="UseHeightInFormRows"/>
+			<xs:enumeration value="UseHeightInTableRows"/>
+			<xs:enumeration value="UseContentHeight"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TableInitialListView">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Beginning"/>
+			<xs:enumeration value="End"/>
+			<xs:enumeration value="Auto"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TableInitialTreeView">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="NoExpand"/>
+			<xs:enumeration value="ExpandTopLevel"/>
+			<xs:enumeration value="ExpandAllLevels"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TableRepresentation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="List"/>
+			<xs:enumeration value="HierarchicalList"/>
+			<xs:enumeration value="Tree"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TableRowInputMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="EndOfList"/>
+			<xs:enumeration value="EndOfWindow"/>
+			<xs:enumeration value="AfterCurrentRow"/>
+			<xs:enumeration value="BeforeCurrentRow"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TableRowSelectionMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Cell"/>
+			<xs:enumeration value="Row"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TableScrollBarUse">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="DontUse"/>
+			<xs:enumeration value="UseAlways"/>
+			<xs:enumeration value="AutoUse"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TableSelectionMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="SingleRow"/>
+			<xs:enumeration value="MultiRow"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TooltipRepresentation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="None"/>
+			<xs:enumeration value="Balloon"/>
+			<xs:enumeration value="Button"/>
+			<xs:enumeration value="ShowAuto"/>
+			<xs:enumeration value="ShowTop"/>
+			<xs:enumeration value="ShowLeft"/>
+			<xs:enumeration value="ShowBottom"/>
+			<xs:enumeration value="ShowRight"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="UsedServer">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Standalone"/>
+			<xs:enumeration value="Main"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="UsualGroupBehavior">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Usual"/>
+			<xs:enumeration value="Collapsible"/>
+			<xs:enumeration value="PopUp"/>
+			<xs:enumeration value="Auto"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="UsualGroupControlRepresentation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="TitleHyperlink"/>
+			<xs:enumeration value="Picture"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="UsualGroupRepresentation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="None"/>
+			<xs:enumeration value="StrongSeparation"/>
+			<xs:enumeration value="WeakSeparation"/>
+			<xs:enumeration value="NormalSeparation"/>
+			<xs:enumeration value="GroupBox"/>
+			<xs:enumeration value="Line"/>
+			<xs:enumeration value="Margin"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="UsualGroupThroughAlign">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Use"/>
+			<xs:enumeration value="DontUse"/>
+			<xs:enumeration value="Auto"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="VerticalAlign">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Top"/>
+			<xs:enumeration value="Bottom"/>
+			<xs:enumeration value="Center"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ViewScalingMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Normal"/>
+			<xs:enumeration value="Large"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ViewStatusLocation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="None"/>
+			<xs:enumeration value="Top"/>
+			<xs:enumeration value="Bottom"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="WarningOnEditRepresentation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Show"/>
+			<xs:enumeration value="DontShow"/>
+			<xs:enumeration value="Auto"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="AddProp">
+		<xs:sequence>
+			<xs:element name="id" type="xs:decimal"/>
+			<xs:element name="val"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="AddProps">
+		<xs:sequence>
+			<xs:element name="prop" type="tns:AddProp" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Addition">
+		<xs:choice>
+			<xs:element name="source" type="tns:AdditionSource"/>
+			<xs:element name="searchStringData" type="tns:SearchStringData" minOccurs="0"/>
+			<xs:element name="viewStatusData" type="tns:ViewStatusData" minOccurs="0"/>
+			<xs:element name="searchControlData" type="tns:SearchControlData" minOccurs="0"/>
+			<xs:element name="predefined" type="tns:Predefined" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="title" type="xs:string" minOccurs="0"/>
+			<xs:element name="tooltip" type="xs:string" minOccurs="0"/>
+			<xs:element name="event" type="tns:Event" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="group" type="tns:Group" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="button" type="tns:Button" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:choice>
+		<xs:attribute name="id" type="xs:decimal"/>
+		<xs:attribute name="name" type="xs:string"/>
+		<xs:attribute name="org" type="tns:FormElementOrigin"/>
+		<xs:attribute name="users" type="xs:boolean"/>
+		<xs:attribute name="kind" type="tns:LogFormElementAdditionKind"/>
+		<xs:attribute name="visible" type="xs:boolean"/>
+		<xs:attribute name="userVisible" type="xs:boolean"/>
+		<xs:attribute name="enabled" type="xs:boolean"/>
+		<xs:attribute name="plcm" type="tns:MenuElementPlacementArea"/>
+		<xs:attribute name="tooltipRepres" type="tns:TooltipRepresentation"/>
+		<xs:attribute name="groupHAlign" type="tns:ItemHorizontalAlignment"/>
+		<xs:attribute name="groupVAlign" type="tns:ItemVerticalAlignment"/>
+		<xs:attribute name="displayImportance" type="tns:DisplayImportance"/>
+	</xs:complexType>
+	<xs:complexType name="AdditionSource">
+		<xs:sequence>
+			<xs:element name="elementId" type="xs:decimal"/>
+			<xs:element name="additionId" type="xs:decimal"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="AutoMenuGroupData">
+		<xs:attribute name="hAlign" type="tns:ItemHorizontalAlignment"/>
+		<xs:attribute name="fillStd" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="Button">
+		<xs:sequence>
+			<xs:element name="command" type="ns1:CompositeID"/>
+			<xs:element name="commandParam"/>
+			<xs:element name="prop" type="tns:DataPath" minOccurs="0"/>
+			<xs:element name="propName" type="xs:string" minOccurs="0"/>
+			<xs:element name="tdp" type="ns1:TypeDescription" minOccurs="0"/>
+			<xs:element name="bkClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="txtClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="brdClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="fnt" type="ns2:Font" minOccurs="0"/>
+			<xs:element name="stcut" type="ns2:ShortCutType" minOccurs="0"/>
+			<xs:element name="pic" type="ns2:Picture" minOccurs="0"/>
+			<xs:element name="title" type="xs:string" minOccurs="0"/>
+			<xs:element name="ricm" type="tns:RepresentationInContextMenu" minOccurs="0"/>
+			<xs:element name="predefined" type="tns:Predefined" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="id" type="xs:decimal"/>
+		<xs:attribute name="name" type="xs:string"/>
+		<xs:attribute name="org" type="tns:FormElementOrigin"/>
+		<xs:attribute name="kind" type="tns:ManagedFormButtonType"/>
+		<xs:attribute name="visible" type="xs:boolean"/>
+		<xs:attribute name="userVisible" type="xs:boolean"/>
+		<xs:attribute name="titleRowsCount" type="xs:decimal"/>
+		<xs:attribute name="repres" type="tns:ButtonRepresentation"/>
+		<xs:attribute name="defButton" type="xs:boolean"/>
+		<xs:attribute name="skipOnInput" type="tns:BWAValue"/>
+		<xs:attribute name="enabled" type="xs:boolean"/>
+		<xs:attribute name="defItem" type="xs:boolean"/>
+		<xs:attribute name="important" type="tns:BWAValue"/>
+		<xs:attribute name="width" type="xs:decimal"/>
+		<xs:attribute name="height" type="xs:decimal"/>
+		<xs:attribute name="horStretch" type="xs:boolean"/>
+		<xs:attribute name="verStretch" type="xs:boolean"/>
+		<xs:attribute name="autoMaxWidth" type="xs:boolean"/>
+		<xs:attribute name="maxWidth" type="xs:decimal"/>
+		<xs:attribute name="minWidth" type="xs:decimal"/>
+		<xs:attribute name="autoMaxHeight" type="xs:boolean"/>
+		<xs:attribute name="maxHeight" type="xs:decimal"/>
+		<xs:attribute name="plcm" type="tns:MenuElementPlacementArea"/>
+		<xs:attribute name="check" type="xs:boolean"/>
+		<xs:attribute name="tooltipRepres" type="tns:TooltipRepresentation"/>
+		<xs:attribute name="groupHAlign" type="tns:ItemHorizontalAlignment"/>
+		<xs:attribute name="groupVAlign" type="tns:ItemVerticalAlignment"/>
+		<xs:attribute name="shape" type="tns:ButtonShape"/>
+		<xs:attribute name="shapeRepres" type="tns:ButtonShapeRepresentation"/>
+		<xs:attribute name="picLocation" type="tns:FormButtonPictureLocation"/>
+		<xs:attribute name="displayImportance" type="tns:DisplayImportance"/>
+		<xs:attribute name="locationInCommandBar" type="tns:ButtonLocationInCommandBar"/>
+		<xs:attribute name="commandUniqueness" type="xs:boolean"/>
+		<xs:attribute name="MSIB" type="tns:OnMainServerUnavalableBehavior"/>
+	</xs:complexType>
+	<xs:complexType name="ButtonsGroupData">
+		<xs:sequence>
+			<xs:element name="cmdGroups" type="ns1:CompositeID"/>
+			<xs:element name="repres" type="tns:ButtonGroupRepresentation"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CalendarFieldData">
+		<xs:sequence>
+			<xs:element name="fnt" type="ns2:Font" minOccurs="0"/>
+			<xs:element name="brdClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="brd" type="ns2:Border" minOccurs="0"/>
+			<xs:element name="event" type="tns:Event" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="width" type="xs:decimal"/>
+		<xs:attribute name="height" type="xs:decimal"/>
+		<xs:attribute name="horStretch" type="xs:boolean"/>
+		<xs:attribute name="verStretch" type="xs:boolean"/>
+		<xs:attribute name="autoMaxWidth" type="xs:boolean"/>
+		<xs:attribute name="maxWidth" type="xs:decimal"/>
+		<xs:attribute name="minWidth" type="xs:decimal"/>
+		<xs:attribute name="autoMaxHeight" type="xs:boolean"/>
+		<xs:attribute name="maxHeight" type="xs:decimal"/>
+		<xs:attribute name="dateSel" type="tns:FormDateSelectionMode"/>
+		<xs:attribute name="showCurDate" type="xs:boolean"/>
+		<xs:attribute name="navigation" type="xs:boolean"/>
+		<xs:attribute name="begPeriod" type="xs:dateTime"/>
+		<xs:attribute name="endPeriod" type="xs:dateTime"/>
+		<xs:attribute name="startDrag" type="xs:boolean"/>
+		<xs:attribute name="drag" type="xs:boolean"/>
+		<xs:attribute name="monthPanelVisible" type="xs:boolean"/>
+		<xs:attribute name="widthInMonths" type="xs:decimal"/>
+		<xs:attribute name="heightInMonths" type="xs:decimal"/>
+		<xs:attribute name="clearEvents" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="ChartFieldData">
+		<xs:sequence>
+			<xs:element name="event" type="tns:Event" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="width" type="xs:decimal"/>
+		<xs:attribute name="height" type="xs:decimal"/>
+		<xs:attribute name="horStretch" type="xs:boolean"/>
+		<xs:attribute name="verStretch" type="xs:boolean"/>
+		<xs:attribute name="autoMaxWidth" type="xs:boolean"/>
+		<xs:attribute name="maxWidth" type="xs:decimal"/>
+		<xs:attribute name="minWidth" type="xs:decimal"/>
+		<xs:attribute name="autoMaxHeight" type="xs:boolean"/>
+		<xs:attribute name="maxHeight" type="xs:decimal"/>
+		<xs:attribute name="clearEvents" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="CheckBoxFieldData">
+		<xs:sequence>
+			<xs:element name="brdClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="bkClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="txtClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="fnt" type="ns2:Font" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="checkBoxType" type="tns:CheckBoxType"/>
+		<xs:attribute name="threeState" type="xs:boolean"/>
+		<xs:attribute name="format" type="xs:string"/>
+		<xs:attribute name="elemTitleHeight" type="xs:decimal"/>
+		<xs:attribute name="elemHeight" type="xs:decimal"/>
+		<xs:attribute name="elemWidth" type="xs:decimal"/>
+		<xs:attribute name="eqWidth" type="tns:BWAValue"/>
+	</xs:complexType>
+	<xs:complexType name="ColumnsGroupData">
+		<xs:sequence>
+			<xs:element name="headerPic" type="ns2:Picture" minOccurs="0"/>
+			<xs:element name="titleBkClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="hdProp" type="tns:DataPath" minOccurs="0"/>
+			<xs:element name="hdPropName" type="xs:string" minOccurs="0"/>
+			<xs:element name="hdTdp" type="ns1:TypeDescription" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="grouping" type="tns:ColumnsGroup"/>
+		<xs:attribute name="showTitle" type="xs:boolean"/>
+		<xs:attribute name="showInHeader" type="xs:boolean"/>
+		<xs:attribute name="headerHAlign" type="tns:ItemHorizontalAlignment"/>
+		<xs:attribute name="headerFormat" type="xs:string"/>
+		<xs:attribute name="fixedInTable" type="tns:FormFixedInTable"/>
+	</xs:complexType>
+	<xs:complexType name="Command">
+		<xs:sequence>
+			<xs:element name="handlers" type="tns:EventHandlers" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="id" type="ns1:CompositeID"/>
+		<xs:attribute name="name" type="xs:string"/>
+		<xs:attribute name="modifiesData" type="xs:boolean"/>
+		<xs:attribute name="currentRowUse" type="tns:CurrentRowUse"/>
+		<xs:attribute name="associatedTableElementId" type="xs:decimal"/>
+	</xs:complexType>
+	<xs:complexType name="CommandsInclusion">
+		<xs:sequence>
+			<xs:element name="uuid" type="ns1:UUID" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ContextMenuGroupData">
+		<xs:attribute name="fillStd" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="DataPath">
+		<xs:sequence>
+			<xs:element name="id" type="ns1:CompositeID" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Decoration">
+		<xs:choice>
+			<xs:element name="txtClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="fnt" type="ns2:Font" minOccurs="0"/>
+			<xs:element name="stcut" type="ns2:ShortCutType" minOccurs="0"/>
+			<xs:element name="textData" type="tns:TextDecorationData" minOccurs="0"/>
+			<xs:element name="pictureData" type="tns:PictureDecorationData" minOccurs="0"/>
+			<xs:element name="predefined" type="tns:Predefined" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="title" type="tns:FormattedString" minOccurs="0"/>
+			<xs:element name="tooltip" type="xs:string" minOccurs="0"/>
+		</xs:choice>
+		<xs:attribute name="id" type="xs:decimal"/>
+		<xs:attribute name="name" type="xs:string"/>
+		<xs:attribute name="org" type="tns:FormElementOrigin"/>
+		<xs:attribute name="users" type="xs:boolean"/>
+		<xs:attribute name="kind" type="tns:ManagedFormDecorationType"/>
+		<xs:attribute name="visible" type="xs:boolean"/>
+		<xs:attribute name="userVisible" type="xs:boolean"/>
+		<xs:attribute name="enabled" type="xs:boolean"/>
+		<xs:attribute name="width" type="xs:decimal"/>
+		<xs:attribute name="height" type="xs:decimal"/>
+		<xs:attribute name="horStretch" type="tns:BWAValue"/>
+		<xs:attribute name="verStretch" type="tns:BWAValue"/>
+		<xs:attribute name="autoMaxWidth" type="xs:boolean"/>
+		<xs:attribute name="maxWidth" type="xs:decimal"/>
+		<xs:attribute name="minWidth" type="xs:decimal"/>
+		<xs:attribute name="autoMaxHeight" type="xs:boolean"/>
+		<xs:attribute name="maxHeight" type="xs:decimal"/>
+		<xs:attribute name="skipOnInput" type="tns:BWAValue"/>
+		<xs:attribute name="tooltipRepres" type="tns:TooltipRepresentation"/>
+		<xs:attribute name="groupHAlign" type="tns:ItemHorizontalAlignment"/>
+		<xs:attribute name="groupVAlign" type="tns:ItemVerticalAlignment"/>
+		<xs:attribute name="displayImportance" type="tns:DisplayImportance"/>
+		<xs:attribute name="MSIB" type="tns:OnMainServerUnavalableBehavior"/>
+	</xs:complexType>
+	<xs:complexType name="DendrogramFieldData">
+		<xs:sequence>
+			<xs:element name="event" type="tns:Event" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="width" type="xs:decimal"/>
+		<xs:attribute name="height" type="xs:decimal"/>
+		<xs:attribute name="horStretch" type="xs:boolean"/>
+		<xs:attribute name="verStretch" type="xs:boolean"/>
+		<xs:attribute name="autoMaxWidth" type="xs:boolean"/>
+		<xs:attribute name="maxWidth" type="xs:decimal"/>
+		<xs:attribute name="minWidth" type="xs:decimal"/>
+		<xs:attribute name="autoMaxHeight" type="xs:boolean"/>
+		<xs:attribute name="maxHeight" type="xs:decimal"/>
+		<xs:attribute name="clearEvents" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="ElementsChanges">
+		<xs:sequence>
+			<xs:element name="elemcs" type="tns:ElementsChangesItem" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ElementsChangesItem">
+		<xs:choice>
+			<xs:element name="guid" type="ns1:UUID"/>
+			<xs:element name="main" type="tns:MainElement" minOccurs="0"/>
+			<xs:element name="field" type="tns:Field" minOccurs="0"/>
+			<xs:element name="group" type="tns:Group" minOccurs="0"/>
+			<xs:element name="table" type="tns:Table" minOccurs="0"/>
+			<xs:element name="button" type="tns:Button" minOccurs="0"/>
+			<xs:element name="decoration" type="tns:Decoration" minOccurs="0"/>
+			<xs:element name="addition" type="tns:Addition" minOccurs="0"/>
+		</xs:choice>
+		<xs:attribute name="type" type="xs:decimal"/>
+		<xs:attribute name="id" type="xs:decimal"/>
+		<xs:attribute name="name" type="xs:string"/>
+		<xs:attribute name="pid" type="xs:decimal"/>
+		<xs:attribute name="aid" type="xs:decimal"/>
+	</xs:complexType>
+	<xs:complexType name="Event">
+		<xs:sequence>
+			<xs:element name="handlers" type="tns:EventHandlers" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="id" type="ns1:UUID"/>
+	</xs:complexType>
+	<xs:complexType name="EventHandler">
+		<xs:attribute name="handlerName" type="xs:string"/>
+		<xs:attribute name="callType" type="tns:EventHandlerCallType"/>
+	</xs:complexType>
+	<xs:complexType name="EventHandlers">
+		<xs:sequence>
+			<xs:element name="handler" type="tns:EventHandler" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Field">
+		<xs:choice>
+			<xs:element name="textData" type="tns:TextFieldData" minOccurs="0"/>
+			<xs:element name="inputData" type="tns:InputFieldData" minOccurs="0"/>
+			<xs:element name="checkData" type="tns:CheckBoxFieldData" minOccurs="0"/>
+			<xs:element name="imageData" type="tns:ImageFieldData" minOccurs="0"/>
+			<xs:element name="radioData" type="tns:RadioButtonsData" minOccurs="0"/>
+			<xs:element name="spereadsheetData" type="tns:SpreadsheetFieldData" minOccurs="0"/>
+			<xs:element name="textDocData" type="tns:TextDocFieldData" minOccurs="0"/>
+			<xs:element name="formattedDocData" type="tns:FormattedDocFieldData" minOccurs="0"/>
+			<xs:element name="plannerData" type="tns:PlannerFieldData" minOccurs="0"/>
+			<xs:element name="calendarData" type="tns:CalendarFieldData" minOccurs="0"/>
+			<xs:element name="periodData" type="tns:PeriodFieldData" minOccurs="0"/>
+			<xs:element name="progressBarData" type="tns:ProgressBarFieldData" minOccurs="0"/>
+			<xs:element name="trackBarData" type="tns:TrackBarFieldData" minOccurs="0"/>
+			<xs:element name="chartData" type="tns:ChartFieldData" minOccurs="0"/>
+			<xs:element name="ganttChartData" type="tns:GanttChartFieldData" minOccurs="0"/>
+			<xs:element name="dendrogramData" type="tns:DendrogramFieldData" minOccurs="0"/>
+			<xs:element name="flowchartData" type="tns:FlowchartFieldData" minOccurs="0"/>
+			<xs:element name="htmlData" type="tns:HTMLFieldData" minOccurs="0"/>
+			<xs:element name="geographicalMapData" type="tns:GeographicalMapFieldData" minOccurs="0"/>
+			<xs:element name="pdfDocumentData" type="tns:PDFDocumentFieldData" minOccurs="0"/>
+			<xs:element name="prop" type="tns:DataPath" minOccurs="0"/>
+			<xs:element name="propName" type="xs:string" minOccurs="0"/>
+			<xs:element name="tdp" type="ns1:TypeDescription" minOccurs="0"/>
+			<xs:element name="ftProp" type="tns:DataPath" minOccurs="0"/>
+			<xs:element name="ftPropName" type="xs:string" minOccurs="0"/>
+			<xs:element name="ftTdp" type="ns1:TypeDescription" minOccurs="0"/>
+			<xs:element name="headerPic" type="ns2:Picture" minOccurs="0"/>
+			<xs:element name="footerPic" type="ns2:Picture" minOccurs="0"/>
+			<xs:element name="titleTxtClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="titleFnt" type="ns2:Font" minOccurs="0"/>
+			<xs:element name="titleBkClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="ftrTxtClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="ftrBkClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="ftrFnt" type="ns2:Font" minOccurs="0"/>
+			<xs:element name="stcut" type="ns2:ShortCutType" minOccurs="0"/>
+			<xs:element name="event" type="tns:Event" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="commands" type="tns:CommandsInclusion"/>
+			<xs:element name="predefined" type="tns:Predefined" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="title" type="xs:string" minOccurs="0"/>
+			<xs:element name="tooltip" type="xs:string" minOccurs="0"/>
+		</xs:choice>
+		<xs:attribute name="id" type="xs:decimal"/>
+		<xs:attribute name="name" type="xs:string"/>
+		<xs:attribute name="org" type="tns:FormElementOrigin"/>
+		<xs:attribute name="users" type="xs:boolean"/>
+		<xs:attribute name="kind" type="tns:ManagedFormFieldType"/>
+		<xs:attribute name="visible" type="xs:boolean"/>
+		<xs:attribute name="userVisible" type="xs:boolean"/>
+		<xs:attribute name="titleLocation" type="tns:FormElementTitleLocation"/>
+		<xs:attribute name="titleRowsCount" type="xs:decimal"/>
+		<xs:attribute name="enabled" type="xs:boolean"/>
+		<xs:attribute name="cellHyper" type="xs:boolean"/>
+		<xs:attribute name="readOnly" type="xs:boolean"/>
+		<xs:attribute name="skipOnInput" type="tns:BWAValue"/>
+		<xs:attribute name="defItem" type="xs:boolean"/>
+		<xs:attribute name="warningOnEditRepresentation" type="tns:WarningOnEditRepresentation"/>
+		<xs:attribute name="warningOnEdit" type="xs:string"/>
+		<xs:attribute name="footerText" type="xs:string"/>
+		<xs:attribute name="showInHeader" type="xs:boolean"/>
+		<xs:attribute name="showInFooter" type="xs:boolean"/>
+		<xs:attribute name="hAlign" type="tns:ItemHorizontalAlignment"/>
+		<xs:attribute name="headerHAlign" type="tns:ItemHorizontalAlignment"/>
+		<xs:attribute name="footerHAlign" type="tns:ItemHorizontalAlignment"/>
+		<xs:attribute name="vAlign" type="tns:ItemVerticalAlignment"/>
+		<xs:attribute name="groupHAlign" type="tns:ItemHorizontalAlignment"/>
+		<xs:attribute name="groupVAlign" type="tns:ItemVerticalAlignment"/>
+		<xs:attribute name="displayImportance" type="tns:DisplayImportance"/>
+		<xs:attribute name="columnEditMode" type="tns:TableFieldEditMode"/>
+		<xs:attribute name="autoCellHeight" type="xs:boolean"/>
+		<xs:attribute name="fixedInTable" type="tns:FormFixedInTable"/>
+		<xs:attribute name="tooltipRepres" type="tns:TooltipRepresentation"/>
+		<xs:attribute name="clearEvents" type="xs:boolean"/>
+		<xs:attribute name="MSIB" type="tns:OnMainServerUnavalableBehavior"/>
+	</xs:complexType>
+	<xs:complexType name="FlowchartFieldData">
+		<xs:sequence>
+			<xs:element name="brdClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="event" type="tns:Event" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="width" type="xs:decimal"/>
+		<xs:attribute name="height" type="xs:decimal"/>
+		<xs:attribute name="horStretch" type="xs:boolean"/>
+		<xs:attribute name="verStretch" type="xs:boolean"/>
+		<xs:attribute name="autoMaxWidth" type="xs:boolean"/>
+		<xs:attribute name="maxWidth" type="xs:decimal"/>
+		<xs:attribute name="minWidth" type="xs:decimal"/>
+		<xs:attribute name="autoMaxHeight" type="xs:boolean"/>
+		<xs:attribute name="maxHeight" type="xs:decimal"/>
+		<xs:attribute name="useOutput" type="ns2:UseOutput"/>
+		<xs:attribute name="edit" type="xs:boolean"/>
+		<xs:attribute name="clearEvents" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="Form">
+		<xs:sequence>
+			<xs:element name="elements" type="tns:MainElement"/>
+			<xs:element name="command" type="tns:Command" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="property" type="tns:Property" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="FormattedDocFieldData">
+		<xs:sequence>
+			<xs:element name="txtClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="bkClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="brdClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="fnt" type="ns2:Font" minOccurs="0"/>
+			<xs:element name="event" type="tns:Event" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="width" type="xs:decimal"/>
+		<xs:attribute name="height" type="xs:decimal"/>
+		<xs:attribute name="horStretch" type="xs:boolean"/>
+		<xs:attribute name="verStretch" type="xs:boolean"/>
+		<xs:attribute name="autoMaxWidth" type="xs:boolean"/>
+		<xs:attribute name="maxWidth" type="xs:decimal"/>
+		<xs:attribute name="minWidth" type="xs:decimal"/>
+		<xs:attribute name="autoMaxHeight" type="xs:boolean"/>
+		<xs:attribute name="maxHeight" type="xs:decimal"/>
+		<xs:attribute name="useOutput" type="ns2:UseOutput"/>
+	</xs:complexType>
+	<xs:complexType name="FormattedString">
+		<xs:sequence>
+			<xs:element name="str" type="xs:string"/>
+			<xs:element name="formatted" type="xs:boolean"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="GanttChartFieldData">
+		<xs:sequence>
+			<xs:element name="event" type="tns:Event" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="width" type="xs:decimal"/>
+		<xs:attribute name="height" type="xs:decimal"/>
+		<xs:attribute name="horStretch" type="xs:boolean"/>
+		<xs:attribute name="verStretch" type="xs:boolean"/>
+		<xs:attribute name="autoMaxWidth" type="xs:boolean"/>
+		<xs:attribute name="maxWidth" type="xs:decimal"/>
+		<xs:attribute name="minWidth" type="xs:decimal"/>
+		<xs:attribute name="autoMaxHeight" type="xs:boolean"/>
+		<xs:attribute name="maxHeight" type="xs:decimal"/>
+		<xs:attribute name="clearEvents" type="xs:boolean"/>
+		<xs:attribute name="tableLocation" type="tns:GanttChartTableLocation"/>
+		<xs:attribute name="valuesSelectionMode"/>
+		<xs:attribute name="intervalsSelectionMode"/>
+		<xs:attribute name="showHorizontalLinesFlag"/>
+		<xs:attribute name="showVerticalLinesFlag"/>
+	</xs:complexType>
+	<xs:complexType name="GeographicalMapFieldData">
+		<xs:sequence>
+			<xs:element name="brdClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="event" type="tns:Event" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="width" type="xs:decimal"/>
+		<xs:attribute name="height" type="xs:decimal"/>
+		<xs:attribute name="horStretch" type="xs:boolean"/>
+		<xs:attribute name="verStretch" type="xs:boolean"/>
+		<xs:attribute name="autoMaxWidth" type="xs:boolean"/>
+		<xs:attribute name="maxWidth" type="xs:decimal"/>
+		<xs:attribute name="minWidth" type="xs:decimal"/>
+		<xs:attribute name="autoMaxHeight" type="xs:boolean"/>
+		<xs:attribute name="maxHeight" type="xs:decimal"/>
+		<xs:attribute name="useOutput" type="ns2:UseOutput"/>
+		<xs:attribute name="clearEvents" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="Group">
+		<xs:choice>
+			<xs:element name="titleTxtClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="titleFnt" type="ns2:Font" minOccurs="0"/>
+			<xs:element name="stcut" type="ns2:ShortCutType" minOccurs="0"/>
+			<xs:element name="menuData" type="tns:MenuGroupData" minOccurs="0"/>
+			<xs:element name="autoMenuData" type="tns:AutoMenuGroupData" minOccurs="0"/>
+			<xs:element name="subMenuData" type="tns:SubmenuGroupData" minOccurs="0"/>
+			<xs:element name="buttonsData" type="tns:ButtonsGroupData" minOccurs="0"/>
+			<xs:element name="contextMenuData" type="tns:ContextMenuGroupData" minOccurs="0"/>
+			<xs:element name="columnsData" type="tns:ColumnsGroupData" minOccurs="0"/>
+			<xs:element name="pagesData" type="tns:PagesGroupData" minOccurs="0"/>
+			<xs:element name="pageData" type="tns:PageGroupData" minOccurs="0"/>
+			<xs:element name="usualData" type="tns:UsualGroupData" minOccurs="0"/>
+			<xs:element name="field" type="tns:Field" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="group" type="tns:Group" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="table" type="tns:Table" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="button" type="tns:Button" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="decoration" type="tns:Decoration" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="addition" type="tns:Addition" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="title" type="xs:string" minOccurs="0"/>
+			<xs:element name="tooltip" type="xs:string" minOccurs="0"/>
+			<xs:element name="predefined" type="tns:Predefined" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:choice>
+		<xs:attribute name="id" type="xs:decimal"/>
+		<xs:attribute name="name" type="xs:string"/>
+		<xs:attribute name="org" type="tns:FormElementOrigin"/>
+		<xs:attribute name="users" type="xs:boolean"/>
+		<xs:attribute name="kind" type="tns:ManagedFormGroupType"/>
+		<xs:attribute name="visible" type="xs:boolean"/>
+		<xs:attribute name="userVisible" type="xs:boolean"/>
+		<xs:attribute name="contentChange" type="xs:boolean"/>
+		<xs:attribute name="enabled" type="xs:boolean"/>
+		<xs:attribute name="readOnly" type="xs:boolean"/>
+		<xs:attribute name="width" type="xs:decimal"/>
+		<xs:attribute name="height" type="xs:decimal"/>
+		<xs:attribute name="horStretch" type="tns:BWAValue"/>
+		<xs:attribute name="verStretch" type="tns:BWAValue"/>
+		<xs:attribute name="tooltipRepres" type="tns:TooltipRepresentation"/>
+		<xs:attribute name="groupHAlign" type="tns:ItemHorizontalAlignment"/>
+		<xs:attribute name="groupVAlign" type="tns:ItemVerticalAlignment"/>
+		<xs:attribute name="degeneratable" type="xs:boolean"/>
+		<xs:attribute name="displayImportance" type="tns:DisplayImportance"/>
+	</xs:complexType>
+	<xs:complexType name="HTMLFieldData">
+		<xs:sequence>
+			<xs:element name="brdClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="event" type="tns:Event" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="width" type="xs:decimal"/>
+		<xs:attribute name="height" type="xs:decimal"/>
+		<xs:attribute name="horStretch" type="xs:boolean"/>
+		<xs:attribute name="verStretch" type="xs:boolean"/>
+		<xs:attribute name="autoMaxWidth" type="xs:boolean"/>
+		<xs:attribute name="maxWidth" type="xs:decimal"/>
+		<xs:attribute name="minWidth" type="xs:decimal"/>
+		<xs:attribute name="autoMaxHeight" type="xs:boolean"/>
+		<xs:attribute name="maxHeight" type="xs:decimal"/>
+		<xs:attribute name="useOutput" type="ns2:UseOutput"/>
+		<xs:attribute name="clearEvents" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="ImageFieldData">
+		<xs:sequence>
+			<xs:element name="picValues" type="ns2:Picture" minOccurs="0"/>
+			<xs:element name="txtClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="brdClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="fnt" type="ns2:Font" minOccurs="0"/>
+			<xs:element name="brd" type="ns2:Border" minOccurs="0"/>
+			<xs:element name="event" type="tns:Event" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="width" type="xs:decimal"/>
+		<xs:attribute name="height" type="xs:decimal"/>
+		<xs:attribute name="horStretch" type="xs:boolean"/>
+		<xs:attribute name="verStretch" type="xs:boolean"/>
+		<xs:attribute name="autoMaxWidth" type="xs:boolean"/>
+		<xs:attribute name="maxWidth" type="xs:decimal"/>
+		<xs:attribute name="minWidth" type="xs:decimal"/>
+		<xs:attribute name="autoMaxHeight" type="xs:boolean"/>
+		<xs:attribute name="maxHeight" type="xs:decimal"/>
+		<xs:attribute name="pictureSize" type="tns:PictureSize"/>
+		<xs:attribute name="zoomable" type="xs:boolean"/>
+		<xs:attribute name="imageScale" type="xs:decimal"/>
+		<xs:attribute name="hyper" type="xs:boolean"/>
+		<xs:attribute name="picText" type="xs:string"/>
+		<xs:attribute name="startDrag" type="xs:boolean"/>
+		<xs:attribute name="drag" type="xs:boolean"/>
+		<xs:attribute name="clearEvents" type="xs:boolean"/>
+		<xs:attribute name="fileDragMode" type="tns:FileDragMode"/>
+	</xs:complexType>
+	<xs:complexType name="InputFieldData">
+		<xs:sequence>
+			<xs:element name="event" type="tns:Event" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="minVal"/>
+			<xs:element name="maxVal"/>
+			<xs:element name="choiceBtnPic" type="ns2:Picture" minOccurs="0"/>
+			<xs:element name="choiceFormId" type="ns1:UUID"/>
+			<xs:element name="choiceParamLinks" type="ns3:ChoiceParameterLinks" minOccurs="0"/>
+			<xs:element name="choiceParams" type="ns3:ChoiceParameters" minOccurs="0"/>
+			<xs:element name="avlTypes" type="ns1:TypeDescription" minOccurs="0"/>
+			<xs:element name="valList" type="ns1:ValueListType"/>
+			<xs:element name="txtClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="bkClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="brdClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="fnt" type="ns2:Font" minOccurs="0"/>
+			<xs:element name="linkByType" type="ns3:TypeLink" minOccurs="0"/>
+			<xs:element name="multipleValuesFont" type="ns2:Font" minOccurs="0"/>
+			<xs:element name="multipleValuesPicture" type="ns2:Picture" minOccurs="0"/>
+			<xs:element name="multipleValueDataPath" type="tns:DataPath" minOccurs="0"/>
+			<xs:element name="multipleValueDataPathName" type="xs:string" minOccurs="0"/>
+			<xs:element name="multipleValuePictureDataPath" type="tns:DataPath" minOccurs="0"/>
+			<xs:element name="multipleValuePictureDataPathName" type="xs:string" minOccurs="0"/>
+			<xs:element name="multipleValuePresentDataPath" type="tns:DataPath" minOccurs="0"/>
+			<xs:element name="multipleValuePresentDataPathName" type="xs:string" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="width" type="xs:decimal"/>
+		<xs:attribute name="rowsCount" type="xs:decimal"/>
+		<xs:attribute name="horStretch" type="tns:BWAValue"/>
+		<xs:attribute name="verStretch" type="tns:BWAValue"/>
+		<xs:attribute name="autoMaxWidth" type="xs:boolean"/>
+		<xs:attribute name="maxWidth" type="xs:decimal"/>
+		<xs:attribute name="minWidth" type="xs:decimal"/>
+		<xs:attribute name="autoMaxHeight" type="xs:boolean"/>
+		<xs:attribute name="maxHeight" type="xs:decimal"/>
+		<xs:attribute name="wrap" type="xs:boolean"/>
+		<xs:attribute name="psw" type="tns:BWAValue"/>
+		<xs:attribute name="mlt" type="tns:BWAValue"/>
+		<xs:attribute name="extEdit" type="tns:BWAValue"/>
+		<xs:attribute name="markNeg" type="tns:BWAValue"/>
+		<xs:attribute name="choiceListBtn" type="tns:BWAValue"/>
+		<xs:attribute name="dropListBtn" type="tns:BWAValue"/>
+		<xs:attribute name="choiceBtn" type="tns:BWAValue"/>
+		<xs:attribute name="choiceBtnRepresentation" type="tns:ChoiceButtonRepresentation"/>
+		<xs:attribute name="clearBtn" type="tns:BWAValue"/>
+		<xs:attribute name="spinBtn" type="tns:BWAValue"/>
+		<xs:attribute name="openBtn" type="tns:BWAValue"/>
+		<xs:attribute name="createBtn" type="tns:BWAValue"/>
+		<xs:attribute name="mask" type="xs:string"/>
+		<xs:attribute name="listChoice" type="xs:boolean"/>
+		<xs:attribute name="choiceListHeight" type="xs:decimal"/>
+		<xs:attribute name="choiceListMinWidth" type="xs:decimal"/>
+		<xs:attribute name="multipleValuesTextColor" type="ns2:Color"/>
+		<xs:attribute name="multipleValuesBackColor" type="ns2:Color"/>
+		<xs:attribute name="multipleValuesHyperlink" type="tns:BWAValue"/>
+		<xs:attribute name="allowInputEmptyMultipleValues" type="xs:boolean"/>
+		<xs:attribute name="allowMultipleValuesDuplicates" type="xs:boolean"/>
+		<xs:attribute name="extendedEditMultipleValues" type="xs:boolean"/>
+		<xs:attribute name="showCheckBoxesInDropList" type="tns:BWAValue"/>
+		<xs:attribute name="autoChoice" type="tns:BWAValue"/>
+		<xs:attribute name="quickChoice" type="tns:BWAValue"/>
+		<xs:attribute name="choice" type="tns:FoldersAndItems"/>
+		<xs:attribute name="format" type="xs:string"/>
+		<xs:attribute name="inputFormat" type="xs:string"/>
+		<xs:attribute name="autoMark" type="tns:BWAValue"/>
+		<xs:attribute name="choiceType" type="xs:boolean"/>
+		<xs:attribute name="incompleteChoice" type="tns:IncompleteItemChoiceMode"/>
+		<xs:attribute name="typeDomainEnabled" type="xs:boolean"/>
+		<xs:attribute name="textEdit" type="xs:boolean"/>
+		<xs:attribute name="editTextUpdateMode" type="tns:EditTextUpdate"/>
+		<xs:attribute name="inputHint" type="xs:string"/>
+		<xs:attribute name="clearEvents" type="xs:boolean"/>
+		<xs:attribute name="choiceHistory" type="tns:ChoiceHistoryOnInput"/>
+		<xs:attribute name="autoShowClearButtonMode" type="tns:AutoShowClearButtonMode"/>
+		<xs:attribute name="autoShowOpenButtonMode" type="tns:AutoShowOpenButtonMode"/>
+		<xs:attribute name="autoCorrectionOnTextInput" type="tns:AutoCorrectionOnTextInput"/>
+		<xs:attribute name="spellCheckingOnTextInput" type="tns:SpellCheckingOnTextInput"/>
+		<xs:attribute name="autoCapitalizationOnTextInput" type="tns:AutoCapitalizationOnTextInput"/>
+		<xs:attribute name="autofillHint" type="tns:AutofillHint"/>
+		<xs:attribute name="specialTextInputMode" type="tns:SpecialTextInputMode"/>
+		<xs:attribute name="onScreenKeyboardReturnKeyText" type="tns:OnScreenKeyboardReturnKeyText"/>
+		<xs:attribute name="heightControlVariant" type="tns:HeightControlVariant"/>
+		<xs:attribute name="multipleValuePictureSize" type="tns:InputFieldMultipleValuePictureSize"/>
+		<xs:attribute name="multipleValuePictureShape" type="tns:InputFieldMultipleValuePictureShape"/>
+	</xs:complexType>
+	<xs:complexType name="ItemRef">
+		<xs:attribute name="id" type="xs:decimal"/>
+		<xs:attribute name="name" type="xs:string"/>
+	</xs:complexType>
+	<xs:complexType name="LFEDataPathRuntimeValue">
+		<xs:sequence>
+			<xs:element name="dataPath" type="ns1:CompositeID" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="stringDataPath" type="xs:string" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="LogFormUserAddedElement">
+		<xs:choice>
+			<xs:element name="fld" type="tns:Field" minOccurs="0"/>
+			<xs:element name="gr" type="tns:Group" minOccurs="0"/>
+			<xs:element name="tbl" type="tns:Table" minOccurs="0"/>
+			<xs:element name="btn" type="tns:Button" minOccurs="0"/>
+			<xs:element name="decor" type="tns:Decoration" minOccurs="0"/>
+			<xs:element name="addition" type="tns:Addition" minOccurs="0"/>
+		</xs:choice>
+		<xs:attribute name="pId" type="xs:decimal"/>
+	</xs:complexType>
+	<xs:complexType name="LogFormUserButtonChange">
+		<xs:attribute name="bId" type="xs:decimal"/>
+		<xs:attribute name="def" type="xs:boolean"/>
+		<xs:attribute name="ttlChg" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="LogFormUserChangesDescription">
+		<xs:sequence>
+			<xs:element name="addEl" type="tns:LogFormUserAddedElement" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="movEl" type="tns:LogFormUserMovedElement" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="tblChg" type="tns:LogFormUserTableChange" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="fldChg" type="tns:LogFormUserFieldChange" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="btnChg" type="tns:LogFormUserButtonChange" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="LogFormUserFieldChange">
+		<xs:attribute name="fId" type="xs:decimal"/>
+		<xs:attribute name="spin" type="tns:BWAValue"/>
+	</xs:complexType>
+	<xs:complexType name="LogFormUserMovedElement">
+		<xs:attribute name="pId" type="xs:decimal"/>
+		<xs:attribute name="eId" type="xs:decimal"/>
+		<xs:attribute name="aId" type="xs:decimal"/>
+	</xs:complexType>
+	<xs:complexType name="LogFormUserTableChange">
+		<xs:sequence>
+			<xs:element name="autoRef" minOccurs="0"/>
+			<xs:element name="autoRefInt" minOccurs="0"/>
+			<xs:element name="updOnDtCng" minOccurs="0"/>
+			<xs:element name="rstCurLn" minOccurs="0"/>
+			<xs:element name="showRoot" minOccurs="0"/>
+			<xs:element name="allowRootCh" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="tId" type="xs:decimal"/>
+		<xs:attribute name="lstView" type="tns:TableInitialListView"/>
+	</xs:complexType>
+	<xs:complexType name="MainElement">
+		<xs:choice>
+			<xs:element name="storage" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="addProps" type="tns:AddProps" minOccurs="0"/>
+			<xs:element name="event" type="tns:Event" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="commands" type="tns:CommandsInclusion"/>
+			<xs:element name="navigator" type="tns:Group" minOccurs="0"/>
+			<xs:element name="autoCommandBar" type="tns:Group" minOccurs="0"/>
+			<xs:element name="field" type="tns:Field" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="group" type="tns:Group" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="table" type="tns:Table" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="button" type="tns:Button" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="decoration" type="tns:Decoration" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="addition" type="tns:Addition" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="title" type="xs:string" minOccurs="0"/>
+			<xs:element name="formURL" type="xs:string" minOccurs="0"/>
+			<xs:element name="mdcbc" type="ns1:ValueListType"/>
+		</xs:choice>
+		<xs:attribute name="showCloseButton" type="xs:boolean"/>
+		<xs:attribute name="showTitle" type="xs:boolean"/>
+		<xs:attribute name="org" type="tns:FormElementOrigin"/>
+		<xs:attribute name="openingMode" type="tns:FormWindowOpeningMode"/>
+		<xs:attribute name="width" type="xs:decimal"/>
+		<xs:attribute name="height" type="xs:decimal"/>
+		<xs:attribute name="scale" type="xs:decimal"/>
+		<xs:attribute name="enterKeyBehavior" type="tns:FormEnterKeyBehavior"/>
+		<xs:attribute name="saveFormDataInSettings" type="tns:SaveFormDataInSettings"/>
+		<xs:attribute name="autoSaveFormDataInSettings" type="tns:AutoSaveFormDataInSettings"/>
+		<xs:attribute name="saveWindowSettings" type="xs:boolean"/>
+		<xs:attribute name="autoTitle" type="xs:boolean"/>
+		<xs:attribute name="autoURL" type="xs:boolean"/>
+		<xs:attribute name="grouping" type="tns:FormChildrenGroup"/>
+		<xs:attribute name="align" type="tns:FormChildrenAlign"/>
+		<xs:attribute name="horizontalSpacing" type="tns:FormItemSpacing"/>
+		<xs:attribute name="verticalSpacing" type="tns:FormItemSpacing"/>
+		<xs:attribute name="hAlign" type="tns:ItemHorizontalAlignment"/>
+		<xs:attribute name="vAlign" type="tns:ItemVerticalAlignment"/>
+		<xs:attribute name="childrenWidth" type="tns:FormChildrenWidth"/>
+		<xs:attribute name="baseFontVariant" type="tns:FormBaseFontVariant"/>
+		<xs:attribute name="scrollMode" type="tns:LogFormScrollMode"/>
+		<xs:attribute name="autoFillCheck" type="xs:boolean"/>
+		<xs:attribute name="customizable" type="xs:boolean"/>
+		<xs:attribute name="enabled" type="xs:boolean"/>
+		<xs:attribute name="readOnly" type="xs:boolean"/>
+		<xs:attribute name="commandBarLocation" type="tns:FormElementCommandBarLocation"/>
+		<xs:attribute name="purposeUseKey" type="xs:string"/>
+		<xs:attribute name="windowOptionsKey" type="xs:string"/>
+		<xs:attribute name="clearEvents" type="xs:boolean"/>
+		<xs:attribute name="convRepresentation" type="tns:LogFormShowConversations"/>
+		<xs:attribute name="currentRowUse" type="tns:TableCurrentRowUse"/>
+		<xs:attribute name="collapseVariant" type="tns:CollapseFormItemsByImportance"/>
+	</xs:complexType>
+	<xs:complexType name="MenuGroupData">
+		<xs:sequence>
+			<xs:element name="cmdGroups" type="ns1:CompositeID"/>
+		</xs:sequence>
+		<xs:attribute name="hAlign" type="tns:ItemHorizontalAlignment"/>
+	</xs:complexType>
+	<xs:complexType name="PDFDocumentFieldData">
+		<xs:sequence>
+			<xs:element name="brdClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="event" type="tns:Event" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="width" type="xs:decimal"/>
+		<xs:attribute name="height" type="xs:decimal"/>
+		<xs:attribute name="horStretch" type="xs:boolean"/>
+		<xs:attribute name="verStretch" type="xs:boolean"/>
+		<xs:attribute name="autoMaxWidth" type="xs:boolean"/>
+		<xs:attribute name="maxWidth" type="xs:decimal"/>
+		<xs:attribute name="minWidth" type="xs:decimal"/>
+		<xs:attribute name="autoMaxHeight" type="xs:boolean"/>
+		<xs:attribute name="maxHeight" type="xs:decimal"/>
+		<xs:attribute name="useOutput" type="ns2:UseOutput"/>
+		<xs:attribute name="scale" type="xs:decimal"/>
+		<xs:attribute name="currentPage" type="xs:decimal"/>
+		<xs:attribute name="orientation" type="xs:decimal"/>
+		<xs:attribute name="viewStatusLocation" type="tns:ViewStatusLocation"/>
+		<xs:attribute name="clearEvents" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="PageGroupData">
+		<xs:sequence>
+			<xs:element name="pic" type="ns2:Picture" minOccurs="0"/>
+			<xs:element name="prop" type="tns:DataPath" minOccurs="0"/>
+			<xs:element name="propName" type="xs:string" minOccurs="0"/>
+			<xs:element name="tdp" type="ns1:TypeDescription" minOccurs="0"/>
+			<xs:element name="bkClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="ttlClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="ttlFnt" type="ns2:Font" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="grouping" type="tns:FormChildrenGroup"/>
+		<xs:attribute name="align" type="tns:FormChildrenAlign"/>
+		<xs:attribute name="horizontalSpacing" type="tns:FormItemSpacing"/>
+		<xs:attribute name="verticalSpacing" type="tns:FormItemSpacing"/>
+		<xs:attribute name="hAlign" type="tns:ItemHorizontalAlignment"/>
+		<xs:attribute name="vAlign" type="tns:ItemVerticalAlignment"/>
+		<xs:attribute name="childrenWidth" type="tns:FormChildrenWidth"/>
+		<xs:attribute name="format" type="xs:string"/>
+		<xs:attribute name="showTitle" type="xs:boolean"/>
+		<xs:attribute name="scrollOnCompress" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="PagesGroupData">
+		<xs:sequence>
+			<xs:element name="event" type="tns:Event" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="repres" type="tns:FormPagesRepresentation"/>
+		<xs:attribute name="currentRowUse" type="tns:CurrentRowUse"/>
+		<xs:attribute name="associatedTableElementId" type="xs:decimal"/>
+		<xs:attribute name="clearEvents" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="PeriodFieldData">
+		<xs:sequence>
+			<xs:element name="fnt" type="ns2:Font" minOccurs="0"/>
+			<xs:element name="brdClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="brd" type="ns2:Border" minOccurs="0"/>
+			<xs:element name="event" type="tns:Event" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="width" type="xs:decimal"/>
+		<xs:attribute name="height" type="xs:decimal"/>
+		<xs:attribute name="horStretch" type="xs:boolean"/>
+		<xs:attribute name="verStretch" type="xs:boolean"/>
+		<xs:attribute name="autoMaxWidth" type="xs:boolean"/>
+		<xs:attribute name="maxWidth" type="xs:decimal"/>
+		<xs:attribute name="minWidth" type="xs:decimal"/>
+		<xs:attribute name="autoMaxHeight" type="xs:boolean"/>
+		<xs:attribute name="maxHeight" type="xs:decimal"/>
+		<xs:attribute name="clearEvents" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="PictureDecorationData">
+		<xs:sequence>
+			<xs:element name="pic" type="ns2:Picture" minOccurs="0"/>
+			<xs:element name="brdClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="brd" type="ns2:Border" minOccurs="0"/>
+			<xs:element name="event" type="tns:Event" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="hyper" type="xs:boolean"/>
+		<xs:attribute name="pictureSize" type="tns:PictureSize"/>
+		<xs:attribute name="zoomable" type="xs:boolean"/>
+		<xs:attribute name="imageScale" type="xs:decimal"/>
+		<xs:attribute name="picText" type="xs:string"/>
+		<xs:attribute name="startDrag" type="xs:boolean"/>
+		<xs:attribute name="drag" type="xs:boolean"/>
+		<xs:attribute name="clearEvents" type="xs:boolean"/>
+		<xs:attribute name="fileDragMode" type="tns:FileDragMode"/>
+	</xs:complexType>
+	<xs:complexType name="PlannerFieldData">
+		<xs:sequence>
+			<xs:element name="event" type="tns:Event" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="width" type="xs:decimal"/>
+		<xs:attribute name="height" type="xs:decimal"/>
+		<xs:attribute name="horStretch" type="xs:boolean"/>
+		<xs:attribute name="verStretch" type="xs:boolean"/>
+		<xs:attribute name="autoMaxWidth" type="xs:boolean"/>
+		<xs:attribute name="maxWidth" type="xs:decimal"/>
+		<xs:attribute name="minWidth" type="xs:decimal"/>
+		<xs:attribute name="autoMaxHeight" type="xs:boolean"/>
+		<xs:attribute name="maxHeight" type="xs:decimal"/>
+		<xs:attribute name="startDrag" type="xs:boolean"/>
+		<xs:attribute name="drag" type="xs:boolean"/>
+		<xs:attribute name="timeScaleItemHyperlink" type="xs:boolean"/>
+		<xs:attribute name="dimensionItemHyperlink" type="xs:boolean"/>
+		<xs:attribute name="wrappedTimeScaleHeaderHyperlink" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="Predefined">
+		<xs:choice>
+			<xs:element name="contextMenu" type="tns:Group" minOccurs="0"/>
+			<xs:element name="contextMenuRef" type="tns:ItemRef" minOccurs="0"/>
+			<xs:element name="autoCommandBar" type="tns:Group" minOccurs="0"/>
+			<xs:element name="autoCommandBarRef" type="tns:ItemRef" minOccurs="0"/>
+			<xs:element name="extTooltip" type="tns:Decoration" minOccurs="0"/>
+			<xs:element name="extTooltipRef" type="tns:ItemRef" minOccurs="0"/>
+			<xs:element name="searchStringRepresentation" type="tns:Addition" minOccurs="0"/>
+			<xs:element name="searchStringRepresentationRef" type="tns:ItemRef" minOccurs="0"/>
+			<xs:element name="viewStatusRepresentation" type="tns:Addition" minOccurs="0"/>
+			<xs:element name="viewStatusRepresentationRef" type="tns:ItemRef" minOccurs="0"/>
+			<xs:element name="searchControl" type="tns:Addition" minOccurs="0"/>
+			<xs:element name="searchControlRef" type="tns:ItemRef" minOccurs="0"/>
+			<xs:element name="predefined" type="tns:Predefined" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="field" type="tns:Field" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="group" type="tns:Group" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="table" type="tns:Table" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="button" type="tns:Button" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="decoration" type="tns:Decoration" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="addition" type="tns:Addition" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="ProgressBarFieldData">
+		<xs:sequence>
+			<xs:element name="brdClr" type="ns2:Color" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="width" type="xs:decimal"/>
+		<xs:attribute name="height" type="xs:decimal"/>
+		<xs:attribute name="horStretch" type="xs:boolean"/>
+		<xs:attribute name="verStretch" type="xs:boolean"/>
+		<xs:attribute name="autoMaxWidth" type="xs:boolean"/>
+		<xs:attribute name="maxWidth" type="xs:decimal"/>
+		<xs:attribute name="minWidth" type="xs:decimal"/>
+		<xs:attribute name="autoMaxHeight" type="xs:boolean"/>
+		<xs:attribute name="maxHeight" type="xs:decimal"/>
+		<xs:attribute name="minVal" type="xs:decimal"/>
+		<xs:attribute name="maxVal" type="xs:decimal"/>
+		<xs:attribute name="orientation" type="tns:FormElementOrientation"/>
+		<xs:attribute name="repres" type="tns:FormProgressBarRepresentation"/>
+		<xs:attribute name="showPercent" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="Property">
+		<xs:sequence>
+			<xs:element name="savingContent" type="tns:DataPath" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="id" type="ns1:CompositeID"/>
+		<xs:attribute name="main" type="xs:boolean"/>
+		<xs:attribute name="storedData" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="RadioButtonsData">
+		<xs:sequence>
+			<xs:element name="valList" type="ns1:ValueListType"/>
+			<xs:element name="txtClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="fnt" type="ns2:Font" minOccurs="0"/>
+			<xs:element name="brdClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="bkClr" type="ns2:Color" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="radioButtonType" type="tns:RadioButtonType"/>
+		<xs:attribute name="colsCount" type="xs:decimal"/>
+		<xs:attribute name="elementTitleHeight" type="xs:decimal"/>
+		<xs:attribute name="elementHeight" type="xs:decimal"/>
+		<xs:attribute name="elementWidth" type="xs:decimal"/>
+		<xs:attribute name="eqWidth" type="tns:BWAValue"/>
+	</xs:complexType>
+	<xs:complexType name="SearchControlData">
+		<xs:sequence>
+			<xs:element name="bkClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="txtClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="brdClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="fnt" type="ns2:Font" minOccurs="0"/>
+			<xs:element name="event" type="tns:Event" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="width" type="xs:decimal"/>
+		<xs:attribute name="autoMaxWidth" type="xs:boolean"/>
+		<xs:attribute name="maxWidth" type="xs:decimal"/>
+		<xs:attribute name="minWidth" type="xs:decimal"/>
+		<xs:attribute name="horStretch" type="tns:BWAValue"/>
+	</xs:complexType>
+	<xs:complexType name="SearchStringData">
+		<xs:sequence>
+			<xs:element name="bkClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="txtClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="brdClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="fnt" type="ns2:Font" minOccurs="0"/>
+			<xs:element name="event" type="tns:Event" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="width" type="xs:decimal"/>
+		<xs:attribute name="autoMaxWidth" type="xs:boolean"/>
+		<xs:attribute name="maxWidth" type="xs:decimal"/>
+		<xs:attribute name="minWidth" type="xs:decimal"/>
+		<xs:attribute name="horStretch" type="tns:BWAValue"/>
+	</xs:complexType>
+	<xs:complexType name="SpreadsheetFieldData">
+		<xs:sequence>
+			<xs:element name="brdClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="event" type="tns:Event" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="width" type="xs:decimal"/>
+		<xs:attribute name="height" type="xs:decimal"/>
+		<xs:attribute name="horStretch" type="xs:boolean"/>
+		<xs:attribute name="verStretch" type="xs:boolean"/>
+		<xs:attribute name="autoMaxWidth" type="xs:boolean"/>
+		<xs:attribute name="maxWidth" type="xs:decimal"/>
+		<xs:attribute name="minWidth" type="xs:decimal"/>
+		<xs:attribute name="autoMaxHeight" type="xs:boolean"/>
+		<xs:attribute name="maxHeight" type="xs:decimal"/>
+		<xs:attribute name="showGrid" type="xs:boolean"/>
+		<xs:attribute name="showHdrs" type="xs:boolean"/>
+		<xs:attribute name="showVerScroll" type="tns:SpreadSheetDocumentScrollBarUse"/>
+		<xs:attribute name="showHorScroll" type="tns:SpreadSheetDocumentScrollBarUse"/>
+		<xs:attribute name="blackAndWhite" type="xs:boolean"/>
+		<xs:attribute name="protection" type="xs:boolean"/>
+		<xs:attribute name="selectionMode" type="tns:SelectionShowMode"/>
+		<xs:attribute name="useOutput" type="ns2:UseOutput"/>
+		<xs:attribute name="edit" type="xs:boolean"/>
+		<xs:attribute name="showGroups" type="xs:boolean"/>
+		<xs:attribute name="startDrag" type="xs:boolean"/>
+		<xs:attribute name="drag" type="xs:boolean"/>
+		<xs:attribute name="clearEvents" type="xs:boolean"/>
+		<xs:attribute name="selShow" type="tns:SelectionShowMode"/>
+		<xs:attribute name="viewScalingMode" type="tns:ViewScalingMode"/>
+		<xs:attribute name="showCellNames" type="xs:boolean"/>
+		<xs:attribute name="showRowAndColumnNames" type="xs:boolean"/>
+		<xs:attribute name="pointerType" type="ns6:SpreadsheetDocumentPointerType"/>
+		<xs:attribute name="drawingSelectionMode" type="tns:DrawingSelectionShowMode"/>
+	</xs:complexType>
+	<xs:complexType name="SubmenuGroupData">
+		<xs:sequence>
+			<xs:element name="pic" type="ns2:Picture" minOccurs="0"/>
+			<xs:element name="cmdGroups" type="ns1:CompositeID"/>
+			<xs:element name="bkClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="brdClr" type="ns2:Color" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="repres" type="tns:ButtonRepresentation"/>
+		<xs:attribute name="shape" type="tns:ButtonShape"/>
+		<xs:attribute name="shapeRepres" type="tns:ButtonShapeRepresentation"/>
+	</xs:complexType>
+	<xs:complexType name="Table">
+		<xs:choice>
+			<xs:element name="prop" type="tns:DataPath" minOccurs="0"/>
+			<xs:element name="propName" type="xs:string" minOccurs="0"/>
+			<xs:element name="tdp" type="ns1:TypeDescription" minOccurs="0"/>
+			<xs:element name="rowsPicProp" type="tns:DataPath" minOccurs="0"/>
+			<xs:element name="rowsPicPropName" type="xs:string" minOccurs="0"/>
+			<xs:element name="rowsPic" type="ns2:Picture" minOccurs="0"/>
+			<xs:element name="bkClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="txtClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="brdClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="fnt" type="ns2:Font" minOccurs="0"/>
+			<xs:element name="titleTxtClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="titleFnt" type="ns2:Font" minOccurs="0"/>
+			<xs:element name="stcut" type="ns2:ShortCutType" minOccurs="0"/>
+			<xs:element name="addProps" type="tns:AddProps" minOccurs="0"/>
+			<xs:element name="event" type="tns:Event" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="commands" type="tns:CommandsInclusion"/>
+			<xs:element name="predefined" type="tns:Predefined" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="field" type="tns:Field" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="group" type="tns:Group" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="title" type="xs:string" minOccurs="0"/>
+			<xs:element name="tooltip" type="xs:string" minOccurs="0"/>
+		</xs:choice>
+		<xs:attribute name="id" type="xs:decimal"/>
+		<xs:attribute name="name" type="xs:string"/>
+		<xs:attribute name="org" type="tns:FormElementOrigin"/>
+		<xs:attribute name="repres" type="tns:TableRepresentation"/>
+		<xs:attribute name="visible" type="xs:boolean"/>
+		<xs:attribute name="userVisible" type="xs:boolean"/>
+		<xs:attribute name="titleLocation" type="tns:FormElementTitleLocation"/>
+		<xs:attribute name="titleRowsCount" type="xs:decimal"/>
+		<xs:attribute name="commandBarLocation" type="tns:FormElementCommandBarLocation"/>
+		<xs:attribute name="autoFill" type="xs:boolean"/>
+		<xs:attribute name="enabled" type="xs:boolean"/>
+		<xs:attribute name="readOnly" type="xs:boolean"/>
+		<xs:attribute name="skipOnInput" type="tns:BWAValue"/>
+		<xs:attribute name="defItem" type="xs:boolean"/>
+		<xs:attribute name="changeRowSet" type="xs:boolean"/>
+		<xs:attribute name="changeRowOrder" type="xs:boolean"/>
+		<xs:attribute name="width" type="xs:decimal"/>
+		<xs:attribute name="height" type="xs:decimal"/>
+		<xs:attribute name="rowsCount" type="xs:decimal"/>
+		<xs:attribute name="heightControlVariant" type="tns:TableHeightControlVariant"/>
+		<xs:attribute name="autoMaxRowsCount" type="xs:boolean"/>
+		<xs:attribute name="maxRowsCount" type="xs:decimal"/>
+		<xs:attribute name="autoMaxWidth" type="xs:boolean"/>
+		<xs:attribute name="maxWidth" type="xs:decimal"/>
+		<xs:attribute name="minWidth" type="xs:decimal"/>
+		<xs:attribute name="autoMaxHeight" type="xs:boolean"/>
+		<xs:attribute name="maxHeight" type="xs:decimal"/>
+		<xs:attribute name="choiceMode" type="xs:boolean"/>
+		<xs:attribute name="multipleChoice" type="xs:boolean"/>
+		<xs:attribute name="rowInput" type="tns:TableRowInputMode"/>
+		<xs:attribute name="rowsSelection" type="tns:TableSelectionMode"/>
+		<xs:attribute name="rowSelection" type="tns:TableRowSelectionMode"/>
+		<xs:attribute name="showHeader" type="xs:boolean"/>
+		<xs:attribute name="headerHeight" type="xs:decimal"/>
+		<xs:attribute name="showFooter" type="xs:boolean"/>
+		<xs:attribute name="footerHeight" type="xs:decimal"/>
+		<xs:attribute name="horScroll" type="tns:TableScrollBarUse"/>
+		<xs:attribute name="verScroll" type="tns:TableScrollBarUse"/>
+		<xs:attribute name="showHorLines" type="xs:boolean"/>
+		<xs:attribute name="showVerLines" type="xs:boolean"/>
+		<xs:attribute name="fixedLeft" type="xs:decimal"/>
+		<xs:attribute name="fixedRight" type="xs:decimal"/>
+		<xs:attribute name="useAltRowColor" type="xs:boolean"/>
+		<xs:attribute name="autoInsert" type="xs:boolean"/>
+		<xs:attribute name="autoInsertNotcompleted" type="tns:BWAValue"/>
+		<xs:attribute name="autoMarkNotcompleted" type="tns:BWAValue"/>
+		<xs:attribute name="searchOnInput" type="tns:SearchOnInput"/>
+		<xs:attribute name="initListView" type="tns:TableInitialListView"/>
+		<xs:attribute name="initTreeView" type="tns:TableInitialTreeView"/>
+		<xs:attribute name="useOutput" type="ns2:UseOutput"/>
+		<xs:attribute name="horStretch" type="xs:boolean"/>
+		<xs:attribute name="verStretch" type="xs:boolean"/>
+		<xs:attribute name="startDrag" type="xs:boolean"/>
+		<xs:attribute name="drag" type="xs:boolean"/>
+		<xs:attribute name="tooltipRepres" type="tns:TooltipRepresentation"/>
+		<xs:attribute name="searchStringLocation" type="tns:SearchStringLocation"/>
+		<xs:attribute name="viewStatusLocation" type="tns:ViewStatusLocation"/>
+		<xs:attribute name="searchControlLocation" type="tns:SearchControlLocation"/>
+		<xs:attribute name="groupHAlign" type="tns:ItemHorizontalAlignment"/>
+		<xs:attribute name="groupVAlign" type="tns:ItemVerticalAlignment"/>
+		<xs:attribute name="clearEvents" type="xs:boolean"/>
+		<xs:attribute name="refreshRequest" type="tns:RefreshRequestMethod"/>
+		<xs:attribute name="currentRowUse" type="tns:TableCurrentRowUse"/>
+		<xs:attribute name="behaviorOnHorizontalCompression" type="tns:TableBehaviorOnHorizontalCompression"/>
+		<xs:attribute name="displayImportance" type="tns:DisplayImportance"/>
+		<xs:attribute name="fileDragMode" type="tns:FileDragMode"/>
+		<xs:attribute name="MSIB" type="tns:OnMainServerUnavalableBehavior"/>
+	</xs:complexType>
+	<xs:complexType name="TextDecorationData">
+		<xs:sequence>
+			<xs:element name="bkClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="brdClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="brd" type="ns2:Border" minOccurs="0"/>
+			<xs:element name="event" type="tns:Event" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="hyper" type="xs:boolean"/>
+		<xs:attribute name="hAlign" type="tns:ItemHorizontalAlignment"/>
+		<xs:attribute name="vAlign" type="tns:ItemVerticalAlignment"/>
+		<xs:attribute name="titleHeight" type="xs:decimal"/>
+		<xs:attribute name="clearEvents" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="TextDocFieldData">
+		<xs:sequence>
+			<xs:element name="txtClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="bkClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="brdClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="fnt" type="ns2:Font" minOccurs="0"/>
+			<xs:element name="event" type="tns:Event" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="width" type="xs:decimal"/>
+		<xs:attribute name="height" type="xs:decimal"/>
+		<xs:attribute name="horStretch" type="xs:boolean"/>
+		<xs:attribute name="verStretch" type="xs:boolean"/>
+		<xs:attribute name="autoMaxWidth" type="xs:boolean"/>
+		<xs:attribute name="maxWidth" type="xs:decimal"/>
+		<xs:attribute name="minWidth" type="xs:decimal"/>
+		<xs:attribute name="autoMaxHeight" type="xs:boolean"/>
+		<xs:attribute name="maxHeight" type="xs:decimal"/>
+		<xs:attribute name="useOutput" type="ns2:UseOutput"/>
+		<xs:attribute name="clearEvents" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="TextFieldData">
+		<xs:sequence>
+			<xs:element name="txtClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="bkClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="brdClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="brd" type="ns2:Border" minOccurs="0"/>
+			<xs:element name="fnt" type="ns2:Font" minOccurs="0"/>
+			<xs:element name="event" type="tns:Event" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="width" type="xs:decimal"/>
+		<xs:attribute name="rowsCount" type="xs:decimal"/>
+		<xs:attribute name="horStretch" type="tns:BWAValue"/>
+		<xs:attribute name="verStretch" type="tns:BWAValue"/>
+		<xs:attribute name="autoMaxWidth" type="xs:boolean"/>
+		<xs:attribute name="maxWidth" type="xs:decimal"/>
+		<xs:attribute name="minWidth" type="xs:decimal"/>
+		<xs:attribute name="autoMaxHeight" type="xs:boolean"/>
+		<xs:attribute name="maxHeight" type="xs:decimal"/>
+		<xs:attribute name="markNeg" type="tns:BWAValue"/>
+		<xs:attribute name="format" type="xs:string"/>
+		<xs:attribute name="hyper" type="xs:boolean"/>
+		<xs:attribute name="psw" type="tns:BWAValue"/>
+		<xs:attribute name="clearEvents" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="TrackBarFieldData">
+		<xs:sequence>
+			<xs:element name="brdClr" type="ns2:Color" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="width" type="xs:decimal"/>
+		<xs:attribute name="height" type="xs:decimal"/>
+		<xs:attribute name="horStretch" type="xs:boolean"/>
+		<xs:attribute name="verStretch" type="xs:boolean"/>
+		<xs:attribute name="autoMaxWidth" type="xs:boolean"/>
+		<xs:attribute name="maxWidth" type="xs:decimal"/>
+		<xs:attribute name="minWidth" type="xs:decimal"/>
+		<xs:attribute name="autoMaxHeight" type="xs:boolean"/>
+		<xs:attribute name="maxHeight" type="xs:decimal"/>
+		<xs:attribute name="minVal" type="xs:decimal"/>
+		<xs:attribute name="maxVal" type="xs:decimal"/>
+		<xs:attribute name="step" type="xs:decimal"/>
+		<xs:attribute name="pageSize" type="xs:decimal"/>
+		<xs:attribute name="markingStep" type="xs:decimal"/>
+		<xs:attribute name="orientation" type="tns:FormElementOrientation"/>
+		<xs:attribute name="marking" type="tns:MarkingStyle"/>
+	</xs:complexType>
+	<xs:complexType name="UsualGroupData">
+		<xs:sequence>
+			<xs:element name="prop" type="tns:DataPath" minOccurs="0"/>
+			<xs:element name="propName" type="xs:string" minOccurs="0"/>
+			<xs:element name="tdp" type="ns1:TypeDescription" minOccurs="0"/>
+			<xs:element name="bkClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="hiddenStateTitleBkClr" type="ns2:Color" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="grouping" type="tns:FormChildrenGroup"/>
+		<xs:attribute name="align" type="tns:FormChildrenAlign"/>
+		<xs:attribute name="horizontalSpacing" type="tns:FormItemSpacing"/>
+		<xs:attribute name="verticalSpacing" type="tns:FormItemSpacing"/>
+		<xs:attribute name="hAlign" type="tns:ItemHorizontalAlignment"/>
+		<xs:attribute name="vAlign" type="tns:ItemVerticalAlignment"/>
+		<xs:attribute name="childrenWidth" type="tns:FormChildrenWidth"/>
+		<xs:attribute name="repres" type="tns:UsualGroupRepresentation"/>
+		<xs:attribute name="bhv" type="tns:UsualGroupBehavior"/>
+		<xs:attribute name="mngRepres" type="tns:UsualGroupControlRepresentation"/>
+		<xs:attribute name="throughAlign" type="tns:UsualGroupThroughAlign"/>
+		<xs:attribute name="showTitle" type="xs:boolean"/>
+		<xs:attribute name="collapsed" type="xs:boolean"/>
+		<xs:attribute name="leftMargin" type="xs:boolean"/>
+		<xs:attribute name="united" type="xs:boolean"/>
+		<xs:attribute name="format" type="xs:string"/>
+		<xs:attribute name="clsTitle" type="xs:string"/>
+		<xs:attribute name="currentRowUse" type="tns:CurrentRowUse"/>
+		<xs:attribute name="associatedTableElementId" type="xs:decimal"/>
+	</xs:complexType>
+	<xs:complexType name="ViewStatusData">
+		<xs:sequence>
+			<xs:element name="bkClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="btnClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="txtClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="titleTxtClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="brdClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="fnt" type="ns2:Font" minOccurs="0"/>
+			<xs:element name="titleFnt" type="ns2:Font" minOccurs="0"/>
+			<xs:element name="brd" type="ns2:Border" minOccurs="0"/>
+			<xs:element name="event" type="tns:Event" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="width" type="xs:decimal"/>
+		<xs:attribute name="autoMaxWidth" type="xs:boolean"/>
+		<xs:attribute name="maxWidth" type="xs:decimal"/>
+		<xs:attribute name="minWidth" type="xs:decimal"/>
+		<xs:attribute name="horStretch" type="tns:BWAValue"/>
+		<xs:attribute name="hAlign" type="tns:ItemHorizontalAlignment"/>
+	</xs:complexType>
+</xs:schema>

--- a/src/main/xsd/v8.3.27/v8.1c.ru-8.2-managed-application-modules.xsd
+++ b/src/main/xsd/v8.3.27/v8.1c.ru-8.2-managed-application-modules.xsd
@@ -1,0 +1,71 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:ns1="http://v8.1c.ru/8.1/data/core" xmlns:ns2="http://v8.1c.ru/8.2/managed-application/core" xmlns:ns3="http://v8.1c.ru/8.2/data/bsl" xmlns:tns="http://v8.1c.ru/8.2/managed-application/modules" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://v8.1c.ru/8.2/managed-application/modules" attributeFormDefault="unqualified" elementFormDefault="qualified">
+	<xs:import namespace="http://v8.1c.ru/8.1/data/core"/>
+	<xs:import namespace="http://v8.1c.ru/8.2/managed-application/core"/>
+	<xs:import namespace="http://v8.1c.ru/8.2/data/bsl"/>
+	<xs:simpleType name="ParamDirection">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="InOut"/>
+			<xs:enumeration value="In"/>
+			<xs:enumeration value="Out"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="MethodCall">
+		<xs:sequence>
+			<xs:element name="ret" nillable="true" minOccurs="0"/>
+			<xs:element name="param" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="pfc" type="tns:ProcessFormsCloseParam" nillable="true" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="name" type="xs:Name"/>
+	</xs:complexType>
+	<xs:complexType name="MethodDef">
+		<xs:choice>
+			<xs:element name="param" type="tns:ParamDef" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:choice>
+		<xs:attribute name="name" type="xs:Name"/>
+		<xs:attribute name="exp" type="xs:boolean" default="false"/>
+		<xs:attribute name="params" type="xs:decimal"/>
+	</xs:complexType>
+	<xs:complexType name="MethodDefs">
+		<xs:choice>
+			<xs:element name="proc" type="tns:MethodDef" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="func" type="tns:MethodDef" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="ModuleContentDef">
+		<xs:sequence>
+			<xs:element name="moduleMethods" type="tns:MethodDefs" minOccurs="0"/>
+			<xs:element name="moduleImage" type="ns3:BSLModuleImage" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ModuleDef">
+		<xs:sequence>
+			<xs:element name="image" type="ns3:BSLModuleImage" minOccurs="0"/>
+			<xs:element name="extension" type="tns:ModuleDef" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="securityInfo" type="xs:string"/>
+		</xs:sequence>
+		<xs:attribute name="id" type="xs:string"/>
+		<xs:attribute name="code" type="xs:Name"/>
+		<xs:attribute name="name" type="xs:Name"/>
+		<xs:attribute name="cached" type="xs:integer"/>
+	</xs:complexType>
+	<xs:complexType name="ModulesDef">
+		<xs:sequence>
+			<xs:element name="main" type="tns:ModuleDef"/>
+			<xs:element name="global" type="tns:ModuleDef" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="client" type="tns:ModuleDef" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="server" type="tns:ModuleDef" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="alias" type="ns2:Alias" default="en"/>
+	</xs:complexType>
+	<xs:complexType name="ParamDef">
+		<xs:attribute name="dir" type="tns:ParamDirection" default="InOut"/>
+		<xs:attribute name="pos" type="xs:decimal"/>
+		<xs:attribute name="def" type="xs:boolean" default="false"/>
+	</xs:complexType>
+	<xs:complexType name="ProcessFormsCloseParam">
+		<xs:sequence>
+			<xs:element name="id" type="ns1:UUID" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+</xs:schema>

--- a/src/main/xsd/v8.3.27/v8.1c.ru-8.2-uobjects.xsd
+++ b/src/main/xsd/v8.3.27/v8.1c.ru-8.2-uobjects.xsd
@@ -1,0 +1,379 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:ns1="http://v8.1c.ru/8.1/data/core" xmlns:tns="http://v8.1c.ru/8.2/uobjects" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://v8.1c.ru/8.2/uobjects" attributeFormDefault="unqualified" elementFormDefault="qualified">
+	<xs:import namespace="http://v8.1c.ru/8.1/data/core"/>
+	<xs:simpleType name="AccessMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="rw"/>
+			<xs:enumeration value="r"/>
+			<xs:enumeration value="none"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CollectionIds">
+		<xs:list itemType="xs:long"/>
+	</xs:simpleType>
+	<xs:simpleType name="RemoteKey">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="StructureFields">
+		<xs:list itemType="xs:unsignedInt"/>
+	</xs:simpleType>
+	<xs:simpleType name="TypeList">
+		<xs:list itemType="ns1:UUID"/>
+	</xs:simpleType>
+	<xs:complexType name="BaseDescription"/>
+	<xs:complexType name="BaseStructure">
+		<xs:sequence>
+			<xs:element name="v" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="fields" type="tns:StructureFields"/>
+		<xs:attribute name="fixedFields" type="tns:StructureFields"/>
+	</xs:complexType>
+	<xs:complexType name="Changes">
+		<xs:choice>
+			<xs:element name="structure" type="tns:StructureChanges" minOccurs="0"/>
+			<xs:element name="collection" type="tns:CollectionChanges" minOccurs="0"/>
+			<xs:element name="structureAndCollection" type="tns:StructureAndCollectionChanges" minOccurs="0"/>
+			<xs:element name="tree" type="tns:TreeChanges" minOccurs="0"/>
+		</xs:choice>
+		<xs:attribute name="sinDesc" type="xs:unsignedInt"/>
+		<xs:attribute name="sin" type="xs:unsignedInt"/>
+		<xs:attribute name="seq" type="xs:unsignedInt"/>
+	</xs:complexType>
+	<xs:complexType name="Collection">
+		<xs:sequence>
+			<xs:element name="column" type="tns:CollectionColumn" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="item" type="tns:CollectionItem" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="count" type="xs:unsignedInt" use="required"/>
+		<xs:attribute name="lastId" type="xs:long" use="required"/>
+		<xs:attribute name="ids" type="tns:CollectionIds"/>
+		<xs:attribute name="fullChanged" type="xs:boolean"/>
+		<xs:attribute name="firstAddedLine" type="xs:integer"/>
+	</xs:complexType>
+	<xs:complexType name="CollectionChanges">
+		<xs:sequence>
+			<xs:element name="operations" type="tns:CollectionOperations" minOccurs="0"/>
+			<xs:element name="items" type="tns:CollectionItemChangesList" minOccurs="0"/>
+			<xs:element name="column" type="tns:CollectionColumn" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="count" type="xs:unsignedInt" use="required"/>
+		<xs:attribute name="lastId" type="xs:long" use="required"/>
+		<xs:attribute name="fullChanged" type="xs:boolean"/>
+		<xs:attribute name="firstAddedLine" type="xs:integer"/>
+		<xs:attribute name="dropOld" type="xs:boolean" default="false"/>
+	</xs:complexType>
+	<xs:complexType name="CollectionColumn">
+		<xs:attribute name="id" type="ns1:CompositeID" use="required"/>
+		<xs:attribute name="total" type="xs:decimal" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="CollectionFragment">
+		<xs:choice>
+			<xs:element name="item" type="tns:CollectionFragmentItem" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="CollectionFragmentItem">
+		<xs:complexContent>
+			<xs:extension base="tns:BaseStructure">
+				<xs:attribute name="id" type="xs:long" use="required"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="CollectionItem">
+		<xs:complexContent>
+			<xs:extension base="tns:BaseStructure">
+				<xs:attribute name="index" type="xs:unsignedInt" use="required"/>
+				<xs:attribute name="id" type="xs:long" use="required"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="CollectionItemChanges">
+		<xs:sequence>
+			<xs:element name="structure" type="tns:StructureChanges" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="index" type="xs:unsignedInt" use="required"/>
+		<xs:attribute name="id" type="xs:long" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="CollectionItemChangesList">
+		<xs:choice>
+			<xs:element name="item" type="tns:CollectionItemChanges" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="CollectionOperationAdd">
+		<xs:attribute name="index" type="xs:unsignedInt" use="required"/>
+		<xs:attribute name="id" type="xs:long" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="CollectionOperationAddRange">
+		<xs:attribute name="index1" type="xs:unsignedInt" use="required"/>
+		<xs:attribute name="index2" type="xs:unsignedInt" use="required"/>
+		<xs:attribute name="startId" type="xs:long" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="CollectionOperationClear"/>
+	<xs:complexType name="CollectionOperationMove">
+		<xs:attribute name="index" type="xs:unsignedInt" use="required"/>
+		<xs:attribute name="delta" type="xs:integer" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="CollectionOperationRemove">
+		<xs:attribute name="index" type="xs:unsignedInt" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="CollectionOperationRemoveRange">
+		<xs:attribute name="index1" type="xs:unsignedInt" use="required"/>
+		<xs:attribute name="index2" type="xs:unsignedInt" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="CollectionOperationSwap">
+		<xs:attribute name="index1" type="xs:unsignedInt" use="required"/>
+		<xs:attribute name="index2" type="xs:unsignedInt" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="CollectionOperations">
+		<xs:choice>
+			<xs:element name="add" type="tns:CollectionOperationAdd" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="addRange" type="tns:CollectionOperationAddRange" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="remove" type="tns:CollectionOperationRemove" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="removeRange" type="tns:CollectionOperationRemoveRange" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="swap" type="tns:CollectionOperationSwap" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="move" type="tns:CollectionOperationMove" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="clear" type="tns:CollectionOperationClear" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="FormDataCollection">
+		<xs:sequence>
+			<xs:element name="descriptions" type="tns:FormDataDescriptions"/>
+			<xs:element name="type" type="xs:string"/>
+			<xs:element name="data" type="tns:Collection"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="FormDataCollectionDescription">
+		<xs:complexContent>
+			<xs:extension base="tns:BaseDescription">
+				<xs:attribute name="name" type="xs:string" use="required"/>
+				<xs:attribute name="maxCount" type="xs:decimal" default="0"/>
+				<xs:attribute name="fixed" type="xs:boolean" default="false"/>
+				<xs:attribute name="itemType" type="xs:string" use="required"/>
+				<xs:attribute name="lineNoFieldId" type="ns1:CompositeID"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="FormDataDescriptionChanges">
+		<xs:choice>
+			<xs:element name="added" type="tns:FormDataDescriptions" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="removed" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="changed" type="tns:FormDataStructureChanges" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:choice>
+		<xs:attribute name="sin" type="xs:decimal" use="required"/>
+		<xs:attribute name="seq" type="xs:decimal" use="required"/>
+		<xs:attribute name="sinUo" type="xs:decimal" use="required"/>
+		<xs:attribute name="seqUo" type="xs:decimal" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="FormDataDescriptions">
+		<xs:choice>
+			<xs:element name="structure" type="tns:FormDataStructureDescription" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="collection" type="tns:FormDataCollectionDescription" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="structureAndCollection" type="tns:FormDataStructureAndCollectionDescription" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="tree" type="tns:FormDataTreeDescription" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:choice>
+		<xs:attribute name="remoteKey" type="tns:RemoteKey" use="required"/>
+		<xs:attribute name="trackChanges" type="xs:boolean" use="required"/>
+		<xs:attribute name="sinDe" type="xs:unsignedInt" use="required"/>
+		<xs:attribute name="seqDe" type="xs:unsignedInt" use="required"/>
+		<xs:attribute name="sinUo" type="xs:unsignedInt" use="required"/>
+		<xs:attribute name="seqUo" type="xs:unsignedInt" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="FormDataFieldDescription">
+		<xs:sequence>
+			<xs:element name="type" type="tns:FormDataTypeDescription"/>
+		</xs:sequence>
+		<xs:attribute name="id" type="ns1:CompositeID" use="required"/>
+		<xs:attribute name="name" type="xs:string" use="required"/>
+		<xs:attribute name="nameRu" type="xs:string" default=""/>
+		<xs:attribute name="mode" type="tns:AccessMode" default="rw"/>
+		<xs:attribute name="imode" type="tns:AccessMode" default="rw"/>
+		<xs:attribute name="fromCntx" type="xs:boolean" default="false"/>
+	</xs:complexType>
+	<xs:complexType name="FormDataStructure">
+		<xs:sequence>
+			<xs:element name="descriptions" type="tns:FormDataDescriptions"/>
+			<xs:element name="type" type="xs:string"/>
+			<xs:element name="data" type="tns:Structure"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="FormDataStructureAndCollection">
+		<xs:sequence>
+			<xs:element name="descriptions" type="tns:FormDataDescriptions"/>
+			<xs:element name="type" type="xs:string"/>
+			<xs:element name="data" type="tns:StructureAndCollection"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="FormDataStructureAndCollectionDescription">
+		<xs:complexContent>
+			<xs:extension base="tns:BaseDescription">
+				<xs:sequence>
+					<xs:element name="structure" type="tns:FormDataStructureDescription"/>
+					<xs:element name="collection" type="tns:FormDataCollectionDescription"/>
+				</xs:sequence>
+				<xs:attribute name="name" type="xs:string" use="required"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="FormDataStructureChanges">
+		<xs:choice>
+			<xs:element name="added" type="tns:FormDataFieldDescription" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="removed" type="ns1:CompositeID" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="changed" type="tns:FormDataFieldDescription" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:choice>
+		<xs:attribute name="name" type="xs:string" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="FormDataStructureDescription">
+		<xs:complexContent>
+			<xs:extension base="tns:BaseDescription">
+				<xs:sequence>
+					<xs:element name="field" type="tns:FormDataFieldDescription" minOccurs="0" maxOccurs="unbounded"/>
+				</xs:sequence>
+				<xs:attribute name="name" type="xs:string" use="required"/>
+				<xs:attribute name="value" type="xs:boolean" default="false"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="FormDataTree">
+		<xs:sequence>
+			<xs:element name="descriptions" type="tns:FormDataDescriptions"/>
+			<xs:element name="type" type="xs:string"/>
+			<xs:element name="data" type="tns:Tree"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="FormDataTreeDescription">
+		<xs:complexContent>
+			<xs:extension base="tns:BaseDescription">
+				<xs:attribute name="name" type="xs:string" use="required"/>
+				<xs:attribute name="itemType" type="xs:string" use="required"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="FormDataTypeDescription">
+		<xs:simpleContent>
+			<xs:extension base="tns:TypeList">
+				<xs:attribute name="object" type="xs:boolean" default="false"/>
+				<xs:attribute name="digits" type="xs:decimal" default="10"/>
+				<xs:attribute name="precision" type="xs:decimal" default="0"/>
+				<xs:attribute name="unsigned" type="xs:boolean" default="false"/>
+				<xs:attribute name="length" type="xs:decimal" default="10"/>
+				<xs:attribute name="fixed" type="xs:boolean" default="false"/>
+				<xs:attribute name="dateFraction" type="ns1:DateFractions" default="DateTime"/>
+				<xs:attribute name="binaryLength" type="xs:decimal" default="0"/>
+				<xs:attribute name="binaryFixed" type="xs:boolean" default="false"/>
+				<xs:attribute name="name" type="xs:string"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:complexType name="Fragment">
+		<xs:choice>
+			<xs:element name="collection" type="tns:CollectionFragment" minOccurs="0"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="Structure">
+		<xs:complexContent>
+			<xs:extension base="tns:BaseStructure"/>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="StructureAndCollection">
+		<xs:sequence>
+			<xs:element name="structure" type="tns:BaseStructure"/>
+			<xs:element name="collection" type="tns:Collection"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="StructureAndCollectionChanges">
+		<xs:sequence>
+			<xs:element name="structure" type="tns:StructureChanges" minOccurs="0"/>
+			<xs:element name="collection" type="tns:CollectionChanges" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="StructureChanges">
+		<xs:choice>
+			<xs:element name="v" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:choice>
+		<xs:attribute name="fields" type="tns:StructureFields"/>
+		<xs:attribute name="fixedFields" type="tns:StructureFields"/>
+	</xs:complexType>
+	<xs:complexType name="Tree">
+		<xs:choice>
+			<xs:element name="item" type="tns:TreeItem" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="TreeChanges">
+		<xs:sequence>
+			<xs:element name="operations" type="tns:TreeOperations" minOccurs="0"/>
+			<xs:element name="items" type="tns:TreeItemChangesList" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TreeItem">
+		<xs:complexContent>
+			<xs:extension base="tns:BaseStructure">
+				<xs:choice>
+					<xs:element name="item" type="tns:TreeItem" minOccurs="0" maxOccurs="unbounded"/>
+				</xs:choice>
+				<xs:attribute name="id" type="xs:long" use="required"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="TreeItemChanges">
+		<xs:sequence>
+			<xs:element name="structure" type="tns:StructureChanges" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="id" type="xs:long" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TreeItemChangesList">
+		<xs:choice>
+			<xs:element name="item" type="tns:TreeItemChanges" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="TreeOperationAdd">
+		<xs:attribute name="parentId" type="xs:long"/>
+		<xs:attribute name="index" type="xs:unsignedInt" use="required"/>
+		<xs:attribute name="id" type="xs:long" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TreeOperationAddRange">
+		<xs:attribute name="parentId" type="xs:long"/>
+		<xs:attribute name="index1" type="xs:unsignedInt" use="required"/>
+		<xs:attribute name="index2" type="xs:unsignedInt" use="required"/>
+		<xs:attribute name="startId" type="xs:long" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TreeOperationClear">
+		<xs:attribute name="parentId" type="xs:long"/>
+	</xs:complexType>
+	<xs:complexType name="TreeOperationMove">
+		<xs:attribute name="parentId" type="xs:long"/>
+		<xs:attribute name="index" type="xs:unsignedInt" use="required"/>
+		<xs:attribute name="delta" type="xs:integer" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TreeOperationRemove">
+		<xs:attribute name="parentId" type="xs:long"/>
+		<xs:attribute name="index" type="xs:unsignedInt" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TreeOperationRemoveRange">
+		<xs:attribute name="parentId" type="xs:long"/>
+		<xs:attribute name="index1" type="xs:unsignedInt" use="required"/>
+		<xs:attribute name="index2" type="xs:unsignedInt" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TreeOperationSwap">
+		<xs:attribute name="parentId" type="xs:long"/>
+		<xs:attribute name="index1" type="xs:unsignedInt" use="required"/>
+		<xs:attribute name="index2" type="xs:unsignedInt" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TreeOperations">
+		<xs:choice>
+			<xs:element name="add" type="tns:TreeOperationAdd" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="addRange" type="tns:TreeOperationAddRange" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="remove" type="tns:TreeOperationRemove" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="removeRange" type="tns:TreeOperationRemoveRange" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="swap" type="tns:TreeOperationSwap" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="move" type="tns:TreeOperationMove" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="clear" type="tns:TreeOperationClear" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="UObject">
+		<xs:sequence>
+			<xs:element name="descriptions" type="tns:FormDataDescriptions" minOccurs="0"/>
+			<xs:element name="name" type="xs:string" minOccurs="0"/>
+			<xs:element name="data"/>
+		</xs:sequence>
+		<xs:attribute name="mode" type="xs:string" use="required"/>
+	</xs:complexType>
+</xs:schema>

--- a/src/main/xsd/v8.3.27/v8.1c.ru-8.3-MDClasses.xsd
+++ b/src/main/xsd/v8.3.27/v8.1c.ru-8.3-MDClasses.xsd
@@ -1,0 +1,2859 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:ns1="http://v8.1c.ru/8.1/data/core" xmlns:ns2="http://v8.1c.ru/8.1/data/enterprise" xmlns:ns3="http://v8.1c.ru/8.1/data/ui" xmlns:ns4="http://v8.1c.ru/8.2/managed-application/core" xmlns:ns5="http://v8.1c.ru/8.2/managed-application/cmi" xmlns:ns6="http://v8.1c.ru/8.2/managed-application/logform" xmlns:ns7="http://v8.1c.ru/8.3/xcf/enums" xmlns:ns8="http://v8.1c.ru/8.3/xcf/readable" xmlns:ns9="http://v8.1c.ru/8.3/xcf/predef" xmlns:tns="http://v8.1c.ru/8.3/MDClasses" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://v8.1c.ru/8.3/MDClasses" attributeFormDefault="unqualified" elementFormDefault="qualified">
+	<xs:import namespace="http://v8.1c.ru/8.1/data/core"/>
+	<xs:import namespace="http://v8.1c.ru/8.1/data/enterprise"/>
+	<xs:import namespace="http://v8.1c.ru/8.1/data/ui"/>
+	<xs:import namespace="http://v8.1c.ru/8.2/managed-application/core"/>
+	<xs:import namespace="http://v8.1c.ru/8.2/managed-application/cmi"/>
+	<xs:import namespace="http://v8.1c.ru/8.2/managed-application/logform"/>
+	<xs:import namespace="http://v8.1c.ru/8.3/xcf/enums"/>
+	<xs:import namespace="http://v8.1c.ru/8.3/xcf/readable"/>
+	<xs:import namespace="http://v8.1c.ru/8.3/xcf/predef"/>
+	<xs:element name="MetaDataObject" type="tns:MetaDataObject"/>
+	<xs:complexType name="AccountingFlag">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:AccountingFlagProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="AccountingFlagProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Type" type="ns1:TypeDescription"/>
+			<xs:element name="PasswordMode" type="xs:boolean"/>
+			<xs:element name="Format" type="ns1:LocalStringType"/>
+			<xs:element name="EditFormat" type="ns1:LocalStringType"/>
+			<xs:element name="ToolTip" type="ns1:LocalStringType"/>
+			<xs:element name="MarkNegatives" type="xs:boolean"/>
+			<xs:element name="Mask" type="xs:string"/>
+			<xs:element name="MultiLine" type="xs:boolean"/>
+			<xs:element name="ExtendedEdit" type="xs:boolean"/>
+			<xs:element name="MinValue"/>
+			<xs:element name="MaxValue"/>
+			<xs:element name="FillFromFillingValue" type="xs:boolean"/>
+			<xs:element name="FillValue"/>
+			<xs:element name="FillChecking" type="ns1:FillChecking"/>
+			<xs:element name="ChoiceFoldersAndItems" type="ns2:FoldersAndItemsUse"/>
+			<xs:element name="ChoiceParameterLinks" type="ns8:ChoiceParameterLinks"/>
+			<xs:element name="ChoiceParameters" type="ns4:ChoiceParameters"/>
+			<xs:element name="QuickChoice" type="ns7:UseQuickChoice"/>
+			<xs:element name="CreateOnInput" type="ns7:CreateOnInput"/>
+			<xs:element name="ChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="LinkByType" type="ns8:TypeLink"/>
+			<xs:element name="ChoiceHistoryOnInput" type="ns6:ChoiceHistoryOnInput"/>
+			<xs:element name="DataHistory" type="ns7:DataHistoryUse"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="AccountingRegister">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:AccountingRegisterProperties"/>
+					<xs:element name="ChildObjects" type="tns:AccountingRegisterChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="AccountingRegisterChildObjects">
+		<xs:sequence>
+			<xs:element name="Dimension" type="tns:Dimension" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Resource" type="tns:Resource" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Attribute" type="tns:Attribute" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Form" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Template" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Command" type="tns:Command" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="AccountingRegisterProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="UseStandardCommands" type="xs:boolean"/>
+			<xs:element name="IncludeHelpInContents" type="xs:boolean"/>
+			<xs:element name="Help" type="ns8:ExternalProperty"/>
+			<xs:element name="ChartOfAccounts" type="ns8:MDObjectRef"/>
+			<xs:element name="Correspondence" type="xs:boolean"/>
+			<xs:element name="PeriodAdjustmentLength" type="xs:decimal"/>
+			<xs:element name="DefaultListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="RecordSetModule" type="ns8:ExternalProperty"/>
+			<xs:element name="ManagerModule" type="ns8:ExternalProperty"/>
+			<xs:element name="StandardAttributes" type="ns8:StandardAttributeDescriptions"/>
+			<xs:element name="DataLockControlMode" type="ns7:DefaultDataLockControlMode"/>
+			<xs:element name="EnableTotalsSplitting" type="xs:boolean"/>
+			<xs:element name="FullTextSearch" type="ns7:FullTextSearchUsing"/>
+			<xs:element name="ListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="Explanation" type="ns1:LocalStringType"/>
+			<xs:element name="AdditionalIndexes" type="ns8:ExternalProperty"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="AccumulationRegister">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:AccumulationRegisterProperties"/>
+					<xs:element name="ChildObjects" type="tns:AccumulationRegisterChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="AccumulationRegisterChildObjects">
+		<xs:sequence>
+			<xs:element name="Resource" type="tns:Resource" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Attribute" type="tns:Attribute" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Dimension" type="tns:Dimension" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Form" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Template" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Command" type="tns:Command" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="AccumulationRegisterProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="UseStandardCommands" type="xs:boolean"/>
+			<xs:element name="DefaultListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="RegisterType" type="ns7:AccumulationRegisterType"/>
+			<xs:element name="IncludeHelpInContents" type="xs:boolean"/>
+			<xs:element name="Help" type="ns8:ExternalProperty"/>
+			<xs:element name="RecordSetModule" type="ns8:ExternalProperty"/>
+			<xs:element name="ManagerModule" type="ns8:ExternalProperty"/>
+			<xs:element name="StandardAttributes" type="ns8:StandardAttributeDescriptions"/>
+			<xs:element name="DataLockControlMode" type="ns7:DefaultDataLockControlMode"/>
+			<xs:element name="FullTextSearch" type="ns7:FullTextSearchUsing"/>
+			<xs:element name="EnableTotalsSplitting" type="xs:boolean"/>
+			<xs:element name="Aggregates" type="ns8:ExternalProperty"/>
+			<xs:element name="ListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="Explanation" type="ns1:LocalStringType"/>
+			<xs:element name="AdditionalIndexes" type="ns8:ExternalProperty"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="AddressingAttribute">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:AddressingAttributeProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="AddressingAttributeProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Type" type="ns1:TypeDescription"/>
+			<xs:element name="PasswordMode" type="xs:boolean"/>
+			<xs:element name="Format" type="ns1:LocalStringType"/>
+			<xs:element name="EditFormat" type="ns1:LocalStringType"/>
+			<xs:element name="ToolTip" type="ns1:LocalStringType"/>
+			<xs:element name="MarkNegatives" type="xs:boolean"/>
+			<xs:element name="Mask" type="xs:string"/>
+			<xs:element name="MultiLine" type="xs:boolean"/>
+			<xs:element name="ExtendedEdit" type="xs:boolean"/>
+			<xs:element name="MinValue"/>
+			<xs:element name="MaxValue"/>
+			<xs:element name="FillFromFillingValue" type="xs:boolean"/>
+			<xs:element name="FillValue"/>
+			<xs:element name="FillChecking" type="ns1:FillChecking"/>
+			<xs:element name="ChoiceFoldersAndItems" type="ns2:FoldersAndItemsUse"/>
+			<xs:element name="ChoiceParameterLinks" type="ns8:ChoiceParameterLinks"/>
+			<xs:element name="ChoiceParameters" type="ns4:ChoiceParameters"/>
+			<xs:element name="QuickChoice" type="ns7:UseQuickChoice"/>
+			<xs:element name="CreateOnInput" type="ns7:CreateOnInput"/>
+			<xs:element name="ChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="LinkByType" type="ns8:TypeLink"/>
+			<xs:element name="ChoiceHistoryOnInput" type="ns6:ChoiceHistoryOnInput"/>
+			<xs:element name="Indexing" type="ns7:Indexing"/>
+			<xs:element name="AddressingDimension" type="ns8:MDObjectRef"/>
+			<xs:element name="FullTextSearch" type="ns7:FullTextSearchUsing"/>
+			<xs:element name="DataHistory" type="ns7:DataHistoryUse"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Attribute">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:AttributeProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="AttributeProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string" minOccurs="0"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="Comment" type="xs:string" minOccurs="0"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging" minOccurs="0"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Type" type="ns1:TypeDescription" minOccurs="0"/>
+			<xs:element name="PasswordMode" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="Format" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="EditFormat" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="ToolTip" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="MarkNegatives" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="Mask" type="xs:string" minOccurs="0"/>
+			<xs:element name="MultiLine" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="ExtendedEdit" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="MinValue" minOccurs="0"/>
+			<xs:element name="MaxValue" minOccurs="0"/>
+			<xs:element name="FillChecking" type="ns1:FillChecking" minOccurs="0"/>
+			<xs:element name="ChoiceFoldersAndItems" type="ns2:FoldersAndItemsUse" minOccurs="0"/>
+			<xs:element name="ChoiceParameterLinks" type="ns8:ChoiceParameterLinks" minOccurs="0"/>
+			<xs:element name="ChoiceParameters" type="ns4:ChoiceParameters" minOccurs="0"/>
+			<xs:element name="QuickChoice" type="ns7:UseQuickChoice" minOccurs="0"/>
+			<xs:element name="CreateOnInput" type="ns7:CreateOnInput" minOccurs="0"/>
+			<xs:element name="ChoiceForm" type="ns8:MDObjectRef" minOccurs="0"/>
+			<xs:element name="LinkByType" type="ns8:TypeLink" minOccurs="0"/>
+			<xs:element name="ChoiceHistoryOnInput" type="ns6:ChoiceHistoryOnInput" minOccurs="0"/>
+			<xs:element name="Indexing" type="ns7:Indexing" minOccurs="0"/>
+			<xs:element name="FullTextSearch" type="ns7:FullTextSearchUsing" minOccurs="0"/>
+			<xs:element name="DataHistory" type="ns7:DataHistoryUse" minOccurs="0"/>
+			<xs:element name="FillFromFillingValue" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="FillValue" minOccurs="0"/>
+			<xs:element name="Use" type="ns7:AttributeUse" minOccurs="0"/>
+			<xs:element name="ScheduleLink" type="ns8:MDObjectRef" minOccurs="0"/>
+			<xs:element name="BinaryDataStorageLocationUse" type="ns7:BinaryDataStorageLocationUse" minOccurs="0"/>
+			<xs:element name="BinaryDataStorageLocationUseField" type="ns8:MDObjectRef" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Bot">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:BotProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="BotProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Predefined" type="xs:boolean"/>
+			<xs:element name="Picture" type="ns8:Picture" minOccurs="0"/>
+			<xs:element name="Module" type="ns8:ExternalProperty"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="BusinessProcess">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:BusinessProcessProperties"/>
+					<xs:element name="ChildObjects" type="tns:BusinessProcessChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="BusinessProcessChildObjects">
+		<xs:sequence>
+			<xs:element name="Attribute" type="tns:Attribute" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="TabularSection" type="tns:TabularSection" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Form" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Template" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Command" type="tns:Command" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="BusinessProcessProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="UseStandardCommands" type="xs:boolean"/>
+			<xs:element name="ObjectModule" type="ns8:ExternalProperty"/>
+			<xs:element name="ManagerModule" type="ns8:ExternalProperty"/>
+			<xs:element name="Flowchart" type="ns8:ExternalProperty"/>
+			<xs:element name="EditType" type="ns7:EditType"/>
+			<xs:element name="InputByString" type="ns8:FieldList"/>
+			<xs:element name="CreateOnInput" type="ns7:CreateOnInput"/>
+			<xs:element name="SearchStringModeOnInputByString" type="ns6:SearchStringModeOnInputByString"/>
+			<xs:element name="ChoiceDataGetModeOnInputByString" type="ns6:ChoiceDataGetModeOnInputByString"/>
+			<xs:element name="FullTextSearchOnInputByString" type="ns6:FullTextSearchOnInputByString"/>
+			<xs:element name="DefaultObjectForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryObjectForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="ChoiceHistoryOnInput" type="ns6:ChoiceHistoryOnInput"/>
+			<xs:element name="NumberType" type="ns7:BusinessProcessNumberType"/>
+			<xs:element name="NumberLength" type="xs:decimal"/>
+			<xs:element name="NumberAllowedLength" type="ns1:AllowedLength"/>
+			<xs:element name="CheckUnique" type="xs:boolean"/>
+			<xs:element name="StandardAttributes" type="ns8:StandardAttributeDescriptions"/>
+			<xs:element name="Characteristics" type="ns8:CharacteristicsDescriptions"/>
+			<xs:element name="Autonumbering" type="xs:boolean"/>
+			<xs:element name="BasedOn" type="ns8:MDListType"/>
+			<xs:element name="NumberPeriodicity" type="ns7:BusinessProcessNumberPeriodicity"/>
+			<xs:element name="Task" type="ns8:MDObjectRef"/>
+			<xs:element name="CreateTaskInPrivilegedMode" type="xs:boolean"/>
+			<xs:element name="DataLockFields" type="ns8:FieldList"/>
+			<xs:element name="DataLockControlMode" type="ns7:DefaultDataLockControlMode"/>
+			<xs:element name="IncludeHelpInContents" type="xs:boolean"/>
+			<xs:element name="Help" type="ns8:ExternalProperty"/>
+			<xs:element name="FullTextSearch" type="ns7:FullTextSearchUsing"/>
+			<xs:element name="ObjectPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedObjectPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="Explanation" type="ns1:LocalStringType"/>
+			<xs:element name="DataHistory" type="ns7:DataHistoryUse"/>
+			<xs:element name="UpdateDataHistoryImmediatelyAfterWrite" type="xs:boolean"/>
+			<xs:element name="ExecuteAfterWriteDataHistoryVersionProcessing" type="xs:boolean"/>
+			<xs:element name="AdditionalIndexes" type="ns8:ExternalProperty"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CalculationRegister">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:CalculationRegisterProperties"/>
+					<xs:element name="ChildObjects" type="tns:CalculationRegisterChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="CalculationRegisterChildObjects">
+		<xs:sequence>
+			<xs:element name="Resource" type="tns:Resource" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Attribute" type="tns:Attribute" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Dimension" type="tns:Dimension" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Recalculation" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Form" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Template" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Command" type="tns:Command" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CalculationRegisterProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="UseStandardCommands" type="xs:boolean"/>
+			<xs:element name="DefaultListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="Periodicity" type="ns7:CalculationRegisterPeriodicity"/>
+			<xs:element name="ActionPeriod" type="xs:boolean"/>
+			<xs:element name="BasePeriod" type="xs:boolean"/>
+			<xs:element name="Schedule" type="ns8:MDObjectRef"/>
+			<xs:element name="ScheduleValue" type="ns8:MDObjectRef"/>
+			<xs:element name="ScheduleDate" type="ns8:MDObjectRef"/>
+			<xs:element name="ChartOfCalculationTypes" type="ns8:MDObjectRef"/>
+			<xs:element name="RecordSetModule" type="ns8:ExternalProperty"/>
+			<xs:element name="ManagerModule" type="ns8:ExternalProperty"/>
+			<xs:element name="IncludeHelpInContents" type="xs:boolean"/>
+			<xs:element name="Help" type="ns8:ExternalProperty"/>
+			<xs:element name="StandardAttributes" type="ns8:StandardAttributeDescriptions"/>
+			<xs:element name="DataLockControlMode" type="ns7:DefaultDataLockControlMode"/>
+			<xs:element name="FullTextSearch" type="ns7:FullTextSearchUsing"/>
+			<xs:element name="ListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="Explanation" type="ns1:LocalStringType"/>
+			<xs:element name="AdditionalIndexes" type="ns8:ExternalProperty"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Catalog">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:CatalogProperties"/>
+					<xs:element name="ChildObjects" type="tns:CatalogChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="CatalogChildObjects">
+		<xs:sequence>
+			<xs:element name="Attribute" type="tns:Attribute" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="TabularSection" type="tns:TabularSection" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Form" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Template" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Command" type="tns:Command" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CatalogProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Hierarchical" type="xs:boolean"/>
+			<xs:element name="HierarchyType" type="ns7:HierarchyType"/>
+			<xs:element name="LimitLevelCount" type="xs:boolean"/>
+			<xs:element name="LevelCount" type="xs:decimal"/>
+			<xs:element name="FoldersOnTop" type="xs:boolean"/>
+			<xs:element name="UseStandardCommands" type="xs:boolean"/>
+			<xs:element name="Owners" type="ns8:MDListType"/>
+			<xs:element name="SubordinationUse" type="ns7:SubordinationUse"/>
+			<xs:element name="CodeLength" type="xs:decimal"/>
+			<xs:element name="DescriptionLength" type="xs:decimal"/>
+			<xs:element name="CodeType" type="ns7:CatalogCodeType"/>
+			<xs:element name="CodeAllowedLength" type="ns1:AllowedLength"/>
+			<xs:element name="CodeSeries" type="ns7:CatalogCodesSeries"/>
+			<xs:element name="CheckUnique" type="xs:boolean"/>
+			<xs:element name="Autonumbering" type="xs:boolean"/>
+			<xs:element name="DefaultPresentation" type="ns7:CatalogMainPresentation"/>
+			<xs:element name="StandardAttributes" type="ns8:StandardAttributeDescriptions"/>
+			<xs:element name="Characteristics" type="ns8:CharacteristicsDescriptions"/>
+			<xs:element name="Predefined" type="ns8:ExternalProperty"/>
+			<xs:element name="PredefinedDataUpdate" type="ns7:PredefinedDataUpdate"/>
+			<xs:element name="EditType" type="ns7:EditType"/>
+			<xs:element name="QuickChoice" type="xs:boolean"/>
+			<xs:element name="ChoiceMode" type="ns7:ChoiceMode"/>
+			<xs:element name="InputByString" type="ns8:FieldList"/>
+			<xs:element name="SearchStringModeOnInputByString" type="ns6:SearchStringModeOnInputByString"/>
+			<xs:element name="FullTextSearchOnInputByString" type="ns6:FullTextSearchOnInputByString"/>
+			<xs:element name="ChoiceDataGetModeOnInputByString" type="ns6:ChoiceDataGetModeOnInputByString"/>
+			<xs:element name="DefaultObjectForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultFolderForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultFolderChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryObjectForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryFolderForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryFolderChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="ObjectModule" type="ns8:ExternalProperty"/>
+			<xs:element name="ManagerModule" type="ns8:ExternalProperty"/>
+			<xs:element name="IncludeHelpInContents" type="xs:boolean"/>
+			<xs:element name="Help" type="ns8:ExternalProperty"/>
+			<xs:element name="BasedOn" type="ns8:MDListType"/>
+			<xs:element name="DataLockFields" type="ns8:FieldList"/>
+			<xs:element name="DataLockControlMode" type="ns7:DefaultDataLockControlMode"/>
+			<xs:element name="FullTextSearch" type="ns7:FullTextSearchUsing"/>
+			<xs:element name="ObjectPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedObjectPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="Explanation" type="ns1:LocalStringType"/>
+			<xs:element name="CreateOnInput" type="ns7:CreateOnInput"/>
+			<xs:element name="ChoiceHistoryOnInput" type="ns6:ChoiceHistoryOnInput"/>
+			<xs:element name="DataHistory" type="ns7:DataHistoryUse"/>
+			<xs:element name="UpdateDataHistoryImmediatelyAfterWrite" type="xs:boolean"/>
+			<xs:element name="ExecuteAfterWriteDataHistoryVersionProcessing" type="xs:boolean"/>
+			<xs:element name="AdditionalIndexes" type="ns8:ExternalProperty"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ChartOfAccounts">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:ChartOfAccountsProperties"/>
+					<xs:element name="ChildObjects" type="tns:ChartOfAccountsChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="ChartOfAccountsChildObjects">
+		<xs:sequence>
+			<xs:element name="Attribute" type="tns:Attribute" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="TabularSection" type="tns:TabularSection" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="AccountingFlag" type="tns:AccountingFlag" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="ExtDimensionAccountingFlag" type="tns:ExtDimensionAccountingFlag" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Form" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Template" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Command" type="tns:Command" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ChartOfAccountsProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="UseStandardCommands" type="xs:boolean"/>
+			<xs:element name="IncludeHelpInContents" type="xs:boolean"/>
+			<xs:element name="Help" type="ns8:ExternalProperty"/>
+			<xs:element name="BasedOn" type="ns8:MDListType"/>
+			<xs:element name="ExtDimensionTypes" type="ns8:MDObjectRef"/>
+			<xs:element name="MaxExtDimensionCount" type="xs:decimal"/>
+			<xs:element name="CodeMask" type="xs:string"/>
+			<xs:element name="CodeLength" type="xs:decimal"/>
+			<xs:element name="DescriptionLength" type="xs:decimal"/>
+			<xs:element name="CodeSeries" type="ns7:CharOfAccountCodeSeries"/>
+			<xs:element name="CheckUnique" type="xs:boolean"/>
+			<xs:element name="DefaultPresentation" type="ns7:AccountMainPresentation"/>
+			<xs:element name="StandardAttributes" type="ns8:StandardAttributeDescriptions"/>
+			<xs:element name="Characteristics" type="ns8:CharacteristicsDescriptions"/>
+			<xs:element name="StandardTabularSections" type="ns8:StandardTabularSectionDescriptions"/>
+			<xs:element name="Predefined" type="ns8:ExternalProperty"/>
+			<xs:element name="PredefinedDataUpdate" type="ns7:PredefinedDataUpdate"/>
+			<xs:element name="EditType" type="ns7:EditType"/>
+			<xs:element name="QuickChoice" type="xs:boolean"/>
+			<xs:element name="ChoiceMode" type="ns7:ChoiceMode"/>
+			<xs:element name="InputByString" type="ns8:FieldList"/>
+			<xs:element name="SearchStringModeOnInputByString" type="ns6:SearchStringModeOnInputByString"/>
+			<xs:element name="FullTextSearchOnInputByString" type="ns6:FullTextSearchOnInputByString"/>
+			<xs:element name="ChoiceDataGetModeOnInputByString" type="ns6:ChoiceDataGetModeOnInputByString"/>
+			<xs:element name="CreateOnInput" type="ns7:CreateOnInput"/>
+			<xs:element name="ChoiceHistoryOnInput" type="ns6:ChoiceHistoryOnInput"/>
+			<xs:element name="DefaultObjectForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryObjectForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="ObjectModule" type="ns8:ExternalProperty"/>
+			<xs:element name="ManagerModule" type="ns8:ExternalProperty"/>
+			<xs:element name="AutoOrderByCode" type="xs:boolean"/>
+			<xs:element name="OrderLength" type="xs:decimal"/>
+			<xs:element name="DataLockFields" type="ns8:FieldList"/>
+			<xs:element name="DataLockControlMode" type="ns7:DefaultDataLockControlMode"/>
+			<xs:element name="FullTextSearch" type="ns7:FullTextSearchUsing"/>
+			<xs:element name="DataHistory" type="ns7:DataHistoryUse"/>
+			<xs:element name="ObjectPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedObjectPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="Explanation" type="ns1:LocalStringType"/>
+			<xs:element name="UpdateDataHistoryImmediatelyAfterWrite" type="xs:boolean"/>
+			<xs:element name="ExecuteAfterWriteDataHistoryVersionProcessing" type="xs:boolean"/>
+			<xs:element name="AdditionalIndexes" type="ns8:ExternalProperty"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ChartOfCalculationTypes">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:ChartOfCalculationTypesProperties"/>
+					<xs:element name="ChildObjects" type="tns:ChartOfCalculationTypesChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="ChartOfCalculationTypesChildObjects">
+		<xs:sequence>
+			<xs:element name="Attribute" type="tns:Attribute" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="TabularSection" type="tns:TabularSection" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Form" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Template" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Command" type="tns:Command" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ChartOfCalculationTypesProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="UseStandardCommands" type="xs:boolean"/>
+			<xs:element name="CodeLength" type="xs:decimal"/>
+			<xs:element name="DescriptionLength" type="xs:decimal"/>
+			<xs:element name="CodeType" type="ns7:ChartOfCalculationTypesCodeType"/>
+			<xs:element name="CodeAllowedLength" type="ns1:AllowedLength"/>
+			<xs:element name="DefaultPresentation" type="ns7:CalculationTypeMainPresentation"/>
+			<xs:element name="EditType" type="ns7:EditType"/>
+			<xs:element name="QuickChoice" type="xs:boolean"/>
+			<xs:element name="ChoiceMode" type="ns7:ChoiceMode"/>
+			<xs:element name="InputByString" type="ns8:FieldList"/>
+			<xs:element name="SearchStringModeOnInputByString" type="ns6:SearchStringModeOnInputByString"/>
+			<xs:element name="FullTextSearchOnInputByString" type="ns6:FullTextSearchOnInputByString"/>
+			<xs:element name="ChoiceDataGetModeOnInputByString" type="ns6:ChoiceDataGetModeOnInputByString"/>
+			<xs:element name="CreateOnInput" type="ns7:CreateOnInput"/>
+			<xs:element name="ChoiceHistoryOnInput" type="ns6:ChoiceHistoryOnInput"/>
+			<xs:element name="DefaultObjectForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryObjectForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="ObjectModule" type="ns8:ExternalProperty"/>
+			<xs:element name="ManagerModule" type="ns8:ExternalProperty"/>
+			<xs:element name="BasedOn" type="ns8:MDListType"/>
+			<xs:element name="DependenceOnCalculationTypes" type="ns7:ChartOfCalculationTypesBaseUse"/>
+			<xs:element name="BaseCalculationTypes" type="ns8:MDListType"/>
+			<xs:element name="ActionPeriodUse" type="xs:boolean"/>
+			<xs:element name="StandardAttributes" type="ns8:StandardAttributeDescriptions"/>
+			<xs:element name="Characteristics" type="ns8:CharacteristicsDescriptions"/>
+			<xs:element name="StandardTabularSections" type="ns8:StandardTabularSectionDescriptions"/>
+			<xs:element name="Predefined" type="ns8:ExternalProperty"/>
+			<xs:element name="PredefinedDataUpdate" type="ns7:PredefinedDataUpdate"/>
+			<xs:element name="IncludeHelpInContents" type="xs:boolean"/>
+			<xs:element name="Help" type="ns8:ExternalProperty"/>
+			<xs:element name="DataLockFields" type="ns8:FieldList"/>
+			<xs:element name="DataLockControlMode" type="ns7:DefaultDataLockControlMode"/>
+			<xs:element name="FullTextSearch" type="ns7:FullTextSearchUsing"/>
+			<xs:element name="ObjectPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedObjectPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="Explanation" type="ns1:LocalStringType"/>
+			<xs:element name="DataHistory" type="ns7:DataHistoryUse"/>
+			<xs:element name="UpdateDataHistoryImmediatelyAfterWrite" type="xs:boolean"/>
+			<xs:element name="ExecuteAfterWriteDataHistoryVersionProcessing" type="xs:boolean"/>
+			<xs:element name="AdditionalIndexes" type="ns8:ExternalProperty"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ChartOfCharacteristicTypes">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:ChartOfCharacteristicTypesProperties"/>
+					<xs:element name="ChildObjects" type="tns:ChartOfCharacteristicTypesChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="ChartOfCharacteristicTypesChildObjects">
+		<xs:sequence>
+			<xs:element name="Attribute" type="tns:Attribute" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="TabularSection" type="tns:TabularSection" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Form" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Template" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Command" type="tns:Command" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ChartOfCharacteristicTypesProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="UseStandardCommands" type="xs:boolean"/>
+			<xs:element name="IncludeHelpInContents" type="xs:boolean"/>
+			<xs:element name="Help" type="ns8:ExternalProperty"/>
+			<xs:element name="CharacteristicExtValues" type="ns8:MDObjectRef"/>
+			<xs:element name="Type" type="ns1:TypeDescription"/>
+			<xs:element name="Hierarchical" type="xs:boolean"/>
+			<xs:element name="FoldersOnTop" type="xs:boolean"/>
+			<xs:element name="CodeLength" type="xs:decimal"/>
+			<xs:element name="CodeAllowedLength" type="ns1:AllowedLength"/>
+			<xs:element name="DescriptionLength" type="xs:decimal"/>
+			<xs:element name="CodeSeries" type="ns7:CharacteristicKindCodesSeries"/>
+			<xs:element name="CheckUnique" type="xs:boolean"/>
+			<xs:element name="Autonumbering" type="xs:boolean"/>
+			<xs:element name="DefaultPresentation" type="ns7:CharacteristicTypeMainPresentation"/>
+			<xs:element name="StandardAttributes" type="ns8:StandardAttributeDescriptions"/>
+			<xs:element name="Characteristics" type="ns8:CharacteristicsDescriptions"/>
+			<xs:element name="Predefined" type="ns8:ExternalProperty"/>
+			<xs:element name="PredefinedDataUpdate" type="ns7:PredefinedDataUpdate"/>
+			<xs:element name="EditType" type="ns7:EditType"/>
+			<xs:element name="QuickChoice" type="xs:boolean"/>
+			<xs:element name="ChoiceMode" type="ns7:ChoiceMode"/>
+			<xs:element name="InputByString" type="ns8:FieldList"/>
+			<xs:element name="CreateOnInput" type="ns7:CreateOnInput"/>
+			<xs:element name="SearchStringModeOnInputByString" type="ns6:SearchStringModeOnInputByString"/>
+			<xs:element name="ChoiceDataGetModeOnInputByString" type="ns6:ChoiceDataGetModeOnInputByString"/>
+			<xs:element name="FullTextSearchOnInputByString" type="ns6:FullTextSearchOnInputByString"/>
+			<xs:element name="ChoiceHistoryOnInput" type="ns6:ChoiceHistoryOnInput"/>
+			<xs:element name="DefaultObjectForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultFolderForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultFolderChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryObjectForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryFolderForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryFolderChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="ObjectModule" type="ns8:ExternalProperty"/>
+			<xs:element name="ManagerModule" type="ns8:ExternalProperty"/>
+			<xs:element name="BasedOn" type="ns8:MDListType"/>
+			<xs:element name="DataLockFields" type="ns8:FieldList"/>
+			<xs:element name="DataLockControlMode" type="ns7:DefaultDataLockControlMode"/>
+			<xs:element name="FullTextSearch" type="ns7:FullTextSearchUsing"/>
+			<xs:element name="ObjectPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedObjectPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="Explanation" type="ns1:LocalStringType"/>
+			<xs:element name="DataHistory" type="ns7:DataHistoryUse"/>
+			<xs:element name="UpdateDataHistoryImmediatelyAfterWrite" type="xs:boolean"/>
+			<xs:element name="ExecuteAfterWriteDataHistoryVersionProcessing" type="xs:boolean"/>
+			<xs:element name="AdditionalIndexes" type="ns8:ExternalProperty"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Column">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:ColumnProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="ColumnProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Indexing" type="ns7:Indexing"/>
+			<xs:element name="References" type="ns8:MDListType"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Command">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:CommandProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="CommandGroup">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:CommandGroupProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="CommandGroupProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Representation" type="ns6:ButtonRepresentation"/>
+			<xs:element name="ToolTip" type="ns1:LocalStringType"/>
+			<xs:element name="Picture" type="ns8:Picture"/>
+			<xs:element name="Category" type="ns4:CommandGroupCategory"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CommandProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string" minOccurs="0"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="Comment" type="xs:string" minOccurs="0"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging" minOccurs="0"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Group" type="ns8:IncludeInCommandCategoriesType" minOccurs="0"/>
+			<xs:element name="CommandParameterType" type="ns1:TypeDescription" minOccurs="0"/>
+			<xs:element name="ParameterUseMode" type="ns5:CommandParameterUseMode" minOccurs="0"/>
+			<xs:element name="ModifiesData" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="Representation" type="ns6:ButtonRepresentation" minOccurs="0"/>
+			<xs:element name="ToolTip" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="Picture" type="ns8:Picture" minOccurs="0"/>
+			<xs:element name="Shortcut" type="ns8:ShortCutType" minOccurs="0"/>
+			<xs:element name="CommandModule" type="ns8:ExternalProperty" minOccurs="0"/>
+			<xs:element name="OnMainServerUnavalableBehavior" type="ns6:OnMainServerUnavalableBehavior"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CommonAttribute">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:CommonAttributeProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="CommonAttributeProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Type" type="ns1:TypeDescription"/>
+			<xs:element name="PasswordMode" type="xs:boolean"/>
+			<xs:element name="Format" type="ns1:LocalStringType"/>
+			<xs:element name="EditFormat" type="ns1:LocalStringType"/>
+			<xs:element name="ToolTip" type="ns1:LocalStringType"/>
+			<xs:element name="MarkNegatives" type="xs:boolean"/>
+			<xs:element name="Mask" type="xs:string"/>
+			<xs:element name="MultiLine" type="xs:boolean"/>
+			<xs:element name="ExtendedEdit" type="xs:boolean"/>
+			<xs:element name="MinValue"/>
+			<xs:element name="MaxValue"/>
+			<xs:element name="FillFromFillingValue" type="xs:boolean"/>
+			<xs:element name="FillValue"/>
+			<xs:element name="FillChecking" type="ns1:FillChecking"/>
+			<xs:element name="ChoiceFoldersAndItems" type="ns2:FoldersAndItemsUse"/>
+			<xs:element name="ChoiceParameterLinks" type="ns8:ChoiceParameterLinks"/>
+			<xs:element name="ChoiceParameters" type="ns4:ChoiceParameters"/>
+			<xs:element name="QuickChoice" type="ns7:UseQuickChoice"/>
+			<xs:element name="CreateOnInput" type="ns7:CreateOnInput"/>
+			<xs:element name="ChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="LinkByType" type="ns8:TypeLink"/>
+			<xs:element name="ChoiceHistoryOnInput" type="ns6:ChoiceHistoryOnInput"/>
+			<xs:element name="Content" type="ns8:CommonAttributeContent"/>
+			<xs:element name="AutoUse" type="ns7:CommonAttributeAutoUse"/>
+			<xs:element name="DataSeparation" type="ns7:CommonAttributeDataSeparation"/>
+			<xs:element name="SeparatedDataUse" type="ns7:CommonAttributeSeparatedDataUse"/>
+			<xs:element name="DataSeparationValue" type="ns8:MDObjectRef"/>
+			<xs:element name="DataSeparationUse" type="ns8:MDObjectRef"/>
+			<xs:element name="ConditionalSeparation" type="ns8:MDObjectRef"/>
+			<xs:element name="UsersSeparation" type="ns7:CommonAttributeUsersSeparation"/>
+			<xs:element name="AuthenticationSeparation" type="ns7:CommonAttributeAuthenticationSeparation"/>
+			<xs:element name="ConfigurationExtensionsSeparation" type="ns7:CommonAttributeConfigurationExtensionsSeparation"/>
+			<xs:element name="Indexing" type="ns7:Indexing"/>
+			<xs:element name="FullTextSearch" type="ns7:FullTextSearchUsing"/>
+			<xs:element name="DataHistory" type="ns7:DataHistoryUse"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CommonCommand">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:CommonCommandProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="CommonCommandProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Group" type="ns8:IncludeInCommandCategoriesType"/>
+			<xs:element name="Representation" type="ns6:ButtonRepresentation"/>
+			<xs:element name="ToolTip" type="ns1:LocalStringType"/>
+			<xs:element name="Picture" type="ns8:Picture"/>
+			<xs:element name="Shortcut" type="ns8:ShortCutType"/>
+			<xs:element name="CommandModule" type="ns8:ExternalProperty"/>
+			<xs:element name="IncludeHelpInContents" type="xs:boolean"/>
+			<xs:element name="Help" type="ns8:ExternalProperty"/>
+			<xs:element name="CommandParameterType" type="ns1:TypeDescription"/>
+			<xs:element name="ParameterUseMode" type="ns5:CommandParameterUseMode"/>
+			<xs:element name="ModifiesData" type="xs:boolean"/>
+			<xs:element name="OnMainServerUnavalableBehavior" type="ns6:OnMainServerUnavalableBehavior"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CommonForm">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:CommonFormProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="CommonFormProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Form" type="ns8:ExternalProperty"/>
+			<xs:element name="FormType" type="ns7:FormType"/>
+			<xs:element name="IncludeHelpInContents" type="xs:boolean"/>
+			<xs:element name="Help" type="ns8:ExternalProperty"/>
+			<xs:element name="UsePurposes" type="ns1:FixedArray"/>
+			<xs:element name="UseStandardCommands" type="xs:boolean"/>
+			<xs:element name="ExtendedPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="Explanation" type="ns1:LocalStringType"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CommonModule">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:CommonModuleProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="CommonModuleProperties">
+		<xs:choice>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Module" type="ns8:ExternalProperty"/>
+			<xs:element name="Global" type="xs:boolean"/>
+			<xs:element name="ClientManagedApplication" type="xs:boolean"/>
+			<xs:element name="Server" type="xs:boolean"/>
+			<xs:element name="ExternalConnection" type="xs:boolean"/>
+			<xs:element name="ClientOrdinaryApplication" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="Client" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="ServerCall" type="xs:boolean"/>
+			<xs:element name="Privileged" type="xs:boolean"/>
+			<xs:element name="ReturnValuesReuse" type="ns7:ReturnValuesReuse"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="CommonPicture">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:CommonPictureProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="CommonPictureProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Picture" type="ns8:ExternalProperty"/>
+			<xs:element name="AvailabilityForChoice" type="xs:boolean"/>
+			<xs:element name="AvailabilityForAppearance" type="xs:boolean"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CommonTemplate">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:CommonTemplateProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="CommonTemplateProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="TemplateType" type="ns7:TemplateType"/>
+			<xs:element name="Template" type="ns8:ExternalProperty"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Configuration">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:ConfigurationProperties"/>
+					<xs:element name="ChildObjects" type="tns:ConfigurationChildObjects"/>
+				</xs:sequence>
+				<xs:attribute name="formatVersion" type="xs:string" use="required"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="ConfigurationChildObjects">
+		<xs:sequence>
+			<xs:element name="Language" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Subsystem" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="StyleItem" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Style" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="CommonPicture" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Interface" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="SessionParameter" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Role" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="CommonTemplate" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="FilterCriterion" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="CommonModule" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="CommonAttribute" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="ExchangePlan" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="XDTOPackage" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="WebService" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="HTTPService" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="WSReference" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="EventSubscription" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="ScheduledJob" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="SettingsStorage" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="FunctionalOption" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="FunctionalOptionsParameter" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="DefinedType" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="CommonCommand" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="CommandGroup" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Constant" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="CommonForm" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Catalog" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Document" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="DocumentNumerator" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Sequence" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="DocumentJournal" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Enum" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Report" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="DataProcessor" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="InformationRegister" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="AccumulationRegister" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="ChartOfCharacteristicTypes" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="ChartOfAccounts" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="AccountingRegister" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="ChartOfCalculationTypes" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="CalculationRegister" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="BusinessProcess" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Task" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="ExternalDataSource" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="IntegrationService" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Bot" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="WebSocketClient" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ConfigurationProperties">
+		<xs:choice>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ConfigurationExtensionPurpose" type="ns7:ConfigurationExtensionPurpose"/>
+			<xs:element name="KeepMappingToExtendedConfigurationObjectsByIDs" type="xs:boolean"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="NamePrefix" type="xs:string"/>
+			<xs:element name="ConfigurationExtensionCompatibilityMode" type="ns7:CompatibilityMode"/>
+			<xs:element name="DefaultRunMode" type="ns4:ClientRunMode"/>
+			<xs:element name="UsePurposes" type="ns1:FixedArray"/>
+			<xs:element name="ScriptVariant" type="ns7:ScriptVariant"/>
+			<xs:element name="DefaultRoles" type="ns8:MDListType"/>
+			<xs:element name="Vendor" type="xs:string"/>
+			<xs:element name="Version" type="xs:string"/>
+			<xs:element name="UpdateCatalogAddress" type="xs:string"/>
+			<xs:element name="ParentConfigurations" type="ns8:ExternalProperty"/>
+			<xs:element name="ManagedApplicationModule" type="ns8:ExternalProperty"/>
+			<xs:element name="SessionModule" type="ns8:ExternalProperty"/>
+			<xs:element name="ExternalConnectionModule" type="ns8:ExternalProperty"/>
+			<xs:element name="OrdinaryApplicationModule" type="ns8:ExternalProperty" minOccurs="0"/>
+			<xs:element name="ApplicationModule" type="ns8:ExternalProperty" minOccurs="0"/>
+			<xs:element name="IncludeHelpInContents" type="xs:boolean"/>
+			<xs:element name="Help" type="ns8:ExternalProperty"/>
+			<xs:element name="UseManagedFormInOrdinaryApplication" type="xs:boolean"/>
+			<xs:element name="UseOrdinaryFormInManagedApplication" type="xs:boolean"/>
+			<xs:element name="AdditionalFullTextSearchDictionaries" type="ns8:MDListType"/>
+			<xs:element name="CommonSettingsStorage" type="ns8:MDObjectRef"/>
+			<xs:element name="ReportsUserSettingsStorage" type="ns8:MDObjectRef"/>
+			<xs:element name="ReportsVariantsStorage" type="ns8:MDObjectRef"/>
+			<xs:element name="FormDataSettingsStorage" type="ns8:MDObjectRef"/>
+			<xs:element name="DynamicListsUserSettingsStorage" type="ns8:MDObjectRef"/>
+			<xs:element name="URLExternalDataStorage" type="ns8:MDObjectRef"/>
+			<xs:element name="Content" type="ns8:MDListType"/>
+			<xs:element name="DefaultReportForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultReportVariantForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultReportSettingsForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultDynamicListSettingsForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultSearchForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultDataHistoryChangeHistoryForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultDataHistoryVersionDataForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultDataHistoryVersionDifferencesForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultCollaborationSystemUsersChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultReportAppearanceTemplate" type="xs:string"/>
+			<xs:element name="RequiredMobileApplicationPermissions" type="ns4:RequiredPermissions"/>
+			<xs:element name="UsedMobileApplicationFunctionalities" type="ns4:UsedFunctionality"/>
+			<xs:element name="MobileApplicationURLs" type="ns1:FixedArray"/>
+			<xs:element name="AllowedIncomingShareRequestTypes" type="ns1:FixedArray"/>
+			<xs:element name="MobileClientSignature" type="ns8:ExternalProperty" minOccurs="0"/>
+			<xs:element name="MobileClientSign" type="ns8:ExternalProperty" minOccurs="0"/>
+			<xs:element name="CommandInterface" type="ns8:ExternalProperty"/>
+			<xs:element name="HomePageWorkArea" type="ns8:ExternalProperty" minOccurs="0"/>
+			<xs:element name="StartPageWorkingArea" type="ns8:ExternalProperty" minOccurs="0"/>
+			<xs:element name="MainSectionCommandInterface" type="ns8:ExternalProperty"/>
+			<xs:element name="MainSectionPicture" type="ns8:ExternalProperty"/>
+			<xs:element name="ClientApplicationInterface" type="ns8:ExternalProperty"/>
+			<xs:element name="MainClientApplicationWindowMode" type="ns1:MainClientApplicationWindowMode"/>
+			<xs:element name="DefaultInterface" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultStyle" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultLanguage" type="ns8:MDObjectRef"/>
+			<xs:element name="BriefInformation" type="ns1:LocalStringType"/>
+			<xs:element name="DetailedInformation" type="ns1:LocalStringType"/>
+			<xs:element name="Logo" type="ns8:ExternalProperty"/>
+			<xs:element name="Splash" type="ns8:ExternalProperty"/>
+			<xs:element name="Copyright" type="ns1:LocalStringType"/>
+			<xs:element name="VendorInformationAddress" type="ns1:LocalStringType"/>
+			<xs:element name="ConfigurationInformationAddress" type="ns1:LocalStringType"/>
+			<xs:element name="DataLockControlMode" type="ns7:DefaultDataLockControlMode"/>
+			<xs:element name="BinaryDataStorageMode" type="ns7:BinaryDataStorageMode"/>
+			<xs:element name="BinaryDataBlockStorageUseMode" type="ns7:BinaryDataBlockStorageUseMode"/>
+			<xs:element name="ObjectAutonumerationMode" type="ns7:ObjectAutonumerationMode"/>
+			<xs:element name="ModalityUseMode" type="ns7:ModalityUseMode"/>
+			<xs:element name="SynchronousPlatformExtensionAndAddInCallUseMode" type="ns7:SynchronousPlatformExtensionAndAddInCallUseMode" minOccurs="0"/>
+			<xs:element name="SynchronousExtensionAndAddInCallUseMode" type="ns7:SynchronousPlatformExtensionAndAddInCallUseMode" minOccurs="0"/>
+			<xs:element name="InterfaceCompatibilityMode" type="ns7:InterfaceCompatibilityMode"/>
+			<xs:element name="CompatibilityMode" type="ns7:CompatibilityMode"/>
+			<xs:element name="DefaultConstantsForm" type="ns8:MDObjectRef" minOccurs="0"/>
+			<xs:element name="DefaultConstantForm" type="ns8:MDObjectRef" minOccurs="0"/>
+			<xs:element name="StandaloneConfigurationRestrictionRoles" type="ns8:MDListType"/>
+			<xs:element name="DatabaseTablespacesUseMode" type="ns7:DatabaseTablespacesUseMode"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="Constant">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:ConstantProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="ConstantProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Type" type="ns1:TypeDescription"/>
+			<xs:element name="UseStandardCommands" type="xs:boolean"/>
+			<xs:element name="DefaultForm" type="ns8:MDObjectRef"/>
+			<xs:element name="ExtendedPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="Explanation" type="ns1:LocalStringType"/>
+			<xs:element name="PasswordMode" type="xs:boolean"/>
+			<xs:element name="Format" type="ns1:LocalStringType"/>
+			<xs:element name="EditFormat" type="ns1:LocalStringType"/>
+			<xs:element name="ToolTip" type="ns1:LocalStringType"/>
+			<xs:element name="MarkNegatives" type="xs:boolean"/>
+			<xs:element name="Mask" type="xs:string"/>
+			<xs:element name="MultiLine" type="xs:boolean"/>
+			<xs:element name="ExtendedEdit" type="xs:boolean"/>
+			<xs:element name="MinValue"/>
+			<xs:element name="MaxValue"/>
+			<xs:element name="FillChecking" type="ns1:FillChecking"/>
+			<xs:element name="ChoiceFoldersAndItems" type="ns2:FoldersAndItemsUse"/>
+			<xs:element name="ChoiceParameterLinks" type="ns8:ChoiceParameterLinks"/>
+			<xs:element name="ChoiceParameters" type="ns4:ChoiceParameters"/>
+			<xs:element name="QuickChoice" type="ns7:UseQuickChoice"/>
+			<xs:element name="ChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="LinkByType" type="ns8:TypeLink"/>
+			<xs:element name="ChoiceHistoryOnInput" type="ns6:ChoiceHistoryOnInput"/>
+			<xs:element name="ValueManagerModule" type="ns8:ExternalProperty"/>
+			<xs:element name="ManagerModule" type="ns8:ExternalProperty"/>
+			<xs:element name="DataLockControlMode" type="ns7:DefaultDataLockControlMode"/>
+			<xs:element name="DataHistory" type="ns7:DataHistoryUse"/>
+			<xs:element name="UpdateDataHistoryImmediatelyAfterWrite" type="xs:boolean"/>
+			<xs:element name="ExecuteAfterWriteDataHistoryVersionProcessing" type="xs:boolean"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Cube">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:CubeProperties"/>
+					<xs:element name="ChildObjects" type="tns:CubeChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="CubeChildObjects">
+		<xs:sequence>
+			<xs:element name="DimensionTable" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Dimension" type="tns:Dimension" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Resource" type="tns:Resource" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Form" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Command" type="tns:Command" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Template" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CubeProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="NameInDataSource" type="xs:string"/>
+			<xs:element name="Characteristics" type="ns8:CharacteristicsDescriptions"/>
+			<xs:element name="UseStandardCommands" type="xs:boolean"/>
+			<xs:element name="DefaultRecordForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="RecordPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedRecordPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="Explanation" type="ns1:LocalStringType"/>
+			<xs:element name="RecordSetModule" type="ns8:ExternalProperty"/>
+			<xs:element name="ManagerModule" type="ns8:ExternalProperty"/>
+			<xs:element name="IncludeHelpInContents" type="xs:boolean"/>
+			<xs:element name="Help" type="ns8:ExternalProperty"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DataProcessor">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:DataProcessorProperties"/>
+					<xs:element name="ChildObjects" type="tns:DataProcessorChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="DataProcessorChildObjects">
+		<xs:sequence>
+			<xs:element name="Attribute" type="tns:Attribute" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="TabularSection" type="tns:TabularSection" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Form" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Template" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Command" type="tns:Command" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DataProcessorProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="UseStandardCommands" type="xs:boolean"/>
+			<xs:element name="DefaultForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryForm" type="ns8:MDObjectRef"/>
+			<xs:element name="ObjectModule" type="ns8:ExternalProperty"/>
+			<xs:element name="ManagerModule" type="ns8:ExternalProperty"/>
+			<xs:element name="IncludeHelpInContents" type="xs:boolean"/>
+			<xs:element name="Help" type="ns8:ExternalProperty"/>
+			<xs:element name="ExtendedPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="Explanation" type="ns1:LocalStringType"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DefinedType">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:DefinedTypeProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="DefinedTypeProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Type" type="ns1:TypeDescription"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Dimension">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:DimensionProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="DimensionProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string" minOccurs="0"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="Comment" type="xs:string" minOccurs="0"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging" minOccurs="0"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Type" type="ns1:TypeDescription" minOccurs="0"/>
+			<xs:element name="DocumentMap" type="ns8:MDListType" minOccurs="0"/>
+			<xs:element name="RegisterRecordsMap" type="ns8:MDListType" minOccurs="0"/>
+			<xs:element name="RegisterDimension" type="ns8:MDObjectRef" minOccurs="0"/>
+			<xs:element name="LeadingRegisterData" type="ns8:MDListType" minOccurs="0"/>
+			<xs:element name="PasswordMode" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="Format" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="EditFormat" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="ToolTip" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="MarkNegatives" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="Mask" type="xs:string" minOccurs="0"/>
+			<xs:element name="MultiLine" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="ExtendedEdit" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="MinValue" minOccurs="0"/>
+			<xs:element name="MaxValue" minOccurs="0"/>
+			<xs:element name="FillChecking" type="ns1:FillChecking" minOccurs="0"/>
+			<xs:element name="ChoiceFoldersAndItems" type="ns2:FoldersAndItemsUse" minOccurs="0"/>
+			<xs:element name="ChoiceParameterLinks" type="ns8:ChoiceParameterLinks" minOccurs="0"/>
+			<xs:element name="ChoiceParameters" type="ns4:ChoiceParameters" minOccurs="0"/>
+			<xs:element name="QuickChoice" type="ns7:UseQuickChoice" minOccurs="0"/>
+			<xs:element name="CreateOnInput" type="ns7:CreateOnInput" minOccurs="0"/>
+			<xs:element name="ChoiceForm" type="ns8:MDObjectRef" minOccurs="0"/>
+			<xs:element name="LinkByType" type="ns8:TypeLink" minOccurs="0"/>
+			<xs:element name="ChoiceHistoryOnInput" type="ns6:ChoiceHistoryOnInput" minOccurs="0"/>
+			<xs:element name="DenyIncompleteValues" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="BaseDimension" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="ScheduleLink" type="ns8:MDObjectRef" minOccurs="0"/>
+			<xs:element name="Indexing" type="ns7:Indexing" minOccurs="0"/>
+			<xs:element name="FullTextSearch" type="ns7:FullTextSearchUsing" minOccurs="0"/>
+			<xs:element name="UseInTotals" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="FillFromFillingValue" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="FillValue" minOccurs="0"/>
+			<xs:element name="Master" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="MainFilter" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="DataHistory" type="ns7:DataHistoryUse" minOccurs="0"/>
+			<xs:element name="Balance" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="AccountingFlag" type="ns8:MDObjectRef" minOccurs="0"/>
+			<xs:element name="TypeReductionMode" type="ns7:TypeReductionMode" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DimensionTable">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:DimensionTableProperties"/>
+					<xs:element name="ChildObjects" type="tns:DimensionTableChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="DimensionTableChildObjects">
+		<xs:sequence>
+			<xs:element name="Field" type="tns:Field" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Form" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Command" type="tns:Command" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Template" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DimensionTableProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="NameInDataSource" type="xs:string"/>
+			<xs:element name="PresentationField" type="ns8:MDObjectRef"/>
+			<xs:element name="HierarchyNameInDataSource" type="xs:string"/>
+			<xs:element name="LevelNumber" type="xs:decimal"/>
+			<xs:element name="Hierarchical" type="xs:boolean"/>
+			<xs:element name="UnfilledParentValue"/>
+			<xs:element name="UseStandardCommands" type="xs:boolean"/>
+			<xs:element name="QuickChoice" type="xs:boolean"/>
+			<xs:element name="DefaultObjectForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="ObjectPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedObjectPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="Explanation" type="ns1:LocalStringType"/>
+			<xs:element name="ObjectModule" type="ns8:ExternalProperty"/>
+			<xs:element name="ManagerModule" type="ns8:ExternalProperty"/>
+			<xs:element name="IncludeHelpInContents" type="xs:boolean"/>
+			<xs:element name="Help" type="ns8:ExternalProperty"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Document">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:DocumentProperties"/>
+					<xs:element name="ChildObjects" type="tns:DocumentChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="DocumentChildObjects">
+		<xs:sequence>
+			<xs:element name="Attribute" type="tns:Attribute" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Form" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="TabularSection" type="tns:TabularSection" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Template" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Command" type="tns:Command" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DocumentJournal">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:DocumentJournalProperties"/>
+					<xs:element name="ChildObjects" type="tns:DocumentJournalChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="DocumentJournalChildObjects">
+		<xs:sequence>
+			<xs:element name="Column" type="tns:Column" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Form" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Template" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Command" type="tns:Command" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DocumentJournalProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="DefaultForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryForm" type="ns8:MDObjectRef"/>
+			<xs:element name="UseStandardCommands" type="xs:boolean"/>
+			<xs:element name="RegisteredDocuments" type="ns8:MDListType"/>
+			<xs:element name="IncludeHelpInContents" type="xs:boolean"/>
+			<xs:element name="Help" type="ns8:ExternalProperty"/>
+			<xs:element name="ManagerModule" type="ns8:ExternalProperty"/>
+			<xs:element name="StandardAttributes" type="ns8:StandardAttributeDescriptions"/>
+			<xs:element name="ListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="Explanation" type="ns1:LocalStringType"/>
+			<xs:element name="AdditionalIndexes" type="ns8:ExternalProperty"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DocumentNumerator">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:DocumentNumeratorProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="DocumentNumeratorProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="NumberType" type="ns7:DocumentNumberType"/>
+			<xs:element name="NumberLength" type="xs:decimal"/>
+			<xs:element name="NumberAllowedLength" type="ns1:AllowedLength"/>
+			<xs:element name="NumberPeriodicity" type="ns7:DocumentNumberPeriodicity"/>
+			<xs:element name="CheckUnique" type="xs:boolean"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DocumentProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="UseStandardCommands" type="xs:boolean"/>
+			<xs:element name="Numerator" type="ns8:MDObjectRef"/>
+			<xs:element name="NumberType" type="ns7:DocumentNumberType"/>
+			<xs:element name="NumberLength" type="xs:decimal"/>
+			<xs:element name="NumberAllowedLength" type="ns1:AllowedLength"/>
+			<xs:element name="NumberPeriodicity" type="ns7:DocumentNumberPeriodicity"/>
+			<xs:element name="CheckUnique" type="xs:boolean"/>
+			<xs:element name="Autonumbering" type="xs:boolean"/>
+			<xs:element name="StandardAttributes" type="ns8:StandardAttributeDescriptions"/>
+			<xs:element name="Characteristics" type="ns8:CharacteristicsDescriptions"/>
+			<xs:element name="BasedOn" type="ns8:MDListType"/>
+			<xs:element name="InputByString" type="ns8:FieldList"/>
+			<xs:element name="CreateOnInput" type="ns7:CreateOnInput"/>
+			<xs:element name="SearchStringModeOnInputByString" type="ns6:SearchStringModeOnInputByString"/>
+			<xs:element name="FullTextSearchOnInputByString" type="ns6:FullTextSearchOnInputByString"/>
+			<xs:element name="ChoiceDataGetModeOnInputByString" type="ns6:ChoiceDataGetModeOnInputByString"/>
+			<xs:element name="DefaultObjectForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryObjectForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="ObjectModule" type="ns8:ExternalProperty"/>
+			<xs:element name="ManagerModule" type="ns8:ExternalProperty"/>
+			<xs:element name="Posting" type="ns7:Posting"/>
+			<xs:element name="RealTimePosting" type="ns7:RealTimePosting"/>
+			<xs:element name="RegisterRecordsDeletion" type="ns7:RegisterRecordsDeletion"/>
+			<xs:element name="RegisterRecordsWritingOnPost" type="ns7:RegisterRecordsWritingOnPost"/>
+			<xs:element name="SequenceFilling" type="ns7:SequenceFilling"/>
+			<xs:element name="RegisterRecords" type="ns8:MDListType"/>
+			<xs:element name="PostInPrivilegedMode" type="xs:boolean"/>
+			<xs:element name="UnpostInPrivilegedMode" type="xs:boolean"/>
+			<xs:element name="IncludeHelpInContents" type="xs:boolean"/>
+			<xs:element name="Help" type="ns8:ExternalProperty"/>
+			<xs:element name="DataLockFields" type="ns8:FieldList"/>
+			<xs:element name="DataLockControlMode" type="ns7:DefaultDataLockControlMode"/>
+			<xs:element name="FullTextSearch" type="ns7:FullTextSearchUsing"/>
+			<xs:element name="ObjectPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedObjectPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="Explanation" type="ns1:LocalStringType"/>
+			<xs:element name="ChoiceHistoryOnInput" type="ns6:ChoiceHistoryOnInput"/>
+			<xs:element name="DataHistory" type="ns7:DataHistoryUse"/>
+			<xs:element name="UpdateDataHistoryImmediatelyAfterWrite" type="xs:boolean"/>
+			<xs:element name="ExecuteAfterWriteDataHistoryVersionProcessing" type="xs:boolean"/>
+			<xs:element name="AdditionalIndexes" type="ns8:ExternalProperty"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Enum">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:EnumProperties"/>
+					<xs:element name="ChildObjects" type="tns:EnumChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="EnumChildObjects">
+		<xs:sequence>
+			<xs:element name="EnumValue" type="tns:EnumValue" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Form" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Template" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Command" type="tns:Command" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="EnumProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="UseStandardCommands" type="xs:boolean"/>
+			<xs:element name="StandardAttributes" type="ns8:StandardAttributeDescriptions"/>
+			<xs:element name="Characteristics" type="ns8:CharacteristicsDescriptions"/>
+			<xs:element name="QuickChoice" type="xs:boolean"/>
+			<xs:element name="ChoiceMode" type="ns7:ChoiceMode"/>
+			<xs:element name="DefaultListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="ManagerModule" type="ns8:ExternalProperty"/>
+			<xs:element name="ListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="Explanation" type="ns1:LocalStringType"/>
+			<xs:element name="ChoiceHistoryOnInput" type="ns6:ChoiceHistoryOnInput"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="EnumValue">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:EnumValueProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="EnumValueProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="EventSubscription">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:EventSubscriptionProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="EventSubscriptionProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Source" type="ns1:TypeDescription"/>
+			<xs:element name="Event" type="ns8:AliasedStringType"/>
+			<xs:element name="Handler" type="ns8:MDMethodRef"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ExchangePlan">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:ExchangePlanProperties"/>
+					<xs:element name="ChildObjects" type="tns:ExchangePlanChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="ExchangePlanChildObjects">
+		<xs:sequence>
+			<xs:element name="Attribute" type="tns:Attribute" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="TabularSection" type="tns:TabularSection" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Form" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Template" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Command" type="tns:Command" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ExchangePlanProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="UseStandardCommands" type="xs:boolean"/>
+			<xs:element name="CodeLength" type="xs:decimal"/>
+			<xs:element name="CodeAllowedLength" type="ns1:AllowedLength"/>
+			<xs:element name="DescriptionLength" type="xs:decimal"/>
+			<xs:element name="Content" type="ns8:ExternalProperty"/>
+			<xs:element name="DefaultPresentation" type="ns7:DataExchangeMainPresentation"/>
+			<xs:element name="EditType" type="ns7:EditType"/>
+			<xs:element name="QuickChoice" type="xs:boolean"/>
+			<xs:element name="ChoiceMode" type="ns7:ChoiceMode"/>
+			<xs:element name="InputByString" type="ns8:FieldList"/>
+			<xs:element name="SearchStringModeOnInputByString" type="ns6:SearchStringModeOnInputByString"/>
+			<xs:element name="FullTextSearchOnInputByString" type="ns6:FullTextSearchOnInputByString"/>
+			<xs:element name="ChoiceDataGetModeOnInputByString" type="ns6:ChoiceDataGetModeOnInputByString"/>
+			<xs:element name="DefaultObjectForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryObjectForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="ObjectModule" type="ns8:ExternalProperty"/>
+			<xs:element name="ManagerModule" type="ns8:ExternalProperty"/>
+			<xs:element name="StandardAttributes" type="ns8:StandardAttributeDescriptions"/>
+			<xs:element name="Characteristics" type="ns8:CharacteristicsDescriptions"/>
+			<xs:element name="BasedOn" type="ns8:MDListType"/>
+			<xs:element name="DistributedInfoBase" type="xs:boolean"/>
+			<xs:element name="IncludeConfigurationExtensions" type="xs:boolean"/>
+			<xs:element name="CreateOnInput" type="ns7:CreateOnInput"/>
+			<xs:element name="ChoiceHistoryOnInput" type="ns6:ChoiceHistoryOnInput"/>
+			<xs:element name="IncludeHelpInContents" type="xs:boolean"/>
+			<xs:element name="Help" type="ns8:ExternalProperty"/>
+			<xs:element name="DataLockFields" type="ns8:FieldList"/>
+			<xs:element name="DataLockControlMode" type="ns7:DefaultDataLockControlMode"/>
+			<xs:element name="FullTextSearch" type="ns7:FullTextSearchUsing"/>
+			<xs:element name="ObjectPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedObjectPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="Explanation" type="ns1:LocalStringType"/>
+			<xs:element name="DataHistory" type="ns7:DataHistoryUse"/>
+			<xs:element name="UpdateDataHistoryImmediatelyAfterWrite" type="xs:boolean"/>
+			<xs:element name="ExecuteAfterWriteDataHistoryVersionProcessing" type="xs:boolean"/>
+			<xs:element name="AdditionalIndexes" type="ns8:ExternalProperty"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ExtDimensionAccountingFlag">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:ExtDimensionAccountingFlagProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="ExtDimensionAccountingFlagProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Type" type="ns1:TypeDescription"/>
+			<xs:element name="PasswordMode" type="xs:boolean"/>
+			<xs:element name="Format" type="ns1:LocalStringType"/>
+			<xs:element name="EditFormat" type="ns1:LocalStringType"/>
+			<xs:element name="ToolTip" type="ns1:LocalStringType"/>
+			<xs:element name="MarkNegatives" type="xs:boolean"/>
+			<xs:element name="Mask" type="xs:string"/>
+			<xs:element name="MultiLine" type="xs:boolean"/>
+			<xs:element name="ExtendedEdit" type="xs:boolean"/>
+			<xs:element name="MinValue"/>
+			<xs:element name="MaxValue"/>
+			<xs:element name="FillFromFillingValue" type="xs:boolean"/>
+			<xs:element name="FillValue"/>
+			<xs:element name="FillChecking" type="ns1:FillChecking"/>
+			<xs:element name="ChoiceFoldersAndItems" type="ns2:FoldersAndItemsUse"/>
+			<xs:element name="ChoiceParameterLinks" type="ns8:ChoiceParameterLinks"/>
+			<xs:element name="ChoiceParameters" type="ns4:ChoiceParameters"/>
+			<xs:element name="QuickChoice" type="ns7:UseQuickChoice"/>
+			<xs:element name="CreateOnInput" type="ns7:CreateOnInput"/>
+			<xs:element name="ChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="LinkByType" type="ns8:TypeLink"/>
+			<xs:element name="ChoiceHistoryOnInput" type="ns6:ChoiceHistoryOnInput"/>
+			<xs:element name="DataHistory" type="ns7:DataHistoryUse"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ExternalDataProcessor">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:ExternalDataProcessorProperties"/>
+					<xs:element name="ChildObjects" type="tns:ExternalDataProcessorChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="ExternalDataProcessorChildObjects">
+		<xs:sequence>
+			<xs:element name="Attribute" type="tns:Attribute" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="TabularSection" type="tns:TabularSection" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Form" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Template" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ExternalDataProcessorProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string" minOccurs="0"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="Comment" type="xs:string" minOccurs="0"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging" minOccurs="0"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="DefaultForm" type="ns8:MDObjectRef" minOccurs="0"/>
+			<xs:element name="AuxiliaryForm" type="ns8:MDObjectRef" minOccurs="0"/>
+			<xs:element name="ObjectModule" type="ns8:ExternalProperty" minOccurs="0"/>
+			<xs:element name="Help" type="ns8:ExternalProperty" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ExternalDataSource">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:ExternalDataSourceProperties"/>
+					<xs:element name="ChildObjects" type="tns:ExternalDataSourceChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="ExternalDataSourceChildObjects">
+		<xs:sequence>
+			<xs:element name="Table" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Cube" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Function" type="tns:Function" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ExternalDataSourceProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="DataLockControlMode" type="ns7:DefaultDataLockControlMode"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ExternalReport">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:ExternalReportProperties"/>
+					<xs:element name="ChildObjects" type="tns:ExternalReportChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="ExternalReportChildObjects">
+		<xs:sequence>
+			<xs:element name="Attribute" type="tns:Attribute" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="TabularSection" type="tns:TabularSection" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Form" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Template" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ExternalReportProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string" minOccurs="0"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="Comment" type="xs:string" minOccurs="0"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging" minOccurs="0"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="DefaultForm" type="ns8:MDObjectRef" minOccurs="0"/>
+			<xs:element name="AuxiliaryForm" type="ns8:MDObjectRef" minOccurs="0"/>
+			<xs:element name="MainDataCompositionSchema" type="ns8:MDObjectRef" minOccurs="0"/>
+			<xs:element name="DefaultSettingsForm" type="ns8:MDObjectRef" minOccurs="0"/>
+			<xs:element name="AuxiliarySettingsForm" type="ns8:MDObjectRef" minOccurs="0"/>
+			<xs:element name="DefaultVariantForm" type="ns8:MDObjectRef" minOccurs="0"/>
+			<xs:element name="VariantsStorage" type="ns8:MDObjectRef" minOccurs="0"/>
+			<xs:element name="SettingsStorage" type="ns8:MDObjectRef" minOccurs="0"/>
+			<xs:element name="ObjectModule" type="ns8:ExternalProperty" minOccurs="0"/>
+			<xs:element name="Help" type="ns8:ExternalProperty" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Field">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:FieldProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="FieldProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Type" type="ns1:TypeDescription"/>
+			<xs:element name="PasswordMode" type="xs:boolean"/>
+			<xs:element name="Format" type="ns1:LocalStringType"/>
+			<xs:element name="EditFormat" type="ns1:LocalStringType"/>
+			<xs:element name="ToolTip" type="ns1:LocalStringType"/>
+			<xs:element name="MarkNegatives" type="xs:boolean"/>
+			<xs:element name="Mask" type="xs:string"/>
+			<xs:element name="MultiLine" type="xs:boolean"/>
+			<xs:element name="ExtendedEdit" type="xs:boolean"/>
+			<xs:element name="MinValue"/>
+			<xs:element name="MaxValue"/>
+			<xs:element name="FillFromFillingValue" type="xs:boolean"/>
+			<xs:element name="FillValue"/>
+			<xs:element name="FillChecking" type="ns1:FillChecking"/>
+			<xs:element name="ChoiceParameterLinks" type="ns8:ChoiceParameterLinks"/>
+			<xs:element name="ChoiceParameters" type="ns4:ChoiceParameters"/>
+			<xs:element name="QuickChoice" type="ns7:UseQuickChoice"/>
+			<xs:element name="CreateOnInput" type="ns7:CreateOnInput"/>
+			<xs:element name="ChoiceHistoryOnInput" type="ns6:ChoiceHistoryOnInput"/>
+			<xs:element name="ChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="NameInDataSource" type="xs:string"/>
+			<xs:element name="ReadOnly" type="xs:boolean"/>
+			<xs:element name="AllowNull" type="xs:boolean"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="FilterCriterion">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:FilterCriterionProperties"/>
+					<xs:element name="ChildObjects" type="tns:FilterCriterionChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="FilterCriterionChildObjects">
+		<xs:sequence>
+			<xs:element name="Form" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Command" type="tns:Command" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="FilterCriterionProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Type" type="ns1:TypeDescription"/>
+			<xs:element name="UseStandardCommands" type="xs:boolean"/>
+			<xs:element name="Content" type="ns8:MDListType"/>
+			<xs:element name="DefaultForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryForm" type="ns8:MDObjectRef"/>
+			<xs:element name="ManagerModule" type="ns8:ExternalProperty"/>
+			<xs:element name="ListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="Explanation" type="ns1:LocalStringType"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Form">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:FormProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="FormProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string" minOccurs="0"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="Comment" type="xs:string" minOccurs="0"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging" minOccurs="0"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Form" type="ns8:ExternalProperty" minOccurs="0"/>
+			<xs:element name="FormType" type="ns7:FormType" minOccurs="0"/>
+			<xs:element name="IncludeHelpInContents" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="Help" type="ns8:ExternalProperty" minOccurs="0"/>
+			<xs:element name="UsePurposes" type="ns1:FixedArray" minOccurs="0"/>
+			<xs:element name="ExtendedPresentation" type="ns1:LocalStringType" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Function">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:FunctionProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="FunctionProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="ReturnValue" type="xs:boolean"/>
+			<xs:element name="Type" type="ns1:TypeDescription"/>
+			<xs:element name="ExpressionInDataSource" type="xs:string"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="FunctionalOption">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:FunctionalOptionProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="FunctionalOptionProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Location" type="ns8:MDObjectRef"/>
+			<xs:element name="PrivilegedGetMode" type="xs:boolean"/>
+			<xs:element name="Content" type="ns8:FuncOptionContentType"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="FunctionalOptionsParameter">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:FunctionalOptionsParameterProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="FunctionalOptionsParameterProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Use" type="ns8:MDListType"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="HTTPService">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:HTTPServiceProperties"/>
+					<xs:element name="ChildObjects" type="tns:HTTPServiceChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="HTTPServiceChildObjects">
+		<xs:sequence>
+			<xs:element name="URLTemplate" type="tns:URLTemplate" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="HTTPServiceProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="RootURL" type="xs:string"/>
+			<xs:element name="Module" type="ns8:ExternalProperty"/>
+			<xs:element name="ReuseSessions" type="ns7:SessionReuseMode"/>
+			<xs:element name="SessionMaxAge" type="xs:decimal"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="InformationRegister">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:InformationRegisterProperties"/>
+					<xs:element name="ChildObjects" type="tns:InformationRegisterChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="InformationRegisterChildObjects">
+		<xs:sequence>
+			<xs:element name="Resource" type="tns:Resource" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Attribute" type="tns:Attribute" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Dimension" type="tns:Dimension" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Form" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Template" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Command" type="tns:Command" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="InformationRegisterProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="UseStandardCommands" type="xs:boolean"/>
+			<xs:element name="EditType" type="ns7:EditType"/>
+			<xs:element name="DefaultRecordForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryRecordForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="StandardAttributes" type="ns8:StandardAttributeDescriptions"/>
+			<xs:element name="InformationRegisterPeriodicity" type="ns7:InformationRegisterPeriodicity"/>
+			<xs:element name="WriteMode" type="ns7:RegisterWriteMode"/>
+			<xs:element name="MainFilterOnPeriod" type="xs:boolean"/>
+			<xs:element name="IncludeHelpInContents" type="xs:boolean"/>
+			<xs:element name="Help" type="ns8:ExternalProperty"/>
+			<xs:element name="RecordSetModule" type="ns8:ExternalProperty"/>
+			<xs:element name="ManagerModule" type="ns8:ExternalProperty"/>
+			<xs:element name="DataLockControlMode" type="ns7:DefaultDataLockControlMode"/>
+			<xs:element name="FullTextSearch" type="ns7:FullTextSearchUsing"/>
+			<xs:element name="EnableTotalsSliceFirst" type="xs:boolean"/>
+			<xs:element name="EnableTotalsSliceLast" type="xs:boolean"/>
+			<xs:element name="RecordPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedRecordPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="Explanation" type="ns1:LocalStringType"/>
+			<xs:element name="DataHistory" type="ns7:DataHistoryUse"/>
+			<xs:element name="UpdateDataHistoryImmediatelyAfterWrite" type="xs:boolean"/>
+			<xs:element name="ExecuteAfterWriteDataHistoryVersionProcessing" type="xs:boolean"/>
+			<xs:element name="AdditionalIndexes" type="ns8:ExternalProperty"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="IntegrationService">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:IntegrationServiceProperties"/>
+					<xs:element name="ChildObjects" type="tns:IntegrationServiceChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="IntegrationServiceChannel">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:IntegrationServiceChannelProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="IntegrationServiceChannelProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="ExternalIntegrationServiceChannelName" type="xs:string"/>
+			<xs:element name="ReceiveMessageProcessing" type="xs:string"/>
+			<xs:element name="MessageDirection" type="ns7:IntegrationServiceChannelMessageDirection" minOccurs="0"/>
+			<xs:element name="Transactioned" type="xs:boolean"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="IntegrationServiceChildObjects">
+		<xs:sequence>
+			<xs:element name="IntegrationServiceChannel" type="tns:IntegrationServiceChannel" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="IntegrationServiceProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="ExternalIntegrationServiceAddress" type="xs:string"/>
+			<xs:element name="Module" type="ns8:ExternalProperty"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Interface">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:InterfaceProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="InterfaceProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Interface" type="ns8:ExternalProperty"/>
+			<xs:element name="Switchable" type="xs:boolean"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Language">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:LanguageProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="LanguageProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="LanguageCode" type="xs:string"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="MDObjectBase">
+		<xs:sequence>
+			<xs:element name="InternalInfo" type="ns8:InternalInfo" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="uuid" type="ns1:UUID" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="MetaDataObject">
+		<xs:complexContent>
+			<xs:extension base="ns8:EntityWithVersion">
+				<xs:choice>
+					<xs:element name="AccountingRegister" type="tns:AccountingRegister" minOccurs="0"/>
+					<xs:element name="AccumulationRegister" type="tns:AccumulationRegister" minOccurs="0"/>
+					<xs:element name="BusinessProcess" type="tns:BusinessProcess" minOccurs="0"/>
+					<xs:element name="CalculationRegister" type="tns:CalculationRegister" minOccurs="0"/>
+					<xs:element name="Catalog" type="tns:Catalog" minOccurs="0"/>
+					<xs:element name="ChartOfAccounts" type="tns:ChartOfAccounts" minOccurs="0"/>
+					<xs:element name="ChartOfCalculationTypes" type="tns:ChartOfCalculationTypes" minOccurs="0"/>
+					<xs:element name="ChartOfCharacteristicTypes" type="tns:ChartOfCharacteristicTypes" minOccurs="0"/>
+					<xs:element name="CommandGroup" type="tns:CommandGroup" minOccurs="0"/>
+					<xs:element name="CommonAttribute" type="tns:CommonAttribute" minOccurs="0"/>
+					<xs:element name="CommonCommand" type="tns:CommonCommand" minOccurs="0"/>
+					<xs:element name="CommonForm" type="tns:CommonForm" minOccurs="0"/>
+					<xs:element name="CommonModule" type="tns:CommonModule" minOccurs="0"/>
+					<xs:element name="CommonPicture" type="tns:CommonPicture" minOccurs="0"/>
+					<xs:element name="CommonTemplate" type="tns:CommonTemplate" minOccurs="0"/>
+					<xs:element name="Configuration" type="tns:Configuration" minOccurs="0"/>
+					<xs:element name="Constant" type="tns:Constant" minOccurs="0"/>
+					<xs:element name="Cube" type="tns:Cube" minOccurs="0"/>
+					<xs:element name="DataProcessor" type="tns:DataProcessor" minOccurs="0"/>
+					<xs:element name="DefinedType" type="tns:DefinedType" minOccurs="0"/>
+					<xs:element name="DimensionTable" type="tns:DimensionTable" minOccurs="0"/>
+					<xs:element name="Document" type="tns:Document" minOccurs="0"/>
+					<xs:element name="DocumentJournal" type="tns:DocumentJournal" minOccurs="0"/>
+					<xs:element name="DocumentNumerator" type="tns:DocumentNumerator" minOccurs="0"/>
+					<xs:element name="Enum" type="tns:Enum" minOccurs="0"/>
+					<xs:element name="EventSubscription" type="tns:EventSubscription" minOccurs="0"/>
+					<xs:element name="ExchangePlan" type="tns:ExchangePlan" minOccurs="0"/>
+					<xs:element name="ExternalDataProcessor" type="tns:ExternalDataProcessor" minOccurs="0"/>
+					<xs:element name="ExternalDataSource" type="tns:ExternalDataSource" minOccurs="0"/>
+					<xs:element name="ExternalReport" type="tns:ExternalReport" minOccurs="0"/>
+					<xs:element name="FilterCriterion" type="tns:FilterCriterion" minOccurs="0"/>
+					<xs:element name="Form" type="tns:Form" minOccurs="0"/>
+					<xs:element name="FunctionalOption" type="tns:FunctionalOption" minOccurs="0"/>
+					<xs:element name="FunctionalOptionsParameter" type="tns:FunctionalOptionsParameter" minOccurs="0"/>
+					<xs:element name="HTTPService" type="tns:HTTPService" minOccurs="0"/>
+					<xs:element name="InformationRegister" type="tns:InformationRegister" minOccurs="0"/>
+					<xs:element name="IntegrationService" type="tns:IntegrationService" minOccurs="0"/>
+					<xs:element name="Interface" type="tns:Interface" minOccurs="0"/>
+					<xs:element name="Language" type="tns:Language" minOccurs="0"/>
+					<xs:element name="Recalculation" type="tns:Recalculation" minOccurs="0"/>
+					<xs:element name="Report" type="tns:Report" minOccurs="0"/>
+					<xs:element name="Role" type="tns:Role" minOccurs="0"/>
+					<xs:element name="ScheduledJob" type="tns:ScheduledJob" minOccurs="0"/>
+					<xs:element name="Sequence" type="tns:Sequence" minOccurs="0"/>
+					<xs:element name="SessionParameter" type="tns:SessionParameter" minOccurs="0"/>
+					<xs:element name="SettingsStorage" type="tns:SettingsStorage" minOccurs="0"/>
+					<xs:element name="Style" type="tns:Style" minOccurs="0"/>
+					<xs:element name="StyleItem" type="tns:StyleItem" minOccurs="0"/>
+					<xs:element name="Subsystem" type="tns:Subsystem" minOccurs="0"/>
+					<xs:element name="Table" type="tns:Table" minOccurs="0"/>
+					<xs:element name="Task" type="tns:Task" minOccurs="0"/>
+					<xs:element name="Template" type="tns:Template" minOccurs="0"/>
+					<xs:element name="WSReference" type="tns:WSReference" minOccurs="0"/>
+					<xs:element name="WebService" type="tns:WebService" minOccurs="0"/>
+					<xs:element name="XDTOPackage" type="tns:XDTOPackage" minOccurs="0"/>
+					<xs:element name="Bot" type="tns:Bot" minOccurs="0"/>
+					<xs:element name="WebSocketClient" type="tns:WebSocketClient" minOccurs="0"/>
+				</xs:choice>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="Method">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:MethodProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="MethodProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="HTTPMethod" type="ns7:HTTPMethod"/>
+			<xs:element name="Handler" type="xs:string"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Operation">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:OperationProperties"/>
+					<xs:element name="ChildObjects" type="tns:OperationChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="OperationChildObjects">
+		<xs:sequence>
+			<xs:element name="Parameter" type="tns:Parameter" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="OperationProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="XDTOReturningValueType" type="xs:QName"/>
+			<xs:element name="Nillable" type="xs:boolean"/>
+			<xs:element name="Transactioned" type="xs:boolean"/>
+			<xs:element name="ProcedureName" type="xs:string"/>
+			<xs:element name="DataLockControlMode" type="ns7:DefaultDataLockControlMode"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Parameter">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:ParameterProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="ParameterProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="XDTOValueType" type="xs:QName"/>
+			<xs:element name="Nillable" type="xs:boolean"/>
+			<xs:element name="TransferDirection" type="ns7:TransferDirection"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Recalculation">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:RecalculationProperties"/>
+					<xs:element name="ChildObjects" type="tns:RecalculationChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="RecalculationChildObjects">
+		<xs:sequence>
+			<xs:element name="Dimension" type="tns:Dimension" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="RecalculationProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="RecordSetModule" type="ns8:ExternalProperty"/>
+			<xs:element name="DataLockControlMode" type="ns7:DefaultDataLockControlMode"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Report">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:ReportProperties"/>
+					<xs:element name="ChildObjects" type="tns:ReportChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="ReportChildObjects">
+		<xs:sequence>
+			<xs:element name="Attribute" type="tns:Attribute" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="TabularSection" type="tns:TabularSection" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Form" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Template" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Command" type="tns:Command" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ReportProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="UseStandardCommands" type="xs:boolean"/>
+			<xs:element name="DefaultForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryForm" type="ns8:MDObjectRef"/>
+			<xs:element name="MainDataCompositionSchema" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultSettingsForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliarySettingsForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultVariantForm" type="ns8:MDObjectRef"/>
+			<xs:element name="VariantsStorage" type="ns8:MDObjectRef"/>
+			<xs:element name="SettingsStorage" type="ns8:MDObjectRef"/>
+			<xs:element name="ObjectModule" type="ns8:ExternalProperty"/>
+			<xs:element name="ManagerModule" type="ns8:ExternalProperty"/>
+			<xs:element name="IncludeHelpInContents" type="xs:boolean"/>
+			<xs:element name="Help" type="ns8:ExternalProperty"/>
+			<xs:element name="ExtendedPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="Explanation" type="ns1:LocalStringType"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Resource">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:ResourceProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="ResourceProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string" minOccurs="0"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="Comment" type="xs:string" minOccurs="0"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging" minOccurs="0"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Type" type="ns1:TypeDescription" minOccurs="0"/>
+			<xs:element name="PasswordMode" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="Format" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="EditFormat" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="ToolTip" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="MarkNegatives" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="Mask" type="xs:string" minOccurs="0"/>
+			<xs:element name="MultiLine" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="ExtendedEdit" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="MinValue" minOccurs="0"/>
+			<xs:element name="MaxValue" minOccurs="0"/>
+			<xs:element name="FillChecking" type="ns1:FillChecking" minOccurs="0"/>
+			<xs:element name="ChoiceFoldersAndItems" type="ns2:FoldersAndItemsUse" minOccurs="0"/>
+			<xs:element name="ChoiceParameterLinks" type="ns8:ChoiceParameterLinks" minOccurs="0"/>
+			<xs:element name="ChoiceParameters" type="ns4:ChoiceParameters" minOccurs="0"/>
+			<xs:element name="QuickChoice" type="ns7:UseQuickChoice" minOccurs="0"/>
+			<xs:element name="CreateOnInput" type="ns7:CreateOnInput" minOccurs="0"/>
+			<xs:element name="ChoiceForm" type="ns8:MDObjectRef" minOccurs="0"/>
+			<xs:element name="LinkByType" type="ns8:TypeLink" minOccurs="0"/>
+			<xs:element name="ChoiceHistoryOnInput" type="ns6:ChoiceHistoryOnInput" minOccurs="0"/>
+			<xs:element name="Balance" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="AccountingFlag" type="ns8:MDObjectRef" minOccurs="0"/>
+			<xs:element name="ExtDimensionAccountingFlag" type="ns8:MDObjectRef" minOccurs="0"/>
+			<xs:element name="FullTextSearch" type="ns7:FullTextSearchUsing" minOccurs="0"/>
+			<xs:element name="FillFromFillingValue" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="FillValue" minOccurs="0"/>
+			<xs:element name="Indexing" type="ns7:Indexing" minOccurs="0"/>
+			<xs:element name="DataHistory" type="ns7:DataHistoryUse" minOccurs="0"/>
+			<xs:element name="NameInDataSource" type="xs:string" minOccurs="0"/>
+			<xs:element name="BinaryDataStorageLocationUse" type="ns7:BinaryDataStorageLocationUse" minOccurs="0"/>
+			<xs:element name="BinaryDataStorageLocationUseField" type="ns8:MDObjectRef" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Role">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:RoleProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="RoleProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Rights" type="ns8:ExternalProperty"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ScheduledJob">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:ScheduledJobProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="ScheduledJobProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="MethodName" type="ns8:MDMethodRef"/>
+			<xs:element name="Description" type="xs:string"/>
+			<xs:element name="Key" type="xs:string"/>
+			<xs:element name="Schedule" type="ns8:ExternalProperty"/>
+			<xs:element name="Use" type="xs:boolean"/>
+			<xs:element name="Predefined" type="xs:boolean"/>
+			<xs:element name="RestartCountOnFailure" type="xs:decimal"/>
+			<xs:element name="RestartIntervalOnFailure" type="xs:decimal"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Sequence">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:SequenceProperties"/>
+					<xs:element name="ChildObjects" type="tns:SequenceChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="SequenceChildObjects">
+		<xs:sequence>
+			<xs:element name="Dimension" type="tns:Dimension" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="SequenceProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="MoveBoundaryOnPosting" type="ns7:MoveBoundaryOnPosting"/>
+			<xs:element name="Documents" type="ns8:MDListType"/>
+			<xs:element name="RegisterRecords" type="ns8:MDListType"/>
+			<xs:element name="RecordSetModule" type="ns8:ExternalProperty"/>
+			<xs:element name="DataLockControlMode" type="ns7:DefaultDataLockControlMode"/>
+			<xs:element name="AdditionalIndexes" type="ns8:ExternalProperty"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="SessionParameter">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:SessionParameterProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="SessionParameterProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Type" type="ns1:TypeDescription"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="SettingsStorage">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:SettingsStorageProperties"/>
+					<xs:element name="ChildObjects" type="tns:SettingsStorageChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="SettingsStorageChildObjects">
+		<xs:sequence>
+			<xs:element name="Form" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Template" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="SettingsStorageProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="DefaultSaveForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultLoadForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliarySaveForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryLoadForm" type="ns8:MDObjectRef"/>
+			<xs:element name="ManagerModule" type="ns8:ExternalProperty"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Style">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:StyleProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="StyleItem">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:StyleItemProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="StyleItemProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Type" type="ns7:StyleElementType"/>
+			<xs:element name="Value"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="StyleProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Style" type="ns8:ExternalProperty"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Subsystem">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:SubsystemProperties"/>
+					<xs:element name="ChildObjects" type="tns:SubsystemChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="SubsystemChildObjects">
+		<xs:sequence>
+			<xs:element name="Subsystem" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="SubsystemProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="IncludeHelpInContents" type="xs:boolean"/>
+			<xs:element name="UseOneCommand" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="Help" type="ns8:ExternalProperty"/>
+			<xs:element name="IncludeInCommandInterface" type="xs:boolean"/>
+			<xs:element name="CommandInterface" type="ns8:ExternalProperty"/>
+			<xs:element name="Explanation" type="ns1:LocalStringType"/>
+			<xs:element name="Picture" type="ns8:Picture"/>
+			<xs:element name="Content" type="ns8:MDListType"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Table">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:TableProperties"/>
+					<xs:element name="ChildObjects" type="tns:TableChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="TableChildObjects">
+		<xs:sequence>
+			<xs:element name="Field" type="tns:Field" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Form" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Command" type="tns:Command" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Template" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TableProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="TableType" type="ns7:ExternalDataSourceTableType"/>
+			<xs:element name="NameInDataSource" type="xs:string"/>
+			<xs:element name="ExpressionInDataSource" type="xs:string"/>
+			<xs:element name="TableDataType" type="ns7:ExternalDataSourceTableDataType"/>
+			<xs:element name="KeyFields" type="ns8:FieldList"/>
+			<xs:element name="PresentationField" type="ns8:MDObjectRef"/>
+			<xs:element name="ParentField" type="ns8:MDObjectRef"/>
+			<xs:element name="UnfilledParentValue"/>
+			<xs:element name="Characteristics" type="ns8:CharacteristicsDescriptions"/>
+			<xs:element name="UseStandardCommands" type="xs:boolean"/>
+			<xs:element name="QuickChoice" type="xs:boolean"/>
+			<xs:element name="InputByString" type="ns8:FieldList"/>
+			<xs:element name="CreateOnInput" type="ns7:CreateOnInput"/>
+			<xs:element name="SearchStringModeOnInputByString" type="ns6:SearchStringModeOnInputByString"/>
+			<xs:element name="ChoiceDataGetModeOnInputByString" type="ns6:ChoiceDataGetModeOnInputByString"/>
+			<xs:element name="ChoiceHistoryOnInput" type="ns6:ChoiceHistoryOnInput"/>
+			<xs:element name="DefaultObjectForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultRecordForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="ObjectPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedObjectPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="RecordPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedRecordPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="Explanation" type="ns1:LocalStringType"/>
+			<xs:element name="ObjectModule" type="ns8:ExternalProperty"/>
+			<xs:element name="RecordSetModule" type="ns8:ExternalProperty"/>
+			<xs:element name="ManagerModule" type="ns8:ExternalProperty"/>
+			<xs:element name="IncludeHelpInContents" type="xs:boolean"/>
+			<xs:element name="Help" type="ns8:ExternalProperty"/>
+			<xs:element name="ReadOnly" type="xs:boolean"/>
+			<xs:element name="TransactionsIsolationLevel" type="ns2:TransactionsIsolationLevel"/>
+			<xs:element name="DataVersionField" type="ns8:MDObjectRef"/>
+			<xs:element name="EditType" type="ns7:EditType"/>
+			<xs:element name="BasedOn" type="ns8:MDListType"/>
+			<xs:element name="DataLockFields" type="ns8:FieldList"/>
+			<xs:element name="DataLockControlMode" type="ns7:DefaultDataLockControlMode"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TabularSection">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:TabularSectionProperties"/>
+					<xs:element name="ChildObjects" type="tns:TabularSectionChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="TabularSectionChildObjects">
+		<xs:sequence>
+			<xs:element name="Attribute" type="tns:Attribute" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TabularSectionProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string" minOccurs="0"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="Comment" type="xs:string" minOccurs="0"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging" minOccurs="0"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="ToolTip" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="FillChecking" type="ns1:FillChecking" minOccurs="0"/>
+			<xs:element name="StandardAttributes" type="ns8:StandardAttributeDescriptions" minOccurs="0"/>
+			<xs:element name="Use" type="ns7:AttributeUse" minOccurs="0"/>
+			<xs:element name="LineNumberLength" type="xs:decimal" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Task">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:TaskProperties"/>
+					<xs:element name="ChildObjects" type="tns:TaskChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="TaskChildObjects">
+		<xs:sequence>
+			<xs:element name="Attribute" type="tns:Attribute" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="TabularSection" type="tns:TabularSection" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Form" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Template" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="AddressingAttribute" type="tns:AddressingAttribute" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Command" type="tns:Command" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TaskProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="UseStandardCommands" type="xs:boolean"/>
+			<xs:element name="ObjectModule" type="ns8:ExternalProperty"/>
+			<xs:element name="ManagerModule" type="ns8:ExternalProperty"/>
+			<xs:element name="NumberType" type="ns7:TaskNumberType"/>
+			<xs:element name="NumberLength" type="xs:decimal"/>
+			<xs:element name="NumberAllowedLength" type="ns1:AllowedLength"/>
+			<xs:element name="CheckUnique" type="xs:boolean"/>
+			<xs:element name="Autonumbering" type="xs:boolean"/>
+			<xs:element name="TaskNumberAutoPrefix" type="ns7:TaskNumberAutoPrefix"/>
+			<xs:element name="DescriptionLength" type="xs:decimal"/>
+			<xs:element name="Addressing" type="ns8:MDObjectRef"/>
+			<xs:element name="MainAddressingAttribute" type="ns8:MDObjectRef"/>
+			<xs:element name="CurrentPerformer" type="ns8:MDObjectRef"/>
+			<xs:element name="BasedOn" type="ns8:MDListType"/>
+			<xs:element name="StandardAttributes" type="ns8:StandardAttributeDescriptions"/>
+			<xs:element name="Characteristics" type="ns8:CharacteristicsDescriptions"/>
+			<xs:element name="DefaultPresentation" type="ns7:TaskMainPresentation"/>
+			<xs:element name="EditType" type="ns7:EditType"/>
+			<xs:element name="InputByString" type="ns8:FieldList"/>
+			<xs:element name="SearchStringModeOnInputByString" type="ns6:SearchStringModeOnInputByString"/>
+			<xs:element name="FullTextSearchOnInputByString" type="ns6:FullTextSearchOnInputByString"/>
+			<xs:element name="ChoiceDataGetModeOnInputByString" type="ns6:ChoiceDataGetModeOnInputByString"/>
+			<xs:element name="CreateOnInput" type="ns7:CreateOnInput"/>
+			<xs:element name="DefaultObjectForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryObjectForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="ChoiceHistoryOnInput" type="ns6:ChoiceHistoryOnInput"/>
+			<xs:element name="IncludeHelpInContents" type="xs:boolean"/>
+			<xs:element name="Help" type="ns8:ExternalProperty"/>
+			<xs:element name="DataLockFields" type="ns8:FieldList"/>
+			<xs:element name="DataLockControlMode" type="ns7:DefaultDataLockControlMode"/>
+			<xs:element name="FullTextSearch" type="ns7:FullTextSearchUsing"/>
+			<xs:element name="ObjectPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedObjectPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="Explanation" type="ns1:LocalStringType"/>
+			<xs:element name="DataHistory" type="ns7:DataHistoryUse"/>
+			<xs:element name="UpdateDataHistoryImmediatelyAfterWrite" type="xs:boolean"/>
+			<xs:element name="ExecuteAfterWriteDataHistoryVersionProcessing" type="xs:boolean"/>
+			<xs:element name="AdditionalIndexes" type="ns8:ExternalProperty"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Template">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:TemplateProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="TemplateProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="TemplateType" type="ns7:TemplateType"/>
+			<xs:element name="Template" type="ns8:ExternalProperty"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="URLTemplate">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:URLTemplateProperties"/>
+					<xs:element name="ChildObjects" type="tns:URLTemplateChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="URLTemplateChildObjects">
+		<xs:sequence>
+			<xs:element name="Method" type="tns:Method" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="URLTemplateProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Template" type="xs:string"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="WSReference">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:WSReferenceProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="WSReferenceProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="LocationURL" type="xs:string"/>
+			<xs:element name="WSDefinition" type="ns8:ExternalProperty"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="WebService">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:WebServiceProperties"/>
+					<xs:element name="ChildObjects" type="tns:WebServiceChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="WebServiceChildObjects">
+		<xs:sequence>
+			<xs:element name="Operation" type="tns:Operation" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="WebServiceProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Namespace" type="xs:string"/>
+			<xs:element name="Module" type="ns8:ExternalProperty"/>
+			<xs:element name="XDTOPackages" type="ns8:ValueList"/>
+			<xs:element name="DescriptorFileName" type="xs:string"/>
+			<xs:element name="ReuseSessions" type="ns7:SessionReuseMode"/>
+			<xs:element name="SessionMaxAge" type="xs:decimal"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="WebSocketClient">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:WebSocketClientProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="WebSocketClientProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Predefined" type="xs:boolean"/>
+			<xs:element name="Module" type="ns8:ExternalProperty"/>
+			<xs:element name="ServerURL" type="xs:string"/>
+			<xs:element name="User" type="xs:string"/>
+			<xs:element name="Password" type="xs:string"/>
+			<xs:element name="Headers"/>
+			<xs:element name="UseOSProxy" type="xs:boolean"/>
+			<xs:element name="UseOSAuthentication" type="xs:boolean"/>
+			<xs:element name="Timeout" type="xs:decimal"/>
+			<xs:element name="AutoConnect" type="xs:boolean"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="XDTOPackage">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:XDTOPackageProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="XDTOPackageProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Namespace" type="xs:string"/>
+			<xs:element name="Package" type="ns8:ExternalProperty"/>
+		</xs:sequence>
+	</xs:complexType>
+</xs:schema>

--- a/src/main/xsd/v8.3.27/v8.1c.ru-8.3-xcf-enums.xsd
+++ b/src/main/xsd/v8.3.27/v8.1c.ru-8.3-xcf-enums.xsd
@@ -1,0 +1,593 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:tns="http://v8.1c.ru/8.3/xcf/enums" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://v8.1c.ru/8.3/xcf/enums" attributeFormDefault="unqualified" elementFormDefault="qualified">
+	<xs:simpleType name="AccountMainPresentation">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="AsCode"/>
+			<xs:enumeration value="AsDescription"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="AccumulationRegisterType">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Balance"/>
+			<xs:enumeration value="Turnovers"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="AttributeUse">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="ForItem"/>
+			<xs:enumeration value="ForFolder"/>
+			<xs:enumeration value="ForFolderAndItem"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="BaseEnumType">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="BinaryDataBlockStorageUseMode">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Use"/>
+			<xs:enumeration value="DontUse"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="BinaryDataStorageLocationUse">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Use"/>
+			<xs:enumeration value="DontUse"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="BinaryDataStorageMode">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="DontUse"/>
+			<xs:enumeration value="Use"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="BusinessProcessNumberPeriodicity">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Nonperiodical"/>
+			<xs:enumeration value="Year"/>
+			<xs:enumeration value="Quarter"/>
+			<xs:enumeration value="Month"/>
+			<xs:enumeration value="Day"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="BusinessProcessNumberType">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Number"/>
+			<xs:enumeration value="String"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CalculationRegisterPeriodicity">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Year"/>
+			<xs:enumeration value="Quarter"/>
+			<xs:enumeration value="Month"/>
+			<xs:enumeration value="Day"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CalculationTypeMainPresentation">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="AsCode"/>
+			<xs:enumeration value="AsDescription"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CatalogCodeType">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Number"/>
+			<xs:enumeration value="String"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CatalogCodesSeries">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="WholeCatalog"/>
+			<xs:enumeration value="WithinSubordination"/>
+			<xs:enumeration value="WithinOwnerSubordination"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CatalogMainPresentation">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="AsCode"/>
+			<xs:enumeration value="AsDescription"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CharOfAccountCodeSeries">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="WholeChartOfAccounts"/>
+			<xs:enumeration value="WithinSubordination"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CharacteristicKindCodesSeries">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="WholeCharacteristicKind"/>
+			<xs:enumeration value="WithinSubordination"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CharacteristicTypeMainPresentation">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="AsCode"/>
+			<xs:enumeration value="AsDescription"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ChartOfCalculationTypesBaseUse">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="DontUse"/>
+			<xs:enumeration value="OnActionPeriod"/>
+			<xs:enumeration value="OnRegistrationPeriod"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ChartOfCalculationTypesCodeType">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Number"/>
+			<xs:enumeration value="String"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ChoiceDataGetModeOnInputByString">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Directly"/>
+			<xs:enumeration value="Background"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ChoiceMode">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="FromForm"/>
+			<xs:enumeration value="QuickChoice"/>
+			<xs:enumeration value="BothWays"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CommonAttributeAuthenticationSeparation">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Separate"/>
+			<xs:enumeration value="DontUse"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CommonAttributeAutoUse">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Use"/>
+			<xs:enumeration value="DontUse"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CommonAttributeConfigurationExtensionsSeparation">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Separate"/>
+			<xs:enumeration value="DontUse"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CommonAttributeDataSeparation">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Separate"/>
+			<xs:enumeration value="DontUse"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CommonAttributeSeparatedDataUse">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Independently"/>
+			<xs:enumeration value="IndependentlyAndSimultaneously"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CommonAttributeUse">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Use"/>
+			<xs:enumeration value="DontUse"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CommonAttributeUsersSeparation">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Separate"/>
+			<xs:enumeration value="DontUse"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CompatibilityMode">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="DontUse"/>
+			<xs:enumeration value="Version8_3_12"/>
+			<xs:enumeration value="Version8_3_11"/>
+			<xs:enumeration value="Version8_3_10"/>
+			<xs:enumeration value="Version8_3_9"/>
+			<xs:enumeration value="Version8_3_8"/>
+			<xs:enumeration value="Version8_3_7"/>
+			<xs:enumeration value="Version8_3_6"/>
+			<xs:enumeration value="Version8_3_5"/>
+			<xs:enumeration value="Version8_3_4"/>
+			<xs:enumeration value="Version8_3_3"/>
+			<xs:enumeration value="Version8_3_2"/>
+			<xs:enumeration value="Version8_3_1"/>
+			<xs:enumeration value="Version8_2_16"/>
+			<xs:enumeration value="Version8_2_13"/>
+			<xs:enumeration value="Version8_1"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ConfigurationExtensionPurpose">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Patch"/>
+			<xs:enumeration value="Customization"/>
+			<xs:enumeration value="AddOn"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CreateOnInput">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="DontUse"/>
+			<xs:enumeration value="Use"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DataExchangeMainPresentation">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="AsCode"/>
+			<xs:enumeration value="AsDescription"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DataHistoryUse">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="DontUse"/>
+			<xs:enumeration value="Use"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DatabaseTablespacesUseMode">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Use"/>
+			<xs:enumeration value="DontUse"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DefaultDataLockControlMode">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Automatic"/>
+			<xs:enumeration value="Managed"/>
+			<xs:enumeration value="AutomaticAndManaged"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DocumentNumberPeriodicity">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Nonperiodical"/>
+			<xs:enumeration value="Year"/>
+			<xs:enumeration value="Quarter"/>
+			<xs:enumeration value="Month"/>
+			<xs:enumeration value="Day"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DocumentNumberType">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Number"/>
+			<xs:enumeration value="String"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="EditType">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="InList"/>
+			<xs:enumeration value="InDialog"/>
+			<xs:enumeration value="BothWays"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ExternalDataSourceTableDataType">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="ObjectData"/>
+			<xs:enumeration value="NonobjectData"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ExternalDataSourceTableType">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Table"/>
+			<xs:enumeration value="Expression"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FormType">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Ordinary"/>
+			<xs:enumeration value="Managed"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FormatVersion">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="1.0"/>
+			<xs:enumeration value="2.0"/>
+			<xs:enumeration value="2.1"/>
+			<xs:enumeration value="2.2"/>
+			<xs:enumeration value="2.3"/>
+			<xs:enumeration value="2.4"/>
+			<xs:enumeration value="2.5"/>
+			<xs:enumeration value="2.6"/>
+			<xs:enumeration value="2.7"/>
+			<xs:enumeration value="2.8"/>
+			<xs:enumeration value="2.9"/>
+			<xs:enumeration value="2.9.1"/>
+			<xs:enumeration value="2.10"/>
+			<xs:enumeration value="2.11"/>
+			<xs:enumeration value="2.12"/>
+			<xs:enumeration value="2.13"/>
+			<xs:enumeration value="2.14"/>
+			<xs:enumeration value="2.15"/>
+			<xs:enumeration value="2.16"/>
+			<xs:enumeration value="2.17"/>
+			<xs:enumeration value="2.18"/>
+			<xs:enumeration value="2.19"/>
+			<xs:enumeration value="2.20"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FullTextSearchOnInputByString">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Use"/>
+			<xs:enumeration value="DontUse"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FullTextSearchUsing">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="DontUse"/>
+			<xs:enumeration value="Use"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="HTTPMethod">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="GET"/>
+			<xs:enumeration value="HEAD"/>
+			<xs:enumeration value="PUT"/>
+			<xs:enumeration value="POST"/>
+			<xs:enumeration value="DELETE"/>
+			<xs:enumeration value="PATCH"/>
+			<xs:enumeration value="MERGE"/>
+			<xs:enumeration value="OPTIONS"/>
+			<xs:enumeration value="TRACE"/>
+			<xs:enumeration value="CONNECT"/>
+			<xs:enumeration value="PROPFIND"/>
+			<xs:enumeration value="PROPPATCH"/>
+			<xs:enumeration value="MOVE"/>
+			<xs:enumeration value="COPY"/>
+			<xs:enumeration value="LOCK"/>
+			<xs:enumeration value="UNLOCK"/>
+			<xs:enumeration value="MKCOL"/>
+			<xs:enumeration value="Any"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="HierarchyType">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="HierarchyFoldersAndItems"/>
+			<xs:enumeration value="HierarchyOfItems"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Indexing">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="DontIndex"/>
+			<xs:enumeration value="Index"/>
+			<xs:enumeration value="IndexWithAdditionalOrder"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="InformationRegisterPeriodicity">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Nonperiodical"/>
+			<xs:enumeration value="RecorderPosition"/>
+			<xs:enumeration value="Second"/>
+			<xs:enumeration value="Day"/>
+			<xs:enumeration value="Month"/>
+			<xs:enumeration value="Quarter"/>
+			<xs:enumeration value="Year"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="IntegrationServiceChannelMessageDirection">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Send"/>
+			<xs:enumeration value="Receive"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="InterfaceCompatibilityMode">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Taxi"/>
+			<xs:enumeration value="TaxiEnableVersion8_2"/>
+			<xs:enumeration value="Version8_2EnableTaxi"/>
+			<xs:enumeration value="Version8_2"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ModalityUseMode">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Use"/>
+			<xs:enumeration value="UseWithWarnings"/>
+			<xs:enumeration value="DontUse"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="MoveBoundaryOnPosting">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Move"/>
+			<xs:enumeration value="DontMove"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ObjectAutonumerationMode">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="AutoFree"/>
+			<xs:enumeration value="NotAutoFree"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ObjectBelonging">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Native"/>
+			<xs:enumeration value="Adopted"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Posting">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Allow"/>
+			<xs:enumeration value="Deny"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="PredefinedDataUpdate">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="AutoUpdate"/>
+			<xs:enumeration value="DontAutoUpdate"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="PropertyState">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="NotSet"/>
+			<xs:enumeration value="Checked"/>
+			<xs:enumeration value="Extended"/>
+			<xs:enumeration value="Notify"/>
+			<xs:enumeration value="MultiState"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="RealTimePosting">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Allow"/>
+			<xs:enumeration value="Deny"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="RegisterRecordsDeletion">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="AutoDeleteOnUnpost"/>
+			<xs:enumeration value="AutoDelete"/>
+			<xs:enumeration value="AutoDeleteOff"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="RegisterRecordsWritingOnPost">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="WriteSelected"/>
+			<xs:enumeration value="WriteModified"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="RegisterWriteMode">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Independent"/>
+			<xs:enumeration value="RecorderSubordinate"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ReturnValuesReuse">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="DontUse"/>
+			<xs:enumeration value="DuringRequest"/>
+			<xs:enumeration value="DuringSession"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ScriptVariant">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="English"/>
+			<xs:enumeration value="Russian"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SearchStringModeOnInputByString">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Begin"/>
+			<xs:enumeration value="AnyPart"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SequenceFilling">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="AutoFill"/>
+			<xs:enumeration value="AutoFillOff"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SessionReuseMode">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="DontUse"/>
+			<xs:enumeration value="Use"/>
+			<xs:enumeration value="AutoUse"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="StyleElementType">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Color"/>
+			<xs:enumeration value="Font"/>
+			<xs:enumeration value="Border"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SubordinationUse">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="ToItems"/>
+			<xs:enumeration value="ToFolders"/>
+			<xs:enumeration value="ToFoldersAndItems"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SynchronousPlatformExtensionAndAddInCallUseMode">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Use"/>
+			<xs:enumeration value="UseWithWarnings"/>
+			<xs:enumeration value="DontUse"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TaskMainPresentation">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="AsNumber"/>
+			<xs:enumeration value="AsDescription"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TaskNumberAutoPrefix">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="BusinessProcessNumber"/>
+			<xs:enumeration value="DontUse"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TaskNumberType">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Number"/>
+			<xs:enumeration value="String"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TemplateType">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="SpreadsheetDocument"/>
+			<xs:enumeration value="BinaryData"/>
+			<xs:enumeration value="ActiveDocument"/>
+			<xs:enumeration value="HTMLDocument"/>
+			<xs:enumeration value="TextDocument"/>
+			<xs:enumeration value="GeographicalSchema"/>
+			<xs:enumeration value="GraphicalSchema"/>
+			<xs:enumeration value="DataCompositionSchema"/>
+			<xs:enumeration value="DataCompositionAppearanceTemplate"/>
+			<xs:enumeration value="AddIn"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TransferDirection">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="In"/>
+			<xs:enumeration value="Out"/>
+			<xs:enumeration value="InOut"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TypeCategories">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="TabularSectionRow"/>
+			<xs:enumeration value="Object"/>
+			<xs:enumeration value="Ref"/>
+			<xs:enumeration value="Selection"/>
+			<xs:enumeration value="List"/>
+			<xs:enumeration value="Manager"/>
+			<xs:enumeration value="ValueManager"/>
+			<xs:enumeration value="RecordManager"/>
+			<xs:enumeration value="RecordSet"/>
+			<xs:enumeration value="RecordKey"/>
+			<xs:enumeration value="Characteristic"/>
+			<xs:enumeration value="ExtDimensions"/>
+			<xs:enumeration value="ExtDimensionTypesRow"/>
+			<xs:enumeration value="DisplacingCalculationTypes"/>
+			<xs:enumeration value="DisplacingCalculationTypesRow"/>
+			<xs:enumeration value="BaseCalculationTypes"/>
+			<xs:enumeration value="BaseCalculationTypesRow"/>
+			<xs:enumeration value="LeadingCalculationTypes"/>
+			<xs:enumeration value="LeadingCalculationTypesRow"/>
+			<xs:enumeration value="Recalcs"/>
+			<xs:enumeration value="RoutePointRef"/>
+			<xs:enumeration value="TablesManager"/>
+			<xs:enumeration value="Record"/>
+			<xs:enumeration value="TabularSection"/>
+			<xs:enumeration value="ExtDimensionTypes"/>
+			<xs:enumeration value="CubesManager"/>
+			<xs:enumeration value="DimensionTables"/>
+			<xs:enumeration value="DefinedType"/>
+			<xs:enumeration value="ValueKey"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TypeReductionMode">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="TransformValues"/>
+			<xs:enumeration value="DeleteData"/>
+			<xs:enumeration value="Deny"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="UseQuickChoice">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Use"/>
+			<xs:enumeration value="DontUse"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="XCFFormat">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Hierarchical"/>
+			<xs:enumeration value="Plain"/>
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>

--- a/src/main/xsd/v8.3.27/v8.1c.ru-8.3-xcf-predef.xsd
+++ b/src/main/xsd/v8.3.27/v8.1c.ru-8.3-xcf-predef.xsd
@@ -1,0 +1,128 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:ns1="http://v8.1c.ru/8.1/data/core" xmlns:ns2="http://v8.1c.ru/8.1/data/enterprise" xmlns:ns3="http://v8.1c.ru/8.3/xcf/readable" xmlns:tns="http://v8.1c.ru/8.3/xcf/predef" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://v8.1c.ru/8.3/xcf/predef" attributeFormDefault="unqualified" elementFormDefault="qualified">
+	<xs:import namespace="http://v8.1c.ru/8.1/data/core"/>
+	<xs:import namespace="http://v8.1c.ru/8.1/data/enterprise"/>
+	<xs:import namespace="http://v8.1c.ru/8.3/xcf/readable"/>
+	<xs:element name="PredefinedData"/>
+	<xs:simpleType name="PredefinedItemExtensionState">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Native"/>
+			<xs:enumeration value="AdoptedCheck"/>
+			<xs:enumeration value="AdoptedNotify"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="AccountingFlags">
+		<xs:sequence>
+			<xs:element name="Flag" type="ns3:FlagType"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CalculationTypeList">
+		<xs:sequence>
+			<xs:element name="CalculationType" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CalculationTypePredefinedItem">
+		<xs:complexContent>
+			<xs:extension base="tns:PredefinedItemBase">
+				<xs:sequence>
+					<xs:element name="ActionPeriodIsBase" type="xs:boolean"/>
+					<xs:element name="Displaced" type="tns:CalculationTypeList" minOccurs="0"/>
+					<xs:element name="Base" type="tns:CalculationTypeList" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="Leading" type="tns:CalculationTypeList" minOccurs="0" maxOccurs="unbounded"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="CalculationTypePredefinedItems">
+		<xs:complexContent>
+			<xs:extension base="ns3:EntityWithVersion">
+				<xs:sequence>
+					<xs:element name="Item" type="tns:CalculationTypePredefinedItem"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="CatalogPredefinedItem">
+		<xs:complexContent>
+			<xs:extension base="tns:PredefinedItemBase">
+				<xs:sequence>
+					<xs:element name="IsFolder" type="xs:boolean"/>
+					<xs:element name="ChildItems" type="tns:CatalogPredefinedItems" minOccurs="0" maxOccurs="unbounded"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="CatalogPredefinedItems">
+		<xs:complexContent>
+			<xs:extension base="ns3:EntityWithVersion">
+				<xs:sequence>
+					<xs:element name="Item" type="tns:CatalogPredefinedItem" maxOccurs="unbounded"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="ChartOfAccountsPredefinedItem">
+		<xs:complexContent>
+			<xs:extension base="tns:PredefinedItemBase">
+				<xs:sequence>
+					<xs:element name="AccountType" type="ns2:AccountType"/>
+					<xs:element name="OffBalance" type="xs:boolean"/>
+					<xs:element name="Order" type="xs:string"/>
+					<xs:element name="AccountingFlags" type="tns:AccountingFlags" minOccurs="0"/>
+					<xs:element name="ExtDimensionTypes" type="tns:ExtDimensionTypes" minOccurs="0"/>
+					<xs:element name="ChildItems" type="tns:ChartOfAccountsPredefinedItems" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="ChartOfAccountsPredefinedItems">
+		<xs:complexContent>
+			<xs:extension base="ns3:EntityWithVersion">
+				<xs:sequence>
+					<xs:element name="Item" type="tns:ChartOfAccountsPredefinedItem" minOccurs="0" maxOccurs="unbounded"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="ExtDimensionType">
+		<xs:sequence>
+			<xs:element name="Turnover" type="xs:boolean"/>
+			<xs:element name="AccountingFlags" type="tns:AccountingFlags" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="name" type="xs:string"/>
+	</xs:complexType>
+	<xs:complexType name="ExtDimensionTypes">
+		<xs:sequence>
+			<xs:element name="ExtDimensionType" type="tns:ExtDimensionType" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PlanOfCharacteristicKindPredefinedItem">
+		<xs:complexContent>
+			<xs:extension base="tns:PredefinedItemBase">
+				<xs:sequence>
+					<xs:element name="Type" type="ns1:TypeDescription"/>
+					<xs:element name="IsFolder" type="xs:boolean"/>
+					<xs:element name="ChildItems" type="tns:PlanOfCharacteristicKindPredefinedItems" minOccurs="0" maxOccurs="unbounded"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="PlanOfCharacteristicKindPredefinedItems">
+		<xs:complexContent>
+			<xs:extension base="ns3:EntityWithVersion">
+				<xs:sequence>
+					<xs:element name="Item" type="tns:PlanOfCharacteristicKindPredefinedItem"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="PredefinedItemBase">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Code" type="xs:string"/>
+			<xs:element name="Description" type="xs:string"/>
+			<xs:element name="ExtensionState" type="tns:PredefinedItemExtensionState"/>
+		</xs:sequence>
+		<xs:attribute name="id" type="ns1:UUID"/>
+	</xs:complexType>
+</xs:schema>

--- a/src/main/xsd/v8.3.27/v8.1c.ru-8.3-xcf-readable.xsd
+++ b/src/main/xsd/v8.3.27/v8.1c.ru-8.3-xcf-readable.xsd
@@ -1,0 +1,271 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:ns1="http://v8.1c.ru/8.1/data/core" xmlns:ns2="http://v8.1c.ru/8.1/data/enterprise" xmlns:ns3="http://v8.1c.ru/8.2/managed-application/core" xmlns:ns4="http://v8.1c.ru/8.3/xcf/enums" xmlns:ns5="http://v8.1c.ru/8.2/managed-application/logform" xmlns:tns="http://v8.1c.ru/8.3/xcf/readable" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://v8.1c.ru/8.3/xcf/readable" attributeFormDefault="unqualified" elementFormDefault="qualified">
+	<xs:import namespace="http://v8.1c.ru/8.1/data/core"/>
+	<xs:import namespace="http://v8.1c.ru/8.1/data/enterprise"/>
+	<xs:import namespace="http://v8.1c.ru/8.2/managed-application/core"/>
+	<xs:import namespace="http://v8.1c.ru/8.3/xcf/enums"/>
+	<xs:import namespace="http://v8.1c.ru/8.2/managed-application/logform"/>
+	<xs:simpleType name="AliasedStringType">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="DataPath">
+		<xs:restriction base="tns:ReferenceType"/>
+	</xs:simpleType>
+	<xs:simpleType name="DesignTimeRef">
+		<xs:restriction base="tns:ReferenceType"/>
+	</xs:simpleType>
+	<xs:simpleType name="EventName">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="ExternalProperty">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="FiedlRef">
+		<xs:restriction base="tns:ReferenceType"/>
+	</xs:simpleType>
+	<xs:simpleType name="IncludeInCommandCategoriesType">
+		<xs:restriction base="tns:ReferenceType"/>
+	</xs:simpleType>
+	<xs:simpleType name="MDMethodRef">
+		<xs:restriction base="tns:ReferenceType"/>
+	</xs:simpleType>
+	<xs:simpleType name="MDObjectRef">
+		<xs:restriction base="tns:ReferenceType"/>
+	</xs:simpleType>
+	<xs:simpleType name="ReferenceType">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="([A-Za-z0-9_])*"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ShortCutType">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:complexType name="AdjustableBoolean">
+		<xs:sequence>
+			<xs:element name="Common" type="xs:boolean"/>
+			<xs:element name="Value" type="tns:AdjustableBooleanItemType" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="AdjustableBooleanItemType">
+		<xs:simpleContent>
+			<xs:extension base="xs:boolean">
+				<xs:attribute name="name" type="tns:MDObjectRef"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:complexType name="CharacteristicTypes">
+		<xs:sequence>
+			<xs:element name="KeyField" type="tns:FiedlRef"/>
+			<xs:element name="TypesFilterField" type="tns:FiedlRef"/>
+			<xs:element name="TypesFilterValue"/>
+			<xs:element name="DataPathField" type="tns:FiedlRef"/>
+			<xs:element name="MultipleValuesUseField" type="tns:FiedlRef"/>
+		</xs:sequence>
+		<xs:attribute name="from" type="tns:MDObjectRef"/>
+	</xs:complexType>
+	<xs:complexType name="CharacteristicValues">
+		<xs:sequence>
+			<xs:element name="ObjectField" type="tns:FiedlRef"/>
+			<xs:element name="TypeField" type="tns:FiedlRef"/>
+			<xs:element name="ValueField" type="tns:FiedlRef"/>
+			<xs:element name="MultipleValuesKeyField" type="tns:FiedlRef"/>
+			<xs:element name="MultipleValuesOrderField" type="tns:FiedlRef"/>
+		</xs:sequence>
+		<xs:attribute name="from" type="tns:MDObjectRef"/>
+	</xs:complexType>
+	<xs:complexType name="CharacteristicsDescription">
+		<xs:sequence>
+			<xs:element name="CharacteristicTypes" type="tns:CharacteristicTypes"/>
+			<xs:element name="CharacteristicValues" type="tns:CharacteristicValues"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CharacteristicsDescriptions">
+		<xs:sequence>
+			<xs:element name="Characteristic" type="tns:CharacteristicsDescription" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ChoiceParameterLink">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string" maxOccurs="unbounded"/>
+			<xs:element name="DataPath" type="tns:DataPath" maxOccurs="unbounded"/>
+			<xs:element name="ValueChange" type="ns2:LinkedValueChangeMode" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ChoiceParameterLinks">
+		<xs:sequence>
+			<xs:element name="Link" type="tns:ChoiceParameterLink" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CommonAttributeContent">
+		<xs:sequence>
+			<xs:element name="Item" type="tns:CommonAttributeContentItem" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CommonAttributeContentItem">
+		<xs:sequence>
+			<xs:element name="Metadata" type="tns:MDObjectRef"/>
+			<xs:element name="Use" type="ns4:CommonAttributeUse"/>
+			<xs:element name="ConditionalSeparation" type="tns:MDObjectRef"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ContainedObject">
+		<xs:sequence>
+			<xs:element name="ClassId" type="ns1:UUID"/>
+			<xs:element name="ObjectId" type="ns1:UUID"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="EntityWithVersion">
+		<xs:attribute name="version" type="ns4:FormatVersion"/>
+	</xs:complexType>
+	<xs:complexType name="ExtendedProperty">
+		<xs:sequence>
+			<xs:element name="CheckValue" nillable="true" minOccurs="0"/>
+			<xs:element name="ExtendValue" nillable="true" minOccurs="0"/>
+			<xs:element name="NotifyValue" nillable="true" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="FieldList">
+		<xs:sequence>
+			<xs:element name="Field" type="tns:FiedlRef" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="FlagType">
+		<xs:simpleContent>
+			<xs:extension base="xs:boolean">
+				<xs:attribute name="ref" type="tns:MDObjectRef"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:complexType name="FormattedStringType">
+		<xs:complexContent>
+			<xs:extension base="ns1:LocalStringType">
+				<xs:attribute name="formatted" type="xs:boolean"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="FuncOptionContentType">
+		<xs:sequence>
+			<xs:element name="Object" type="tns:MDObjectRef" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="GeneratedType">
+		<xs:sequence>
+			<xs:element name="TypeId" type="ns1:UUID"/>
+			<xs:element name="ValueId" type="ns1:UUID"/>
+		</xs:sequence>
+		<xs:attribute name="category" type="ns4:TypeCategories"/>
+		<xs:attribute name="name" type="xs:string"/>
+	</xs:complexType>
+	<xs:complexType name="InternalInfo">
+		<xs:sequence>
+			<xs:element name="ThisNode" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="GeneratedType" type="tns:GeneratedType" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="ContainedObject" type="tns:ContainedObject" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="PropertyState" type="tns:PropertyState" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="MDListType">
+		<xs:choice>
+			<xs:element name="Item" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="Picture">
+		<xs:choice>
+			<xs:element name="Ref" type="xs:string" minOccurs="0"/>
+			<xs:element name="Url" type="xs:string" minOccurs="0"/>
+			<xs:element name="Abs" type="xs:string" minOccurs="0"/>
+			<xs:element name="LoadTransparent" type="xs:boolean"/>
+			<xs:element name="TransparentPixel" type="tns:Point" minOccurs="0"/>
+			<xs:element name="GlyphPoint" type="tns:Point" minOccurs="0"/>
+			<xs:element name="ZipEntryParams" type="xs:string" minOccurs="0"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="Point">
+		<xs:attribute name="x" type="xs:decimal"/>
+		<xs:attribute name="y" type="xs:decimal"/>
+	</xs:complexType>
+	<xs:complexType name="PropertyState">
+		<xs:sequence>
+			<xs:element name="Property" type="xs:string"/>
+			<xs:element name="State" type="ns4:PropertyState"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Rect">
+		<xs:attribute name="top" type="xs:decimal"/>
+		<xs:attribute name="left" type="xs:decimal"/>
+		<xs:attribute name="bottom" type="xs:decimal"/>
+		<xs:attribute name="right" type="xs:decimal"/>
+	</xs:complexType>
+	<xs:complexType name="Size">
+		<xs:attribute name="cx" type="xs:decimal"/>
+		<xs:attribute name="cy" type="xs:decimal"/>
+	</xs:complexType>
+	<xs:complexType name="StandardAttributeDescription">
+		<xs:choice>
+			<xs:element name="Synonym" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="Comment" type="xs:string" minOccurs="0"/>
+			<xs:element name="ToolTip" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="QuickChoice" type="ns4:UseQuickChoice" minOccurs="0"/>
+			<xs:element name="FillChecking" type="ns1:FillChecking" minOccurs="0"/>
+			<xs:element name="FillValue" minOccurs="0"/>
+			<xs:element name="FillFromFillingValue" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="ChoiceParameterLinks" type="tns:ChoiceParameterLinks" minOccurs="0"/>
+			<xs:element name="ChoiceParameters" type="ns3:ChoiceParameters" minOccurs="0"/>
+			<xs:element name="LinkByType" type="tns:TypeLink" minOccurs="0"/>
+			<xs:element name="FullTextSearch" type="ns4:FullTextSearchUsing" minOccurs="0"/>
+			<xs:element name="PasswordMode" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="Format" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="EditFormat" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="Mask" type="xs:string" minOccurs="0"/>
+			<xs:element name="MultiLine" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="ExtendedEdit" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="MinValue" minOccurs="0"/>
+			<xs:element name="MaxValue" minOccurs="0"/>
+			<xs:element name="MarkNegatives" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="ChoiceForm" type="tns:MDObjectRef" minOccurs="0"/>
+			<xs:element name="CreateOnInput" type="ns4:CreateOnInput" minOccurs="0"/>
+			<xs:element name="ChoiceHistoryOnInput" type="ns5:ChoiceHistoryOnInput" minOccurs="0"/>
+			<xs:element name="DataHistory" type="ns4:DataHistoryUse" minOccurs="0"/>
+			<xs:element name="TypeReductionMode" type="ns4:TypeReductionMode" minOccurs="0"/>
+		</xs:choice>
+		<xs:attribute name="name" type="xs:string" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="StandardAttributeDescriptions">
+		<xs:sequence>
+			<xs:element name="StandardAttribute" type="tns:StandardAttributeDescription" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="StandardTabularSectionDescription">
+		<xs:sequence>
+			<xs:element name="Synonym" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="Comment" type="xs:string" minOccurs="0"/>
+			<xs:element name="ToolTip" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="FillChecking" type="ns1:FillChecking" minOccurs="0"/>
+			<xs:element name="StandardAttributes" type="tns:StandardAttributeDescriptions"/>
+		</xs:sequence>
+		<xs:attribute name="name" type="xs:string" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="StandardTabularSectionDescriptions">
+		<xs:sequence>
+			<xs:element name="StandardTabularSection" type="tns:StandardTabularSectionDescription" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TypeLink">
+		<xs:sequence>
+			<xs:element name="DataPath" type="tns:DataPath" maxOccurs="unbounded"/>
+			<xs:element name="LinkItem" type="xs:decimal" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ValueList">
+		<xs:sequence>
+			<xs:element name="Item" type="tns:ValueListItem"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ValueListItem">
+		<xs:sequence>
+			<xs:element name="Presentation" type="xs:string"/>
+			<xs:element name="CheckState" type="xs:decimal"/>
+			<xs:element name="Value"/>
+		</xs:sequence>
+	</xs:complexType>
+</xs:schema>

--- a/src/main/xsd/v8.5/bindings.xjb
+++ b/src/main/xsd/v8.5/bindings.xjb
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<jaxb:bindings version="3.0" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <jaxb:bindings scd="x-schema::tns" xmlns:tns="http://v8.1c.ru/8.1/data/core">
+    <jaxb:schemaBindings>
+      <jaxb:package name="com.github._1c_syntax.bsl.mdclasses.jaxb.v8_1_data_core"/>
+    </jaxb:schemaBindings>
+  </jaxb:bindings>
+  <jaxb:bindings scd="x-schema::tns" xmlns:tns="http://v8.1c.ru/8.1/data/enterprise">
+    <jaxb:schemaBindings>
+      <jaxb:package name="com.github._1c_syntax.bsl.mdclasses.jaxb.v8_1_data_enterprise"/>
+    </jaxb:schemaBindings>
+  </jaxb:bindings>
+  <jaxb:bindings scd="x-schema::tns" xmlns:tns="http://v8.1c.ru/8.1/data/ui">
+    <jaxb:schemaBindings>
+      <jaxb:package name="com.github._1c_syntax.bsl.mdclasses.jaxb.v8_1_data_ui"/>
+    </jaxb:schemaBindings>
+  </jaxb:bindings>
+  <jaxb:bindings scd="x-schema::tns" xmlns:tns="http://v8.1c.ru/8.2/managed-application/core">
+    <jaxb:schemaBindings>
+      <jaxb:package name="com.github._1c_syntax.bsl.mdclasses.jaxb.v8_2_managed_application_core"/>
+    </jaxb:schemaBindings>
+  </jaxb:bindings>
+  <jaxb:bindings scd="x-schema::tns" xmlns:tns="http://v8.1c.ru/8.2/managed-application/cmi">
+    <jaxb:schemaBindings>
+      <jaxb:package name="com.github._1c_syntax.bsl.mdclasses.jaxb.v8_2_managed_application_cmi"/>
+    </jaxb:schemaBindings>
+  </jaxb:bindings>
+  <jaxb:bindings scd="x-schema::tns" xmlns:tns="http://v8.1c.ru/8.2/managed-application/logform">
+    <jaxb:schemaBindings>
+      <jaxb:package name="com.github._1c_syntax.bsl.mdclasses.jaxb.v8_2_managed_application_logform"/>
+    </jaxb:schemaBindings>
+  </jaxb:bindings>
+  <jaxb:bindings scd="x-schema::tns" xmlns:tns="http://v8.1c.ru/8.3/xcf/enums">
+    <jaxb:schemaBindings>
+      <jaxb:package name="com.github._1c_syntax.bsl.mdclasses.jaxb.v8_3_xcf_enums"/>
+    </jaxb:schemaBindings>
+  </jaxb:bindings>
+  <jaxb:bindings scd="x-schema::tns" xmlns:tns="http://v8.1c.ru/8.3/xcf/readable">
+    <jaxb:schemaBindings>
+      <jaxb:package name="com.github._1c_syntax.bsl.mdclasses.jaxb.v8_3_xcf_readable"/>
+    </jaxb:schemaBindings>
+  </jaxb:bindings>
+  <jaxb:bindings scd="x-schema::tns" xmlns:tns="http://v8.1c.ru/8.3/xcf/predef">
+    <jaxb:schemaBindings>
+      <jaxb:package name="com.github._1c_syntax.bsl.mdclasses.jaxb.v8_3_xcf_predef"/>
+    </jaxb:schemaBindings>
+  </jaxb:bindings>
+  <jaxb:bindings scd="x-schema::tns" xmlns:tns="http://v8.1c.ru/8.2/data/spreadsheet">
+    <jaxb:schemaBindings>
+      <jaxb:package name="com.github._1c_syntax.bsl.mdclasses.jaxb.v8_2_data_spreadsheet"/>
+    </jaxb:schemaBindings>
+  </jaxb:bindings>
+  <jaxb:bindings scd="x-schema::tns" xmlns:tns="http://v8.1c.ru/8.2/data/bsl">
+    <jaxb:schemaBindings>
+      <jaxb:package name="com.github._1c_syntax.bsl.mdclasses.jaxb.v8_2_data_bsl"/>
+    </jaxb:schemaBindings>
+  </jaxb:bindings>
+  <jaxb:bindings scd="x-schema::tns" xmlns:tns="http://v8.1c.ru/8.2/managed-application/modules">
+    <jaxb:schemaBindings>
+      <jaxb:package name="com.github._1c_syntax.bsl.mdclasses.jaxb.v8_2_managed_application_modules"/>
+    </jaxb:schemaBindings>
+  </jaxb:bindings>
+  <jaxb:bindings scd="x-schema::tns" xmlns:tns="http://v8.1c.ru/8.2/uobjects">
+    <jaxb:schemaBindings>
+      <jaxb:package name="com.github._1c_syntax.bsl.mdclasses.jaxb.v8_2_uobjects"/>
+    </jaxb:schemaBindings>
+  </jaxb:bindings>
+  <jaxb:bindings scd="x-schema::tns" xmlns:tns="http://v8.1c.ru/8.3/MDClasses">
+    <jaxb:schemaBindings>
+      <jaxb:package name="com.github._1c_syntax.bsl.mdclasses.jaxb.mdclasses"/>
+    </jaxb:schemaBindings>
+  </jaxb:bindings>
+</jaxb:bindings>

--- a/src/main/xsd/v8.5/catalog.xml
+++ b/src/main/xsd/v8.5/catalog.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+  <uri name="http://v8.1c.ru/8.1/data/core" uri="v8.1c.ru-8.1-data-core.xsd"/>
+  <uri name="http://v8.1c.ru/8.1/data/enterprise" uri="v8.1c.ru-8.1-data-enterprise.xsd"/>
+  <uri name="http://v8.1c.ru/8.1/data/ui" uri="v8.1c.ru-8.1-data-ui.xsd"/>
+  <uri name="http://v8.1c.ru/8.2/managed-application/core" uri="v8.1c.ru-8.2-managed-application-core.xsd"/>
+  <uri name="http://v8.1c.ru/8.2/managed-application/cmi" uri="v8.1c.ru-8.2-managed-application-cmi.xsd"/>
+  <uri name="http://v8.1c.ru/8.2/managed-application/logform" uri="v8.1c.ru-8.2-managed-application-logform.xsd"/>
+  <uri name="http://v8.1c.ru/8.3/xcf/enums" uri="v8.1c.ru-8.3-xcf-enums.xsd"/>
+  <uri name="http://v8.1c.ru/8.3/xcf/readable" uri="v8.1c.ru-8.3-xcf-readable.xsd"/>
+  <uri name="http://v8.1c.ru/8.3/xcf/predef" uri="v8.1c.ru-8.3-xcf-predef.xsd"/>
+  <uri name="http://v8.1c.ru/8.2/data/spreadsheet" uri="v8.1c.ru-8.2-data-spreadsheet.xsd"/>
+  <uri name="http://v8.1c.ru/8.2/data/bsl" uri="v8.1c.ru-8.2-data-bsl.xsd"/>
+  <uri name="http://v8.1c.ru/8.2/managed-application/modules" uri="v8.1c.ru-8.2-managed-application-modules.xsd"/>
+  <uri name="http://v8.1c.ru/8.2/uobjects" uri="v8.1c.ru-8.2-uobjects.xsd"/>
+</catalog>

--- a/src/main/xsd/v8.5/v8.1c.ru-8.1-data-core.xsd
+++ b/src/main/xsd/v8.5/v8.1c.ru-8.1-data-core.xsd
@@ -1,0 +1,398 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:tns="http://v8.1c.ru/8.1/data/core" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://v8.1c.ru/8.1/data/core" attributeFormDefault="unqualified" elementFormDefault="qualified">
+	<xs:simpleType name="AllowedLength">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Fixed"/>
+			<xs:enumeration value="Variable"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="AllowedSign">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Any"/>
+			<xs:enumeration value="Nonnegative"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CompositeID">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="-?[0-9]+(:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DateFractions">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Date"/>
+			<xs:enumeration value="Time"/>
+			<xs:enumeration value="DateTime"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ErrorCategory">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="AccessViolation"/>
+			<xs:enumeration value="LocalFileAccessError"/>
+			<xs:enumeration value="NetworkError"/>
+			<xs:enumeration value="PrinterError"/>
+			<xs:enumeration value="ScriptCompileError"/>
+			<xs:enumeration value="ScriptRuntimeError"/>
+			<xs:enumeration value="ScriptUseError"/>
+			<xs:enumeration value="ExceptionRaisedFromScript"/>
+			<xs:enumeration value="CollaborationSystemError"/>
+			<xs:enumeration value="DataCompositionSettingsError"/>
+			<xs:enumeration value="SessionError"/>
+			<xs:enumeration value="StoredDataError"/>
+			<xs:enumeration value="FullTextSearchError"/>
+			<xs:enumeration value="ExternalDataSourceError"/>
+			<xs:enumeration value="GotoURLError"/>
+			<xs:enumeration value="DatabaseCopyError"/>
+			<xs:enumeration value="NoPermissionToUseFunctionality"/>
+			<xs:enumeration value="MultimediaToolsError"/>
+			<xs:enumeration value="DocumentConversionError"/>
+			<xs:enumeration value="InvalidPassword"/>
+			<xs:enumeration value="SignatureVerificationError"/>
+			<xs:enumeration value="ConfigurationError"/>
+			<xs:enumeration value="DatabaseTablespaceError"/>
+			<xs:enumeration value="SpeechProcessingError"/>
+			<xs:enumeration value="ForcedShutdown"/>
+			<xs:enumeration value="UnsupportedFormat"/>
+			<xs:enumeration value="OtherError"/>
+			<xs:enumeration value="AllErrors"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FileDragMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="AsFile"/>
+			<xs:enumeration value="AsFileRef"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FillCheckErrorStatus">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Error"/>
+			<xs:enumeration value="Warning"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FillChecking">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="DontCheck"/>
+			<xs:enumeration value="ShowError"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="MainClientApplicationWindowMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Normal"/>
+			<xs:enumeration value="Workplace"/>
+			<xs:enumeration value="FullscreenWorkplace"/>
+			<xs:enumeration value="Kiosk"/>
+			<xs:enumeration value="EmbeddedWorkplace"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Null">
+		<xs:restriction base="xs:string">
+			<xs:length value="0"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ObjectVersion">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[0-9a-fA-F]{40}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="StandardBeginningDateVariant">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Custom"/>
+			<xs:enumeration value="BeginningOfThisDay"/>
+			<xs:enumeration value="BeginningOfThisWeek"/>
+			<xs:enumeration value="BeginningOfThisTenDays"/>
+			<xs:enumeration value="BeginningOfThisMonth"/>
+			<xs:enumeration value="BeginningOfThisQuarter"/>
+			<xs:enumeration value="BeginningOfThisHalfYear"/>
+			<xs:enumeration value="BeginningOfThisYear"/>
+			<xs:enumeration value="BeginningOfLastDay"/>
+			<xs:enumeration value="BeginningOfLastWeek"/>
+			<xs:enumeration value="BeginningOfLastTenDays"/>
+			<xs:enumeration value="BeginningOfLastMonth"/>
+			<xs:enumeration value="BeginningOfLastQuarter"/>
+			<xs:enumeration value="BeginningOfLastHalfYear"/>
+			<xs:enumeration value="BeginningOfLastYear"/>
+			<xs:enumeration value="BeginningOfNextDay"/>
+			<xs:enumeration value="BeginningOfNextWeek"/>
+			<xs:enumeration value="BeginningOfNextTenDays"/>
+			<xs:enumeration value="BeginningOfNextMonth"/>
+			<xs:enumeration value="BeginningOfNextQuarter"/>
+			<xs:enumeration value="BeginningOfNextHalfYear"/>
+			<xs:enumeration value="BeginningOfNextYear"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="StandardPeriodVariant">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Custom"/>
+			<xs:enumeration value="Today"/>
+			<xs:enumeration value="ThisWeek"/>
+			<xs:enumeration value="ThisTenDays"/>
+			<xs:enumeration value="ThisMonth"/>
+			<xs:enumeration value="ThisQuarter"/>
+			<xs:enumeration value="ThisHalfYear"/>
+			<xs:enumeration value="ThisYear"/>
+			<xs:enumeration value="FromBeginningOfThisWeek"/>
+			<xs:enumeration value="FromBeginningOfThisTenDays"/>
+			<xs:enumeration value="FromBeginningOfThisMonth"/>
+			<xs:enumeration value="FromBeginningOfThisQuarter"/>
+			<xs:enumeration value="FromBeginningOfThisHalfYear"/>
+			<xs:enumeration value="FromBeginningOfThisYear"/>
+			<xs:enumeration value="Yesterday"/>
+			<xs:enumeration value="LastWeek"/>
+			<xs:enumeration value="LastTenDays"/>
+			<xs:enumeration value="LastMonth"/>
+			<xs:enumeration value="LastQuarter"/>
+			<xs:enumeration value="LastHalfYear"/>
+			<xs:enumeration value="LastYear"/>
+			<xs:enumeration value="LastWeekTillSameWeekDay"/>
+			<xs:enumeration value="LastTenDaysTillSameDayNumber"/>
+			<xs:enumeration value="LastMonthTillSameDate"/>
+			<xs:enumeration value="LastQuarterTillSameDate"/>
+			<xs:enumeration value="LastHalfYearTillSameDate"/>
+			<xs:enumeration value="LastYearTillSameDate"/>
+			<xs:enumeration value="Tomorrow"/>
+			<xs:enumeration value="NextWeek"/>
+			<xs:enumeration value="NextTenDays"/>
+			<xs:enumeration value="NextMonth"/>
+			<xs:enumeration value="NextQuarter"/>
+			<xs:enumeration value="NextHalfYear"/>
+			<xs:enumeration value="NextYear"/>
+			<xs:enumeration value="NextWeekTillSameWeekDay"/>
+			<xs:enumeration value="NextTenDaysTillSameDayNumber"/>
+			<xs:enumeration value="NextMonthTillSameDate"/>
+			<xs:enumeration value="NextQuarterTillSameDate"/>
+			<xs:enumeration value="NextHalfYearTillSameDate"/>
+			<xs:enumeration value="NextYearTillSameDate"/>
+			<xs:enumeration value="TillEndOfThisWeek"/>
+			<xs:enumeration value="TillEndOfThisTenDays"/>
+			<xs:enumeration value="TillEndOfThisMonth"/>
+			<xs:enumeration value="TillEndOfThisQuarter"/>
+			<xs:enumeration value="TillEndOfThisHalfYear"/>
+			<xs:enumeration value="TillEndOfThisYear"/>
+			<xs:enumeration value="Last7Days"/>
+			<xs:enumeration value="Next7Days"/>
+			<xs:enumeration value="Month"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Type">
+		<xs:restriction base="xs:QName"/>
+	</xs:simpleType>
+	<xs:simpleType name="UUID">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ValueStorage">
+		<xs:restriction base="xs:base64Binary"/>
+	</xs:simpleType>
+	<xs:complexType name="Array">
+		<xs:sequence>
+			<xs:element name="Value" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="BinaryDataQualifiers">
+		<xs:sequence>
+			<xs:element name="Length" type="xs:decimal"/>
+			<xs:element name="AllowedLength" type="tns:AllowedLength"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DataFillError">
+		<xs:sequence>
+			<xs:element name="Data" type="xs:string"/>
+			<xs:element name="DataDescr" type="xs:string"/>
+			<xs:element name="Text" type="xs:string"/>
+			<xs:element name="Status" type="tns:FillCheckErrorStatus"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DataFillErrors">
+		<xs:sequence>
+			<xs:element name="item" type="tns:DataFillError" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DateQualifiers">
+		<xs:sequence>
+			<xs:element name="DateFractions" type="tns:DateFractions"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Exception">
+		<xs:complexContent>
+			<xs:extension base="tns:GenericException">
+				<xs:sequence>
+					<xs:element name="data" type="xs:base64Binary" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="FixedArray">
+		<xs:sequence>
+			<xs:element name="Value" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="FixedMap">
+		<xs:sequence>
+			<xs:element name="pair" type="tns:KeyAndValue" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="FixedStructure">
+		<xs:sequence>
+			<xs:element name="Property" minOccurs="0" maxOccurs="unbounded">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="Value" nillable="true"/>
+					</xs:sequence>
+					<xs:attribute name="name" type="xs:NMTOKEN" use="required"/>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="GenericException" abstract="true">
+		<xs:sequence>
+			<xs:element name="descr" type="xs:string"/>
+			<xs:element name="inner" type="tns:GenericException" minOccurs="0"/>
+			<xs:element name="category" type="xs:string" minOccurs="0"/>
+			<xs:element name="uiHelperUUID" type="tns:UUID" minOccurs="0"/>
+			<xs:element name="creationStack" type="xs:string" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="clsid" type="tns:UUID" use="required"/>
+		<xs:attribute name="encoded" type="xs:boolean" default="false"/>
+	</xs:complexType>
+	<xs:complexType name="KeyAndValue">
+		<xs:sequence>
+			<xs:element name="Key"/>
+			<xs:element name="Value" nillable="true"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="LocalStringItemType">
+		<xs:sequence>
+			<xs:element name="lang" type="xs:NMTOKEN"/>
+			<xs:element name="content" type="xs:string"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="LocalStringType">
+		<xs:sequence>
+			<xs:element name="item" type="tns:LocalStringItemType" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Map">
+		<xs:sequence>
+			<xs:element name="pair" type="tns:KeyAndValue" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="NumberQualifiers">
+		<xs:sequence>
+			<xs:element name="Digits" type="xs:decimal"/>
+			<xs:element name="FractionDigits" type="xs:decimal"/>
+			<xs:element name="AllowedSign" type="tns:AllowedSign"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="StandardBeginningDate">
+		<xs:sequence>
+			<xs:element name="variant"/>
+			<xs:element name="date" type="xs:dateTime" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="StandardPeriod">
+		<xs:sequence>
+			<xs:element name="variant"/>
+			<xs:element name="startDate" type="xs:dateTime" minOccurs="0"/>
+			<xs:element name="endDate" type="xs:dateTime" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="StringQualifiers">
+		<xs:sequence>
+			<xs:element name="Length" type="xs:decimal"/>
+			<xs:element name="AllowedLength" type="tns:AllowedLength"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Structure">
+		<xs:sequence>
+			<xs:element name="Property" minOccurs="0" maxOccurs="unbounded">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="Value" nillable="true"/>
+					</xs:sequence>
+					<xs:attribute name="name" type="xs:NMTOKEN" use="required"/>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TypeDescription">
+		<xs:sequence>
+			<xs:element name="Type" type="xs:QName" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="TypeSet" type="xs:QName" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="TypeId" type="tns:UUID" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="NumberQualifiers" type="tns:NumberQualifiers" minOccurs="0"/>
+			<xs:element name="StringQualifiers" type="tns:StringQualifiers" minOccurs="0"/>
+			<xs:element name="DateQualifiers" type="tns:DateQualifiers" minOccurs="0"/>
+			<xs:element name="BinaryDataQualifiers" type="tns:BinaryDataQualifiers" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ValueListItemType">
+		<xs:sequence>
+			<xs:element name="value" nillable="true"/>
+			<xs:element name="presentation" type="xs:string" minOccurs="0"/>
+			<xs:element name="checkState" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="picture" minOccurs="0"/>
+			<xs:element name="id" type="xs:long" minOccurs="0"/>
+			<xs:element name="formatPresentationSpecified" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="formatPresentation" type="xs:string" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ValueListType">
+		<xs:choice>
+			<xs:element name="valueType" type="tns:TypeDescription"/>
+			<xs:element name="availableValues" type="tns:ValueListType" minOccurs="0"/>
+			<xs:element name="lastId" type="xs:long" minOccurs="0"/>
+			<xs:element name="item" type="tns:ValueListItemType" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="ValueTable">
+		<xs:sequence>
+			<xs:element name="column" type="tns:ValueTableColumn" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="index" type="tns:ValueTableIndex" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="row" type="tns:ValueTableRow" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ValueTableColumn">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:NMTOKEN" minOccurs="0"/>
+			<xs:element name="ValueType" type="tns:TypeDescription" minOccurs="0"/>
+			<xs:element name="Title" type="xs:string" minOccurs="0"/>
+			<xs:element name="Width" type="xs:nonNegativeInteger" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ValueTableIndex">
+		<xs:sequence>
+			<xs:element name="column" type="xs:NMTOKEN" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ValueTableRow">
+		<xs:sequence>
+			<xs:element name="Value" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ValueTree">
+		<xs:sequence>
+			<xs:element name="column" type="tns:ValueTreeColumn" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="row" type="tns:ValueTreeRow" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ValueTreeColumn">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:NMTOKEN" minOccurs="0"/>
+			<xs:element name="ValueType" type="tns:TypeDescription" minOccurs="0"/>
+			<xs:element name="Title" type="xs:string" minOccurs="0"/>
+			<xs:element name="Width" type="xs:nonNegativeInteger" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ValueTreeRow">
+		<xs:sequence>
+			<xs:element name="row" type="tns:ValueTreeRow" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Value" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="LocalFormattedStringType">
+		<xs:sequence>
+			<xs:element name="lws" type="tns:LocalStringType" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="formatted" type="xs:boolean" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+</xs:schema>

--- a/src/main/xsd/v8.5/v8.1c.ru-8.1-data-enterprise.xsd
+++ b/src/main/xsd/v8.5/v8.1c.ru-8.1-data-enterprise.xsd
@@ -1,0 +1,441 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:ns1="http://v8.1c.ru/8.1/data/core" xmlns:tns="http://v8.1c.ru/8.1/data/enterprise" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://v8.1c.ru/8.1/data/enterprise" attributeFormDefault="unqualified" elementFormDefault="qualified">
+	<xs:import namespace="http://v8.1c.ru/8.1/data/core"/>
+	<xs:simpleType name="AccountType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Active"/>
+			<xs:enumeration value="Passive"/>
+			<xs:enumeration value="ActivePassive"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="AccountingRecordType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Debit"/>
+			<xs:enumeration value="Credit"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="AccumulationRecordType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Receipt"/>
+			<xs:enumeration value="Expense"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="AccumulationRegisterAggregatePeriodicity">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Nonperiodical"/>
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Day"/>
+			<xs:enumeration value="Month"/>
+			<xs:enumeration value="Quarter"/>
+			<xs:enumeration value="HalfYear"/>
+			<xs:enumeration value="Year"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="AccumulationRegisterAggregateUse">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Always"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="AnyDBRef">
+		<xs:restriction base="tns:AnyRef"/>
+	</xs:simpleType>
+	<xs:simpleType name="AnyIBRef">
+		<xs:union memberTypes="tns:AnyDBRef tns:AnyMDEnum"/>
+	</xs:simpleType>
+	<xs:simpleType name="AnyMDEnum">
+		<xs:restriction base="xs:NCName"/>
+	</xs:simpleType>
+	<xs:simpleType name="AnyRef">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="AutoShowStateMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="DontShow"/>
+			<xs:enumeration value="Show"/>
+			<xs:enumeration value="ShowOnComposition"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="AutoTimeMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="DontUse"/>
+			<xs:enumeration value="Last"/>
+			<xs:enumeration value="First"/>
+			<xs:enumeration value="CurrentOrLast"/>
+			<xs:enumeration value="CurrentOrFirst"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CalculationRegisterPeriodType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="RegistrationPeriod"/>
+			<xs:enumeration value="ActionPeriod"/>
+			<xs:enumeration value="ActualActionPeriod"/>
+			<xs:enumeration value="BasePeriod"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ClientApplicationBaseFontVariant">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Normal"/>
+			<xs:enumeration value="Large"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ClientApplicationFormScaleVariant">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Normal"/>
+			<xs:enumeration value="Compact"/>
+			<xs:enumeration value="NormalIfPossible"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ClientApplicationInterfaceVariant">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Version8_2"/>
+			<xs:enumeration value="Taxi"/>
+			<xs:enumeration value="Version8_5"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ClientApplicationScaleVariant">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Normal"/>
+			<xs:enumeration value="Compact"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ClientApplicationTheme">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Light"/>
+			<xs:enumeration value="Dark"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ClientApplicationType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="ThickClient"/>
+			<xs:enumeration value="ThinClient"/>
+			<xs:enumeration value="WebClient"/>
+			<xs:enumeration value="MobileClient"/>
+			<xs:enumeration value="MobileAppClient"/>
+			<xs:enumeration value="ExternalConnection"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ClientApplicationWindowsOpenVariant">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="OpenDataInTabs"/>
+			<xs:enumeration value="OpenDataInDialogs"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ClientConnectionSpeed">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Normal"/>
+			<xs:enumeration value="Low"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ClientInterfaceScale">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Normal"/>
+			<xs:enumeration value="Compact"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ClientInterfaceTheme">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Light"/>
+			<xs:enumeration value="Dark"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ClientInterfaceVariant">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Version8_0"/>
+			<xs:enumeration value="Version8_2"/>
+			<xs:enumeration value="Version8_2_OrdinaryApp"/>
+			<xs:enumeration value="TaxiCompact"/>
+			<xs:enumeration value="Taxi"/>
+			<xs:enumeration value="TaxiMobile"/>
+			<xs:enumeration value="Version8_5"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ComparisonType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Equal"/>
+			<xs:enumeration value="NotEqual"/>
+			<xs:enumeration value="Less"/>
+			<xs:enumeration value="LessOrEqual"/>
+			<xs:enumeration value="Greater"/>
+			<xs:enumeration value="GreaterOrEqual"/>
+			<xs:enumeration value="Interval"/>
+			<xs:enumeration value="IntervalIncludingBounds"/>
+			<xs:enumeration value="IntervalIncludingLowerBound"/>
+			<xs:enumeration value="IntervalIncludingUpperBound"/>
+			<xs:enumeration value="Contains"/>
+			<xs:enumeration value="InList"/>
+			<xs:enumeration value="InListByHierarchy"/>
+			<xs:enumeration value="NotInList"/>
+			<xs:enumeration value="NotInListByHierarchy"/>
+			<xs:enumeration value="InHierarchy"/>
+			<xs:enumeration value="NotInHierarchy"/>
+			<xs:enumeration value="NotContains"/>
+			<xs:enumeration value="BeginsWith"/>
+			<xs:enumeration value="NotBeginsWith"/>
+			<xs:enumeration value="Like"/>
+			<xs:enumeration value="NotLike"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DataChangeType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Create"/>
+			<xs:enumeration value="Update"/>
+			<xs:enumeration value="Delete"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DataLineChangeType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Add"/>
+			<xs:enumeration value="Update"/>
+			<xs:enumeration value="Delete"/>
+			<xs:enumeration value="Move"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DatabaseCopiesUse">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="UseCopiesOnly"/>
+			<xs:enumeration value="PreferUseCopies"/>
+			<xs:enumeration value="DontUseCopies"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DocumentPostingMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Regular"/>
+			<xs:enumeration value="RealTime"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DocumentWriteMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Write"/>
+			<xs:enumeration value="Posting"/>
+			<xs:enumeration value="UndoPosting"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FoldersAndItemsUse">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Items"/>
+			<xs:enumeration value="Folders"/>
+			<xs:enumeration value="FoldersAndItems"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="JobScheduleMonths">
+		<xs:list itemType="xs:decimal"/>
+	</xs:simpleType>
+	<xs:simpleType name="JobScheduleWeekDays">
+		<xs:list itemType="xs:decimal"/>
+	</xs:simpleType>
+	<xs:simpleType name="LinkedValueChangeMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Clear"/>
+			<xs:enumeration value="DontChange"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="MainClientApplicationWindowInterfaceVariant">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="NavigationLeft"/>
+			<xs:enumeration value="NavigationTop"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="MessageStatus">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="WithoutStatus"/>
+			<xs:enumeration value="Ordinary"/>
+			<xs:enumeration value="Information"/>
+			<xs:enumeration value="Attention"/>
+			<xs:enumeration value="Important"/>
+			<xs:enumeration value="VeryImportant"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ModalityUseMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Use"/>
+			<xs:enumeration value="UseWithWarnings"/>
+			<xs:enumeration value="DontUse"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="PostingModeUse">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Regular"/>
+			<xs:enumeration value="RealTime"/>
+			<xs:enumeration value="Ask"/>
+			<xs:enumeration value="Auto"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="PredefinedDataUpdate">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="AutoUpdate"/>
+			<xs:enumeration value="DontAutoUpdate"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ReplacementMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Append"/>
+			<xs:enumeration value="Replace"/>
+			<xs:enumeration value="Merge"/>
+			<xs:enumeration value="Delete"/>
+			<xs:enumeration value="Update"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ReportResultViewMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Default"/>
+			<xs:enumeration value="Compact"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="RequiredDataRelevance">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Relevant"/>
+			<xs:enumeration value="Any"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ResultCompositionMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Background"/>
+			<xs:enumeration value="Directly"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SliceUse">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="DontUse"/>
+			<xs:enumeration value="First"/>
+			<xs:enumeration value="Last"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SortDirection">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Asc"/>
+			<xs:enumeration value="Desc"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TransactionsIsolationLevel">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="ReadUncommitted"/>
+			<xs:enumeration value="ReadCommitted"/>
+			<xs:enumeration value="RepeatableRead"/>
+			<xs:enumeration value="Serializable"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="UpdateOnDataChange">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="DontUpdate"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ViewModeApplicationOnSetReportResult">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Apply"/>
+			<xs:enumeration value="DontApply"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="Aggregate">
+		<xs:sequence>
+			<xs:element name="use" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="periodicity" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="beginOfPeriod" type="xs:dateTime" minOccurs="0"/>
+			<xs:element name="endOfPeriod" type="xs:dateTime" minOccurs="0"/>
+			<xs:element name="size" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="dimension" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="AggregateList">
+		<xs:sequence>
+			<xs:element name="buildDate" type="xs:dateTime" minOccurs="0"/>
+			<xs:element name="sizeLimit" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="size" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="effect" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="aggregate" type="tns:Aggregate" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Bound">
+		<xs:sequence>
+			<xs:element name="value" nillable="true"/>
+			<xs:element name="kind" type="xs:decimal"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Filter">
+		<xs:sequence>
+			<xs:element name="FilterItem" type="tns:FilterItem" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="FilterItem">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:NCName"/>
+			<xs:element name="Usage" type="xs:boolean" default="true" minOccurs="0"/>
+			<xs:element name="ComparisonType" type="tns:ComparisonType" default="Equal" minOccurs="0"/>
+			<xs:element name="Value" nillable="true" minOccurs="0"/>
+			<xs:element name="ValueFrom" nillable="true" minOccurs="0"/>
+			<xs:element name="ValueTo" nillable="true" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="JobSchedule">
+		<xs:sequence>
+			<xs:element name="WeekDays" type="tns:JobScheduleWeekDays"/>
+			<xs:element name="Months" type="tns:JobScheduleMonths"/>
+			<xs:element name="DetailedDailySchedules" type="tns:JobSchedule" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="BeginDate" type="xs:date"/>
+		<xs:attribute name="EndDate" type="xs:date"/>
+		<xs:attribute name="BeginTime" type="xs:time"/>
+		<xs:attribute name="EndTime" type="xs:time"/>
+		<xs:attribute name="CompletionTime" type="xs:time"/>
+		<xs:attribute name="CompletionInterval" type="xs:decimal"/>
+		<xs:attribute name="RepeatPeriodInDay" type="xs:decimal"/>
+		<xs:attribute name="RepeatPause" type="xs:decimal"/>
+		<xs:attribute name="WeekDayInMonth" type="xs:decimal"/>
+		<xs:attribute name="DayInMonth" type="xs:decimal"/>
+		<xs:attribute name="WeeksPeriod" type="xs:decimal"/>
+		<xs:attribute name="DaysRepeatPeriod" type="xs:decimal"/>
+	</xs:complexType>
+	<xs:complexType name="ObjectDeletion">
+		<xs:sequence>
+			<xs:element name="Ref" type="tns:AnyRef"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PointOfTime">
+		<xs:sequence>
+			<xs:element name="date" type="xs:dateTime"/>
+			<xs:element name="reference" type="tns:AnyRef" nillable="true"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PointOfTimeWithPeriodAdjustment">
+		<xs:sequence>
+			<xs:element name="date" type="xs:dateTime"/>
+			<xs:element name="dateAdjustment" type="xs:decimal"/>
+			<xs:element name="reference" type="tns:AnyRef" nillable="true"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="UserMessage">
+		<xs:sequence>
+			<xs:element name="Text" type="xs:string" minOccurs="0"/>
+			<xs:element name="Ref" type="tns:AnyRef" nillable="true"/>
+			<xs:element name="pic" minOccurs="0"/>
+			<xs:element name="details" type="xs:string" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="MessageMarker" type="xs:decimal"/>
+		<xs:attribute name="DataPath" type="xs:string"/>
+		<xs:attribute name="FormAttributePath" type="xs:string"/>
+		<xs:attribute name="FormID" type="ns1:UUID"/>
+		<xs:attribute name="notification" type="xs:boolean"/>
+		<xs:attribute name="caption" type="xs:string"/>
+		<xs:attribute name="url" type="xs:string"/>
+		<xs:attribute name="tag" type="xs:string"/>
+	</xs:complexType>
+	<xs:complexType name="UserMessages">
+		<xs:sequence>
+			<xs:element name="message" type="tns:UserMessage" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+</xs:schema>

--- a/src/main/xsd/v8.5/v8.1c.ru-8.1-data-ui.xsd
+++ b/src/main/xsd/v8.5/v8.1c.ru-8.1-data-ui.xsd
@@ -1,0 +1,436 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:ns1="http://v8.1c.ru/8.1/data/core" xmlns:tns="http://v8.1c.ru/8.1/data/ui" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://v8.1c.ru/8.1/data/ui" attributeFormDefault="unqualified" elementFormDefault="qualified">
+	<xs:import namespace="http://v8.1c.ru/8.1/data/core"/>
+	<xs:simpleType name="AbsoluteColor">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="#[0-9a-fA-F]{6}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CustomColor">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="#@-?[0-9]+:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SurrogatePalId">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="#@[0-9]+"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="AbstractRef">
+		<xs:union memberTypes="ns1:CompositeID xs:QName"/>
+	</xs:simpleType>
+	<xs:simpleType name="AutoColor">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="auto"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="AutoSeriesSeparation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="None"/>
+			<xs:enumeration value="All"/>
+			<xs:enumeration value="Maximum"/>
+			<xs:enumeration value="Minimum"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="BorderType">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="ChartColorPalette">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Palette8"/>
+			<xs:enumeration value="Palette32"/>
+			<xs:enumeration value="Pastel"/>
+			<xs:enumeration value="Bright"/>
+			<xs:enumeration value="Soft"/>
+			<xs:enumeration value="Warm"/>
+			<xs:enumeration value="Cold"/>
+			<xs:enumeration value="Blue"/>
+			<xs:enumeration value="Orange"/>
+			<xs:enumeration value="Green"/>
+			<xs:enumeration value="Yellow"/>
+			<xs:enumeration value="Gray"/>
+			<xs:enumeration value="Custom"/>
+			<xs:enumeration value="Gradient"/>
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="SoftAdaptive"/>
+			<xs:enumeration value="Rich"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ChartLabelType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="None"/>
+			<xs:enumeration value="Series"/>
+			<xs:enumeration value="Value"/>
+			<xs:enumeration value="Percent"/>
+			<xs:enumeration value="SeriesPercent"/>
+			<xs:enumeration value="SeriesValue"/>
+			<xs:enumeration value="SeriesValuePercent"/>
+			<xs:enumeration value="ValuePercent"/>
+			<xs:enumeration value="Point"/>
+			<xs:enumeration value="PointPercent"/>
+			<xs:enumeration value="PointValue"/>
+			<xs:enumeration value="PointValuePercent"/>
+			<xs:enumeration value="SeriesPoint"/>
+			<xs:enumeration value="SeriesPointPercent"/>
+			<xs:enumeration value="SeriesPointValue"/>
+			<xs:enumeration value="SeriesPointValuePercent"/>
+			<xs:enumeration value="ValueSize"/>
+			<xs:enumeration value="SeriesSize"/>
+			<xs:enumeration value="SeriesValueSize"/>
+			<xs:enumeration value="SeriesPointSize"/>
+			<xs:enumeration value="SeriesPointValueSize"/>
+			<xs:enumeration value="PointSize"/>
+			<xs:enumeration value="PointValueSize"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ChartLabelsOrientation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Horizontal"/>
+			<xs:enumeration value="Vertical"/>
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="CustomAngle"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ChartLineType">
+		<xs:restriction base="tns:LineType">
+			<xs:enumeration value="None"/>
+			<xs:enumeration value="Solid"/>
+			<xs:enumeration value="Dotted"/>
+			<xs:enumeration value="Dashed"/>
+			<xs:enumeration value="DashDotted"/>
+			<xs:enumeration value="DashDottedDotted"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ChartType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Line"/>
+			<xs:enumeration value="Step"/>
+			<xs:enumeration value="StackedLine"/>
+			<xs:enumeration value="Area"/>
+			<xs:enumeration value="StackedArea"/>
+			<xs:enumeration value="NormalizedArea"/>
+			<xs:enumeration value="Column"/>
+			<xs:enumeration value="StackedColumn"/>
+			<xs:enumeration value="NormalizedColumn"/>
+			<xs:enumeration value="Column3D"/>
+			<xs:enumeration value="StackedColumn3D"/>
+			<xs:enumeration value="NormalizedColumn3D"/>
+			<xs:enumeration value="Bar"/>
+			<xs:enumeration value="StackedBar"/>
+			<xs:enumeration value="NormalizedBar"/>
+			<xs:enumeration value="Bar3D"/>
+			<xs:enumeration value="StackedBar3D"/>
+			<xs:enumeration value="NormalizedBar3D"/>
+			<xs:enumeration value="Pie"/>
+			<xs:enumeration value="Pie3D"/>
+			<xs:enumeration value="Stock"/>
+			<xs:enumeration value="OpenHighLowClose"/>
+			<xs:enumeration value="BarGraph"/>
+			<xs:enumeration value="CeilGraph"/>
+			<xs:enumeration value="TapeGraph"/>
+			<xs:enumeration value="PyramidGraph"/>
+			<xs:enumeration value="Waterfall"/>
+			<xs:enumeration value="WireframeSurface"/>
+			<xs:enumeration value="Honeycomb"/>
+			<xs:enumeration value="Surface"/>
+			<xs:enumeration value="ConvexSurface"/>
+			<xs:enumeration value="ConcaveSurface"/>
+			<xs:enumeration value="ShadedSurface"/>
+			<xs:enumeration value="RadarLine"/>
+			<xs:enumeration value="RadarArea"/>
+			<xs:enumeration value="RadarStackedLine"/>
+			<xs:enumeration value="RadarStackedArea"/>
+			<xs:enumeration value="RadarNormalizedArea"/>
+			<xs:enumeration value="Gauge"/>
+			<xs:enumeration value="Funnel"/>
+			<xs:enumeration value="Funnel3D"/>
+			<xs:enumeration value="NormalizedFunnel"/>
+			<xs:enumeration value="NormalizedFunnel3D"/>
+			<xs:enumeration value="Scatter"/>
+			<xs:enumeration value="Bubble"/>
+			<xs:enumeration value="Donut"/>
+			<xs:enumeration value="Donut3D"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Color">
+		<xs:union memberTypes="tns:AbsoluteColor tns:AutoColor tns:CustomColor tns:SurrogatePalId ns1:CompositeID xs:QName"/>
+	</xs:simpleType>
+	<xs:simpleType name="ControlBorderType">
+		<xs:restriction base="tns:BorderType">
+			<xs:enumeration value="WithoutBorder"/>
+			<xs:enumeration value="Single"/>
+			<xs:enumeration value="Double"/>
+			<xs:enumeration value="Embossed"/>
+			<xs:enumeration value="Indented"/>
+			<xs:enumeration value="Underline"/>
+			<xs:enumeration value="DoubleUnderline"/>
+			<xs:enumeration value="Rounded"/>
+			<xs:enumeration value="Overline"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FontType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Absolute"/>
+			<xs:enumeration value="WindowsFont"/>
+			<xs:enumeration value="StyleItem"/>
+			<xs:enumeration value="AutoFont"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FormattedString">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="GeographicalSchemeLineType">
+		<xs:restriction base="tns:LineType">
+			<xs:enumeration value="None"/>
+			<xs:enumeration value="Solid"/>
+			<xs:enumeration value="Dotted"/>
+			<xs:enumeration value="Dashed"/>
+			<xs:enumeration value="DashDotted"/>
+			<xs:enumeration value="DashDottedDotted"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="HorizontalAlign">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Left"/>
+			<xs:enumeration value="Center"/>
+			<xs:enumeration value="Right"/>
+			<xs:enumeration value="Justify"/>
+			<xs:enumeration value="Auto"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Key">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="None"/>
+			<xs:enumeration value="BackSpace"/>
+			<xs:enumeration value="Space"/>
+			<xs:enumeration value="PageUp"/>
+			<xs:enumeration value="PageDown"/>
+			<xs:enumeration value="Home"/>
+			<xs:enumeration value="End"/>
+			<xs:enumeration value="Left"/>
+			<xs:enumeration value="Up"/>
+			<xs:enumeration value="Right"/>
+			<xs:enumeration value="Down"/>
+			<xs:enumeration value="Ins"/>
+			<xs:enumeration value="Del"/>
+			<xs:enumeration value="Tab"/>
+			<xs:enumeration value="Enter"/>
+			<xs:enumeration value="Esc"/>
+			<xs:enumeration value="_0"/>
+			<xs:enumeration value="_1"/>
+			<xs:enumeration value="_2"/>
+			<xs:enumeration value="_3"/>
+			<xs:enumeration value="_4"/>
+			<xs:enumeration value="_5"/>
+			<xs:enumeration value="_6"/>
+			<xs:enumeration value="_7"/>
+			<xs:enumeration value="_8"/>
+			<xs:enumeration value="_9"/>
+			<xs:enumeration value="A"/>
+			<xs:enumeration value="B"/>
+			<xs:enumeration value="C"/>
+			<xs:enumeration value="D"/>
+			<xs:enumeration value="E"/>
+			<xs:enumeration value="F"/>
+			<xs:enumeration value="G"/>
+			<xs:enumeration value="H"/>
+			<xs:enumeration value="I"/>
+			<xs:enumeration value="J"/>
+			<xs:enumeration value="K"/>
+			<xs:enumeration value="L"/>
+			<xs:enumeration value="M"/>
+			<xs:enumeration value="N"/>
+			<xs:enumeration value="O"/>
+			<xs:enumeration value="P"/>
+			<xs:enumeration value="Q"/>
+			<xs:enumeration value="R"/>
+			<xs:enumeration value="S"/>
+			<xs:enumeration value="T"/>
+			<xs:enumeration value="U"/>
+			<xs:enumeration value="V"/>
+			<xs:enumeration value="W"/>
+			<xs:enumeration value="X"/>
+			<xs:enumeration value="Y"/>
+			<xs:enumeration value="Z"/>
+			<xs:enumeration value="Num0"/>
+			<xs:enumeration value="Num1"/>
+			<xs:enumeration value="Num2"/>
+			<xs:enumeration value="Num3"/>
+			<xs:enumeration value="Num4"/>
+			<xs:enumeration value="Num5"/>
+			<xs:enumeration value="Num6"/>
+			<xs:enumeration value="Num7"/>
+			<xs:enumeration value="Num8"/>
+			<xs:enumeration value="Num9"/>
+			<xs:enumeration value="NumMultiply"/>
+			<xs:enumeration value="NumAdd"/>
+			<xs:enumeration value="NumSubtract"/>
+			<xs:enumeration value="NumDecimal"/>
+			<xs:enumeration value="NumDivide"/>
+			<xs:enumeration value="F1"/>
+			<xs:enumeration value="F2"/>
+			<xs:enumeration value="F3"/>
+			<xs:enumeration value="F4"/>
+			<xs:enumeration value="F5"/>
+			<xs:enumeration value="F6"/>
+			<xs:enumeration value="F7"/>
+			<xs:enumeration value="F8"/>
+			<xs:enumeration value="F9"/>
+			<xs:enumeration value="F10"/>
+			<xs:enumeration value="F11"/>
+			<xs:enumeration value="F12"/>
+			<xs:enumeration value="Break"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="LineType">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="PictureFormat">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="BMP"/>
+			<xs:enumeration value="EMF"/>
+			<xs:enumeration value="GIF"/>
+			<xs:enumeration value="Icon"/>
+			<xs:enumeration value="JPEG"/>
+			<xs:enumeration value="PNG"/>
+			<xs:enumeration value="TIFF"/>
+			<xs:enumeration value="WMF"/>
+			<xs:enumeration value="UnknownFormat"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="PictureRef">
+		<xs:union memberTypes="ns1:CompositeID xs:QName"/>
+	</xs:simpleType>
+	<xs:simpleType name="PivotChartType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Column"/>
+			<xs:enumeration value="Column3D"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SizeChangeMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Normal"/>
+			<xs:enumeration value="QuickChange"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SpreadsheetDocumentCellLineType">
+		<xs:restriction base="tns:LineType">
+			<xs:enumeration value="None"/>
+			<xs:enumeration value="Solid"/>
+			<xs:enumeration value="Dotted"/>
+			<xs:enumeration value="Double"/>
+			<xs:enumeration value="ThinDashed"/>
+			<xs:enumeration value="ThickDashed"/>
+			<xs:enumeration value="LargeDashed"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SpreadsheetDocumentDrawingLineType">
+		<xs:restriction base="tns:LineType">
+			<xs:enumeration value="None"/>
+			<xs:enumeration value="Solid"/>
+			<xs:enumeration value="Dashed"/>
+			<xs:enumeration value="Dotted"/>
+			<xs:enumeration value="DashDotted"/>
+			<xs:enumeration value="DashDottedDotted"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="StyleRef">
+		<xs:union memberTypes="ns1:CompositeID xs:QName"/>
+	</xs:simpleType>
+	<xs:simpleType name="TextDirection">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="LeftToRight"/>
+			<xs:enumeration value="RightToLeft"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TextEncoding">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="UTF16"/>
+			<xs:enumeration value="UTF8"/>
+			<xs:enumeration value="ANSI"/>
+			<xs:enumeration value="OEM"/>
+			<xs:enumeration value="System"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="UseOutput">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Enable"/>
+			<xs:enumeration value="Disable"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="VerticalAlign">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Top"/>
+			<xs:enumeration value="Center"/>
+			<xs:enumeration value="Bottom"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="Border">
+		<xs:sequence>
+			<xs:element name="style" type="tns:BorderType" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="ref" type="tns:StyleRef"/>
+		<xs:attribute name="width" type="xs:unsignedInt"/>
+	</xs:complexType>
+	<xs:complexType name="Font">
+		<xs:attribute name="ref" type="tns:StyleRef"/>
+		<xs:attribute name="faceName" type="xs:string"/>
+		<xs:attribute name="height" type="xs:decimal"/>
+		<xs:attribute name="bold" type="xs:boolean" default="false"/>
+		<xs:attribute name="italic" type="xs:boolean" default="false"/>
+		<xs:attribute name="underline" type="xs:boolean" default="false"/>
+		<xs:attribute name="strikeout" type="xs:boolean" default="false"/>
+		<xs:attribute name="kind" type="tns:FontType"/>
+		<xs:attribute name="scale" type="xs:decimal"/>
+		<xs:attribute name="lineHeight" type="xs:decimal"/>
+	</xs:complexType>
+	<xs:complexType name="GaugeChartQualityBand">
+		<xs:sequence>
+			<xs:element name="begin" type="xs:decimal"/>
+			<xs:element name="end" type="xs:decimal"/>
+			<xs:element name="backColor" type="tns:Color"/>
+			<xs:element name="text" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="tooltip" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="textStr" type="xs:string" minOccurs="0"/>
+			<xs:element name="tooltipStr" type="xs:string" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="GaugeChartQualityBands">
+		<xs:sequence>
+			<xs:element name="item" type="tns:GaugeChartQualityBand" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="useTextStr" type="xs:boolean"/>
+		<xs:attribute name="useTooltipStr" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="Line">
+		<xs:sequence>
+			<xs:element name="style" type="tns:LineType" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="width" type="xs:unsignedInt"/>
+		<xs:attribute name="gap" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="Picture">
+		<xs:simpleContent>
+			<xs:extension base="xs:base64Binary">
+				<xs:attribute name="url" type="xs:string"/>
+				<xs:attribute name="ref" type="tns:PictureRef"/>
+				<xs:attribute name="t" type="xs:boolean"/>
+				<xs:attribute name="tx" type="xs:decimal"/>
+				<xs:attribute name="ty" type="xs:decimal"/>
+				<xs:attribute name="gx" type="xs:decimal"/>
+				<xs:attribute name="gy" type="xs:decimal"/>
+				<xs:attribute name="gw" type="xs:decimal"/>
+				<xs:attribute name="gh" type="xs:decimal"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:complexType name="ShortCutType">
+		<xs:sequence>
+			<xs:element name="Key" type="tns:Key"/>
+		</xs:sequence>
+		<xs:attribute name="Alt" type="xs:boolean"/>
+		<xs:attribute name="Ctrl" type="xs:boolean"/>
+		<xs:attribute name="Shift" type="xs:boolean"/>
+	</xs:complexType>
+</xs:schema>

--- a/src/main/xsd/v8.5/v8.1c.ru-8.2-data-bsl.xsd
+++ b/src/main/xsd/v8.5/v8.1c.ru-8.2-data-bsl.xsd
@@ -1,0 +1,56 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:tns="http://v8.1c.ru/8.2/data/bsl" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://v8.1c.ru/8.2/data/bsl" attributeFormDefault="unqualified" elementFormDefault="qualified">
+	<xs:complexType name="BSLAnnotation">
+		<xs:sequence>
+			<xs:element name="attribute" type="tns:BSLAnnotationAttribute" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="name" type="xs:string"/>
+	</xs:complexType>
+	<xs:complexType name="BSLAnnotationAttribute">
+		<xs:attribute name="name" type="xs:string"/>
+		<xs:attribute name="value" type="xs:string"/>
+	</xs:complexType>
+	<xs:complexType name="BSLLabel">
+		<xs:attribute name="name" type="xs:string"/>
+		<xs:attribute name="addr" type="xs:unsignedInt"/>
+	</xs:complexType>
+	<xs:complexType name="BSLModuleImage">
+		<xs:sequence>
+			<xs:element name="cmdOpCode" type="xs:string"/>
+			<xs:element name="cmdOperand" type="xs:string"/>
+			<xs:element name="constant" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="variable" type="tns:BSLVariableImage" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="label" type="tns:BSLLabel" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="procedure" type="tns:BSLProcedureImage" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="version" type="xs:unsignedInt"/>
+		<xs:attribute name="startAddr" type="xs:unsignedInt" default="4294967295"/>
+	</xs:complexType>
+	<xs:complexType name="BSLProcedureImage">
+		<xs:sequence>
+			<xs:element name="label" type="tns:BSLLabel" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="variable" type="tns:BSLVariableImage" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="paramsDefValue" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="annotation" type="tns:BSLAnnotation" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="isAsync" type="xs:boolean" default="false"/>
+		<xs:attribute name="name" type="xs:string"/>
+		<xs:attribute name="isFunction" type="xs:boolean" default="false"/>
+		<xs:attribute name="isExported" type="xs:boolean" default="false"/>
+		<xs:attribute name="isExternal" type="xs:boolean" default="false"/>
+		<xs:attribute name="parametersCount" type="xs:unsignedInt" default="0"/>
+		<xs:attribute name="startAddr" type="xs:unsignedInt"/>
+	</xs:complexType>
+	<xs:complexType name="BSLVariableImage">
+		<xs:sequence>
+			<xs:element name="annotation" type="tns:BSLAnnotation" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="name" type="xs:string"/>
+		<xs:attribute name="isLocal" type="xs:boolean" default="false"/>
+		<xs:attribute name="isExternal" type="xs:boolean" default="false"/>
+		<xs:attribute name="isParam" type="xs:boolean" default="false"/>
+		<xs:attribute name="isByValue" type="xs:boolean" default="false"/>
+		<xs:attribute name="isExported" type="xs:boolean" default="false"/>
+		<xs:attribute name="initConstPos" type="xs:int" default="-1"/>
+	</xs:complexType>
+</xs:schema>

--- a/src/main/xsd/v8.5/v8.1c.ru-8.2-data-spreadsheet.xsd
+++ b/src/main/xsd/v8.5/v8.1c.ru-8.2-data-spreadsheet.xsd
@@ -1,0 +1,710 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:ns1="http://v8.1c.ru/8.1/data/core" xmlns:ns2="http://v8.1c.ru/8.1/data/ui" xmlns:tns="http://v8.1c.ru/8.2/data/spreadsheet" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://v8.1c.ru/8.2/data/spreadsheet" attributeFormDefault="unqualified" elementFormDefault="qualified">
+	<xs:import namespace="http://v8.1c.ru/8.1/data/core"/>
+	<xs:import namespace="http://v8.1c.ru/8.1/data/ui"/>
+	<xs:element name="document" type="tns:SpreadsheetDocument"/>
+	<xs:simpleType name="DimensionAttributePlacementType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="WithDimensions"/>
+			<xs:enumeration value="Separately"/>
+			<xs:enumeration value="Together"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DimensionPlacementType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Together"/>
+			<xs:enumeration value="Separately"/>
+			<xs:enumeration value="SeparatelyAndInTotalsOnly"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DuplexPrintingType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="None"/>
+			<xs:enumeration value="FlipPagesLeft"/>
+			<xs:enumeration value="FlipPagesUp"/>
+			<xs:enumeration value="UsePrinterSettings"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="NamedItemType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Cells"/>
+			<xs:enumeration value="Drawing"/>
+			<xs:enumeration value="EmbeddedTable"/>
+			<xs:enumeration value="DataSource"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="PageOrientation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Portrait"/>
+			<xs:enumeration value="Landscape"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="PagePlacementAlternation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="DontUse"/>
+			<xs:enumeration value="MirrorOnLeft"/>
+			<xs:enumeration value="MirrorOnTop"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="PictureSize">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="RealSize"/>
+			<xs:enumeration value="Stretch"/>
+			<xs:enumeration value="Proportionally"/>
+			<xs:enumeration value="Tile"/>
+			<xs:enumeration value="AutoSize"/>
+			<xs:enumeration value="RealSizeIgnoreScale"/>
+			<xs:enumeration value="AutoSizeIgnoreScale"/>
+			<xs:enumeration value="ByFontSize"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="PivotTableLinesShowType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Always"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="PrintAccuracy">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Accurate"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SpreadsheetDocumentAreaFillType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Text"/>
+			<xs:enumeration value="Parameter"/>
+			<xs:enumeration value="Template"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SpreadsheetDocumentCellAreaType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Table"/>
+			<xs:enumeration value="Rows"/>
+			<xs:enumeration value="Columns"/>
+			<xs:enumeration value="Rectangle"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SpreadsheetDocumentCellHighlightMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Cell"/>
+			<xs:enumeration value="Row"/>
+			<xs:enumeration value="DontHighlight"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SpreadsheetDocumentDetailUse">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Cell"/>
+			<xs:enumeration value="Row"/>
+			<xs:enumeration value="WithoutProcessing"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SpreadsheetDocumentDrawingType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Line"/>
+			<xs:enumeration value="Rectangle"/>
+			<xs:enumeration value="Text"/>
+			<xs:enumeration value="Ellipse"/>
+			<xs:enumeration value="Picture"/>
+			<xs:enumeration value="Object"/>
+			<xs:enumeration value="Group"/>
+			<xs:enumeration value="Chart"/>
+			<xs:enumeration value="GanttChart"/>
+			<xs:enumeration value="PivotChart"/>
+			<xs:enumeration value="Dendrogram"/>
+			<xs:enumeration value="GeographicalSchema"/>
+			<xs:enumeration value="Control"/>
+			<xs:enumeration value="Comment"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SpreadsheetDocumentEditableCellShowType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="AsInputField"/>
+			<xs:enumeration value="Regular"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SpreadsheetDocumentExtensionAlgorithm">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Replace"/>
+			<xs:enumeration value="Merge"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SpreadsheetDocumentFileType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="MXL"/>
+			<xs:enumeration value="XLS"/>
+			<xs:enumeration value="HTML"/>
+			<xs:enumeration value="TXT"/>
+			<xs:enumeration value="MXL7"/>
+			<xs:enumeration value="HTML3"/>
+			<xs:enumeration value="HTML4"/>
+			<xs:enumeration value="HTML5"/>
+			<xs:enumeration value="XLS95"/>
+			<xs:enumeration value="XLS97"/>
+			<xs:enumeration value="ANSITXT"/>
+			<xs:enumeration value="DOCX"/>
+			<xs:enumeration value="XLSX"/>
+			<xs:enumeration value="ODS"/>
+			<xs:enumeration value="PDF"/>
+			<xs:enumeration value="PDF_A_1"/>
+			<xs:enumeration value="PDF_A_2"/>
+			<xs:enumeration value="PDF_A_3"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SpreadsheetDocumentGroupHeaderPlacement">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Begin"/>
+			<xs:enumeration value="End"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SpreadsheetDocumentPatternType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="WithoutPattern"/>
+			<xs:enumeration value="Solid"/>
+			<xs:enumeration value="Pattern1"/>
+			<xs:enumeration value="Pattern2"/>
+			<xs:enumeration value="Pattern3"/>
+			<xs:enumeration value="Pattern4"/>
+			<xs:enumeration value="Pattern5"/>
+			<xs:enumeration value="Pattern6"/>
+			<xs:enumeration value="Pattern7"/>
+			<xs:enumeration value="Pattern8"/>
+			<xs:enumeration value="Pattern9"/>
+			<xs:enumeration value="Pattern10"/>
+			<xs:enumeration value="Pattern11"/>
+			<xs:enumeration value="Pattern12"/>
+			<xs:enumeration value="Pattern13"/>
+			<xs:enumeration value="Pattern14"/>
+			<xs:enumeration value="Pattern15"/>
+			<xs:enumeration value="Pattern16"/>
+			<xs:enumeration value="Pattern17"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SpreadsheetDocumentPointerType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Special"/>
+			<xs:enumeration value="Regular"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SpreadsheetDocumentSavedPicturesDensity">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Original"/>
+			<xs:enumeration value="High"/>
+			<xs:enumeration value="Medium"/>
+			<xs:enumeration value="Low"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SpreadsheetDocumentStepDirectionType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="ByRows"/>
+			<xs:enumeration value="ByColumns"/>
+			<xs:enumeration value="WithoutMove"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SpreadsheetDocumentTextPlacementType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Cut"/>
+			<xs:enumeration value="Block"/>
+			<xs:enumeration value="Wrap"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="StandardAppearance">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="None"/>
+			<xs:enumeration value="Stone"/>
+			<xs:enumeration value="Classic"/>
+			<xs:enumeration value="Classic2"/>
+			<xs:enumeration value="Classic3"/>
+			<xs:enumeration value="Spring"/>
+			<xs:enumeration value="Summer"/>
+			<xs:enumeration value="Autumn"/>
+			<xs:enumeration value="Winter"/>
+			<xs:enumeration value="Asphalt"/>
+			<xs:enumeration value="Copper"/>
+			<xs:enumeration value="Bronze"/>
+			<xs:enumeration value="Platinum"/>
+			<xs:enumeration value="Silver"/>
+			<xs:enumeration value="Turquoise"/>
+			<xs:enumeration value="Sand"/>
+			<xs:enumeration value="Grass"/>
+			<xs:enumeration value="Ice"/>
+			<xs:enumeration value="Orange"/>
+			<xs:enumeration value="Textile"/>
+			<xs:enumeration value="Wood"/>
+			<xs:enumeration value="Interface"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TextPositionRelativeToPicture">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Left"/>
+			<xs:enumeration value="Right"/>
+			<xs:enumeration value="Top"/>
+			<xs:enumeration value="Bottom"/>
+			<xs:enumeration value="OnTop"/>
+			<xs:enumeration value="Auto"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="Area">
+		<xs:sequence>
+			<xs:element name="type" type="tns:SpreadsheetDocumentCellAreaType"/>
+			<xs:element name="beginRow" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="endRow" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="beginColumn" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="endColumn" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="columnsID" type="ns1:UUID" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Cell">
+		<xs:sequence>
+			<xs:element name="f" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="tl" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="t" type="xs:string" minOccurs="0"/>
+			<xs:element name="tfl" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="tf" type="xs:string" minOccurs="0"/>
+			<xs:element name="parameter" type="xs:string" minOccurs="0"/>
+			<xs:element name="v" minOccurs="0"/>
+			<xs:element name="detailParameter" type="xs:string" minOccurs="0"/>
+			<xs:element name="d" minOccurs="0"/>
+			<xs:element name="r" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="note" type="tns:Drawing" minOccurs="0"/>
+			<xs:element name="control" type="xs:base64Binary" minOccurs="0"/>
+			<xs:element name="pictureParameter" type="xs:string" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ChangedCell">
+		<xs:sequence>
+			<xs:element name="NewElement" type="xs:string"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ChangedCellItem">
+		<xs:sequence>
+			<xs:element name="i" type="xs:decimal"/>
+			<xs:element name="c" type="tns:Cell"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ChangedRow">
+		<xs:sequence>
+			<xs:element name="c" type="tns:ChangedCellItem" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ChangedRowItem">
+		<xs:sequence>
+			<xs:element name="index" type="xs:decimal"/>
+			<xs:element name="row" type="tns:ChangedRow"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Changes">
+		<xs:sequence>
+			<xs:element name="commonPart" type="tns:SpreadsheetDocument" minOccurs="0"/>
+			<xs:element name="fullDocument" type="tns:SpreadsheetDocument" minOccurs="0"/>
+			<xs:element name="fullDocumentWithoutContent" type="tns:SpreadsheetDocument" minOccurs="0"/>
+			<xs:element name="row" type="tns:ChangedRowItem" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="vg" type="tns:Group" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Column">
+		<xs:sequence>
+			<xs:element name="formatIndex" type="xs:decimal" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Columns">
+		<xs:sequence>
+			<xs:element name="id" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="formatIndex" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="size" type="xs:decimal"/>
+			<xs:element name="columnsItem" type="tns:ColumnsItem" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ColumnsItem">
+		<xs:sequence>
+			<xs:element name="index" type="xs:decimal"/>
+			<xs:element name="column" type="tns:Column"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Drawing">
+		<xs:sequence>
+			<xs:element name="drawingType" type="tns:SpreadsheetDocumentDrawingType"/>
+			<xs:element name="id" type="xs:decimal"/>
+			<xs:element name="formatIndex" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="text" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="textString" type="xs:string" minOccurs="0"/>
+			<xs:element name="tfl" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="tf" type="xs:string" minOccurs="0"/>
+			<xs:element name="parameter" type="xs:string" minOccurs="0"/>
+			<xs:element name="value" minOccurs="0"/>
+			<xs:element name="detailParameter" type="xs:string" minOccurs="0"/>
+			<xs:element name="detailValue" minOccurs="0"/>
+			<xs:element name="beginRow" type="xs:decimal"/>
+			<xs:element name="beginRowOffset" type="xs:decimal"/>
+			<xs:element name="endRow" type="xs:decimal"/>
+			<xs:element name="endRowOffset" type="xs:decimal"/>
+			<xs:element name="beginColumn" type="xs:decimal"/>
+			<xs:element name="beginColumnOffset" type="xs:decimal"/>
+			<xs:element name="endColumn" type="xs:decimal"/>
+			<xs:element name="endColumnOffset" type="xs:decimal"/>
+			<xs:element name="autoSize" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="pictureSize" type="tns:PictureSize" minOccurs="0"/>
+			<xs:element name="zOrder" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="nestedDrawing" type="tns:Drawing" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="object" minOccurs="0"/>
+			<xs:element name="pictureIndex" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="picture" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DrawingsDataSource">
+		<xs:sequence>
+			<xs:element name="drawingID" type="xs:decimal"/>
+			<xs:element name="area" type="tns:Area"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="EmbeddedTableItem">
+		<xs:sequence>
+			<xs:element name="id" type="xs:decimal"/>
+			<xs:element name="table"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Format">
+		<xs:sequence>
+			<xs:element name="font" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="border" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="leftBorder" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="rightBorder" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="topBorder" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="bottomBorder" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="borderColor" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="height" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="width" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="autoWidthCalculation" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="widthWeightFactor" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="horizontalAlignment" type="ns2:HorizontalAlign" minOccurs="0"/>
+			<xs:element name="verticalAlignment" type="ns2:VerticalAlign" minOccurs="0"/>
+			<xs:element name="textColor" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="backColor" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="patternColor" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="pattern" type="tns:SpreadsheetDocumentPatternType" minOccurs="0"/>
+			<xs:element name="textPlacement" type="tns:SpreadsheetDocumentTextPlacementType" minOccurs="0"/>
+			<xs:element name="fillType" type="tns:SpreadsheetDocumentAreaFillType" minOccurs="0"/>
+			<xs:element name="protection" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="hidden" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="textOrientation" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="detailsUse" type="tns:SpreadsheetDocumentDetailUse" minOccurs="0"/>
+			<xs:element name="bySelectedColumns" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="markNegatives" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="containsValue" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="valueType" type="ns1:TypeDescription" minOccurs="0"/>
+			<xs:element name="format" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="controlType" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="hyperLink" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="quickDrag" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="autoMarkIncomplete" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="markIncomplete" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="indent" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="autoIndent" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="editFormat" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="columnSizeChange" type="ns2:SizeChangeMode" minOccurs="0"/>
+			<xs:element name="print" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="drawingBorder" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="drawingHaveLeftBorder" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="drawingHaveTopBorder" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="drawingHaveRightBorder" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="drawingHaveBottomBorder" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="mask" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="picIndex" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="pictureSizeMode" type="tns:PictureSize" minOccurs="0"/>
+			<xs:element name="picHorizontalAlignment" type="ns2:HorizontalAlign" minOccurs="0"/>
+			<xs:element name="picVerticalAlignment" type="ns2:VerticalAlign" minOccurs="0"/>
+			<xs:element name="textPosition" type="tns:TextPositionRelativeToPicture" minOccurs="0"/>
+			<xs:element name="leftMargin" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="topMargin" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="rightMargin" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="bottomMargin" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="highlightMode" type="tns:SpreadsheetDocumentCellHighlightMode" minOccurs="0"/>
+			<xs:element name="showEditMode" type="tns:SpreadsheetDocumentEditableCellShowType" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Group">
+		<xs:sequence>
+			<xs:element name="columnsID" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="b" type="xs:decimal"/>
+			<xs:element name="e" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="t" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="o" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="g" type="tns:SpreadsheetDocumentGroupHeaderPlacement" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Merge">
+		<xs:sequence>
+			<xs:element name="r" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="c" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="h" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="w" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="columnsID" type="ns1:UUID" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="MoxelImageMap">
+		<xs:sequence>
+			<xs:element name="mi" type="tns:MoxelImageMapItem" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="MoxelImageMapItem">
+		<xs:sequence>
+			<xs:element name="p" type="xs:decimal" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="d" minOccurs="0"/>
+			<xs:element name="r" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="t" type="xs:string" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="NamedItem">
+		<xs:sequence>
+			<xs:element name="name" type="xs:string"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="NamedItemCells">
+		<xs:complexContent>
+			<xs:extension base="tns:NamedItem">
+				<xs:sequence>
+					<xs:element name="area" type="tns:Area" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="NamedItemDataSource">
+		<xs:complexContent>
+			<xs:extension base="tns:NamedItem">
+				<xs:sequence>
+					<xs:element name="area" type="tns:Area" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="NamedItemDrawing">
+		<xs:complexContent>
+			<xs:extension base="tns:NamedItem">
+				<xs:sequence>
+					<xs:element name="drawingID" type="xs:decimal" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="NamedItemEmbeddedTable">
+		<xs:complexContent>
+			<xs:extension base="tns:NamedItem">
+				<xs:sequence>
+					<xs:element name="area" type="tns:Area" minOccurs="0"/>
+					<xs:element name="embeddedTableID" type="xs:decimal" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="NewComplexType"/>
+	<xs:complexType name="PageBreak">
+		<xs:sequence>
+			<xs:element name="position" type="xs:decimal"/>
+			<xs:element name="columnsID" type="ns1:UUID" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Picture">
+		<xs:sequence>
+			<xs:element name="index" type="xs:decimal"/>
+			<xs:element name="picture"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PivotTable">
+		<xs:sequence>
+			<xs:element name="showFields" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="measuresAxis" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="horizontalRows" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="verticalRows" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="horizontalColumns" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="verticalColumns" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="horizontalOveralls" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="verticalOveralls" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="horizontalFullSize" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="verticalFullSize" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="horizontalFieldsArea" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="verticalFieldsArea" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="horizontalEmptyArea" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="verticalEmptyArea" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="autoFixation" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="rowsGroupping" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="columnsGroupping" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="totalRowsOnTop" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="totalColumnsOnLeft" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="dimensionAttributePlacementInRows" type="tns:DimensionAttributePlacementType" minOccurs="0"/>
+			<xs:element name="dimensionAttributePlacementInColumns" type="tns:DimensionAttributePlacementType" minOccurs="0"/>
+			<xs:element name="dimensionsPlacementOnRows" type="tns:DimensionPlacementType" minOccurs="0"/>
+			<xs:element name="dimensionsPlacementOnColumns" type="tns:DimensionPlacementType" minOccurs="0"/>
+			<xs:element name="standardAppearance" type="tns:StandardAppearance" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="notStandardAppearance" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="horizontalAdditionalSize" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="verticalAdditionalSize" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="showLines" type="tns:PivotTableLinesShowType" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PrintSettings">
+		<xs:sequence>
+			<xs:element name="pageOrientation" type="tns:PageOrientation" minOccurs="0"/>
+			<xs:element name="scale" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="collate" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="copies" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="perPage" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="topMargin" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="leftMargin" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="bottomMargin" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="rightMargin" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="headerSize" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="footerSize" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="fitToPage" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="blackAndWhite" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="printerName" type="xs:string" minOccurs="0"/>
+			<xs:element name="paper" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="pageSize" type="xs:string" minOccurs="0"/>
+			<xs:element name="paperSource" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="pageWidth" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="pageHeight" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="printAccuracy" type="tns:PrintAccuracy" minOccurs="0"/>
+			<xs:element name="duplexType" type="tns:DuplexPrintingType" minOccurs="0"/>
+			<xs:element name="pagePlacementAlternation" type="tns:PagePlacementAlternation" minOccurs="0"/>
+			<xs:element name="firstPageNumber" type="xs:decimal" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Row">
+		<xs:sequence>
+			<xs:element name="columnsID" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="formatIndex" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="empty" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="c" type="tns:RowCellsItem" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="RowCellsItem">
+		<xs:sequence>
+			<xs:element name="i" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="c" type="tns:Cell"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Rows">
+		<xs:sequence>
+			<xs:element name="index" type="xs:decimal"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="RowsItem">
+		<xs:sequence>
+			<xs:element name="index" type="xs:decimal"/>
+			<xs:element name="indexTo" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="row" type="tns:Row"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="SpreadsheetDocument">
+		<xs:choice>
+			<xs:element name="distributedKey" type="xs:string" minOccurs="0"/>
+			<xs:element name="languageSettings" minOccurs="0">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="currentLanguage" type="xs:string"/>
+						<xs:element name="defaultLanguage" type="xs:string"/>
+						<xs:element name="languageInfo" minOccurs="0" maxOccurs="unbounded">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="id" type="xs:string"/>
+									<xs:element name="code" type="xs:string"/>
+									<xs:element name="description" type="xs:string" minOccurs="0"/>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="languageCode" type="xs:string" minOccurs="0"/>
+			<xs:element name="columns" type="tns:Columns" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="rowsItem" type="tns:RowsItem" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="drawing" type="tns:Drawing" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="backPicture" minOccurs="0"/>
+			<xs:element name="fixedBackground" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="leftHeader" type="tns:Cell" minOccurs="0"/>
+			<xs:element name="centerHeader" type="tns:Cell" minOccurs="0"/>
+			<xs:element name="rightHeader" type="tns:Cell" minOccurs="0"/>
+			<xs:element name="leftFooter" type="tns:Cell" minOccurs="0"/>
+			<xs:element name="centerFooter" type="tns:Cell" minOccurs="0"/>
+			<xs:element name="rightFooter" type="tns:Cell" minOccurs="0"/>
+			<xs:element name="templateMode" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="stepDirection" type="tns:SpreadsheetDocumentStepDirectionType" minOccurs="0"/>
+			<xs:element name="totalsRight" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="totalsBelow" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="defaultFormatIndex" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="height" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="vgLevels" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="vgRows" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="vg" type="tns:Group" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="hg" type="tns:Group" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="verticalPageBreak" type="tns:PageBreak" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="horizontalPageBreak" type="tns:PageBreak" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="merge" type="tns:Merge" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="verticalUnmerge" type="tns:Merge" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="horizontalUnmerge" type="tns:Merge" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="namedItem" type="tns:NamedItem" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="printSettingsName" type="xs:string" minOccurs="0"/>
+			<xs:element name="printSettings" type="tns:PrintSettings" minOccurs="0"/>
+			<xs:element name="printArea" type="tns:Area" minOccurs="0"/>
+			<xs:element name="repeatRows" type="tns:Area" minOccurs="0"/>
+			<xs:element name="repeatColumns" type="tns:Area" minOccurs="0"/>
+			<xs:element name="drawingDataSource" type="tns:DrawingsDataSource" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="groupsBackColor" type="ns2:Color" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="groupsColor" type="ns2:Color" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="headersBackColor" type="ns2:Color" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="headersColor" type="ns2:Color" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="saveViewSettings" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="viewSettings" type="tns:ViewSettings" minOccurs="0"/>
+			<xs:element name="embeddedTable" type="tns:EmbeddedTableItem" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="line" type="ns2:Line" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="font" type="ns2:Font" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="format" type="tns:Format" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="picture" type="tns:Picture" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="usedFileName" type="xs:string" minOccurs="0"/>
+			<xs:element name="output" type="ns2:UseOutput" minOccurs="0"/>
+			<xs:element name="nextInsertionRow" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="nextInsertionCol" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="readOnly" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="protection" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="baseSheet" type="tns:SpreadsheetDocument" minOccurs="0"/>
+			<xs:element name="extensionMethod" type="tns:SpreadsheetDocumentExtensionAlgorithm" minOccurs="0"/>
+			<xs:element name="isCompactMode" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="originalSheet" type="tns:SpreadsheetDocument" minOccurs="0"/>
+			<xs:element name="textDirection" type="ns2:TextDirection" minOccurs="0"/>
+			<xs:element name="savedPicturesDensity" type="tns:SpreadsheetDocumentSavedPicturesDensity" minOccurs="0"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="ViewSettings">
+		<xs:sequence>
+			<xs:element name="currentColumn" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="currentRow" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="scale" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="showGrid" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="showHeaders" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="showNames" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="showGroups" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="showGroupsText" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="showPageBreaks" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="blackAndWhite" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="fixedColumn" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="fixedColumnRow" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="fixedRow" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="fixationPointColumn" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="fixationPointRow" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="topFixationPointColumn" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="topFixationPointRow" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="screenBeginPointColumn" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="screenBeginPointRow" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="showNamedRowsAndColumns" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="showNamedRowsAndColumnsText" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="currentLanguage" type="xs:string" minOccurs="0"/>
+			<xs:element name="showComments" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="selection" type="tns:Area" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="selectedDrawing" type="xs:decimal" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+</xs:schema>

--- a/src/main/xsd/v8.5/v8.1c.ru-8.2-managed-application-cmi.xsd
+++ b/src/main/xsd/v8.5/v8.1c.ru-8.2-managed-application-cmi.xsd
@@ -1,0 +1,278 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:ns1="http://v8.1c.ru/8.1/data/core" xmlns:ns2="http://v8.1c.ru/8.1/data/ui" xmlns:ns3="http://v8.1c.ru/8.2/uobjects" xmlns:ns4="http://v8.1c.ru/8.2/managed-application/logform" xmlns:ns5="http://v8.1c.ru/8.2/managed-application/modules" xmlns:ns6="http://v8.1c.ru/8.2/managed-application/core" xmlns:ns7="http://v8.1c.ru/8.2/data/bsl" xmlns:tns="http://v8.1c.ru/8.2/managed-application/cmi" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://v8.1c.ru/8.2/managed-application/cmi" attributeFormDefault="unqualified" elementFormDefault="qualified">
+	<xs:import namespace="http://v8.1c.ru/8.1/data/core"/>
+	<xs:import namespace="http://v8.1c.ru/8.1/data/ui"/>
+	<xs:import namespace="http://v8.1c.ru/8.2/uobjects"/>
+	<xs:import namespace="http://v8.1c.ru/8.2/managed-application/logform"/>
+	<xs:import namespace="http://v8.1c.ru/8.2/managed-application/modules"/>
+	<xs:import namespace="http://v8.1c.ru/8.2/managed-application/core"/>
+	<xs:import namespace="http://v8.1c.ru/8.2/data/bsl"/>
+	<xs:element name="command" type="tns:Command"/>
+	<xs:element name="group" type="tns:Group"/>
+	<xs:element name="section" type="tns:Section"/>
+	<xs:simpleType name="CommandParameterUseMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Single"/>
+			<xs:enumeration value="Multiple"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FuncMenuGroupType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Simple"/>
+			<xs:enumeration value="SubSystem"/>
+			<xs:enumeration value="Section"/>
+			<xs:enumeration value="Group"/>
+			<xs:enumeration value="Actions"/>
+			<xs:enumeration value="SeeAlso"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="GroupCategories">
+		<xs:list itemType="tns:GroupCategory"/>
+	</xs:simpleType>
+	<xs:simpleType name="GroupCategory">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="undefined"/>
+			<xs:enumeration value="navigator"/>
+			<xs:enumeration value="form"/>
+			<xs:enumeration value="panel"/>
+			<xs:enumeration value="toolbar"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="ClientCMIStartUpDataType">
+		<xs:sequence>
+			<xs:element name="defaultNPHandleInfo" type="tns:HandlerInfo" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="toplevelSubsystems" type="tns:Fragment" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="urls" type="tns:URLsByNavigationPoints" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="panels" type="tns:Fragment" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="commandsWithShortCuts" type="tns:CommansShortCutInfoVector" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ClientCMIUpdateInterfaceDataType">
+		<xs:sequence>
+			<xs:element name="foVer" type="xs:string" minOccurs="0"/>
+			<xs:element name="defaultNP" type="ns6:NavigationPoint" minOccurs="0"/>
+			<xs:element name="currentNPUrl" type="xs:string" minOccurs="0"/>
+			<xs:element name="startUpData" type="tns:ClientCMIStartUpDataType" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Command">
+		<xs:complexContent>
+			<xs:extension base="tns:CommandInfo">
+				<xs:attribute name="include" type="xs:boolean" default="true"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="CommandIDs">
+		<xs:sequence>
+			<xs:element name="id" type="ns1:CompositeID" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CommandInfo">
+		<xs:choice>
+			<xs:element name="text" type="xs:string" minOccurs="0"/>
+			<xs:element name="tooltip" type="xs:string" minOccurs="0"/>
+			<xs:element name="pic" type="ns2:Picture" minOccurs="0"/>
+			<xs:element name="picSizeCX" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="picSizeCY" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="picMask" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="shortcut" type="ns2:ShortCutType" minOccurs="0"/>
+			<xs:element name="param" type="ns1:TypeDescription" minOccurs="0"/>
+		</xs:choice>
+		<xs:attribute name="id" type="ns1:CompositeID" use="required"/>
+		<xs:attribute name="nameInt" type="xs:string" use="required"/>
+		<xs:attribute name="nameRus" type="xs:string" use="required"/>
+		<xs:attribute name="md" type="xs:string" use="required"/>
+		<xs:attribute name="kind" type="ns4:ButtonRepresentation"/>
+		<xs:attribute name="helpTopic" type="xs:string" use="required"/>
+		<xs:attribute name="url" type="xs:string" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="CommandInterfaceItems">
+		<xs:sequence>
+			<xs:element name="uitems" type="ns3:FormDataTree" minOccurs="0"/>
+			<xs:element name="present" type="ns6:SectionPanelRepresentation" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CommandPath">
+		<xs:sequence>
+			<xs:element name="cmd" type="tns:CommandInfo" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CommandsInfo">
+		<xs:sequence>
+			<xs:element name="info" type="tns:CommandInfo" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CommansShortCutInfo">
+		<xs:sequence>
+			<xs:element name="shortCut" type="ns2:ShortCutType"/>
+			<xs:element name="fragments" type="tns:SubsystemAndPanel" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="commandId" type="ns1:CompositeID"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CommansShortCutInfoVector">
+		<xs:sequence>
+			<xs:element name="info" type="tns:CommansShortCutInfo" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Fragment">
+		<xs:choice>
+			<xs:element ref="tns:command" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element ref="tns:group" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element ref="tns:section" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:choice>
+		<xs:attribute name="kind" type="ns6:SectionPanelRepresentation"/>
+	</xs:complexType>
+	<xs:complexType name="FuncMenuCommand">
+		<xs:sequence>
+			<xs:element name="id" type="ns1:CompositeID" minOccurs="0"/>
+			<xs:element name="url" type="xs:string" minOccurs="0"/>
+			<xs:element name="text" type="xs:string" minOccurs="0"/>
+			<xs:element name="tooltip" type="xs:string" minOccurs="0"/>
+			<xs:element name="picture" type="ns2:Picture" minOccurs="0"/>
+			<xs:element name="shortCut" type="ns2:ShortCutType" minOccurs="0"/>
+			<xs:element name="important" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="highlight" type="tns:FuncMenuHighlight"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="FuncMenuGroup">
+		<xs:sequence>
+			<xs:element name="type" type="tns:FuncMenuGroupType" minOccurs="0"/>
+			<xs:element name="id" type="ns1:CompositeID" minOccurs="0"/>
+			<xs:element name="text" type="xs:string" minOccurs="0"/>
+			<xs:element name="picture" type="ns2:Picture" minOccurs="0"/>
+			<xs:element name="newColumn" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="command" type="tns:FuncMenuCommand" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="group" type="tns:FuncMenuGroup" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="highlight" type="tns:FuncMenuHighlight"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="FuncMenuHighlight">
+		<xs:attribute name="position" type="xs:decimal"/>
+		<xs:attribute name="length" type="xs:decimal"/>
+	</xs:complexType>
+	<xs:complexType name="Group">
+		<xs:complexContent>
+			<xs:extension base="tns:GroupInfo">
+				<xs:choice>
+					<xs:element ref="tns:command" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element ref="tns:group" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element ref="tns:section" minOccurs="0" maxOccurs="unbounded"/>
+				</xs:choice>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="GroupInfo">
+		<xs:choice>
+			<xs:element name="text" type="xs:string" minOccurs="0"/>
+			<xs:element name="tooltip" type="xs:string" minOccurs="0"/>
+			<xs:element name="pic" type="ns2:Picture" minOccurs="0"/>
+			<xs:element name="picSizeCX" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="picSizeCY" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="picMask" type="xs:decimal" minOccurs="0"/>
+		</xs:choice>
+		<xs:attribute name="id" type="ns1:UUID" use="required"/>
+		<xs:attribute name="cat" type="tns:GroupCategory"/>
+		<xs:attribute name="order" type="xs:decimal"/>
+		<xs:attribute name="kind" type="ns4:ButtonRepresentation"/>
+	</xs:complexType>
+	<xs:complexType name="HandlerInfo">
+		<xs:sequence>
+			<xs:element name="formId" type="ns1:CompositeID"/>
+			<xs:element name="formName" type="xs:string" minOccurs="0"/>
+			<xs:element name="moduleInfo" type="tns:ModuleInfo" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="name" type="xs:string" minOccurs="0"/>
+			<xs:element name="nameRu" type="xs:string" minOccurs="0"/>
+			<xs:element name="listFilter" type="xs:boolean"/>
+			<xs:element name="param" type="xs:string" minOccurs="0"/>
+			<xs:element name="usageMode" type="tns:CommandParameterUseMode"/>
+			<xs:element name="modifiesData" type="xs:boolean"/>
+			<xs:element name="createGroupCommand" type="xs:boolean"/>
+		</xs:sequence>
+		<xs:attribute name="theme" type="xs:boolean"/>
+		<xs:attribute name="subTheme" type="xs:boolean"/>
+		<xs:attribute name="standard" type="xs:boolean"/>
+		<xs:attribute name="defGroupCat" type="tns:GroupCategory"/>
+	</xs:complexType>
+	<xs:complexType name="HandlerInfoByID">
+		<xs:sequence>
+			<xs:element name="id" type="ns1:CompositeID"/>
+			<xs:element name="handleInfo" type="tns:HandlerInfo" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="HandlerInfoEx">
+		<xs:complexContent>
+			<xs:extension base="tns:HandlerInfo">
+				<xs:sequence>
+					<xs:element name="moduleInfoEx" type="tns:ModuleInfoEx" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="url" type="xs:string" minOccurs="0"/>
+					<xs:element name="presentation" type="xs:string" minOccurs="0"/>
+					<xs:element name="shortPresentation" type="xs:string" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="HandlersInfosVector">
+		<xs:sequence>
+			<xs:element name="item" type="tns:HandlerInfoByID" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ModuleInfo">
+		<xs:sequence>
+			<xs:element name="securityInfo" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="moduleId" type="xs:string"/>
+		<xs:attribute name="moduleName" type="xs:string"/>
+	</xs:complexType>
+	<xs:complexType name="ModuleInfoEx">
+		<xs:sequence>
+			<xs:element name="clnModule" type="xs:string" minOccurs="0"/>
+			<xs:element name="mtd" type="ns5:MethodDefs" minOccurs="0"/>
+			<xs:element name="moduleImage" type="ns7:BSLModuleImage" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Section">
+		<xs:complexContent>
+			<xs:extension base="tns:SectionInfo">
+				<xs:choice>
+					<xs:element ref="tns:command" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element ref="tns:group" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element ref="tns:section" minOccurs="0" maxOccurs="unbounded"/>
+				</xs:choice>
+				<xs:attribute name="include" type="xs:boolean" default="true"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="SectionInfo">
+		<xs:choice>
+			<xs:element name="text" type="xs:string" minOccurs="0"/>
+			<xs:element name="tooltip" type="xs:string" minOccurs="0"/>
+			<xs:element name="pic" type="ns2:Picture" minOccurs="0"/>
+			<xs:element name="picSizeCX" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="picSizeCY" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="picMask" type="xs:decimal" minOccurs="0"/>
+		</xs:choice>
+		<xs:attribute name="id" type="ns1:UUID" use="required"/>
+		<xs:attribute name="name" type="xs:string" use="required"/>
+		<xs:attribute name="helpTopic" type="xs:string" use="required"/>
+		<xs:attribute name="oneCommandSubsystem" type="xs:boolean" default="false"/>
+	</xs:complexType>
+	<xs:complexType name="SubsystemAndPanel">
+		<xs:sequence>
+			<xs:element name="subsystem" type="ns1:UUID"/>
+			<xs:element name="panel" type="xs:decimal"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="URLByNavigationPoint">
+		<xs:sequence>
+			<xs:element name="np" type="ns6:NavigationPoint"/>
+			<xs:element name="url" type="xs:string"/>
+			<xs:element name="presentation" type="xs:string"/>
+			<xs:element name="shortPresentation" type="xs:string"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="URLsByNavigationPoints">
+		<xs:sequence>
+			<xs:element name="data" type="tns:URLByNavigationPoint" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+</xs:schema>

--- a/src/main/xsd/v8.5/v8.1c.ru-8.2-managed-application-core.xsd
+++ b/src/main/xsd/v8.5/v8.1c.ru-8.2-managed-application-core.xsd
@@ -1,0 +1,1161 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:ns1="http://v8.1c.ru/8.1/data/core" xmlns:ns2="http://v8.1c.ru/8.1/data/ui" xmlns:ns3="http://v8.1c.ru/8.1/data/enterprise" xmlns:ns4="http://v8.1c.ru/8.2/data/bsl" xmlns:tns="http://v8.1c.ru/8.2/managed-application/core" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://v8.1c.ru/8.2/managed-application/core" attributeFormDefault="unqualified" elementFormDefault="qualified">
+	<xs:import namespace="http://v8.1c.ru/8.1/data/core"/>
+	<xs:import namespace="http://v8.1c.ru/8.1/data/ui"/>
+	<xs:import namespace="http://v8.1c.ru/8.1/data/enterprise"/>
+	<xs:import namespace="http://v8.1c.ru/8.2/data/bsl"/>
+	<xs:element name="ClientApplicationInterface" type="tns:InterfaceLayouter"/>
+	<xs:simpleType name="Alias">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="en"/>
+			<xs:enumeration value="ru"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ApplicationUsePurpose">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="PlatformApplication"/>
+			<xs:enumeration value="MobilePlatformApplication"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ClientRunMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="ManagedApplication"/>
+			<xs:enumeration value="OrdinaryApplication"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CommandGroupCategory">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="NavigationPanel"/>
+			<xs:enumeration value="ActionsPanel"/>
+			<xs:enumeration value="FormNavigationPanel"/>
+			<xs:enumeration value="FormCommandBar"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ErrorMessageDisplayVariant">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="ErrorMessageForUser"/>
+			<xs:enumeration value="BriefErrorDescription"/>
+			<xs:enumeration value="DetailErrorDescription"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ErrorReportingMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="DontSend"/>
+			<xs:enumeration value="AskUser"/>
+			<xs:enumeration value="Send"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="MainWindowMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Normal"/>
+			<xs:enumeration value="Workplace"/>
+			<xs:enumeration value="FullscreenWorkplace"/>
+			<xs:enumeration value="Kiosk"/>
+			<xs:enumeration value="EmbeddedWorkplace"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="MobileApplicationFunctionalities">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Biometrics"/>
+			<xs:enumeration value="Location"/>
+			<xs:enumeration value="BackgroundLocation"/>
+			<xs:enumeration value="BluetoothPrinters"/>
+			<xs:enumeration value="WiFiPrinters"/>
+			<xs:enumeration value="Contacts"/>
+			<xs:enumeration value="Calendars"/>
+			<xs:enumeration value="PushNotifications"/>
+			<xs:enumeration value="LocalNotifications"/>
+			<xs:enumeration value="InAppPurchases"/>
+			<xs:enumeration value="PersonalComputerFileExchange"/>
+			<xs:enumeration value="Ads"/>
+			<xs:enumeration value="NumberDialing"/>
+			<xs:enumeration value="CallProcessing"/>
+			<xs:enumeration value="CallLog"/>
+			<xs:enumeration value="AutoSendSMS"/>
+			<xs:enumeration value="ReceiveSMS"/>
+			<xs:enumeration value="SMSLog"/>
+			<xs:enumeration value="Camera"/>
+			<xs:enumeration value="Microphone"/>
+			<xs:enumeration value="MusicLibrary"/>
+			<xs:enumeration value="PictureAndVideoLibraries"/>
+			<xs:enumeration value="AudioPlaybackAndVibration"/>
+			<xs:enumeration value="BackgroundAudioPlaybackAndVibration"/>
+			<xs:enumeration value="InstallPackages"/>
+			<xs:enumeration value="OSBackup"/>
+			<xs:enumeration value="ApplicationUsageStatistics"/>
+			<xs:enumeration value="BarcodeScanning"/>
+			<xs:enumeration value="BackgroundAudioRecording"/>
+			<xs:enumeration value="AllFilesAccess"/>
+			<xs:enumeration value="Videoconferences"/>
+			<xs:enumeration value="NFC"/>
+			<xs:enumeration value="DocumentScanning"/>
+			<xs:enumeration value="Geofences"/>
+			<xs:enumeration value="IncomingShareRequests"/>
+			<xs:enumeration value="AllIncomingShareRequestsTypesProcessing"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="RequiredMobileApplicationPermissionMessages">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Biometrics"/>
+			<xs:enumeration value="Location"/>
+			<xs:enumeration value="BackgroundLocation"/>
+			<xs:enumeration value="BluetoothPrinters"/>
+			<xs:enumeration value="Contacts"/>
+			<xs:enumeration value="Calendars"/>
+			<xs:enumeration value="NumberDialing"/>
+			<xs:enumeration value="CallProcessing"/>
+			<xs:enumeration value="CallLog"/>
+			<xs:enumeration value="AutoSendSMS"/>
+			<xs:enumeration value="ReceiveSMS"/>
+			<xs:enumeration value="SMSLog"/>
+			<xs:enumeration value="Camera"/>
+			<xs:enumeration value="Microphone"/>
+			<xs:enumeration value="MusicLibrary"/>
+			<xs:enumeration value="PictureAndVideoLibraries"/>
+			<xs:enumeration value="AudioPlaybackAndVibration"/>
+			<xs:enumeration value="PermissionGroupPhone"/>
+			<xs:enumeration value="PermissionGroupCallLog"/>
+			<xs:enumeration value="PermissionGroupSMS"/>
+			<xs:enumeration value="PostNotifications"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="RequiredMobileApplicationPermissions">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Multimedia"/>
+			<xs:enumeration value="Location"/>
+			<xs:enumeration value="Contacts"/>
+			<xs:enumeration value="Calendars"/>
+			<xs:enumeration value="Telephony"/>
+			<xs:enumeration value="PushNotification"/>
+			<xs:enumeration value="LocalNotification"/>
+			<xs:enumeration value="Print"/>
+			<xs:enumeration value="InAppPurchases"/>
+			<xs:enumeration value="Ads"/>
+			<xs:enumeration value="BackgroundLocation"/>
+			<xs:enumeration value="BackgroundAudioPlayback"/>
+			<xs:enumeration value="FileExchangeWithPersonalComputer"/>
+			<xs:enumeration value="CallPhone"/>
+			<xs:enumeration value="HandlePhoneCalls"/>
+			<xs:enumeration value="CallLog"/>
+			<xs:enumeration value="SendSMS"/>
+			<xs:enumeration value="ReceiveSMS"/>
+			<xs:enumeration value="SMSLog"/>
+			<xs:enumeration value="Camera"/>
+			<xs:enumeration value="Microphone"/>
+			<xs:enumeration value="MusicLibrary"/>
+			<xs:enumeration value="PicturesAndVideoLibraries"/>
+			<xs:enumeration value="AudioAndVibrationPlayback"/>
+			<xs:enumeration value="PermissionGroupPhone"/>
+			<xs:enumeration value="PermissionGroupCallLog"/>
+			<xs:enumeration value="PermissionGroupSMS"/>
+			<xs:enumeration value="InstallPackages"/>
+			<xs:enumeration value="AllowOSBackup"/>
+			<xs:enumeration value="Biometrics"/>
+			<xs:enumeration value="BluetoothPrinters"/>
+			<xs:enumeration value="WiFiPrinters"/>
+			<xs:enumeration value="AllFilesAccess"/>
+			<xs:enumeration value="Videoconferences"/>
+			<xs:enumeration value="NFC"/>
+			<xs:enumeration value="PostNotifications"/>
+			<xs:enumeration value="Geofences"/>
+			<xs:enumeration value="IncomingShareRequests"/>
+			<xs:enumeration value="AllIncomingShareRequestsTypesProcessing"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SectionPanelRepresentation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Picture"/>
+			<xs:enumeration value="PictureAndText"/>
+			<xs:enumeration value="Text"/>
+			<xs:enumeration value="PictureOnTopAndText"/>
+			<xs:enumeration value="PictureOnLeftAndText"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="StandardGlobalSearchType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="UserWorkFavorites"/>
+			<xs:enumeration value="UserWorkHistory"/>
+			<xs:enumeration value="FunctionsMenu"/>
+			<xs:enumeration value="CollaborationSystemConversations"/>
+			<xs:enumeration value="CollaborationSystemMessages"/>
+			<xs:enumeration value="Data"/>
+			<xs:enumeration value="Help"/>
+			<xs:enumeration value="Expression"/>
+			<xs:enumeration value="URL"/>
+			<xs:enumeration value="FunctionsForTechnicalSpecialist"/>
+			<xs:enumeration value="GlobalStandardCommands"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="StyleEntryKind">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="color"/>
+			<xs:enumeration value="font"/>
+			<xs:enumeration value="border"/>
+			<xs:enumeration value="line"/>
+			<xs:enumeration value="palcolor"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="AboutInfo">
+		<xs:sequence>
+			<xs:element name="title" type="xs:string"/>
+			<xs:element name="user" type="xs:string"/>
+			<xs:element name="config" type="xs:string"/>
+			<xs:element name="logo" type="ns2:Picture" minOccurs="0"/>
+			<xs:element name="presentation" type="xs:string"/>
+			<xs:element name="extensions" type="xs:string" minOccurs="0"/>
+			<xs:element name="runMode" type="xs:string" minOccurs="0"/>
+			<xs:element name="compress" type="xs:string" minOccurs="0"/>
+			<xs:element name="configLicenseInfo" type="xs:string"/>
+			<xs:element name="version" type="xs:string" minOccurs="0"/>
+			<xs:element name="developerInfo" type="xs:string" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="AllowedIncomingShareRequestType">
+		<xs:sequence>
+			<xs:element name="mime" type="xs:string"/>
+			<xs:element name="uti" type="xs:string"/>
+			<xs:element name="ext" type="xs:string"/>
+			<xs:element name="processingVariant" type="xs:integer"/>
+			<xs:element name="isCustom" type="xs:boolean"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="AllowedIncomingShareRequestTypes">
+		<xs:sequence>
+			<xs:element name="allowedIncomingShareRequestType" type="tns:AllowedIncomingShareRequestType" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ApplicationInfo">
+		<xs:sequence>
+			<xs:element name="infoBaseInstanceID" type="ns1:UUID"/>
+			<xs:element name="infoBaseAlias" type="xs:string"/>
+			<xs:element name="locale" type="tns:LocaleInfo" minOccurs="0"/>
+			<xs:element name="langs" type="tns:LangSettings"/>
+			<xs:element name="config" type="ns1:ObjectVersion"/>
+			<xs:element name="types" type="xs:string"/>
+			<xs:element name="user" type="ns1:UUID"/>
+			<xs:element name="rolesID" type="xs:decimal"/>
+			<xs:element name="seance" type="ns1:UUID"/>
+			<xs:element name="seanceNo" type="xs:decimal"/>
+			<xs:element name="userRunMode" type="xs:decimal"/>
+			<xs:element name="configRunMode" type="xs:decimal"/>
+			<xs:element name="splash" type="tns:SplashInfo" minOccurs="0"/>
+			<xs:element name="fullLocale" type="tns:MngLocale" minOccurs="0"/>
+			<xs:element name="compatibilityMode" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="compatibilityModeLive" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="interfaceCompatibilityMode" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="userSeparatorsEmpty" type="xs:boolean"/>
+			<xs:element name="training" type="xs:boolean"/>
+			<xs:element name="modalityUseMode" type="xs:decimal"/>
+			<xs:element name="rigthClientsStart" type="xs:decimal"/>
+			<xs:element name="syncCallsUseMode" type="xs:decimal"/>
+			<xs:element name="assemblyVersion" type="ns1:ObjectVersion"/>
+			<xs:element name="interactiveSecurity" type="xs:boolean"/>
+			<xs:element name="defaultPaperWidth" type="xs:decimal"/>
+			<xs:element name="defaultPaperHeight" type="xs:decimal"/>
+			<xs:element name="serverVersion" type="xs:string" minOccurs="0"/>
+			<xs:element name="beginningOfCentury" type="xs:decimal"/>
+			<xs:element name="authMessage" type="xs:string" minOccurs="0"/>
+			<xs:element name="infoBaseInFileMode" type="xs:boolean"/>
+			<xs:element name="countryUA" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="objectFileExtensionChrome" type="xs:string"/>
+			<xs:element name="objectFileExtensionFirefox" type="xs:string"/>
+			<xs:element name="objectFileExtensionIE" type="xs:string"/>
+			<xs:element name="objectFileExtensionSafari" type="xs:string"/>
+			<xs:element name="objectFileExtensionAnyChromiumBased" type="xs:string"/>
+			<xs:element name="objectFileExtensionChromiumGost" type="xs:string"/>
+			<xs:element name="objectFileExtensionYandex" type="xs:string"/>
+			<xs:element name="objectFileExtensionEdge" type="xs:string"/>
+			<xs:element name="objectCryptoExtensionChrome" type="xs:string"/>
+			<xs:element name="objectCryptoExtensionFirefox" type="xs:string"/>
+			<xs:element name="objectCryptoExtensionIE" type="xs:string"/>
+			<xs:element name="objectCryptoExtensionSafari" type="xs:string"/>
+			<xs:element name="objectCryptoExtensionAnyChromiumBased" type="xs:string"/>
+			<xs:element name="objectCryptoExtensionChromiumGost" type="xs:string"/>
+			<xs:element name="objectCryptoExtensionYandex" type="xs:string"/>
+			<xs:element name="objectCryptoExtensionEdge" type="xs:string"/>
+			<xs:element name="objectAgentExtensionChrome" type="xs:string"/>
+			<xs:element name="objectAgentExtensionFirefox" type="xs:string"/>
+			<xs:element name="objectAgentExtensionIE" type="xs:string"/>
+			<xs:element name="objectAgentExtensionSafari" type="xs:string"/>
+			<xs:element name="objectAgentExtensionAnyChromiumBased" type="xs:string"/>
+			<xs:element name="objectAgentExtensionChromiumGost" type="xs:string"/>
+			<xs:element name="objectAgentExtensionYandex" type="xs:string"/>
+			<xs:element name="objectAgentExtensionEdge" type="xs:string"/>
+			<xs:element name="objectCompInfoExtensionChrome" type="xs:string"/>
+			<xs:element name="objectCompInfoExtensionFirefox" type="xs:string"/>
+			<xs:element name="objectCompInfoExtensionIE" type="xs:string"/>
+			<xs:element name="objectCompInfoExtensionSafari" type="xs:string"/>
+			<xs:element name="objectCompInfoExtensionAnyChromiumBased" type="xs:string"/>
+			<xs:element name="objectCompInfoExtensionChromiumGost" type="xs:string"/>
+			<xs:element name="objectCompInfoExtensionYandex" type="xs:string"/>
+			<xs:element name="objectCompInfoExtensionEdge" type="xs:string"/>
+			<xs:element name="credAns4" type="xs:string" minOccurs="0"/>
+			<xs:element name="credAns6" type="xs:string" minOccurs="0"/>
+			<xs:element name="passwordRequirementsComplianceStatus" type="xs:decimal"/>
+			<xs:element name="passwordExpirationTicksLeft" type="xs:decimal"/>
+			<xs:element name="passwordMinLength" type="xs:decimal"/>
+			<xs:element name="cannotChangePassword" type="xs:boolean"/>
+			<xs:element name="seanceLicenseInfoPrs" type="xs:string" minOccurs="0"/>
+			<xs:element name="passwordExpirationStatus" type="xs:decimal"/>
+			<xs:element name="pushNotificationsApplicationID" type="xs:string" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="confNotSaved" type="xs:boolean"/>
+		<xs:attribute name="noFontsOnServer" type="xs:boolean"/>
+		<xs:attribute name="noFontConfigOnServer" type="xs:boolean"/>
+		<xs:attribute name="needUpdateMCSignature" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="BinaryDataQualifiers">
+		<xs:attribute name="length" type="xs:decimal" default="0"/>
+		<xs:attribute name="varying" type="xs:boolean" default="true"/>
+	</xs:complexType>
+	<xs:complexType name="BoolFormat">
+		<xs:attribute name="true" type="xs:string"/>
+		<xs:attribute name="false" type="xs:string"/>
+	</xs:complexType>
+	<xs:complexType name="ChoiceParameter">
+		<xs:sequence>
+			<xs:element name="name" type="xs:string"/>
+			<xs:element name="mode" type="ns3:LinkedValueChangeMode"/>
+			<xs:element name="pathItem" type="ns1:CompositeID" maxOccurs="unbounded"/>
+			<xs:element name="webDataPath" type="xs:string" minOccurs="0"/>
+			<xs:element name="strPath" type="xs:string" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ChoiceParameterItem">
+		<xs:sequence>
+			<xs:element name="value"/>
+		</xs:sequence>
+		<xs:attribute name="name" type="xs:string"/>
+	</xs:complexType>
+	<xs:complexType name="ChoiceParameterLink">
+		<xs:sequence>
+			<xs:element name="dataPath" type="xs:string"/>
+		</xs:sequence>
+		<xs:attribute name="name" type="xs:string"/>
+		<xs:attribute name="mode" type="ns3:LinkedValueChangeMode"/>
+	</xs:complexType>
+	<xs:complexType name="ChoiceParameterLinks">
+		<xs:sequence>
+			<xs:element name="item" type="tns:ChoiceParameter" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ChoiceParameters">
+		<xs:sequence>
+			<xs:element name="item" type="tns:ChoiceParameterItem" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ClientDisplayInformation">
+		<xs:attribute name="x" type="xs:decimal"/>
+		<xs:attribute name="y" type="xs:decimal"/>
+		<xs:attribute name="dpi" type="xs:decimal"/>
+	</xs:complexType>
+	<xs:complexType name="ColorConvertationHelper">
+		<xs:sequence>
+			<xs:element name="id" type="xs:string" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ConstValueKey">
+		<xs:complexContent>
+			<xs:extension base="tns:Type">
+				<xs:sequence>
+					<xs:element name="sep" type="tns:ConstValueKeySep"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="ConstValueKeySep">
+		<xs:attribute name="name" type="xs:NCName"/>
+		<xs:attribute name="type" type="xs:QName"/>
+	</xs:complexType>
+	<xs:complexType name="ConstValueKeyTypeSet">
+		<xs:complexContent>
+			<xs:extension base="tns:TypeSetDef">
+				<xs:sequence>
+					<xs:element name="type" type="tns:ConstValueKey" minOccurs="0" maxOccurs="unbounded"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="DateFormat">
+		<xs:attribute name="shortDate" type="xs:string"/>
+		<xs:attribute name="time" type="xs:string"/>
+	</xs:complexType>
+	<xs:complexType name="DateQualifiers">
+		<xs:attribute name="fractions" type="ns1:DateFractions" default="DateTime"/>
+	</xs:complexType>
+	<xs:complexType name="DesktopFormInfo">
+		<xs:attribute name="id" type="xs:string"/>
+		<xs:attribute name="height" type="xs:decimal"/>
+		<xs:attribute name="visible" type="xs:boolean" default="true"/>
+		<xs:attribute name="title" type="xs:string"/>
+	</xs:complexType>
+	<xs:complexType name="DesktopInfo">
+		<xs:sequence>
+			<xs:element name="left" type="tns:DesktopFormInfo" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="right" type="tns:DesktopFormInfo" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="state" type="xs:decimal"/>
+		<xs:attribute name="commandInterfaceDisplays" type="xs:decimal"/>
+		<xs:attribute name="availFormCount" type="xs:decimal"/>
+	</xs:complexType>
+	<xs:complexType name="Enum">
+		<xs:complexContent>
+			<xs:extension base="tns:Type">
+				<xs:sequence>
+					<xs:element name="val" type="tns:EnumValue" maxOccurs="unbounded"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="EnumPresentations">
+		<xs:sequence>
+			<xs:element name="val" type="xs:string" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="EnumTypeSet">
+		<xs:complexContent>
+			<xs:extension base="tns:TypeSetDef">
+				<xs:sequence>
+					<xs:element name="type" type="tns:Enum" minOccurs="0" maxOccurs="unbounded"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="EnumVal">
+		<xs:attribute name="uuid" type="ns1:UUID"/>
+		<xs:attribute name="code" type="xs:string"/>
+		<xs:attribute name="presentation" type="xs:string"/>
+	</xs:complexType>
+	<xs:complexType name="EnumVals">
+		<xs:sequence>
+			<xs:element name="enumVals" type="tns:EnumVal" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="EnumValue">
+		<xs:attribute name="uuid" type="ns1:UUID" use="required"/>
+		<xs:attribute name="code" type="xs:string"/>
+		<xs:attribute name="color" type="ns2:Color"/>
+	</xs:complexType>
+	<xs:complexType name="ErrorMessageTemplatesCollectionItem">
+		<xs:sequence>
+			<xs:element name="category" type="ns1:ErrorCategory"/>
+			<xs:element name="messageTemplate" type="tns:ErrorMessageTexts"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ErrorMessageTexts">
+		<xs:sequence>
+			<xs:element name="templateNotRequiresRestartFormatted" type="xs:boolean"/>
+			<xs:element name="templateNotRequiresRestart" type="xs:string"/>
+			<xs:element name="templateRequiresRestartFormatted" type="xs:boolean"/>
+			<xs:element name="templateRequiresRestart" type="xs:string"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ErrorMessagesTexts">
+		<xs:sequence>
+			<xs:element name="item" type="tns:ErrorMessageTemplatesCollectionItem" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ErrorOnStartupProcessingSettings">
+		<xs:sequence>
+			<xs:element name="helpTextFormatted" type="xs:boolean"/>
+			<xs:element name="helpText" type="xs:string"/>
+			<xs:element name="helpUrl" type="xs:string" minOccurs="0"/>
+			<xs:element name="serviceUrl" type="xs:string" minOccurs="0"/>
+			<xs:element name="additionalInfo" type="xs:string" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ErrorProcessingSettings">
+		<xs:sequence>
+			<xs:element name="descriptionLevel" type="tns:ErrorMessageDisplayVariant" minOccurs="0"/>
+			<xs:element name="serverUrl" type="xs:string" minOccurs="0"/>
+			<xs:element name="createReportMode" type="tns:ErrorReportingMode" minOccurs="0"/>
+			<xs:element name="createCrashReport" type="tns:ErrorReportingMode" minOccurs="0"/>
+			<xs:element name="addUserName" type="tns:ErrorReportingMode" minOccurs="0"/>
+			<xs:element name="addSystemInfo" type="tns:ErrorReportingMode" minOccurs="0"/>
+			<xs:element name="addScreenshot" type="tns:ErrorReportingMode" minOccurs="0"/>
+			<xs:element name="addErrorFullDescription" type="tns:ErrorReportingMode" minOccurs="0"/>
+			<xs:element name="addConfigInfo" type="tns:ErrorReportingMode" minOccurs="0"/>
+			<xs:element name="sendCrashReportTo1C" type="tns:ErrorReportingMode" minOccurs="0"/>
+			<xs:element name="additionalInfo" type="xs:string" minOccurs="0"/>
+			<xs:element name="messageTemplates" type="tns:ErrorMessagesTexts" minOccurs="0"/>
+			<xs:element name="createReportModeOnServer" type="tns:ErrorReportingMode" minOccurs="0"/>
+			<xs:element name="createCrashReportOnServer" type="tns:ErrorReportingMode" minOccurs="0"/>
+			<xs:element name="sendCrashReportOnServerTo1C" type="tns:ErrorReportingMode" minOccurs="0"/>
+			<xs:element name="addUserNameOnServer" type="tns:ErrorReportingMode" minOccurs="0"/>
+			<xs:element name="addErrorFullDescriptionOnServer" type="tns:ErrorReportingMode" minOccurs="0"/>
+			<xs:element name="addConfigInfoOnServer" type="tns:ErrorReportingMode" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ExtKey">
+		<xs:complexContent>
+			<xs:extension base="tns:Type">
+				<xs:sequence>
+					<xs:element name="key" type="tns:ExtKeyKey"/>
+				</xs:sequence>
+				<xs:attribute name="present" type="xs:string"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="ExtKeyKey">
+		<xs:attribute name="name" type="xs:NCName"/>
+		<xs:attribute name="type" type="xs:QName"/>
+	</xs:complexType>
+	<xs:complexType name="ExtKeyTypeSet">
+		<xs:sequence>
+			<xs:element name="type" type="tns:ExtKey" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="en" type="xs:NCName"/>
+		<xs:attribute name="ru" type="xs:NCName"/>
+	</xs:complexType>
+	<xs:complexType name="ExtRefTypeSet">
+		<xs:sequence>
+			<xs:element name="type" type="tns:ExtReference" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="en" type="xs:NCName"/>
+		<xs:attribute name="ru" type="xs:NCName"/>
+	</xs:complexType>
+	<xs:complexType name="ExtReference">
+		<xs:complexContent>
+			<xs:extension base="tns:Type">
+				<xs:sequence>
+					<xs:element name="tdp" type="ns1:TypeDescription" minOccurs="0"/>
+				</xs:sequence>
+				<xs:attribute name="valueType" type="xs:QName"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="GlobalSearchFetch">
+		<xs:sequence>
+			<xs:element name="id" type="ns1:UUID"/>
+		</xs:sequence>
+		<xs:attribute name="cancel" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="GlobalSearchHistory">
+		<xs:sequence>
+			<xs:element name="item" type="tns:GlobalSearchHistoryItem" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="GlobalSearchHistoryItem">
+		<xs:sequence>
+			<xs:element name="searchString" type="xs:string"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="GlobalSearchQuery">
+		<xs:sequence>
+			<xs:element name="id" type="ns1:UUID"/>
+			<xs:element name="item" type="tns:GlobalSearchQueryItem" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="pattern" type="xs:string" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="GlobalSearchQueryItem">
+		<xs:sequence>
+			<xs:element name="params"/>
+		</xs:sequence>
+		<xs:attribute name="type" type="tns:StandardGlobalSearchType"/>
+		<xs:attribute name="module" type="xs:string"/>
+		<xs:attribute name="method" type="xs:string"/>
+		<xs:attribute name="requestId" type="xs:decimal"/>
+		<xs:attribute name="async" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="GlobalSearchResult">
+		<xs:sequence>
+			<xs:element name="item" type="tns:GlobalSearchResultItem" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="more" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="GlobalSearchResultItem">
+		<xs:sequence>
+			<xs:element name="presentation" type="xs:string" minOccurs="0"/>
+			<xs:element name="presentationFmt" type="xs:string" minOccurs="0"/>
+			<xs:element name="description" type="xs:string" minOccurs="0"/>
+			<xs:element name="descriptionFmt" type="xs:string" minOccurs="0"/>
+			<xs:element name="value"/>
+			<xs:element name="picture" type="ns2:Picture"/>
+			<xs:element name="actions" type="tns:GlobalSearchResultItemActionCollection"/>
+		</xs:sequence>
+		<xs:attribute name="type" type="tns:StandardGlobalSearchType"/>
+		<xs:attribute name="typeStr" type="xs:string"/>
+		<xs:attribute name="requestId" type="xs:decimal"/>
+	</xs:complexType>
+	<xs:complexType name="GlobalSearchResultItemAction">
+		<xs:sequence>
+			<xs:element name="value"/>
+			<xs:element name="text" type="xs:string" minOccurs="0"/>
+			<xs:element name="formatted" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="picture" type="ns2:Picture"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="GlobalSearchResultItemActionCollection">
+		<xs:sequence>
+			<xs:element name="item" type="tns:GlobalSearchResultItemAction" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="InfoRegKey">
+		<xs:complexContent>
+			<xs:extension base="tns:Type">
+				<xs:sequence>
+					<xs:element name="dim" type="tns:InfoRegKeyDim"/>
+					<xs:element name="sep" type="tns:InfoRegKeyDim"/>
+				</xs:sequence>
+				<xs:attribute name="recorder" type="xs:QName"/>
+				<xs:attribute name="period" type="xs:boolean"/>
+				<xs:attribute name="present" type="xs:string"/>
+				<xs:attribute name="timePeriodicity" type="xs:boolean"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="InfoRegKeyDim">
+		<xs:attribute name="name" type="xs:NCName"/>
+		<xs:attribute name="type" type="xs:QName"/>
+	</xs:complexType>
+	<xs:complexType name="InfoRegKeyTypeSet">
+		<xs:complexContent>
+			<xs:extension base="tns:TypeSetDef">
+				<xs:sequence>
+					<xs:element name="type" type="tns:InfoRegKey" minOccurs="0" maxOccurs="unbounded"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="InterfaceLayouter">
+		<xs:sequence>
+			<xs:element name="top" type="tns:PanelLayouter" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="left" type="tns:PanelLayouter" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="right" type="tns:PanelLayouter" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="bottom" type="tns:PanelLayouter" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="panelDef" type="tns:PanelDef" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="LFEFChoiceHistory">
+		<xs:sequence>
+			<xs:element name="group" type="tns:LFEFChoiceHistoryGroup"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="LFEFChoiceHistoryGroup">
+		<xs:sequence>
+			<xs:element name="choiceParams" type="tns:ChoiceParameters" minOccurs="0"/>
+			<xs:element name="usage" type="ns3:FoldersAndItemsUse" minOccurs="0"/>
+			<xs:element name="items" type="tns:LFEFChoiceHistoryItems" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="LFEFChoiceHistoryItem">
+		<xs:sequence>
+			<xs:element name="value" nillable="true"/>
+			<xs:element name="presentation" type="xs:string" minOccurs="0"/>
+			<xs:element name="score" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="lastHitDate" type="xs:dateTime" minOccurs="0"/>
+			<xs:element name="sample" type="tns:LFEFChoiceHistorySample"/>
+			<xs:element name="deleted" type="xs:boolean" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="LFEFChoiceHistoryItems">
+		<xs:sequence>
+			<xs:element name="item" type="tns:LFEFChoiceHistoryItem" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="LFEFChoiceHistorySample">
+		<xs:attribute name="date" type="xs:dateTime"/>
+		<xs:attribute name="hits" type="xs:decimal"/>
+	</xs:complexType>
+	<xs:complexType name="LangSettings">
+		<xs:sequence>
+			<xs:element name="lang" type="tns:LanguageInfo"/>
+		</xs:sequence>
+		<xs:attribute name="current" type="xs:string"/>
+		<xs:attribute name="default" type="xs:string"/>
+		<xs:attribute name="alias" type="tns:Alias"/>
+	</xs:complexType>
+	<xs:complexType name="LanguageInfo">
+		<xs:simpleContent>
+			<xs:extension base="xs:string">
+				<xs:attribute name="code" type="xs:string"/>
+				<xs:attribute name="id" type="xs:string"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:complexType name="LocaleBoolFormat">
+		<xs:attribute name="falseName" type="xs:string"/>
+		<xs:attribute name="trueName" type="xs:string"/>
+	</xs:complexType>
+	<xs:complexType name="LocaleDateFormat">
+		<xs:choice>
+			<xs:element name="longDayNames" type="xs:string" minOccurs="7" maxOccurs="7"/>
+			<xs:element name="shortDayNames" type="xs:string" minOccurs="7" maxOccurs="7"/>
+			<xs:element name="longMonthNames" type="xs:string" minOccurs="12" maxOccurs="12"/>
+			<xs:element name="shortMonthNames" type="xs:string" minOccurs="12" maxOccurs="12"/>
+			<xs:element name="longAloneMonthNames" type="xs:string" minOccurs="12" maxOccurs="12"/>
+			<xs:element name="shortAloneMonthNames" type="xs:string" minOccurs="12" maxOccurs="12"/>
+		</xs:choice>
+		<xs:attribute name="fullDatePattern" type="xs:string"/>
+		<xs:attribute name="longDatePattern" type="xs:string"/>
+		<xs:attribute name="shortDatePattern" type="xs:string"/>
+		<xs:attribute name="timePattern" type="xs:string"/>
+		<xs:attribute name="shortTimePattern" type="xs:string"/>
+		<xs:attribute name="longDateTimePattern" type="xs:string"/>
+		<xs:attribute name="shortDateTimePattern" type="xs:string"/>
+		<xs:attribute name="amPmMarkers" type="xs:string"/>
+	</xs:complexType>
+	<xs:complexType name="LocaleInfo">
+		<xs:sequence>
+			<xs:element name="bool" type="tns:BoolFormat" minOccurs="0"/>
+			<xs:element name="date" type="tns:DateFormat" minOccurs="0"/>
+			<xs:element name="numeric" type="tns:NumericFormat" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="name" type="xs:string"/>
+		<xs:attribute name="useSeanceFormats" type="xs:boolean"/>
+		<xs:attribute name="firstDayOfWeek" type="xs:int" default="0"/>
+	</xs:complexType>
+	<xs:complexType name="LocaleNumericFormat">
+		<xs:attribute name="decimalSeparator" type="xs:string"/>
+		<xs:attribute name="groupingSeparator" type="xs:string"/>
+		<xs:attribute name="groupingSize" type="xs:decimal"/>
+		<xs:attribute name="secondaryGroupingSize" type="xs:decimal"/>
+		<xs:attribute name="negativePrefix" type="xs:string"/>
+		<xs:attribute name="negativeSuffix" type="xs:string"/>
+		<xs:attribute name="positivePrefix" type="xs:string"/>
+		<xs:attribute name="positiveSuffix" type="xs:string"/>
+		<xs:attribute name="digitSymbols" type="xs:string"/>
+	</xs:complexType>
+	<xs:complexType name="LocaleWeekInfo">
+		<xs:attribute name="firstDayOfWeek" type="xs:int"/>
+		<xs:attribute name="weekendOnSet" type="xs:int"/>
+		<xs:attribute name="weekendCease" type="xs:int"/>
+	</xs:complexType>
+	<xs:complexType name="MCDigestDeltaItem">
+		<xs:sequence>
+			<xs:element name="add" type="tns:MCDigestItem" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="ch" type="tns:MCDigestItem" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="del" type="ns1:UUID" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="MCDigestItem">
+		<xs:attribute name="uuid" type="ns1:UUID"/>
+		<xs:attribute name="name" type="xs:NCName"/>
+	</xs:complexType>
+	<xs:complexType name="MngLocale">
+		<xs:sequence>
+			<xs:element name="boolFormat" type="tns:LocaleBoolFormat"/>
+			<xs:element name="numericFormat" type="tns:LocaleNumericFormat"/>
+			<xs:element name="dateFormat" type="tns:LocaleDateFormat"/>
+			<xs:element name="weekInfo" type="tns:LocaleWeekInfo"/>
+		</xs:sequence>
+		<xs:attribute name="localeCode" type="xs:string"/>
+		<xs:attribute name="displayName" type="xs:string"/>
+		<xs:attribute name="cdisplayName" type="xs:string"/>
+		<xs:attribute name="localeName" type="xs:string"/>
+		<xs:attribute name="sessionLocaleCode" type="xs:string"/>
+		<xs:attribute name="resourceLocaleCode" type="xs:string"/>
+	</xs:complexType>
+	<xs:complexType name="MobileApplicationURL">
+		<xs:sequence>
+			<xs:element name="baseUrl" type="xs:string"/>
+			<xs:element name="useAndroid" type="xs:boolean"/>
+			<xs:element name="useIOS" type="xs:boolean"/>
+			<xs:element name="useWindows" type="xs:boolean"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="MobileApplicationURLs">
+		<xs:sequence>
+			<xs:element name="url" type="tns:MobileApplicationURL" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="NavigationPoint">
+		<xs:attribute name="fragment" type="ns1:UUID"/>
+		<xs:attribute name="subTheme" type="ns1:CompositeID"/>
+	</xs:complexType>
+	<xs:complexType name="NumberQualifiers">
+		<xs:attribute name="length" type="xs:decimal" default="0"/>
+		<xs:attribute name="precision" type="xs:decimal" default="0"/>
+		<xs:attribute name="positive" type="xs:boolean" default="false"/>
+	</xs:complexType>
+	<xs:complexType name="NumericFormat">
+		<xs:attribute name="decimal" type="xs:string"/>
+		<xs:attribute name="group" type="xs:string"/>
+		<xs:attribute name="grouping" type="xs:string"/>
+		<xs:attribute name="negative" type="xs:decimal"/>
+	</xs:complexType>
+	<xs:complexType name="PaletteColorInfo">
+		<xs:sequence>
+			<xs:element name="dark" type="xs:string" maxOccurs="unbounded"/>
+			<xs:element name="light" type="xs:string" maxOccurs="unbounded"/>
+			<xs:element name="darkForeColor" type="xs:string"/>
+			<xs:element name="lightForeColor" type="xs:string"/>
+			<xs:element name="darkBackColor" type="xs:string"/>
+			<xs:element name="lightBackColor" type="xs:string"/>
+			<xs:element name="darkBackColor80" type="xs:string"/>
+			<xs:element name="lightBackColor80" type="xs:string"/>
+		</xs:sequence>
+		<xs:attribute name="id" type="xs:string"/>
+		<xs:attribute name="name" type="xs:string"/>
+		<xs:attribute name="uuid" type="ns1:CompositeID"/>
+		<xs:attribute name="presentation" type="xs:string"/>
+	</xs:complexType>
+	<xs:complexType name="Panel">
+		<xs:choice>
+			<xs:element name="uuid" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="name" type="xs:string" minOccurs="0"/>
+			<xs:element name="height" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="kind" type="tns:SectionPanelRepresentation" minOccurs="0"/>
+		</xs:choice>
+		<xs:attribute name="id" type="ns1:UUID"/>
+	</xs:complexType>
+	<xs:complexType name="PanelDef">
+		<xs:sequence>
+			<xs:element name="name" type="xs:string" minOccurs="0"/>
+			<xs:element name="spr" type="tns:SectionPanelRepresentation" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="id" type="ns1:UUID"/>
+	</xs:complexType>
+	<xs:complexType name="PanelGroup">
+		<xs:sequence>
+			<xs:element name="group" type="tns:PanelLayouter" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="id" type="ns1:UUID"/>
+	</xs:complexType>
+	<xs:complexType name="PanelLayouter">
+		<xs:choice>
+			<xs:element name="panel" type="tns:Panel" minOccurs="0"/>
+			<xs:element name="group" type="tns:PanelGroup" minOccurs="0"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="PersistingView">
+		<xs:sequence>
+			<xs:element name="url" type="xs:string"/>
+			<xs:element name="title" type="xs:string" minOccurs="0"/>
+			<xs:element name="docNumber" type="xs:string" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PersistingViews">
+		<xs:sequence>
+			<xs:element name="item" type="tns:PersistingView" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="RefTypeSet">
+		<xs:complexContent>
+			<xs:extension base="tns:TypeSetDef">
+				<xs:sequence>
+					<xs:element name="type" type="tns:Reference" minOccurs="0" maxOccurs="unbounded"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="Reference">
+		<xs:complexContent>
+			<xs:extension base="tns:Type">
+				<xs:attribute name="bppoint" type="xs:boolean"/>
+				<xs:attribute name="hasAccess" type="xs:boolean"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="RegKey">
+		<xs:complexContent>
+			<xs:extension base="tns:Type">
+				<xs:attribute name="recorder" type="xs:QName"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="RegKeyTypeSet">
+		<xs:complexContent>
+			<xs:extension base="tns:TypeSetDef">
+				<xs:sequence>
+					<xs:element name="type" type="tns:RegKey" minOccurs="0" maxOccurs="unbounded"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="RequiredPermission">
+		<xs:sequence>
+			<xs:element name="permission" type="tns:RequiredMobileApplicationPermissions"/>
+			<xs:element name="use" type="xs:boolean"/>
+			<xs:element name="description" type="ns1:LocalStringType"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="RequiredPermissionMessage">
+		<xs:sequence>
+			<xs:element name="permission" type="tns:RequiredMobileApplicationPermissionMessages"/>
+			<xs:element name="description" type="ns1:LocalStringType"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="RequiredPermissions">
+		<xs:sequence>
+			<xs:element name="permission" type="tns:RequiredPermission" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ResourceString">
+		<xs:sequence>
+			<xs:element name="resName" type="xs:string"/>
+			<xs:element name="resString" type="xs:string"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ResourceStrings">
+		<xs:sequence>
+			<xs:element name="content" type="tns:ResourceString" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="SearchBlock">
+		<xs:sequence>
+			<xs:element name="value"/>
+		</xs:sequence>
+		<xs:attribute name="fieldName" type="xs:string"/>
+		<xs:attribute name="compareType" type="xs:decimal"/>
+	</xs:complexType>
+	<xs:complexType name="SettingsChoice">
+		<xs:sequence>
+			<xs:element name="settingsKey"/>
+			<xs:element name="additionalProperties" type="ns1:Structure" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="SplashInfo">
+		<xs:sequence>
+			<xs:element name="copyright" type="xs:string" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="exist" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="StartInfo">
+		<xs:sequence>
+			<xs:element name="navStartPoint" type="tns:NavigationPoint"/>
+			<xs:element name="subsystemVer" type="tns:SubsystemVerInfo" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="desktop" type="tns:DesktopInfo"/>
+			<xs:element name="styleEntries" type="tns:StyleEntriesInfo"/>
+			<xs:element name="paletteColor" type="tns:PaletteColorInfo" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="fullConfName" type="xs:string"/>
+			<xs:element name="extName" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="disabledExtName" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="extIssue" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="compress" type="xs:string"/>
+			<xs:element name="panels" type="tns:InterfaceLayouter" minOccurs="0"/>
+			<xs:element name="choiceHistory" type="tns:LFEFChoiceHistory" minOccurs="0"/>
+			<xs:element name="favs" type="tns:UserFavorites" minOccurs="0"/>
+			<xs:element name="userName" type="xs:string"/>
+			<xs:element name="fullUserName" type="xs:string"/>
+			<xs:element name="externalResourceMode" type="xs:string"/>
+			<xs:element name="deploymentType" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="errorProcessingSettings" type="tns:ErrorProcessingSettings" minOccurs="0"/>
+			<xs:element name="configHash" type="xs:string" minOccurs="0"/>
+			<xs:element name="configCode" type="xs:string" minOccurs="0"/>
+			<xs:element name="configVersion" type="xs:string" minOccurs="0"/>
+			<xs:element name="dataZoneString" type="xs:string" minOccurs="0"/>
+			<xs:element name="configChangeEnabled" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="extensionVersion" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="serverVersion" type="xs:string" minOccurs="0"/>
+			<xs:element name="serverType" type="xs:string" minOccurs="0"/>
+			<xs:element name="serverDBMS" type="xs:string" minOccurs="0"/>
+			<xs:element name="serverNeedFunctionalities" type="xs:string" minOccurs="0"/>
+			<xs:element name="urlExtDataSupport" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="startupErrorProcessingSettings" type="tns:ErrorOnStartupProcessingSettings" minOccurs="0"/>
+			<xs:element name="appVariant" type="xs:string" minOccurs="0"/>
+			<xs:element name="dataZoneStringExclCondOff" type="xs:string" minOccurs="0"/>
+			<xs:element name="confCaption" type="xs:string"/>
+			<xs:element name="confShortCaption" type="xs:string"/>
+			<xs:element name="persistingViews" type="tns:PersistingViews"/>
+			<xs:element name="extensionLicensingText" type="xs:string" minOccurs="0"/>
+			<xs:element name="configLicenseInfo" type="xs:string" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="agentVersion" type="xs:string"/>
+		<xs:attribute name="hasConfigExt" type="xs:boolean"/>
+		<xs:attribute name="mainWindowMode" type="tns:MainWindowMode"/>
+		<xs:attribute name="infoBaseInstanceID" type="ns1:UUID"/>
+		<xs:attribute name="confName" type="xs:string"/>
+		<xs:attribute name="subsystemsPanelVer" type="ns1:UUID"/>
+		<xs:attribute name="foVer" type="ns1:UUID"/>
+		<xs:attribute name="mainWindowOptionsVer" type="ns1:UUID"/>
+		<xs:attribute name="desktopSpliterPosVer" type="ns1:UUID"/>
+		<xs:attribute name="notifyWindowOptionsVer" type="ns1:UUID"/>
+		<xs:attribute name="stateWindowOptionsVer" type="ns1:UUID"/>
+		<xs:attribute name="commConfName" type="xs:string"/>
+		<xs:attribute name="commConfURL" type="xs:string"/>
+		<xs:attribute name="commProvName" type="xs:string"/>
+		<xs:attribute name="commProvURL" type="xs:string"/>
+		<xs:attribute name="desktopFormsWindowSettingsVerHash" type="xs:string"/>
+		<xs:attribute name="enableOutput" type="xs:boolean"/>
+		<xs:attribute name="allowAllFunctionsMode" type="xs:boolean"/>
+		<xs:attribute name="allowSaveUserData" type="xs:boolean"/>
+		<xs:attribute name="clientSettings" type="xs:decimal"/>
+		<xs:attribute name="debugServerHTTP" type="xs:string"/>
+		<xs:attribute name="allowFullTextSearch" type="xs:boolean"/>
+		<xs:attribute name="taxi" type="xs:boolean"/>
+		<xs:attribute name="clientInterfaceVariant" type="ns3:ClientInterfaceVariant"/>
+		<xs:attribute name="clientInterfaceTheme" type="ns3:ClientInterfaceTheme"/>
+		<xs:attribute name="clientInterfaceThemeFromSettings" type="ns3:ClientInterfaceTheme"/>
+		<xs:attribute name="clientInterfaceThemeFromAuto" type="ns3:ClientInterfaceTheme"/>
+		<xs:attribute name="clientInterfaceScale" type="ns3:ClientInterfaceScale"/>
+		<xs:attribute name="clientInterfaceScaleFromSettings" type="ns3:ClientInterfaceScale"/>
+		<xs:attribute name="defWindowOpeningVariant" type="ns3:ClientApplicationWindowsOpenVariant"/>
+		<xs:attribute name="sdi" type="xs:boolean"/>
+		<xs:attribute name="enableChoiceInterface" type="xs:boolean"/>
+		<xs:attribute name="newInterfaceByDefault" type="xs:boolean"/>
+		<xs:attribute name="largeFont" type="xs:boolean"/>
+		<xs:attribute name="rtl" type="xs:boolean"/>
+		<xs:attribute name="ecsServer" type="xs:string"/>
+		<xs:attribute name="ecsClientId" type="xs:string"/>
+		<xs:attribute name="ecsAdmin" type="xs:boolean"/>
+		<xs:attribute name="ecsUserChoiceForm" type="xs:string"/>
+		<xs:attribute name="searchFormPresent" type="xs:boolean"/>
+		<xs:attribute name="allowMWMNormal" type="xs:boolean"/>
+		<xs:attribute name="allowMWMWorkplace" type="xs:boolean"/>
+		<xs:attribute name="allowMWMEmbeddedWorkplace" type="xs:boolean"/>
+		<xs:attribute name="allowMWMFullscreenWorkplace" type="xs:boolean"/>
+		<xs:attribute name="allowMWMKiosk" type="xs:boolean"/>
+		<xs:attribute name="allowOpenAnalytics" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="StringQualifiers">
+		<xs:attribute name="length" type="xs:decimal" default="0"/>
+		<xs:attribute name="varying" type="xs:boolean" default="true"/>
+	</xs:complexType>
+	<xs:complexType name="StyleEntriesInfo">
+		<xs:sequence>
+			<xs:element name="styleEntries" type="tns:StyleEntryInfo" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="StyleEntryInfo">
+		<xs:sequence>
+			<xs:element name="value"/>
+		</xs:sequence>
+		<xs:attribute name="uuid" type="ns1:CompositeID"/>
+		<xs:attribute name="code" type="xs:string"/>
+		<xs:attribute name="description" type="xs:string"/>
+		<xs:attribute name="kind" type="tns:StyleEntryKind"/>
+	</xs:complexType>
+	<xs:complexType name="SubsystemVerInfo">
+		<xs:attribute name="id" type="ns1:UUID"/>
+		<xs:attribute name="actionPanelVer" type="ns1:UUID"/>
+		<xs:attribute name="navPanelVer" type="ns1:UUID"/>
+	</xs:complexType>
+	<xs:complexType name="SysEnum">
+		<xs:sequence>
+			<xs:element name="values" type="tns:SysEnumValue" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="factoryClsid" type="ns1:UUID"/>
+		<xs:attribute name="clsid" type="ns1:UUID"/>
+		<xs:attribute name="enumName" type="xs:string"/>
+		<xs:attribute name="enumName2" type="xs:string"/>
+		<xs:attribute name="enumName3" type="xs:string"/>
+		<xs:attribute name="enumName4" type="xs:string"/>
+		<xs:attribute name="xmlName" type="xs:string"/>
+		<xs:attribute name="namespace" type="xs:anyURI"/>
+		<xs:attribute name="defValue" type="xs:string"/>
+	</xs:complexType>
+	<xs:complexType name="SysEnumValue">
+		<xs:attribute name="name" type="xs:string"/>
+		<xs:attribute name="name2" type="xs:string"/>
+		<xs:attribute name="name3" type="xs:string"/>
+		<xs:attribute name="name4" type="xs:string"/>
+		<xs:attribute name="presentation" type="xs:string"/>
+	</xs:complexType>
+	<xs:complexType name="SysEnums">
+		<xs:sequence>
+			<xs:element name="sysEnums" type="tns:SysEnum" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Type" abstract="true">
+		<xs:attribute name="clsid" type="ns1:UUID" use="required"/>
+		<xs:attribute name="table" type="xs:decimal" use="required"/>
+		<xs:attribute name="code" type="xs:NCName"/>
+		<xs:attribute name="extension" type="xs:boolean" default="false"/>
+	</xs:complexType>
+	<xs:complexType name="TypeIDList">
+		<xs:sequence>
+			<xs:element name="type" type="ns1:UUID" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TypeLink">
+		<xs:sequence>
+			<xs:element name="pathItem" type="ns1:CompositeID" maxOccurs="unbounded"/>
+			<xs:element name="linkItem" type="xs:decimal" minOccurs="0"/>
+			<xs:element name="webDataPath" type="xs:string" minOccurs="0"/>
+			<xs:element name="strPath" type="xs:string" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TypePresentation">
+		<xs:attribute name="clsid" type="ns1:UUID" use="required"/>
+		<xs:attribute name="view" type="xs:string" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TypePresentations">
+		<xs:sequence>
+			<xs:element name="type" type="tns:TypePresentation"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TypeSet">
+		<xs:sequence>
+			<xs:element name="type" type="ns1:UUID" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="string" type="tns:StringQualifiers" minOccurs="0"/>
+			<xs:element name="number" type="tns:NumberQualifiers" minOccurs="0"/>
+			<xs:element name="date" type="tns:DateQualifiers" minOccurs="0"/>
+			<xs:element name="binary" type="tns:BinaryDataQualifiers" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="clsid" type="ns1:UUID"/>
+		<xs:attribute name="name" type="xs:QName"/>
+	</xs:complexType>
+	<xs:complexType name="TypeSetDef">
+		<xs:attribute name="clsid" type="ns1:UUID"/>
+		<xs:attribute name="en" type="xs:NCName"/>
+		<xs:attribute name="ru" type="xs:NCName"/>
+		<xs:attribute name="name" type="xs:QName"/>
+	</xs:complexType>
+	<xs:complexType name="TypeSystem">
+		<xs:choice>
+			<xs:element name="enums" type="tns:EnumTypeSet" minOccurs="0"/>
+			<xs:element name="refs" type="tns:RefTypeSet" minOccurs="0"/>
+			<xs:element name="regs" type="tns:RegKeyTypeSet" minOccurs="0"/>
+			<xs:element name="infoRegs" type="tns:InfoRegKeyTypeSet" minOccurs="0"/>
+			<xs:element name="typeSet" type="tns:TypeSet" minOccurs="0"/>
+			<xs:element name="extRef" type="tns:ExtRefTypeSet" minOccurs="0"/>
+			<xs:element name="extKey" type="tns:ExtKeyTypeSet" minOccurs="0"/>
+			<xs:element name="constValueKeys" type="tns:ConstValueKeyTypeSet" minOccurs="0"/>
+			<xs:element name="mcDigitalSignature" type="xs:string" minOccurs="0"/>
+			<xs:element name="mcTaskName" type="xs:Name" minOccurs="0"/>
+			<xs:element name="mcTaskSynonym" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="mcTaskSynonym2" type="xs:Name" minOccurs="0"/>
+			<xs:element name="mcDSAKey" type="xs:Name" minOccurs="0"/>
+			<xs:element name="mcAppName" type="xs:Name" minOccurs="0"/>
+			<xs:element name="mcAppURL" type="xs:Name" minOccurs="0"/>
+			<xs:element name="mcdEnums" type="tns:MCDigestDeltaItem" minOccurs="0"/>
+			<xs:element name="mcdRefs" type="tns:MCDigestDeltaItem" minOccurs="0"/>
+			<xs:element name="mcdRegKeys" type="tns:MCDigestDeltaItem" minOccurs="0"/>
+			<xs:element name="mcdInfoRegKeys" type="tns:MCDigestDeltaItem" minOccurs="0"/>
+		</xs:choice>
+		<xs:attribute name="namespace" type="xs:anyURI"/>
+	</xs:complexType>
+	<xs:complexType name="UUIDAndStringsVectorType">
+		<xs:sequence>
+			<xs:element name="UUID" type="ns1:UUID"/>
+			<xs:element name="item" type="tns:UserFavoriteItem" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="UpdateInfo">
+		<xs:attribute name="date" type="xs:dateTime"/>
+		<xs:attribute name="version" type="xs:string"/>
+		<xs:attribute name="win32" type="xs:string"/>
+		<xs:attribute name="win64" type="xs:string"/>
+		<xs:attribute name="lin32" type="xs:string"/>
+		<xs:attribute name="lin64" type="xs:string"/>
+		<xs:attribute name="mac64" type="xs:string"/>
+	</xs:complexType>
+	<xs:complexType name="UsedFunctionality">
+		<xs:sequence>
+			<xs:element name="functionality" type="tns:UsedFunctionalityFlag" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="permissionMessage" type="tns:RequiredPermissionMessage" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="UsedFunctionalityFlag">
+		<xs:sequence>
+			<xs:element name="functionality" type="tns:MobileApplicationFunctionalities"/>
+			<xs:element name="use" type="xs:boolean"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="UserFavoriteItem">
+		<xs:sequence>
+			<xs:element name="url" type="xs:string"/>
+			<xs:element name="pres" type="xs:string" minOccurs="0"/>
+			<xs:element name="darling" type="xs:boolean" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="UserFavorites">
+		<xs:sequence>
+			<xs:element name="item" type="tns:UserFavoriteItem" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+</xs:schema>

--- a/src/main/xsd/v8.5/v8.1c.ru-8.2-managed-application-logform.xsd
+++ b/src/main/xsd/v8.5/v8.1c.ru-8.2-managed-application-logform.xsd
@@ -1,0 +1,2363 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:ns1="http://v8.1c.ru/8.1/data/core" xmlns:ns2="http://v8.1c.ru/8.1/data/ui" xmlns:ns3="http://v8.1c.ru/8.2/managed-application/core" xmlns:ns4="http://v8.1c.ru/8.2/uobjects" xmlns:ns5="http://v8.1c.ru/8.1/data/enterprise" xmlns:ns6="http://v8.1c.ru/8.2/data/spreadsheet" xmlns:tns="http://v8.1c.ru/8.2/managed-application/logform" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://v8.1c.ru/8.2/managed-application/logform" attributeFormDefault="unqualified" elementFormDefault="qualified">
+	<xs:import namespace="http://v8.1c.ru/8.1/data/core"/>
+	<xs:import namespace="http://v8.1c.ru/8.1/data/ui"/>
+	<xs:import namespace="http://v8.1c.ru/8.2/managed-application/core"/>
+	<xs:import namespace="http://v8.1c.ru/8.2/uobjects"/>
+	<xs:import namespace="http://v8.1c.ru/8.1/data/enterprise"/>
+	<xs:import namespace="http://v8.1c.ru/8.2/data/spreadsheet"/>
+	<xs:simpleType name="AppearanceVariantInCard">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Extended"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="AutoCapitalizationOnTextInput">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="None"/>
+			<xs:enumeration value="Words"/>
+			<xs:enumeration value="Sentences"/>
+			<xs:enumeration value="AllCharacters"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="AutoCorrectionOnTextInput">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Use"/>
+			<xs:enumeration value="DontUse"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="AutoSaveFormDataInSettings">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="DontUse"/>
+			<xs:enumeration value="Use"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="AutoShowClearButtonMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Always"/>
+			<xs:enumeration value="FilledOnly"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="AutoShowOpenButtonMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Always"/>
+			<xs:enumeration value="FilledOnly"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="AutoWidthInTable">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="ByData"/>
+			<xs:enumeration value="None"/>
+			<xs:enumeration value="ByDataAndTitle"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="AutofillHint">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="DontUse"/>
+			<xs:enumeration value="FullName"/>
+			<xs:enumeration value="GivenName"/>
+			<xs:enumeration value="FamilyName"/>
+			<xs:enumeration value="MiddleName"/>
+			<xs:enumeration value="NamePrefix"/>
+			<xs:enumeration value="NameSuffix"/>
+			<xs:enumeration value="Street"/>
+			<xs:enumeration value="City"/>
+			<xs:enumeration value="Region"/>
+			<xs:enumeration value="Country"/>
+			<xs:enumeration value="PostalCode"/>
+			<xs:enumeration value="UserName"/>
+			<xs:enumeration value="Password"/>
+			<xs:enumeration value="NewPassword"/>
+			<xs:enumeration value="OneTimeCode"/>
+			<xs:enumeration value="Email"/>
+			<xs:enumeration value="PhoneNumber"/>
+			<xs:enumeration value="CreditCardNumber"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="BWAValue">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="true"/>
+			<xs:enumeration value="false"/>
+			<xs:enumeration value="auto"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ButtonGroupRepresentation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Usual"/>
+			<xs:enumeration value="Compact"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ButtonImportance">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Main"/>
+			<xs:enumeration value="Normal"/>
+			<xs:enumeration value="Supplementary"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ButtonLocationInCommandBar">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="InAdditionalSubmenu"/>
+			<xs:enumeration value="InCommandBar"/>
+			<xs:enumeration value="InCommandBarAndInAdditionalSubmenu"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ButtonRepresentation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Text"/>
+			<xs:enumeration value="Picture"/>
+			<xs:enumeration value="PictureAndText"/>
+			<xs:enumeration value="Auto"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ButtonShape">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Usual"/>
+			<xs:enumeration value="Oval"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ButtonShapeRepresentation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Always"/>
+			<xs:enumeration value="WhenActive"/>
+			<xs:enumeration value="None"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CardBehaviorOnVerticalCompression">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="MoveItemsToSwipeablePages"/>
+			<xs:enumeration value="HideItems"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CardPictureAndTitleAlignVariant">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="LeftHorizontallySidesVertically"/>
+			<xs:enumeration value="CenterHorizontallySidesVertically"/>
+			<xs:enumeration value="CenterHorizontallyCenterVertically"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CardRepresentationType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Usual"/>
+			<xs:enumeration value="Group"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CellActionsButtonViewMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="DontShow"/>
+			<xs:enumeration value="ShowOnHover"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CellHyperlinkDisplayVariant">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Always"/>
+			<xs:enumeration value="OnRowHover"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CellHyperlinkRepresentation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Show"/>
+			<xs:enumeration value="DontShow"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CellHyperlinksRepresentation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="AutoForSingle"/>
+			<xs:enumeration value="ForAll"/>
+			<xs:enumeration value="DontShow"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CheckBoxType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="CheckBox"/>
+			<xs:enumeration value="Tumbler"/>
+			<xs:enumeration value="Switcher"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ChildrenTitleLocation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Left"/>
+			<xs:enumeration value="LeftIfPossible"/>
+			<xs:enumeration value="Top"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ChoiceButtonRepresentation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="ShowInDropList"/>
+			<xs:enumeration value="ShowInDropListAndInInputField"/>
+			<xs:enumeration value="ShowInInputField"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ChoiceDataGetModeOnInputByString">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Directly"/>
+			<xs:enumeration value="Background"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ChoiceHistoryOnInput">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="DontUse"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CollapseFormItemsByImportance">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Use"/>
+			<xs:enumeration value="DontUse"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ColumnsGroup">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Horizontal"/>
+			<xs:enumeration value="Vertical"/>
+			<xs:enumeration value="InCell"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CommandActionPurpose">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Usual"/>
+			<xs:enumeration value="Create"/>
+			<xs:enumeration value="Finish"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CurrentRowUse">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Use"/>
+			<xs:enumeration value="DontUse"/>
+			<xs:enumeration value="Auto"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DisplayImportance">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="VeryHigh"/>
+			<xs:enumeration value="High"/>
+			<xs:enumeration value="Usual"/>
+			<xs:enumeration value="Low"/>
+			<xs:enumeration value="VeryLow"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DrawingSelectionShowMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Show"/>
+			<xs:enumeration value="DontShow"/>
+			<xs:enumeration value="Auto"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="EditTextUpdate">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="DontUse"/>
+			<xs:enumeration value="OnValueChange"/>
+			<xs:enumeration value="Always"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="EventHandlerCallType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Before"/>
+			<xs:enumeration value="After"/>
+			<xs:enumeration value="Override"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FileDragMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="AsFile"/>
+			<xs:enumeration value="AsFileRef"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FoldersAndItems">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Items"/>
+			<xs:enumeration value="Folders"/>
+			<xs:enumeration value="FoldersAndItems"/>
+			<xs:enumeration value="Auto"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FormBaseFontVariant">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Normal"/>
+			<xs:enumeration value="Compact"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FormButtonPictureLocation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Left"/>
+			<xs:enumeration value="Right"/>
+			<xs:enumeration value="Top"/>
+			<xs:enumeration value="Bottom"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FormChildrenAlign">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="None"/>
+			<xs:enumeration value="ItemsLeftTitlesLeft"/>
+			<xs:enumeration value="ItemsRightTitlesLeft"/>
+			<xs:enumeration value="ItemsLeftTitlesRight"/>
+			<xs:enumeration value="ItemsRightTitlesRight"/>
+			<xs:enumeration value="TitlesLeftDataLeft"/>
+			<xs:enumeration value="TitlesLeftDataRight"/>
+			<xs:enumeration value="TitlesRightDataLeft"/>
+			<xs:enumeration value="TitlesRightDataRight"/>
+			<xs:enumeration value="TitlesLeftDataAuto"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FormChildrenGroup">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Horizontal"/>
+			<xs:enumeration value="Vertical"/>
+			<xs:enumeration value="HorizontalIfPossible"/>
+			<xs:enumeration value="AlwaysHorizontal"/>
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="AutoScreenTypeSensitive"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FormChildrenWidth">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Equal"/>
+			<xs:enumeration value="LeftWide"/>
+			<xs:enumeration value="LeftWidest"/>
+			<xs:enumeration value="LeftNarrow"/>
+			<xs:enumeration value="LeftNarrowest"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FormCommandBarAppearanceMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="CommandBar"/>
+			<xs:enumeration value="UsualGroup"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FormDateSelectionMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Single"/>
+			<xs:enumeration value="Multiple"/>
+			<xs:enumeration value="Interval"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FormElementCommandBarLocation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="None"/>
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Top"/>
+			<xs:enumeration value="Bottom"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FormElementOrientation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Horizontal"/>
+			<xs:enumeration value="Vertical"/>
+			<xs:enumeration value="HorizontalIfPossible"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FormElementOrigin">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Source"/>
+			<xs:enumeration value="AutoGenerated"/>
+			<xs:enumeration value="AddedFromContext"/>
+			<xs:enumeration value="AddedFromMainConf"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FormElementTitleLocation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="None"/>
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Left"/>
+			<xs:enumeration value="Top"/>
+			<xs:enumeration value="Right"/>
+			<xs:enumeration value="Bottom"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FormEnterKeyBehavior">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="ControlNavigation"/>
+			<xs:enumeration value="DefaultButton"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FormFixedInTable">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="None"/>
+			<xs:enumeration value="Left"/>
+			<xs:enumeration value="Right"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FormItemSpacing">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="None"/>
+			<xs:enumeration value="Half"/>
+			<xs:enumeration value="Single"/>
+			<xs:enumeration value="OneAndHalf"/>
+			<xs:enumeration value="Double"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FormPagesRepresentation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="None"/>
+			<xs:enumeration value="TabsOnTop"/>
+			<xs:enumeration value="TabsOnBottom"/>
+			<xs:enumeration value="TabsOnLeftHorizontal"/>
+			<xs:enumeration value="TabsOnRightHorizontal"/>
+			<xs:enumeration value="Swipe"/>
+			<xs:enumeration value="Auto"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FormPagesState">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="TitlesAndCurrentPage"/>
+			<xs:enumeration value="Titles"/>
+			<xs:enumeration value="CurrentPage"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FormProgressBarRepresentation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Smooth"/>
+			<xs:enumeration value="Broken"/>
+			<xs:enumeration value="BrokenTilt"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FormStandardURLVariant">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Object"/>
+			<xs:enumeration value="Record"/>
+			<xs:enumeration value="Report"/>
+			<xs:enumeration value="ReportVariant"/>
+			<xs:enumeration value="ReportWithCurrentSettings"/>
+			<xs:enumeration value="List"/>
+			<xs:enumeration value="ListWithCurrentSettings"/>
+			<xs:enumeration value="ListWithCurrentSettingsAndRow"/>
+			<xs:enumeration value="ListCurrentRowObject"/>
+			<xs:enumeration value="ListCurrentRowRecord"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FormTableType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="List"/>
+			<xs:enumeration value="Cards"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FormTimeChoiceMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="DontChoose"/>
+			<xs:enumeration value="CustomTime"/>
+			<xs:enumeration value="Interval1Minute"/>
+			<xs:enumeration value="Interval5Minutes"/>
+			<xs:enumeration value="Interval10Minutes"/>
+			<xs:enumeration value="Interval15Minutes"/>
+			<xs:enumeration value="Interval15And20Minutes"/>
+			<xs:enumeration value="Interval20Minutes"/>
+			<xs:enumeration value="Interval30Minutes"/>
+			<xs:enumeration value="Interval60Minutes"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FormWindowOpeningMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Independent"/>
+			<xs:enumeration value="LockOwnerWindow"/>
+			<xs:enumeration value="LockWholeInterface"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FormWindowViewMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="InMainWindow"/>
+			<xs:enumeration value="InDialogWindow"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FullTextSearchOnInputByString">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Use"/>
+			<xs:enumeration value="DontUse"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="GanttChartIntervalsSelectionMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Multiple"/>
+			<xs:enumeration value="Single"/>
+			<xs:enumeration value="None"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="GanttChartTableLocation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Left"/>
+			<xs:enumeration value="Right"/>
+			<xs:enumeration value="None"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="GanttChartValuesSelectionMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Multiple"/>
+			<xs:enumeration value="Single"/>
+			<xs:enumeration value="None"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="HeightControlVariant">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="UseHeightInFormRows"/>
+			<xs:enumeration value="UseContentHeight"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="HierarchyPanelLocation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="None"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="IncompleteItemChoiceMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="OnEnterPressed"/>
+			<xs:enumeration value="OnActivate"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="InputFieldMultipleValuePictureShape">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Rect"/>
+			<xs:enumeration value="Circle"/>
+			<xs:enumeration value="Square"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="InputFieldMultipleValuePictureSize">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Small"/>
+			<xs:enumeration value="Medium"/>
+			<xs:enumeration value="Large"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ItemHorizontalAlignment">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Left"/>
+			<xs:enumeration value="Center"/>
+			<xs:enumeration value="Right"/>
+			<xs:enumeration value="Auto"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ItemVerticalAlignment">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Top"/>
+			<xs:enumeration value="Center"/>
+			<xs:enumeration value="Bottom"/>
+			<xs:enumeration value="Auto"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="LFTableListEditingMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="None"/>
+			<xs:enumeration value="MultipleSelection"/>
+			<xs:enumeration value="LinesRearrangement"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="LogFormElementAdditionKind">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="SearchStringRepresentation"/>
+			<xs:enumeration value="ViewStatusRepresentation"/>
+			<xs:enumeration value="SearchControl"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="LogFormScrollMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="auto"/>
+			<xs:enumeration value="use"/>
+			<xs:enumeration value="useIfNecessary"/>
+			<xs:enumeration value="useWithoutStretch"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="LogFormShowConversations">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Show"/>
+			<xs:enumeration value="DontShow"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ManagedFormButtonType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="CommandBarButton"/>
+			<xs:enumeration value="UsualButton"/>
+			<xs:enumeration value="Hyperlink"/>
+			<xs:enumeration value="CommandBarHyperlink"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ManagedFormDecorationType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Label"/>
+			<xs:enumeration value="Picture"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ManagedFormFieldType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Default"/>
+			<xs:enumeration value="LabelField"/>
+			<xs:enumeration value="InputField"/>
+			<xs:enumeration value="CheckBoxField"/>
+			<xs:enumeration value="PictureField"/>
+			<xs:enumeration value="RadioButtonField"/>
+			<xs:enumeration value="SpreadsheetDocumentField"/>
+			<xs:enumeration value="TextDocumentField"/>
+			<xs:enumeration value="FormattedDocumentField"/>
+			<xs:enumeration value="PlannerField"/>
+			<xs:enumeration value="CalendarField"/>
+			<xs:enumeration value="PeriodField"/>
+			<xs:enumeration value="ProgressBarField"/>
+			<xs:enumeration value="TrackBarField"/>
+			<xs:enumeration value="ChartField"/>
+			<xs:enumeration value="GanttChartField"/>
+			<xs:enumeration value="DendrogramField"/>
+			<xs:enumeration value="GraphicalSchemaField"/>
+			<xs:enumeration value="HTMLDocumentField"/>
+			<xs:enumeration value="GeographicalSchemaField"/>
+			<xs:enumeration value="PDFDocumentField"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ManagedFormGroupType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="CommandBar"/>
+			<xs:enumeration value="Popup"/>
+			<xs:enumeration value="ColumnGroup"/>
+			<xs:enumeration value="Pages"/>
+			<xs:enumeration value="Page"/>
+			<xs:enumeration value="UsualGroup"/>
+			<xs:enumeration value="ButtonGroup"/>
+			<xs:enumeration value="ContextMenu"/>
+			<xs:enumeration value="AutoCommandBar"/>
+			<xs:enumeration value="Navigator"/>
+			<xs:enumeration value="SelectedItemsActionsPanel"/>
+			<xs:enumeration value="RowActionsPanel"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="MarkingStyle">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="DontShow"/>
+			<xs:enumeration value="TopLeft"/>
+			<xs:enumeration value="BottomRight"/>
+			<xs:enumeration value="BothSides"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="MenuElementPlacementArea">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="mainCmdsLeft"/>
+			<xs:enumeration value="autoCmds"/>
+			<xs:enumeration value="userCmds"/>
+			<xs:enumeration value="mainCmdsRight"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="OnFormWindowOpenLockMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="DontBlock"/>
+			<xs:enumeration value="LockOwner"/>
+			<xs:enumeration value="LockWholeInterface"/>
+			<xs:enumeration value="Independent"/>
+			<xs:enumeration value="LockOwnerWindow"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="OnMainServerUnavalableBehavior">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="MakeDisable"/>
+			<xs:enumeration value="DontChangeBehavior"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="OnScreenKeyboardReturnKeyText">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Return"/>
+			<xs:enumeration value="Go"/>
+			<xs:enumeration value="Join"/>
+			<xs:enumeration value="Next"/>
+			<xs:enumeration value="Search"/>
+			<xs:enumeration value="Send"/>
+			<xs:enumeration value="Done"/>
+			<xs:enumeration value="Continue"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="PictureBackgroundShowMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="DontShow"/>
+			<xs:enumeration value="ShowAndIncreaseSize"/>
+			<xs:enumeration value="ShowAndDontIncreaseSize"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="PictureRepresentationEffect">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="None"/>
+			<xs:enumeration value="Semitransparency"/>
+			<xs:enumeration value="SemitransparencyAndBlur"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="PictureSize">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="RealSize"/>
+			<xs:enumeration value="Stretch"/>
+			<xs:enumeration value="Proportionally"/>
+			<xs:enumeration value="Tile"/>
+			<xs:enumeration value="AutoSize"/>
+			<xs:enumeration value="RealSizeIgnoreScale"/>
+			<xs:enumeration value="AutoSizeIgnoreScale"/>
+			<xs:enumeration value="ByFontSize"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="RadioButtonType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="RadioButtons"/>
+			<xs:enumeration value="Tumbler"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="RefreshRequestMethod">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="None"/>
+			<xs:enumeration value="PullFromTop"/>
+			<xs:enumeration value="PullFromBottom"/>
+			<xs:enumeration value="PullFromTopOrBottom"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ReportFormType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Main"/>
+			<xs:enumeration value="Settings"/>
+			<xs:enumeration value="Variant"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="RepresentationInContextMenu">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="None"/>
+			<xs:enumeration value="AdditionalInContextMenu"/>
+			<xs:enumeration value="OnlyInContextMenu"/>
+			<xs:enumeration value="Auto"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SaveFormDataInSettings">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="DontUse"/>
+			<xs:enumeration value="UseList"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SaveTableAppearance">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="ForUser"/>
+			<xs:enumeration value="ByKeyForUser"/>
+			<xs:enumeration value="DontUse"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SearchControlLocation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="None"/>
+			<xs:enumeration value="CommandBar"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SearchOnInput">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Use"/>
+			<xs:enumeration value="DontUse"/>
+			<xs:enumeration value="Auto"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SearchStringLocation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="None"/>
+			<xs:enumeration value="CommandBar"/>
+			<xs:enumeration value="Top"/>
+			<xs:enumeration value="Bottom"/>
+			<xs:enumeration value="FormCaption"/>
+			<xs:enumeration value="PullFromTop"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SearchStringModeOnInputByString">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Begin"/>
+			<xs:enumeration value="AnyPart"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SelectedRowsUse">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Use"/>
+			<xs:enumeration value="DontUse"/>
+			<xs:enumeration value="Auto"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SelectionShowMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="WhenActive"/>
+			<xs:enumeration value="Always"/>
+			<xs:enumeration value="DontShow"/>
+			<xs:enumeration value="WhenMultipleCellsSelected"/>
+			<xs:enumeration value="WhenMultipleCellsSelectedWhenActive"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SpecialTextInputMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="None"/>
+			<xs:enumeration value="DigitsAndPunctuation"/>
+			<xs:enumeration value="URL"/>
+			<xs:enumeration value="Email"/>
+			<xs:enumeration value="PhoneNumber"/>
+			<xs:enumeration value="Digits"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SpellCheckingOnTextInput">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Use"/>
+			<xs:enumeration value="DontUse"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SpreadSheetDocumentScrollBarUse">
+		<xs:union memberTypes="tns:TableScrollBarUse xs:boolean"/>
+	</xs:simpleType>
+	<xs:simpleType name="SpreadsheetDocumentMultipleSelectionPanelViewMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="DontShow"/>
+			<xs:enumeration value="ShowOnMultipleSelection"/>
+			<xs:enumeration value="ShowAlways"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TableBehaviorOnHorizontalCompression">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="HideItemsByImportance"/>
+			<xs:enumeration value="MoveItemsByImportance"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TableCellMarkType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="None"/>
+			<xs:enumeration value="ShapeUnderTextOval"/>
+			<xs:enumeration value="IconCircle"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TableColumnCheckBoxKind">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="CheckBox"/>
+			<xs:enumeration value="Tumbler"/>
+			<xs:enumeration value="Switcher"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TableCurrentRowUse">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Choice"/>
+			<xs:enumeration value="SelectionPresentation"/>
+			<xs:enumeration value="SelectionPresentationAndChoice"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TableFieldEditMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Directly"/>
+			<xs:enumeration value="Enter"/>
+			<xs:enumeration value="EnterOnInput"/>
+			<xs:enumeration value="Auto"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TableHeightControlVariant">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="UseHeightInFormRows"/>
+			<xs:enumeration value="UseHeightInTableRows"/>
+			<xs:enumeration value="UseContentHeight"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TableInitialListView">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Beginning"/>
+			<xs:enumeration value="End"/>
+			<xs:enumeration value="Auto"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TableInitialRowActivation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Activate"/>
+			<xs:enumeration value="NoActivate"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TableInitialTreeView">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="NoExpand"/>
+			<xs:enumeration value="ExpandTopLevel"/>
+			<xs:enumeration value="ExpandAllLevels"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TableRepresentation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="List"/>
+			<xs:enumeration value="HierarchicalList"/>
+			<xs:enumeration value="Tree"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TableRowActionsShowType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="DontShow"/>
+			<xs:enumeration value="ShowOnHover"/>
+			<xs:enumeration value="ShowAlways"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TableRowInputMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="EndOfList"/>
+			<xs:enumeration value="EndOfWindow"/>
+			<xs:enumeration value="AfterCurrentRow"/>
+			<xs:enumeration value="BeforeCurrentRow"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TableRowSelectionMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Cell"/>
+			<xs:enumeration value="Row"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TableScrollBarUse">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="DontUse"/>
+			<xs:enumeration value="UseAlways"/>
+			<xs:enumeration value="AutoUse"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TableSelectionMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="SingleRow"/>
+			<xs:enumeration value="MultiRow"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TextSize">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Enlarged"/>
+			<xs:enumeration value="Normal"/>
+			<xs:enumeration value="Reduced"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TooltipRepresentation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="None"/>
+			<xs:enumeration value="Balloon"/>
+			<xs:enumeration value="Button"/>
+			<xs:enumeration value="ShowAuto"/>
+			<xs:enumeration value="ShowTop"/>
+			<xs:enumeration value="ShowLeft"/>
+			<xs:enumeration value="ShowBottom"/>
+			<xs:enumeration value="ShowRight"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TumblerRepresentation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Text"/>
+			<xs:enumeration value="Picture"/>
+			<xs:enumeration value="Auto"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="UsedServer">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Standalone"/>
+			<xs:enumeration value="Main"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="UsualGroupBehavior">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Usual"/>
+			<xs:enumeration value="Collapsible"/>
+			<xs:enumeration value="PopUp"/>
+			<xs:enumeration value="Auto"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="UsualGroupControlRepresentation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="TitleHyperlink"/>
+			<xs:enumeration value="Picture"/>
+			<xs:enumeration value="Button"/>
+			<xs:enumeration value="ButtonInParentElement"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="UsualGroupRepresentation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="None"/>
+			<xs:enumeration value="StrongSeparation"/>
+			<xs:enumeration value="WeakSeparation"/>
+			<xs:enumeration value="NormalSeparation"/>
+			<xs:enumeration value="GroupBox"/>
+			<xs:enumeration value="Line"/>
+			<xs:enumeration value="Margin"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="UsualGroupThroughAlign">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Use"/>
+			<xs:enumeration value="DontUse"/>
+			<xs:enumeration value="Auto"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="VerticalAlign">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Top"/>
+			<xs:enumeration value="Bottom"/>
+			<xs:enumeration value="Center"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ViewScalingMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Normal"/>
+			<xs:enumeration value="Large"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ViewStatusLocation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="None"/>
+			<xs:enumeration value="Top"/>
+			<xs:enumeration value="Bottom"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="WarningOnEditRepresentation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Show"/>
+			<xs:enumeration value="DontShow"/>
+			<xs:enumeration value="Auto"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="WidthVariantInCard">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Full"/>
+			<xs:enumeration value="Half"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="AddProp">
+		<xs:sequence>
+			<xs:element name="id" type="xs:decimal"/>
+			<xs:element name="val"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="AddProps">
+		<xs:sequence>
+			<xs:element name="prop" type="tns:AddProp" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Addition">
+		<xs:choice>
+			<xs:element name="source" type="tns:AdditionSource"/>
+			<xs:element name="searchStringData" type="tns:SearchStringData" minOccurs="0"/>
+			<xs:element name="viewStatusData" type="tns:ViewStatusData" minOccurs="0"/>
+			<xs:element name="searchControlData" type="tns:SearchControlData" minOccurs="0"/>
+			<xs:element name="predefined" type="tns:Predefined" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="title" type="xs:string" minOccurs="0"/>
+			<xs:element name="tooltip" type="xs:string" minOccurs="0"/>
+			<xs:element name="event" type="tns:Event" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="group" type="tns:Group" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="button" type="tns:Button" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:choice>
+		<xs:attribute name="id" type="xs:decimal"/>
+		<xs:attribute name="name" type="xs:string"/>
+		<xs:attribute name="org" type="tns:FormElementOrigin"/>
+		<xs:attribute name="users" type="xs:boolean"/>
+		<xs:attribute name="kind" type="tns:LogFormElementAdditionKind"/>
+		<xs:attribute name="visible" type="xs:boolean"/>
+		<xs:attribute name="userVisible" type="xs:boolean"/>
+		<xs:attribute name="enabled" type="xs:boolean"/>
+		<xs:attribute name="plcm" type="tns:MenuElementPlacementArea"/>
+		<xs:attribute name="tooltipRepres" type="tns:TooltipRepresentation"/>
+		<xs:attribute name="groupHAlign" type="tns:ItemHorizontalAlignment"/>
+		<xs:attribute name="groupVAlign" type="tns:ItemVerticalAlignment"/>
+		<xs:attribute name="displayImportance" type="tns:DisplayImportance"/>
+	</xs:complexType>
+	<xs:complexType name="AdditionSource">
+		<xs:sequence>
+			<xs:element name="elementId" type="xs:decimal"/>
+			<xs:element name="additionId" type="xs:decimal"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="AutoMenuGroupData">
+		<xs:attribute name="hAlign" type="tns:ItemHorizontalAlignment"/>
+		<xs:attribute name="fillStd" type="xs:boolean"/>
+		<xs:attribute name="apMode" type="tns:FormCommandBarAppearanceMode"/>
+	</xs:complexType>
+	<xs:complexType name="Button">
+		<xs:sequence>
+			<xs:element name="command" type="ns1:CompositeID"/>
+			<xs:element name="commandParam"/>
+			<xs:element name="prop" type="tns:DataPath" minOccurs="0"/>
+			<xs:element name="propName" type="xs:string" minOccurs="0"/>
+			<xs:element name="tdp" type="ns1:TypeDescription" minOccurs="0"/>
+			<xs:element name="bkClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="txtClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="brdClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="fnt" type="ns2:Font" minOccurs="0"/>
+			<xs:element name="stcut" type="ns2:ShortCutType" minOccurs="0"/>
+			<xs:element name="pic" type="ns2:Picture" minOccurs="0"/>
+			<xs:element name="title" type="xs:string" minOccurs="0"/>
+			<xs:element name="ricm" type="tns:RepresentationInContextMenu" minOccurs="0"/>
+			<xs:element name="backPic" type="ns2:Picture" minOccurs="0"/>
+			<xs:element name="predefined" type="tns:Predefined" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="id" type="xs:decimal"/>
+		<xs:attribute name="name" type="xs:string"/>
+		<xs:attribute name="org" type="tns:FormElementOrigin"/>
+		<xs:attribute name="kind" type="tns:ManagedFormButtonType"/>
+		<xs:attribute name="visible" type="xs:boolean"/>
+		<xs:attribute name="userVisible" type="xs:boolean"/>
+		<xs:attribute name="titleRowsCount" type="xs:decimal"/>
+		<xs:attribute name="repres" type="tns:ButtonRepresentation"/>
+		<xs:attribute name="defButton" type="xs:boolean"/>
+		<xs:attribute name="skipOnInput" type="tns:BWAValue"/>
+		<xs:attribute name="enabled" type="xs:boolean"/>
+		<xs:attribute name="defItem" type="xs:boolean"/>
+		<xs:attribute name="important" type="tns:BWAValue"/>
+		<xs:attribute name="width" type="xs:decimal"/>
+		<xs:attribute name="height" type="xs:decimal"/>
+		<xs:attribute name="horStretch" type="xs:boolean"/>
+		<xs:attribute name="verStretch" type="xs:boolean"/>
+		<xs:attribute name="autoMaxWidth" type="xs:boolean"/>
+		<xs:attribute name="maxWidth" type="xs:decimal"/>
+		<xs:attribute name="minWidth" type="xs:decimal"/>
+		<xs:attribute name="autoMaxHeight" type="xs:boolean"/>
+		<xs:attribute name="maxHeight" type="xs:decimal"/>
+		<xs:attribute name="plcm" type="tns:MenuElementPlacementArea"/>
+		<xs:attribute name="check" type="xs:boolean"/>
+		<xs:attribute name="tooltipRepres" type="tns:TooltipRepresentation"/>
+		<xs:attribute name="groupHAlign" type="tns:ItemHorizontalAlignment"/>
+		<xs:attribute name="groupVAlign" type="tns:ItemVerticalAlignment"/>
+		<xs:attribute name="shape" type="tns:ButtonShape"/>
+		<xs:attribute name="shapeRepres" type="tns:ButtonShapeRepresentation"/>
+		<xs:attribute name="picLocation" type="tns:FormButtonPictureLocation"/>
+		<xs:attribute name="displayImportance" type="tns:DisplayImportance"/>
+		<xs:attribute name="locationInCommandBar" type="tns:ButtonLocationInCommandBar"/>
+		<xs:attribute name="commandUniqueness" type="xs:boolean"/>
+		<xs:attribute name="MSIB" type="tns:OnMainServerUnavalableBehavior"/>
+		<xs:attribute name="showAsCard" type="xs:boolean"/>
+		<xs:attribute name="backPictRepresEffect" type="tns:PictureRepresentationEffect"/>
+		<xs:attribute name="cardPictureAndTitleAlign" type="tns:CardPictureAndTitleAlignVariant"/>
+		<xs:attribute name="pictureHeight" type="xs:decimal"/>
+		<xs:attribute name="buttonImportance" type="tns:ButtonImportance"/>
+	</xs:complexType>
+	<xs:complexType name="ButtonsGroupData">
+		<xs:sequence>
+			<xs:element name="cmdGroups" type="ns1:CompositeID"/>
+			<xs:element name="repres" type="tns:ButtonGroupRepresentation"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CalendarFieldData">
+		<xs:sequence>
+			<xs:element name="fnt" type="ns2:Font" minOccurs="0"/>
+			<xs:element name="brdClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="brd" type="ns2:Border" minOccurs="0"/>
+			<xs:element name="event" type="tns:Event" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="width" type="xs:decimal"/>
+		<xs:attribute name="height" type="xs:decimal"/>
+		<xs:attribute name="horStretch" type="xs:boolean"/>
+		<xs:attribute name="verStretch" type="xs:boolean"/>
+		<xs:attribute name="autoMaxWidth" type="xs:boolean"/>
+		<xs:attribute name="maxWidth" type="xs:decimal"/>
+		<xs:attribute name="minWidth" type="xs:decimal"/>
+		<xs:attribute name="autoMaxHeight" type="xs:boolean"/>
+		<xs:attribute name="maxHeight" type="xs:decimal"/>
+		<xs:attribute name="dateSel" type="tns:FormDateSelectionMode"/>
+		<xs:attribute name="showCurDate" type="xs:boolean"/>
+		<xs:attribute name="navigation" type="xs:boolean"/>
+		<xs:attribute name="begPeriod" type="xs:dateTime"/>
+		<xs:attribute name="endPeriod" type="xs:dateTime"/>
+		<xs:attribute name="startDrag" type="xs:boolean"/>
+		<xs:attribute name="drag" type="xs:boolean"/>
+		<xs:attribute name="monthPanelVisible" type="xs:boolean"/>
+		<xs:attribute name="widthInMonths" type="xs:decimal"/>
+		<xs:attribute name="heightInMonths" type="xs:decimal"/>
+		<xs:attribute name="clearEvents" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="ChartFieldData">
+		<xs:sequence>
+			<xs:element name="event" type="tns:Event" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="width" type="xs:decimal"/>
+		<xs:attribute name="height" type="xs:decimal"/>
+		<xs:attribute name="horStretch" type="xs:boolean"/>
+		<xs:attribute name="verStretch" type="xs:boolean"/>
+		<xs:attribute name="autoMaxWidth" type="xs:boolean"/>
+		<xs:attribute name="maxWidth" type="xs:decimal"/>
+		<xs:attribute name="minWidth" type="xs:decimal"/>
+		<xs:attribute name="autoMaxHeight" type="xs:boolean"/>
+		<xs:attribute name="maxHeight" type="xs:decimal"/>
+		<xs:attribute name="clearEvents" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="CheckBoxFieldData">
+		<xs:sequence>
+			<xs:element name="brdClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="bkClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="txtClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="fnt" type="ns2:Font" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="checkBoxType" type="tns:CheckBoxType"/>
+		<xs:attribute name="threeState" type="xs:boolean"/>
+		<xs:attribute name="format" type="xs:string"/>
+		<xs:attribute name="tbRepres" type="tns:TumblerRepresentation"/>
+		<xs:attribute name="horStretch" type="tns:BWAValue"/>
+		<xs:attribute name="elemTitleHeight" type="xs:decimal"/>
+		<xs:attribute name="elemHeight" type="xs:decimal"/>
+		<xs:attribute name="elemWidth" type="xs:decimal"/>
+		<xs:attribute name="eqWidth" type="tns:BWAValue"/>
+	</xs:complexType>
+	<xs:complexType name="ColumnsGroupData">
+		<xs:sequence>
+			<xs:element name="headerPic" type="ns2:Picture" minOccurs="0"/>
+			<xs:element name="titleBkClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="hdProp" type="tns:DataPath" minOccurs="0"/>
+			<xs:element name="hdPropName" type="xs:string" minOccurs="0"/>
+			<xs:element name="hdTdp" type="ns1:TypeDescription" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="grouping" type="tns:ColumnsGroup"/>
+		<xs:attribute name="showTitle" type="tns:BWAValue"/>
+		<xs:attribute name="showInHeader" type="xs:boolean"/>
+		<xs:attribute name="headerHAlign" type="tns:ItemHorizontalAlignment"/>
+		<xs:attribute name="headerFormat" type="xs:string"/>
+		<xs:attribute name="fixedInTable" type="tns:FormFixedInTable"/>
+		<xs:attribute name="showInCard" type="xs:boolean"/>
+		<xs:attribute name="fixInCard" type="tns:BWAValue"/>
+		<xs:attribute name="showTitleInCard" type="tns:BWAValue"/>
+	</xs:complexType>
+	<xs:complexType name="Command">
+		<xs:sequence>
+			<xs:element name="handlers" type="tns:EventHandlers" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="id" type="ns1:CompositeID"/>
+		<xs:attribute name="name" type="xs:string"/>
+		<xs:attribute name="modifiesData" type="xs:boolean"/>
+		<xs:attribute name="currentRowUse" type="tns:CurrentRowUse"/>
+		<xs:attribute name="associatedTableElementId" type="xs:decimal"/>
+		<xs:attribute name="actionPurpose" type="tns:CommandActionPurpose"/>
+		<xs:attribute name="selectedRowsUse" type="tns:SelectedRowsUse"/>
+	</xs:complexType>
+	<xs:complexType name="CommandsInclusion">
+		<xs:sequence>
+			<xs:element name="uuid" type="ns1:UUID" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ContextMenuGroupData">
+		<xs:attribute name="fillStd" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="DataPath">
+		<xs:sequence>
+			<xs:element name="id" type="ns1:CompositeID" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Decoration">
+		<xs:choice>
+			<xs:element name="txtClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="fnt" type="ns2:Font" minOccurs="0"/>
+			<xs:element name="stcut" type="ns2:ShortCutType" minOccurs="0"/>
+			<xs:element name="textData" type="tns:TextDecorationData" minOccurs="0"/>
+			<xs:element name="pictureData" type="tns:PictureDecorationData" minOccurs="0"/>
+			<xs:element name="predefined" type="tns:Predefined" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="title" type="tns:FormattedString" minOccurs="0"/>
+			<xs:element name="tooltip" type="xs:string" minOccurs="0"/>
+		</xs:choice>
+		<xs:attribute name="id" type="xs:decimal"/>
+		<xs:attribute name="name" type="xs:string"/>
+		<xs:attribute name="org" type="tns:FormElementOrigin"/>
+		<xs:attribute name="users" type="xs:boolean"/>
+		<xs:attribute name="kind" type="tns:ManagedFormDecorationType"/>
+		<xs:attribute name="visible" type="xs:boolean"/>
+		<xs:attribute name="userVisible" type="xs:boolean"/>
+		<xs:attribute name="enabled" type="xs:boolean"/>
+		<xs:attribute name="width" type="xs:decimal"/>
+		<xs:attribute name="height" type="xs:decimal"/>
+		<xs:attribute name="horStretch" type="tns:BWAValue"/>
+		<xs:attribute name="verStretch" type="tns:BWAValue"/>
+		<xs:attribute name="autoMaxWidth" type="xs:boolean"/>
+		<xs:attribute name="maxWidth" type="xs:decimal"/>
+		<xs:attribute name="minWidth" type="xs:decimal"/>
+		<xs:attribute name="autoMaxHeight" type="xs:boolean"/>
+		<xs:attribute name="maxHeight" type="xs:decimal"/>
+		<xs:attribute name="skipOnInput" type="tns:BWAValue"/>
+		<xs:attribute name="tooltipRepres" type="tns:TooltipRepresentation"/>
+		<xs:attribute name="groupHAlign" type="tns:ItemHorizontalAlignment"/>
+		<xs:attribute name="groupVAlign" type="tns:ItemVerticalAlignment"/>
+		<xs:attribute name="displayImportance" type="tns:DisplayImportance"/>
+		<xs:attribute name="MSIB" type="tns:OnMainServerUnavalableBehavior"/>
+	</xs:complexType>
+	<xs:complexType name="DendrogramFieldData">
+		<xs:sequence>
+			<xs:element name="event" type="tns:Event" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="width" type="xs:decimal"/>
+		<xs:attribute name="height" type="xs:decimal"/>
+		<xs:attribute name="horStretch" type="xs:boolean"/>
+		<xs:attribute name="verStretch" type="xs:boolean"/>
+		<xs:attribute name="autoMaxWidth" type="xs:boolean"/>
+		<xs:attribute name="maxWidth" type="xs:decimal"/>
+		<xs:attribute name="minWidth" type="xs:decimal"/>
+		<xs:attribute name="autoMaxHeight" type="xs:boolean"/>
+		<xs:attribute name="maxHeight" type="xs:decimal"/>
+		<xs:attribute name="clearEvents" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="ElementsChanges">
+		<xs:sequence>
+			<xs:element name="elemcs" type="tns:ElementsChangesItem" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ElementsChangesItem">
+		<xs:choice>
+			<xs:element name="guid" type="ns1:UUID"/>
+			<xs:element name="main" type="tns:MainElement" minOccurs="0"/>
+			<xs:element name="field" type="tns:Field" minOccurs="0"/>
+			<xs:element name="group" type="tns:Group" minOccurs="0"/>
+			<xs:element name="table" type="tns:Table" minOccurs="0"/>
+			<xs:element name="button" type="tns:Button" minOccurs="0"/>
+			<xs:element name="decoration" type="tns:Decoration" minOccurs="0"/>
+			<xs:element name="addition" type="tns:Addition" minOccurs="0"/>
+		</xs:choice>
+		<xs:attribute name="type" type="xs:decimal"/>
+		<xs:attribute name="id" type="xs:decimal"/>
+		<xs:attribute name="name" type="xs:string"/>
+		<xs:attribute name="pid" type="xs:decimal"/>
+		<xs:attribute name="aid" type="xs:decimal"/>
+	</xs:complexType>
+	<xs:complexType name="Event">
+		<xs:sequence>
+			<xs:element name="handlers" type="tns:EventHandlers" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="id" type="ns1:UUID"/>
+	</xs:complexType>
+	<xs:complexType name="EventHandler">
+		<xs:attribute name="handlerName" type="xs:string"/>
+		<xs:attribute name="callType" type="tns:EventHandlerCallType"/>
+	</xs:complexType>
+	<xs:complexType name="EventHandlers">
+		<xs:sequence>
+			<xs:element name="handler" type="tns:EventHandler" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Field">
+		<xs:choice>
+			<xs:element name="textData" type="tns:TextFieldData" minOccurs="0"/>
+			<xs:element name="inputData" type="tns:InputFieldData" minOccurs="0"/>
+			<xs:element name="checkData" type="tns:CheckBoxFieldData" minOccurs="0"/>
+			<xs:element name="imageData" type="tns:ImageFieldData" minOccurs="0"/>
+			<xs:element name="radioData" type="tns:RadioButtonsData" minOccurs="0"/>
+			<xs:element name="spereadsheetData" type="tns:SpreadsheetFieldData" minOccurs="0"/>
+			<xs:element name="textDocData" type="tns:TextDocFieldData" minOccurs="0"/>
+			<xs:element name="formattedDocData" type="tns:FormattedDocFieldData" minOccurs="0"/>
+			<xs:element name="plannerData" type="tns:PlannerFieldData" minOccurs="0"/>
+			<xs:element name="calendarData" type="tns:CalendarFieldData" minOccurs="0"/>
+			<xs:element name="periodData" type="tns:PeriodFieldData" minOccurs="0"/>
+			<xs:element name="progressBarData" type="tns:ProgressBarFieldData" minOccurs="0"/>
+			<xs:element name="trackBarData" type="tns:TrackBarFieldData" minOccurs="0"/>
+			<xs:element name="chartData" type="tns:ChartFieldData" minOccurs="0"/>
+			<xs:element name="ganttChartData" type="tns:GanttChartFieldData" minOccurs="0"/>
+			<xs:element name="dendrogramData" type="tns:DendrogramFieldData" minOccurs="0"/>
+			<xs:element name="flowchartData" type="tns:FlowchartFieldData" minOccurs="0"/>
+			<xs:element name="htmlData" type="tns:HTMLFieldData" minOccurs="0"/>
+			<xs:element name="geographicalMapData" type="tns:GeographicalMapFieldData" minOccurs="0"/>
+			<xs:element name="pdfDocumentData" type="tns:PDFDocumentFieldData" minOccurs="0"/>
+			<xs:element name="prop" type="tns:DataPath" minOccurs="0"/>
+			<xs:element name="propName" type="xs:string" minOccurs="0"/>
+			<xs:element name="tdp" type="ns1:TypeDescription" minOccurs="0"/>
+			<xs:element name="ftProp" type="tns:DataPath" minOccurs="0"/>
+			<xs:element name="ftPropName" type="xs:string" minOccurs="0"/>
+			<xs:element name="ftTdp" type="ns1:TypeDescription" minOccurs="0"/>
+			<xs:element name="headerPic" type="ns2:Picture" minOccurs="0"/>
+			<xs:element name="footerPic" type="ns2:Picture" minOccurs="0"/>
+			<xs:element name="titleTxtClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="titleFnt" type="ns2:Font" minOccurs="0"/>
+			<xs:element name="titleBkClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="ftrTxtClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="ftrBkClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="ftrFnt" type="ns2:Font" minOccurs="0"/>
+			<xs:element name="stcut" type="ns2:ShortCutType" minOccurs="0"/>
+			<xs:element name="event" type="tns:Event" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="commands" type="tns:CommandsInclusion"/>
+			<xs:element name="predefined" type="tns:Predefined" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="title" type="xs:string" minOccurs="0"/>
+			<xs:element name="tooltip" type="xs:string" minOccurs="0"/>
+		</xs:choice>
+		<xs:attribute name="id" type="xs:decimal"/>
+		<xs:attribute name="name" type="xs:string"/>
+		<xs:attribute name="org" type="tns:FormElementOrigin"/>
+		<xs:attribute name="users" type="xs:boolean"/>
+		<xs:attribute name="kind" type="tns:ManagedFormFieldType"/>
+		<xs:attribute name="visible" type="xs:boolean"/>
+		<xs:attribute name="userVisible" type="xs:boolean"/>
+		<xs:attribute name="titleLocation" type="tns:FormElementTitleLocation"/>
+		<xs:attribute name="titleRowsCount" type="xs:decimal"/>
+		<xs:attribute name="enabled" type="xs:boolean"/>
+		<xs:attribute name="cellHyper" type="xs:boolean"/>
+		<xs:attribute name="readOnly" type="xs:boolean"/>
+		<xs:attribute name="skipOnInput" type="tns:BWAValue"/>
+		<xs:attribute name="defItem" type="xs:boolean"/>
+		<xs:attribute name="warningOnEditRepresentation" type="tns:WarningOnEditRepresentation"/>
+		<xs:attribute name="warningOnEdit" type="xs:string"/>
+		<xs:attribute name="footerText" type="xs:string"/>
+		<xs:attribute name="showInHeader" type="xs:boolean"/>
+		<xs:attribute name="showInFooter" type="xs:boolean"/>
+		<xs:attribute name="hAlign" type="tns:ItemHorizontalAlignment"/>
+		<xs:attribute name="headerHAlign" type="tns:ItemHorizontalAlignment"/>
+		<xs:attribute name="footerHAlign" type="tns:ItemHorizontalAlignment"/>
+		<xs:attribute name="vAlign" type="tns:ItemVerticalAlignment"/>
+		<xs:attribute name="groupHAlign" type="tns:ItemHorizontalAlignment"/>
+		<xs:attribute name="groupVAlign" type="tns:ItemVerticalAlignment"/>
+		<xs:attribute name="displayImportance" type="tns:DisplayImportance"/>
+		<xs:attribute name="columnEditMode" type="tns:TableFieldEditMode"/>
+		<xs:attribute name="autoCellHeight" type="xs:boolean"/>
+		<xs:attribute name="fixedInTable" type="tns:FormFixedInTable"/>
+		<xs:attribute name="tooltipRepres" type="tns:TooltipRepresentation"/>
+		<xs:attribute name="clearEvents" type="xs:boolean"/>
+		<xs:attribute name="MSIB" type="tns:OnMainServerUnavalableBehavior"/>
+		<xs:attribute name="markRequiredComplete" type="tns:BWAValue"/>
+		<xs:attribute name="cellMark" type="tns:TableCellMarkType"/>
+		<xs:attribute name="autoEditMode" type="xs:boolean"/>
+		<xs:attribute name="checkBoxKind" type="tns:TableColumnCheckBoxKind"/>
+		<xs:attribute name="multilineSelect" type="xs:boolean"/>
+		<xs:attribute name="appearanceInCard" type="tns:AppearanceVariantInCard"/>
+		<xs:attribute name="showTitleInCard" type="tns:BWAValue"/>
+		<xs:attribute name="widthInCard" type="tns:WidthVariantInCard"/>
+		<xs:attribute name="showInCard" type="xs:boolean"/>
+		<xs:attribute name="fixInCard" type="tns:BWAValue"/>
+		<xs:attribute name="autoWidthInTable" type="tns:AutoWidthInTable"/>
+		<xs:attribute name="cellHyperlinkRepresentation" type="tns:CellHyperlinkRepresentation"/>
+		<xs:attribute name="cellHyperlinkDisplayVariant" type="tns:CellHyperlinkDisplayVariant"/>
+	</xs:complexType>
+	<xs:complexType name="FlowchartFieldData">
+		<xs:sequence>
+			<xs:element name="brdClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="event" type="tns:Event" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="width" type="xs:decimal"/>
+		<xs:attribute name="height" type="xs:decimal"/>
+		<xs:attribute name="horStretch" type="xs:boolean"/>
+		<xs:attribute name="verStretch" type="xs:boolean"/>
+		<xs:attribute name="autoMaxWidth" type="xs:boolean"/>
+		<xs:attribute name="maxWidth" type="xs:decimal"/>
+		<xs:attribute name="minWidth" type="xs:decimal"/>
+		<xs:attribute name="autoMaxHeight" type="xs:boolean"/>
+		<xs:attribute name="maxHeight" type="xs:decimal"/>
+		<xs:attribute name="useOutput" type="ns2:UseOutput"/>
+		<xs:attribute name="edit" type="xs:boolean"/>
+		<xs:attribute name="clearEvents" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="Form">
+		<xs:sequence>
+			<xs:element name="elements" type="tns:MainElement"/>
+			<xs:element name="command" type="tns:Command" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="property" type="tns:Property" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="FormattedDocFieldData">
+		<xs:sequence>
+			<xs:element name="txtClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="bkClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="brdClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="fnt" type="ns2:Font" minOccurs="0"/>
+			<xs:element name="event" type="tns:Event" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="width" type="xs:decimal"/>
+		<xs:attribute name="height" type="xs:decimal"/>
+		<xs:attribute name="horStretch" type="xs:boolean"/>
+		<xs:attribute name="verStretch" type="xs:boolean"/>
+		<xs:attribute name="autoMaxWidth" type="xs:boolean"/>
+		<xs:attribute name="maxWidth" type="xs:decimal"/>
+		<xs:attribute name="minWidth" type="xs:decimal"/>
+		<xs:attribute name="autoMaxHeight" type="xs:boolean"/>
+		<xs:attribute name="maxHeight" type="xs:decimal"/>
+		<xs:attribute name="useOutput" type="ns2:UseOutput"/>
+	</xs:complexType>
+	<xs:complexType name="FormattedString">
+		<xs:sequence>
+			<xs:element name="str" type="xs:string"/>
+			<xs:element name="formatted" type="xs:boolean"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="GanttChartFieldData">
+		<xs:sequence>
+			<xs:element name="event" type="tns:Event" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="width" type="xs:decimal"/>
+		<xs:attribute name="height" type="xs:decimal"/>
+		<xs:attribute name="horStretch" type="xs:boolean"/>
+		<xs:attribute name="verStretch" type="xs:boolean"/>
+		<xs:attribute name="autoMaxWidth" type="xs:boolean"/>
+		<xs:attribute name="maxWidth" type="xs:decimal"/>
+		<xs:attribute name="minWidth" type="xs:decimal"/>
+		<xs:attribute name="autoMaxHeight" type="xs:boolean"/>
+		<xs:attribute name="maxHeight" type="xs:decimal"/>
+		<xs:attribute name="clearEvents" type="xs:boolean"/>
+		<xs:attribute name="tableLocation" type="tns:GanttChartTableLocation"/>
+		<xs:attribute name="valuesSelectionMode" type="tns:GanttChartValuesSelectionMode"/>
+		<xs:attribute name="intervalsSelectionMode" type="tns:GanttChartIntervalsSelectionMode"/>
+		<xs:attribute name="showHorizontalLinesFlag" type="tns:BWAValue"/>
+		<xs:attribute name="showVerticalLinesFlag" type="tns:BWAValue"/>
+	</xs:complexType>
+	<xs:complexType name="GeographicalMapFieldData">
+		<xs:sequence>
+			<xs:element name="brdClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="event" type="tns:Event" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="width" type="xs:decimal"/>
+		<xs:attribute name="height" type="xs:decimal"/>
+		<xs:attribute name="horStretch" type="xs:boolean"/>
+		<xs:attribute name="verStretch" type="xs:boolean"/>
+		<xs:attribute name="autoMaxWidth" type="xs:boolean"/>
+		<xs:attribute name="maxWidth" type="xs:decimal"/>
+		<xs:attribute name="minWidth" type="xs:decimal"/>
+		<xs:attribute name="autoMaxHeight" type="xs:boolean"/>
+		<xs:attribute name="maxHeight" type="xs:decimal"/>
+		<xs:attribute name="useOutput" type="ns2:UseOutput"/>
+		<xs:attribute name="clearEvents" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="Group">
+		<xs:choice>
+			<xs:element name="titleTxtClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="titleFnt" type="ns2:Font" minOccurs="0"/>
+			<xs:element name="stcut" type="ns2:ShortCutType" minOccurs="0"/>
+			<xs:element name="menuData" type="tns:MenuGroupData" minOccurs="0"/>
+			<xs:element name="autoMenuData" type="tns:AutoMenuGroupData" minOccurs="0"/>
+			<xs:element name="subMenuData" type="tns:SubmenuGroupData" minOccurs="0"/>
+			<xs:element name="buttonsData" type="tns:ButtonsGroupData" minOccurs="0"/>
+			<xs:element name="contextMenuData" type="tns:ContextMenuGroupData" minOccurs="0"/>
+			<xs:element name="columnsData" type="tns:ColumnsGroupData" minOccurs="0"/>
+			<xs:element name="pagesData" type="tns:PagesGroupData" minOccurs="0"/>
+			<xs:element name="pageData" type="tns:PageGroupData" minOccurs="0"/>
+			<xs:element name="usualData" type="tns:UsualGroupData" minOccurs="0"/>
+			<xs:element name="siapData" type="tns:SelectedItemsActionsPanelGroupData" minOccurs="0"/>
+			<xs:element name="racbData" type="tns:RowActionsCommandBarGroupData" minOccurs="0"/>
+			<xs:element name="field" type="tns:Field" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="group" type="tns:Group" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="table" type="tns:Table" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="button" type="tns:Button" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="decoration" type="tns:Decoration" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="addition" type="tns:Addition" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="title" type="xs:string" minOccurs="0"/>
+			<xs:element name="tooltip" type="xs:string" minOccurs="0"/>
+			<xs:element name="predefined" type="tns:Predefined" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:choice>
+		<xs:attribute name="id" type="xs:decimal"/>
+		<xs:attribute name="name" type="xs:string"/>
+		<xs:attribute name="org" type="tns:FormElementOrigin"/>
+		<xs:attribute name="users" type="xs:boolean"/>
+		<xs:attribute name="kind" type="tns:ManagedFormGroupType"/>
+		<xs:attribute name="visible" type="xs:boolean"/>
+		<xs:attribute name="userVisible" type="xs:boolean"/>
+		<xs:attribute name="contentChange" type="xs:boolean"/>
+		<xs:attribute name="enabled" type="xs:boolean"/>
+		<xs:attribute name="readOnly" type="xs:boolean"/>
+		<xs:attribute name="width" type="xs:decimal"/>
+		<xs:attribute name="height" type="xs:decimal"/>
+		<xs:attribute name="horStretch" type="tns:BWAValue"/>
+		<xs:attribute name="verStretch" type="tns:BWAValue"/>
+		<xs:attribute name="tooltipRepres" type="tns:TooltipRepresentation"/>
+		<xs:attribute name="groupHAlign" type="tns:ItemHorizontalAlignment"/>
+		<xs:attribute name="groupVAlign" type="tns:ItemVerticalAlignment"/>
+		<xs:attribute name="degeneratable" type="xs:boolean"/>
+		<xs:attribute name="displayImportance" type="tns:DisplayImportance"/>
+	</xs:complexType>
+	<xs:complexType name="HTMLFieldData">
+		<xs:sequence>
+			<xs:element name="brdClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="brd" type="ns2:Border" minOccurs="0"/>
+			<xs:element name="event" type="tns:Event" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="width" type="xs:decimal"/>
+		<xs:attribute name="height" type="xs:decimal"/>
+		<xs:attribute name="horStretch" type="xs:boolean"/>
+		<xs:attribute name="verStretch" type="xs:boolean"/>
+		<xs:attribute name="autoMaxWidth" type="xs:boolean"/>
+		<xs:attribute name="maxWidth" type="xs:decimal"/>
+		<xs:attribute name="minWidth" type="xs:decimal"/>
+		<xs:attribute name="autoMaxHeight" type="xs:boolean"/>
+		<xs:attribute name="maxHeight" type="xs:decimal"/>
+		<xs:attribute name="useOutput" type="ns2:UseOutput"/>
+		<xs:attribute name="clearEvents" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="HierarchyPanelMenuGroupData">
+		<xs:attribute name="fillStdCommands" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="ImageFieldData">
+		<xs:sequence>
+			<xs:element name="picValues" type="ns2:Picture" minOccurs="0"/>
+			<xs:element name="txtClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="brdClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="fnt" type="ns2:Font" minOccurs="0"/>
+			<xs:element name="brd" type="ns2:Border" minOccurs="0"/>
+			<xs:element name="backgroundShowMode" type="tns:PictureBackgroundShowMode" minOccurs="0"/>
+			<xs:element name="picClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="event" type="tns:Event" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="width" type="xs:decimal"/>
+		<xs:attribute name="height" type="xs:decimal"/>
+		<xs:attribute name="horStretch" type="xs:boolean"/>
+		<xs:attribute name="verStretch" type="xs:boolean"/>
+		<xs:attribute name="autoMaxWidth" type="xs:boolean"/>
+		<xs:attribute name="maxWidth" type="xs:decimal"/>
+		<xs:attribute name="minWidth" type="xs:decimal"/>
+		<xs:attribute name="autoMaxHeight" type="xs:boolean"/>
+		<xs:attribute name="maxHeight" type="xs:decimal"/>
+		<xs:attribute name="pictureSize" type="tns:PictureSize"/>
+		<xs:attribute name="zoomable" type="xs:boolean"/>
+		<xs:attribute name="imageScale" type="xs:decimal"/>
+		<xs:attribute name="hyper" type="xs:boolean"/>
+		<xs:attribute name="picText" type="xs:string"/>
+		<xs:attribute name="startDrag" type="xs:boolean"/>
+		<xs:attribute name="drag" type="xs:boolean"/>
+		<xs:attribute name="clearEvents" type="xs:boolean"/>
+		<xs:attribute name="fileDragMode" type="tns:FileDragMode"/>
+	</xs:complexType>
+	<xs:complexType name="InputFieldData">
+		<xs:sequence>
+			<xs:element name="event" type="tns:Event" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="minVal"/>
+			<xs:element name="maxVal"/>
+			<xs:element name="choiceBtnPic" type="ns2:Picture" minOccurs="0"/>
+			<xs:element name="choiceFormId" type="ns1:UUID"/>
+			<xs:element name="choiceParamLinks" type="ns3:ChoiceParameterLinks" minOccurs="0"/>
+			<xs:element name="choiceParams" type="ns3:ChoiceParameters" minOccurs="0"/>
+			<xs:element name="avlTypes" type="ns1:TypeDescription" minOccurs="0"/>
+			<xs:element name="valList" type="ns1:ValueListType"/>
+			<xs:element name="txtClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="bkClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="brdClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="fnt" type="ns2:Font" minOccurs="0"/>
+			<xs:element name="linkByType" type="ns3:TypeLink" minOccurs="0"/>
+			<xs:element name="multipleValuesFont" type="ns2:Font" minOccurs="0"/>
+			<xs:element name="multipleValuesPicture" type="ns2:Picture" minOccurs="0"/>
+			<xs:element name="multipleValueDataPath" type="tns:DataPath" minOccurs="0"/>
+			<xs:element name="multipleValueDataPathName" type="xs:string" minOccurs="0"/>
+			<xs:element name="multipleValuePictureDataPath" type="tns:DataPath" minOccurs="0"/>
+			<xs:element name="multipleValuePictureDataPathName" type="xs:string" minOccurs="0"/>
+			<xs:element name="multipleValuePresentDataPath" type="tns:DataPath" minOccurs="0"/>
+			<xs:element name="multipleValuePresentDataPathName" type="xs:string" minOccurs="0"/>
+			<xs:element name="pict" type="ns2:Picture" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="width" type="xs:decimal"/>
+		<xs:attribute name="rowsCount" type="xs:decimal"/>
+		<xs:attribute name="horStretch" type="tns:BWAValue"/>
+		<xs:attribute name="verStretch" type="tns:BWAValue"/>
+		<xs:attribute name="autoMaxWidth" type="xs:boolean"/>
+		<xs:attribute name="maxWidth" type="xs:decimal"/>
+		<xs:attribute name="minWidth" type="xs:decimal"/>
+		<xs:attribute name="autoMaxHeight" type="xs:boolean"/>
+		<xs:attribute name="maxHeight" type="xs:decimal"/>
+		<xs:attribute name="wrap" type="xs:boolean"/>
+		<xs:attribute name="psw" type="tns:BWAValue"/>
+		<xs:attribute name="mlt" type="tns:BWAValue"/>
+		<xs:attribute name="extEdit" type="tns:BWAValue"/>
+		<xs:attribute name="markNeg" type="tns:BWAValue"/>
+		<xs:attribute name="choiceListBtn" type="tns:BWAValue"/>
+		<xs:attribute name="dropListBtn" type="tns:BWAValue"/>
+		<xs:attribute name="choiceBtn" type="tns:BWAValue"/>
+		<xs:attribute name="choiceBtnRepresentation" type="tns:ChoiceButtonRepresentation"/>
+		<xs:attribute name="clearBtn" type="tns:BWAValue"/>
+		<xs:attribute name="spinBtn" type="tns:BWAValue"/>
+		<xs:attribute name="openBtn" type="tns:BWAValue"/>
+		<xs:attribute name="createBtn" type="tns:BWAValue"/>
+		<xs:attribute name="mask" type="xs:string"/>
+		<xs:attribute name="listChoice" type="xs:boolean"/>
+		<xs:attribute name="choiceListHeight" type="xs:decimal"/>
+		<xs:attribute name="choiceListMinWidth" type="xs:decimal"/>
+		<xs:attribute name="multipleValuesTextColor" type="ns2:Color"/>
+		<xs:attribute name="multipleValuesBackColor" type="ns2:Color"/>
+		<xs:attribute name="multipleValuesHyperlink" type="tns:BWAValue"/>
+		<xs:attribute name="allowInputEmptyMultipleValues" type="xs:boolean"/>
+		<xs:attribute name="allowMultipleValuesDuplicates" type="xs:boolean"/>
+		<xs:attribute name="extendedEditMultipleValues" type="xs:boolean"/>
+		<xs:attribute name="showCheckBoxesInDropList" type="tns:BWAValue"/>
+		<xs:attribute name="autoChoice" type="tns:BWAValue"/>
+		<xs:attribute name="quickChoice" type="tns:BWAValue"/>
+		<xs:attribute name="choice" type="tns:FoldersAndItems"/>
+		<xs:attribute name="format" type="xs:string"/>
+		<xs:attribute name="inputFormat" type="xs:string"/>
+		<xs:attribute name="autoMark" type="tns:BWAValue"/>
+		<xs:attribute name="choiceType" type="xs:boolean"/>
+		<xs:attribute name="incompleteChoice" type="tns:IncompleteItemChoiceMode"/>
+		<xs:attribute name="typeDomainEnabled" type="xs:boolean"/>
+		<xs:attribute name="textEdit" type="xs:boolean"/>
+		<xs:attribute name="editTextUpdateMode" type="tns:EditTextUpdate"/>
+		<xs:attribute name="inputHint" type="xs:string"/>
+		<xs:attribute name="dropListTooltip" type="xs:string"/>
+		<xs:attribute name="choiceButtonTitle" type="xs:string"/>
+		<xs:attribute name="timeChoiceMode" type="tns:FormTimeChoiceMode"/>
+		<xs:attribute name="textSize" type="tns:TextSize"/>
+		<xs:attribute name="clearEvents" type="xs:boolean"/>
+		<xs:attribute name="choiceHistory" type="tns:ChoiceHistoryOnInput"/>
+		<xs:attribute name="autoShowClearButtonMode" type="tns:AutoShowClearButtonMode"/>
+		<xs:attribute name="autoShowOpenButtonMode" type="tns:AutoShowOpenButtonMode"/>
+		<xs:attribute name="autoCorrectionOnTextInput" type="tns:AutoCorrectionOnTextInput"/>
+		<xs:attribute name="spellCheckingOnTextInput" type="tns:SpellCheckingOnTextInput"/>
+		<xs:attribute name="autoCapitalizationOnTextInput" type="tns:AutoCapitalizationOnTextInput"/>
+		<xs:attribute name="autofillHint" type="tns:AutofillHint"/>
+		<xs:attribute name="specialTextInputMode" type="tns:SpecialTextInputMode"/>
+		<xs:attribute name="onScreenKeyboardReturnKeyText" type="tns:OnScreenKeyboardReturnKeyText"/>
+		<xs:attribute name="heightControlVariant" type="tns:HeightControlVariant"/>
+		<xs:attribute name="multipleValuePictureSize" type="tns:InputFieldMultipleValuePictureSize"/>
+		<xs:attribute name="multipleValuePictureShape" type="tns:InputFieldMultipleValuePictureShape"/>
+	</xs:complexType>
+	<xs:complexType name="ItemRef">
+		<xs:attribute name="id" type="xs:decimal"/>
+		<xs:attribute name="name" type="xs:string"/>
+	</xs:complexType>
+	<xs:complexType name="LFEDataPathRuntimeValue">
+		<xs:sequence>
+			<xs:element name="dataPath" type="ns1:CompositeID" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="stringDataPath" type="xs:string" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="LogFormUserAddedElement">
+		<xs:choice>
+			<xs:element name="fld" type="tns:Field" minOccurs="0"/>
+			<xs:element name="gr" type="tns:Group" minOccurs="0"/>
+			<xs:element name="tbl" type="tns:Table" minOccurs="0"/>
+			<xs:element name="btn" type="tns:Button" minOccurs="0"/>
+			<xs:element name="decor" type="tns:Decoration" minOccurs="0"/>
+			<xs:element name="addition" type="tns:Addition" minOccurs="0"/>
+		</xs:choice>
+		<xs:attribute name="pId" type="xs:decimal"/>
+	</xs:complexType>
+	<xs:complexType name="LogFormUserButtonChange">
+		<xs:attribute name="bId" type="xs:decimal"/>
+		<xs:attribute name="def" type="xs:boolean"/>
+		<xs:attribute name="ttlChg" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="LogFormUserChangesDescription">
+		<xs:sequence>
+			<xs:element name="addEl" type="tns:LogFormUserAddedElement" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="movEl" type="tns:LogFormUserMovedElement" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="tblChg" type="tns:LogFormUserTableChange" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="fldChg" type="tns:LogFormUserFieldChange" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="btnChg" type="tns:LogFormUserButtonChange" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="LogFormUserFieldChange">
+		<xs:attribute name="fId" type="xs:decimal"/>
+		<xs:attribute name="spin" type="tns:BWAValue"/>
+	</xs:complexType>
+	<xs:complexType name="LogFormUserMovedElement">
+		<xs:attribute name="pId" type="xs:decimal"/>
+		<xs:attribute name="eId" type="xs:decimal"/>
+		<xs:attribute name="aId" type="xs:decimal"/>
+	</xs:complexType>
+	<xs:complexType name="LogFormUserTableChange">
+		<xs:sequence>
+			<xs:element name="autoRef" minOccurs="0"/>
+			<xs:element name="autoRefInt" minOccurs="0"/>
+			<xs:element name="updOnDtCng" minOccurs="0"/>
+			<xs:element name="rstCurLn" minOccurs="0"/>
+			<xs:element name="showRoot" minOccurs="0"/>
+			<xs:element name="allowRootCh" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="tId" type="xs:decimal"/>
+		<xs:attribute name="lstView" type="tns:TableInitialListView"/>
+	</xs:complexType>
+	<xs:complexType name="MainElement">
+		<xs:choice>
+			<xs:element name="storage" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="addProps" type="tns:AddProps" minOccurs="0"/>
+			<xs:element name="event" type="tns:Event" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="commands" type="tns:CommandsInclusion"/>
+			<xs:element name="navigator" type="tns:Group" minOccurs="0"/>
+			<xs:element name="autoCommandBar" type="tns:Group" minOccurs="0"/>
+			<xs:element name="field" type="tns:Field" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="group" type="tns:Group" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="table" type="tns:Table" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="button" type="tns:Button" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="decoration" type="tns:Decoration" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="addition" type="tns:Addition" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="title" type="xs:string" minOccurs="0"/>
+			<xs:element name="formURL" type="xs:string" minOccurs="0"/>
+			<xs:element name="mdcbc" type="ns1:ValueListType"/>
+			<xs:element name="createButtonsGroupTitle" type="xs:string" minOccurs="0"/>
+			<xs:element name="createButtonsGroupPicture" type="ns2:Picture" minOccurs="0"/>
+		</xs:choice>
+		<xs:attribute name="showCloseButton" type="xs:boolean"/>
+		<xs:attribute name="showTitle" type="tns:BWAValue"/>
+		<xs:attribute name="org" type="tns:FormElementOrigin"/>
+		<xs:attribute name="openingMode" type="tns:FormWindowOpeningMode"/>
+		<xs:attribute name="lockMode" type="tns:OnFormWindowOpenLockMode"/>
+		<xs:attribute name="width" type="xs:decimal"/>
+		<xs:attribute name="height" type="xs:decimal"/>
+		<xs:attribute name="scale" type="xs:decimal"/>
+		<xs:attribute name="enterKeyBehavior" type="tns:FormEnterKeyBehavior"/>
+		<xs:attribute name="saveFormDataInSettings" type="tns:SaveFormDataInSettings"/>
+		<xs:attribute name="autoSaveFormDataInSettings" type="tns:AutoSaveFormDataInSettings"/>
+		<xs:attribute name="saveWindowSettings" type="xs:boolean"/>
+		<xs:attribute name="autoTitle" type="xs:boolean"/>
+		<xs:attribute name="autoURL" type="xs:boolean"/>
+		<xs:attribute name="grouping" type="tns:FormChildrenGroup"/>
+		<xs:attribute name="align" type="tns:FormChildrenAlign"/>
+		<xs:attribute name="horizontalSpacing" type="tns:FormItemSpacing"/>
+		<xs:attribute name="verticalSpacing" type="tns:FormItemSpacing"/>
+		<xs:attribute name="hAlign" type="tns:ItemHorizontalAlignment"/>
+		<xs:attribute name="vAlign" type="tns:ItemVerticalAlignment"/>
+		<xs:attribute name="childrenWidth" type="tns:FormChildrenWidth"/>
+		<xs:attribute name="childrenTitleLocation" type="tns:ChildrenTitleLocation"/>
+		<xs:attribute name="scaleVariant" type="ns5:ClientApplicationFormScaleVariant"/>
+		<xs:attribute name="baseFontVariant" type="tns:FormBaseFontVariant"/>
+		<xs:attribute name="scrollMode" type="tns:LogFormScrollMode"/>
+		<xs:attribute name="autoFillCheck" type="xs:boolean"/>
+		<xs:attribute name="customizable" type="xs:boolean"/>
+		<xs:attribute name="enabled" type="xs:boolean"/>
+		<xs:attribute name="readOnly" type="xs:boolean"/>
+		<xs:attribute name="commandBarLocation" type="tns:FormElementCommandBarLocation"/>
+		<xs:attribute name="purposeUseKey" type="xs:string"/>
+		<xs:attribute name="windowOptionsKey" type="xs:string"/>
+		<xs:attribute name="clearEvents" type="xs:boolean"/>
+		<xs:attribute name="convRepresentation" type="tns:LogFormShowConversations"/>
+		<xs:attribute name="currentRowUse" type="tns:TableCurrentRowUse"/>
+		<xs:attribute name="collapseVariant" type="tns:CollapseFormItemsByImportance"/>
+		<xs:attribute name="windowRepresentationMode" type="tns:FormWindowViewMode"/>
+		<xs:attribute name="showCommandBar" type="tns:BWAValue"/>
+	</xs:complexType>
+	<xs:complexType name="MenuGroupData">
+		<xs:sequence>
+			<xs:element name="cmdGroups" type="ns1:CompositeID"/>
+		</xs:sequence>
+		<xs:attribute name="hAlign" type="tns:ItemHorizontalAlignment"/>
+		<xs:attribute name="apMode" type="tns:FormCommandBarAppearanceMode"/>
+	</xs:complexType>
+	<xs:complexType name="PDFDocumentFieldData">
+		<xs:sequence>
+			<xs:element name="brdClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="event" type="tns:Event" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="width" type="xs:decimal"/>
+		<xs:attribute name="height" type="xs:decimal"/>
+		<xs:attribute name="horStretch" type="xs:boolean"/>
+		<xs:attribute name="verStretch" type="xs:boolean"/>
+		<xs:attribute name="autoMaxWidth" type="xs:boolean"/>
+		<xs:attribute name="maxWidth" type="xs:decimal"/>
+		<xs:attribute name="minWidth" type="xs:decimal"/>
+		<xs:attribute name="autoMaxHeight" type="xs:boolean"/>
+		<xs:attribute name="maxHeight" type="xs:decimal"/>
+		<xs:attribute name="useOutput" type="ns2:UseOutput"/>
+		<xs:attribute name="scale" type="xs:decimal"/>
+		<xs:attribute name="currentPage" type="xs:decimal"/>
+		<xs:attribute name="orientation" type="xs:decimal"/>
+		<xs:attribute name="viewStatusLocation" type="tns:ViewStatusLocation"/>
+		<xs:attribute name="clearEvents" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="PageGroupData">
+		<xs:sequence>
+			<xs:element name="pic" type="ns2:Picture" minOccurs="0"/>
+			<xs:element name="prop" type="tns:DataPath" minOccurs="0"/>
+			<xs:element name="propName" type="xs:string" minOccurs="0"/>
+			<xs:element name="tdp" type="ns1:TypeDescription" minOccurs="0"/>
+			<xs:element name="bkClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="ttlClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="ttlFnt" type="ns2:Font" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="grouping" type="tns:FormChildrenGroup"/>
+		<xs:attribute name="align" type="tns:FormChildrenAlign"/>
+		<xs:attribute name="horizontalSpacing" type="tns:FormItemSpacing"/>
+		<xs:attribute name="verticalSpacing" type="tns:FormItemSpacing"/>
+		<xs:attribute name="hAlign" type="tns:ItemHorizontalAlignment"/>
+		<xs:attribute name="vAlign" type="tns:ItemVerticalAlignment"/>
+		<xs:attribute name="childrenWidth" type="tns:FormChildrenWidth"/>
+		<xs:attribute name="childrenTitleLocation" type="tns:ChildrenTitleLocation"/>
+		<xs:attribute name="format" type="xs:string"/>
+		<xs:attribute name="showTitle" type="tns:BWAValue"/>
+		<xs:attribute name="scrollOnCompress" type="tns:BWAValue"/>
+	</xs:complexType>
+	<xs:complexType name="PagesGroupData">
+		<xs:sequence>
+			<xs:element name="event" type="tns:Event" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="repres" type="tns:FormPagesRepresentation"/>
+		<xs:attribute name="currentRowUse" type="tns:CurrentRowUse"/>
+		<xs:attribute name="associatedTableElementId" type="xs:decimal"/>
+		<xs:attribute name="clearEvents" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="PeriodFieldData">
+		<xs:sequence>
+			<xs:element name="fnt" type="ns2:Font" minOccurs="0"/>
+			<xs:element name="brdClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="brd" type="ns2:Border" minOccurs="0"/>
+			<xs:element name="event" type="tns:Event" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="width" type="xs:decimal"/>
+		<xs:attribute name="height" type="xs:decimal"/>
+		<xs:attribute name="horStretch" type="xs:boolean"/>
+		<xs:attribute name="verStretch" type="xs:boolean"/>
+		<xs:attribute name="autoMaxWidth" type="xs:boolean"/>
+		<xs:attribute name="maxWidth" type="xs:decimal"/>
+		<xs:attribute name="minWidth" type="xs:decimal"/>
+		<xs:attribute name="autoMaxHeight" type="xs:boolean"/>
+		<xs:attribute name="maxHeight" type="xs:decimal"/>
+		<xs:attribute name="clearEvents" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="PictureDecorationData">
+		<xs:sequence>
+			<xs:element name="pic" type="ns2:Picture" minOccurs="0"/>
+			<xs:element name="brdClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="brd" type="ns2:Border" minOccurs="0"/>
+			<xs:element name="backgroundShowMode" type="tns:PictureBackgroundShowMode" minOccurs="0"/>
+			<xs:element name="picClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="event" type="tns:Event" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="hyper" type="xs:boolean"/>
+		<xs:attribute name="pictureSize" type="tns:PictureSize"/>
+		<xs:attribute name="zoomable" type="xs:boolean"/>
+		<xs:attribute name="imageScale" type="xs:decimal"/>
+		<xs:attribute name="picText" type="xs:string"/>
+		<xs:attribute name="startDrag" type="xs:boolean"/>
+		<xs:attribute name="drag" type="xs:boolean"/>
+		<xs:attribute name="clearEvents" type="xs:boolean"/>
+		<xs:attribute name="fileDragMode" type="tns:FileDragMode"/>
+	</xs:complexType>
+	<xs:complexType name="PlannerFieldData">
+		<xs:sequence>
+			<xs:element name="event" type="tns:Event" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="width" type="xs:decimal"/>
+		<xs:attribute name="height" type="xs:decimal"/>
+		<xs:attribute name="horStretch" type="xs:boolean"/>
+		<xs:attribute name="verStretch" type="xs:boolean"/>
+		<xs:attribute name="autoMaxWidth" type="xs:boolean"/>
+		<xs:attribute name="maxWidth" type="xs:decimal"/>
+		<xs:attribute name="minWidth" type="xs:decimal"/>
+		<xs:attribute name="autoMaxHeight" type="xs:boolean"/>
+		<xs:attribute name="maxHeight" type="xs:decimal"/>
+		<xs:attribute name="startDrag" type="xs:boolean"/>
+		<xs:attribute name="drag" type="xs:boolean"/>
+		<xs:attribute name="timeScaleItemHyperlink" type="xs:boolean"/>
+		<xs:attribute name="dimensionItemHyperlink" type="xs:boolean"/>
+		<xs:attribute name="wrappedTimeScaleHeaderHyperlink" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="Predefined">
+		<xs:choice>
+			<xs:element name="contextMenu" type="tns:Group" minOccurs="0"/>
+			<xs:element name="contextMenuRef" type="tns:ItemRef" minOccurs="0"/>
+			<xs:element name="autoCommandBar" type="tns:Group" minOccurs="0"/>
+			<xs:element name="autoCommandBarRef" type="tns:ItemRef" minOccurs="0"/>
+			<xs:element name="extTooltip" type="tns:Decoration" minOccurs="0"/>
+			<xs:element name="extTooltipRef" type="tns:ItemRef" minOccurs="0"/>
+			<xs:element name="searchStringRepresentation" type="tns:Addition" minOccurs="0"/>
+			<xs:element name="searchStringRepresentationRef" type="tns:ItemRef" minOccurs="0"/>
+			<xs:element name="viewStatusRepresentation" type="tns:Addition" minOccurs="0"/>
+			<xs:element name="viewStatusRepresentationRef" type="tns:ItemRef" minOccurs="0"/>
+			<xs:element name="searchControl" type="tns:Addition" minOccurs="0"/>
+			<xs:element name="searchControlRef" type="tns:ItemRef" minOccurs="0"/>
+			<xs:element name="predefined" type="tns:Predefined" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="field" type="tns:Field" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="group" type="tns:Group" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="table" type="tns:Table" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="button" type="tns:Button" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="decoration" type="tns:Decoration" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="addition" type="tns:Addition" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="ProgressBarFieldData">
+		<xs:sequence>
+			<xs:element name="brdClr" type="ns2:Color" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="width" type="xs:decimal"/>
+		<xs:attribute name="height" type="xs:decimal"/>
+		<xs:attribute name="horStretch" type="xs:boolean"/>
+		<xs:attribute name="verStretch" type="xs:boolean"/>
+		<xs:attribute name="autoMaxWidth" type="xs:boolean"/>
+		<xs:attribute name="maxWidth" type="xs:decimal"/>
+		<xs:attribute name="minWidth" type="xs:decimal"/>
+		<xs:attribute name="autoMaxHeight" type="xs:boolean"/>
+		<xs:attribute name="maxHeight" type="xs:decimal"/>
+		<xs:attribute name="minVal" type="xs:decimal"/>
+		<xs:attribute name="maxVal" type="xs:decimal"/>
+		<xs:attribute name="orientation" type="tns:FormElementOrientation"/>
+		<xs:attribute name="repres" type="tns:FormProgressBarRepresentation"/>
+		<xs:attribute name="showPercent" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="Property">
+		<xs:sequence>
+			<xs:element name="savingContent" type="tns:DataPath" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="id" type="ns1:CompositeID"/>
+		<xs:attribute name="main" type="xs:boolean"/>
+		<xs:attribute name="storedData" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="RadioButtonsData">
+		<xs:sequence>
+			<xs:element name="valList" type="ns1:ValueListType"/>
+			<xs:element name="txtClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="fnt" type="ns2:Font" minOccurs="0"/>
+			<xs:element name="brdClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="bkClr" type="ns2:Color" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="radioButtonType" type="tns:RadioButtonType"/>
+		<xs:attribute name="colsCount" type="xs:decimal"/>
+		<xs:attribute name="tbRepres" type="tns:TumblerRepresentation"/>
+		<xs:attribute name="horStretch" type="tns:BWAValue"/>
+		<xs:attribute name="orientation" type="tns:FormElementOrientation"/>
+		<xs:attribute name="elementTitleHeight" type="xs:decimal"/>
+		<xs:attribute name="elementHeight" type="xs:decimal"/>
+		<xs:attribute name="elementWidth" type="xs:decimal"/>
+		<xs:attribute name="eqWidth" type="tns:BWAValue"/>
+	</xs:complexType>
+	<xs:complexType name="RowActionsCommandBarGroupData">
+		<xs:attribute name="fillStdCommands" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="SearchControlData">
+		<xs:sequence>
+			<xs:element name="bkClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="txtClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="brdClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="fnt" type="ns2:Font" minOccurs="0"/>
+			<xs:element name="event" type="tns:Event" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="width" type="xs:decimal"/>
+		<xs:attribute name="autoMaxWidth" type="xs:boolean"/>
+		<xs:attribute name="maxWidth" type="xs:decimal"/>
+		<xs:attribute name="minWidth" type="xs:decimal"/>
+		<xs:attribute name="horStretch" type="tns:BWAValue"/>
+	</xs:complexType>
+	<xs:complexType name="SearchStringData">
+		<xs:sequence>
+			<xs:element name="bkClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="txtClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="brdClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="fnt" type="ns2:Font" minOccurs="0"/>
+			<xs:element name="event" type="tns:Event" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="width" type="xs:decimal"/>
+		<xs:attribute name="autoMaxWidth" type="xs:boolean"/>
+		<xs:attribute name="maxWidth" type="xs:decimal"/>
+		<xs:attribute name="minWidth" type="xs:decimal"/>
+		<xs:attribute name="horStretch" type="tns:BWAValue"/>
+	</xs:complexType>
+	<xs:complexType name="SelectedItemsActionsPanelGroupData">
+		<xs:attribute name="fillStdCommands" type="xs:boolean"/>
+		<xs:attribute name="hAlign" type="tns:ItemHorizontalAlignment"/>
+		<xs:attribute name="appearanceMode" type="tns:FormCommandBarAppearanceMode"/>
+	</xs:complexType>
+	<xs:complexType name="SpreadsheetFieldData">
+		<xs:sequence>
+			<xs:element name="brdClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="event" type="tns:Event" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="width" type="xs:decimal"/>
+		<xs:attribute name="height" type="xs:decimal"/>
+		<xs:attribute name="horStretch" type="xs:boolean"/>
+		<xs:attribute name="verStretch" type="xs:boolean"/>
+		<xs:attribute name="autoMaxWidth" type="xs:boolean"/>
+		<xs:attribute name="maxWidth" type="xs:decimal"/>
+		<xs:attribute name="minWidth" type="xs:decimal"/>
+		<xs:attribute name="autoMaxHeight" type="xs:boolean"/>
+		<xs:attribute name="maxHeight" type="xs:decimal"/>
+		<xs:attribute name="showGrid" type="xs:boolean"/>
+		<xs:attribute name="showHdrs" type="xs:boolean"/>
+		<xs:attribute name="showVerScroll" type="tns:SpreadSheetDocumentScrollBarUse"/>
+		<xs:attribute name="showHorScroll" type="tns:SpreadSheetDocumentScrollBarUse"/>
+		<xs:attribute name="blackAndWhite" type="xs:boolean"/>
+		<xs:attribute name="protection" type="xs:boolean"/>
+		<xs:attribute name="selectionMode" type="tns:SelectionShowMode"/>
+		<xs:attribute name="useOutput" type="ns2:UseOutput"/>
+		<xs:attribute name="edit" type="xs:boolean"/>
+		<xs:attribute name="showGroups" type="xs:boolean"/>
+		<xs:attribute name="startDrag" type="xs:boolean"/>
+		<xs:attribute name="drag" type="xs:boolean"/>
+		<xs:attribute name="clearEvents" type="xs:boolean"/>
+		<xs:attribute name="selShow" type="tns:SelectionShowMode"/>
+		<xs:attribute name="viewScalingMode" type="tns:ViewScalingMode"/>
+		<xs:attribute name="showCellNames" type="xs:boolean"/>
+		<xs:attribute name="showRowAndColumnNames" type="xs:boolean"/>
+		<xs:attribute name="pointerType" type="ns6:SpreadsheetDocumentPointerType"/>
+		<xs:attribute name="drawingSelectionMode" type="tns:DrawingSelectionShowMode"/>
+		<xs:attribute name="cellActionsButtonShowMode" type="tns:CellActionsButtonViewMode"/>
+		<xs:attribute name="moxelActionBarShowMode" type="tns:SpreadsheetDocumentMultipleSelectionPanelViewMode"/>
+	</xs:complexType>
+	<xs:complexType name="SubmenuGroupData">
+		<xs:sequence>
+			<xs:element name="pic" type="ns2:Picture" minOccurs="0"/>
+			<xs:element name="cmdGroups" type="ns1:CompositeID"/>
+			<xs:element name="bkClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="brdClr" type="ns2:Color" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="repres" type="tns:ButtonRepresentation"/>
+		<xs:attribute name="shape" type="tns:ButtonShape"/>
+		<xs:attribute name="shapeRepres" type="tns:ButtonShapeRepresentation"/>
+		<xs:attribute name="importance" type="tns:ButtonImportance"/>
+	</xs:complexType>
+	<xs:complexType name="Table">
+		<xs:choice>
+			<xs:element name="prop" type="tns:DataPath" minOccurs="0"/>
+			<xs:element name="propName" type="xs:string" minOccurs="0"/>
+			<xs:element name="tdp" type="ns1:TypeDescription" minOccurs="0"/>
+			<xs:element name="rowsPicProp" type="tns:DataPath" minOccurs="0"/>
+			<xs:element name="rowsPicPropName" type="xs:string" minOccurs="0"/>
+			<xs:element name="rowsPic" type="ns2:Picture" minOccurs="0"/>
+			<xs:element name="bkClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="txtClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="brdClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="fnt" type="ns2:Font" minOccurs="0"/>
+			<xs:element name="titleTxtClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="titleFnt" type="ns2:Font" minOccurs="0"/>
+			<xs:element name="stcut" type="ns2:ShortCutType" minOccurs="0"/>
+			<xs:element name="addProps" type="tns:AddProps" minOccurs="0"/>
+			<xs:element name="event" type="tns:Event" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="commands" type="tns:CommandsInclusion"/>
+			<xs:element name="predefined" type="tns:Predefined" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="field" type="tns:Field" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="group" type="tns:Group" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="title" type="xs:string" minOccurs="0"/>
+			<xs:element name="tooltip" type="xs:string" minOccurs="0"/>
+		</xs:choice>
+		<xs:attribute name="id" type="xs:decimal"/>
+		<xs:attribute name="name" type="xs:string"/>
+		<xs:attribute name="org" type="tns:FormElementOrigin"/>
+		<xs:attribute name="repres" type="tns:TableRepresentation"/>
+		<xs:attribute name="visible" type="xs:boolean"/>
+		<xs:attribute name="userVisible" type="xs:boolean"/>
+		<xs:attribute name="titleLocation" type="tns:FormElementTitleLocation"/>
+		<xs:attribute name="titleRowsCount" type="xs:decimal"/>
+		<xs:attribute name="commandBarLocation" type="tns:FormElementCommandBarLocation"/>
+		<xs:attribute name="autoFill" type="xs:boolean"/>
+		<xs:attribute name="enabled" type="xs:boolean"/>
+		<xs:attribute name="readOnly" type="xs:boolean"/>
+		<xs:attribute name="skipOnInput" type="tns:BWAValue"/>
+		<xs:attribute name="defItem" type="xs:boolean"/>
+		<xs:attribute name="changeRowSet" type="xs:boolean"/>
+		<xs:attribute name="changeRowOrder" type="xs:boolean"/>
+		<xs:attribute name="width" type="xs:decimal"/>
+		<xs:attribute name="height" type="xs:decimal"/>
+		<xs:attribute name="rowsCount" type="xs:decimal"/>
+		<xs:attribute name="heightControlVariant" type="tns:TableHeightControlVariant"/>
+		<xs:attribute name="autoMaxRowsCount" type="xs:boolean"/>
+		<xs:attribute name="maxRowsCount" type="xs:decimal"/>
+		<xs:attribute name="autoMaxWidth" type="xs:boolean"/>
+		<xs:attribute name="maxWidth" type="xs:decimal"/>
+		<xs:attribute name="minWidth" type="xs:decimal"/>
+		<xs:attribute name="autoMaxHeight" type="xs:boolean"/>
+		<xs:attribute name="maxHeight" type="xs:decimal"/>
+		<xs:attribute name="choiceMode" type="xs:boolean"/>
+		<xs:attribute name="multipleChoice" type="xs:boolean"/>
+		<xs:attribute name="rowInput" type="tns:TableRowInputMode"/>
+		<xs:attribute name="rowsSelection" type="tns:TableSelectionMode"/>
+		<xs:attribute name="rowSelection" type="tns:TableRowSelectionMode"/>
+		<xs:attribute name="showHeader" type="xs:boolean"/>
+		<xs:attribute name="headerHeight" type="xs:decimal"/>
+		<xs:attribute name="showFooter" type="xs:boolean"/>
+		<xs:attribute name="footerHeight" type="xs:decimal"/>
+		<xs:attribute name="horScroll" type="tns:TableScrollBarUse"/>
+		<xs:attribute name="verScroll" type="tns:TableScrollBarUse"/>
+		<xs:attribute name="showHorLines" type="xs:boolean"/>
+		<xs:attribute name="showVerLines" type="xs:boolean"/>
+		<xs:attribute name="showHorLinesBWA" type="tns:BWAValue"/>
+		<xs:attribute name="showVerLinesBWA" type="tns:BWAValue"/>
+		<xs:attribute name="fixedLeft" type="xs:decimal"/>
+		<xs:attribute name="fixedRight" type="xs:decimal"/>
+		<xs:attribute name="useAltRowColor" type="xs:boolean"/>
+		<xs:attribute name="useAltRowColorBWA" type="tns:BWAValue"/>
+		<xs:attribute name="autoInsert" type="xs:boolean"/>
+		<xs:attribute name="autoInsertNotcompleted" type="tns:BWAValue"/>
+		<xs:attribute name="autoMarkNotcompleted" type="tns:BWAValue"/>
+		<xs:attribute name="markRequiredComplete" type="tns:BWAValue"/>
+		<xs:attribute name="searchOnInput" type="tns:SearchOnInput"/>
+		<xs:attribute name="initListView" type="tns:TableInitialListView"/>
+		<xs:attribute name="initTreeView" type="tns:TableInitialTreeView"/>
+		<xs:attribute name="initRowActivation" type="tns:TableInitialRowActivation"/>
+		<xs:attribute name="rowActionsShowType" type="tns:TableRowActionsShowType"/>
+		<xs:attribute name="useOutput" type="ns2:UseOutput"/>
+		<xs:attribute name="horStretch" type="xs:boolean"/>
+		<xs:attribute name="verStretch" type="xs:boolean"/>
+		<xs:attribute name="startDrag" type="xs:boolean"/>
+		<xs:attribute name="drag" type="xs:boolean"/>
+		<xs:attribute name="tooltipRepres" type="tns:TooltipRepresentation"/>
+		<xs:attribute name="searchStringLocation" type="tns:SearchStringLocation"/>
+		<xs:attribute name="viewStatusLocation" type="tns:ViewStatusLocation"/>
+		<xs:attribute name="searchControlLocation" type="tns:SearchControlLocation"/>
+		<xs:attribute name="groupHAlign" type="tns:ItemHorizontalAlignment"/>
+		<xs:attribute name="groupVAlign" type="tns:ItemVerticalAlignment"/>
+		<xs:attribute name="clearEvents" type="xs:boolean"/>
+		<xs:attribute name="refreshRequest" type="tns:RefreshRequestMethod"/>
+		<xs:attribute name="currentRowUse" type="tns:TableCurrentRowUse"/>
+		<xs:attribute name="behaviorOnHorizontalCompression" type="tns:TableBehaviorOnHorizontalCompression"/>
+		<xs:attribute name="displayImportance" type="tns:DisplayImportance"/>
+		<xs:attribute name="fileDragMode" type="tns:FileDragMode"/>
+		<xs:attribute name="MSIB" type="tns:OnMainServerUnavalableBehavior"/>
+		<xs:attribute name="hierarchyPanelLocation" type="tns:HierarchyPanelLocation"/>
+		<xs:attribute name="hierarchyPanelVisible" type="xs:boolean"/>
+		<xs:attribute name="verticalScrollPanelVisible" type="xs:boolean"/>
+		<xs:attribute name="saveColors" type="tns:SaveTableAppearance"/>
+		<xs:attribute name="iconSaveColorsKey" type="xs:string"/>
+		<xs:attribute name="shapeSaveColorsKey" type="xs:string"/>
+		<xs:attribute name="showCommandBarNeedDereferenced" type="xs:boolean"/>
+		<xs:attribute name="showCommandBar" type="tns:BWAValue"/>
+		<xs:attribute name="mobileDeviceTableType" type="tns:FormTableType"/>
+		<xs:attribute name="autoMaxCardHeight" type="xs:boolean"/>
+		<xs:attribute name="maxCardHeight" type="xs:decimal"/>
+		<xs:attribute name="cardBehaviorOnVerticalCompression" type="tns:CardBehaviorOnVerticalCompression"/>
+		<xs:attribute name="cellHyperlinksRepresentation" type="tns:CellHyperlinksRepresentation"/>
+	</xs:complexType>
+	<xs:complexType name="TableColorPaletteDescription">
+		<xs:sequence>
+			<xs:element name="customPalette" type="ns1:Array" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TextDecorationData">
+		<xs:sequence>
+			<xs:element name="bkClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="brdClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="brd" type="ns2:Border" minOccurs="0"/>
+			<xs:element name="event" type="tns:Event" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="hyper" type="xs:boolean"/>
+		<xs:attribute name="hAlign" type="tns:ItemHorizontalAlignment"/>
+		<xs:attribute name="vAlign" type="tns:ItemVerticalAlignment"/>
+		<xs:attribute name="titleHeight" type="xs:decimal"/>
+		<xs:attribute name="clearEvents" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="TextDocFieldData">
+		<xs:sequence>
+			<xs:element name="txtClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="bkClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="brdClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="fnt" type="ns2:Font" minOccurs="0"/>
+			<xs:element name="event" type="tns:Event" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="width" type="xs:decimal"/>
+		<xs:attribute name="height" type="xs:decimal"/>
+		<xs:attribute name="horStretch" type="xs:boolean"/>
+		<xs:attribute name="verStretch" type="xs:boolean"/>
+		<xs:attribute name="autoMaxWidth" type="xs:boolean"/>
+		<xs:attribute name="maxWidth" type="xs:decimal"/>
+		<xs:attribute name="minWidth" type="xs:decimal"/>
+		<xs:attribute name="autoMaxHeight" type="xs:boolean"/>
+		<xs:attribute name="maxHeight" type="xs:decimal"/>
+		<xs:attribute name="useOutput" type="ns2:UseOutput"/>
+		<xs:attribute name="clearEvents" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="TextFieldData">
+		<xs:sequence>
+			<xs:element name="txtClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="bkClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="brdClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="brd" type="ns2:Border" minOccurs="0"/>
+			<xs:element name="fnt" type="ns2:Font" minOccurs="0"/>
+			<xs:element name="event" type="tns:Event" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="width" type="xs:decimal"/>
+		<xs:attribute name="rowsCount" type="xs:decimal"/>
+		<xs:attribute name="horStretch" type="tns:BWAValue"/>
+		<xs:attribute name="verStretch" type="tns:BWAValue"/>
+		<xs:attribute name="autoMaxWidth" type="xs:boolean"/>
+		<xs:attribute name="maxWidth" type="xs:decimal"/>
+		<xs:attribute name="minWidth" type="xs:decimal"/>
+		<xs:attribute name="autoMaxHeight" type="xs:boolean"/>
+		<xs:attribute name="maxHeight" type="xs:decimal"/>
+		<xs:attribute name="markNeg" type="tns:BWAValue"/>
+		<xs:attribute name="format" type="xs:string"/>
+		<xs:attribute name="hyper" type="xs:boolean"/>
+		<xs:attribute name="psw" type="tns:BWAValue"/>
+		<xs:attribute name="useCopy" type="tns:BWAValue"/>
+		<xs:attribute name="clearEvents" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="TrackBarFieldData">
+		<xs:sequence>
+			<xs:element name="brdClr" type="ns2:Color" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="width" type="xs:decimal"/>
+		<xs:attribute name="height" type="xs:decimal"/>
+		<xs:attribute name="horStretch" type="xs:boolean"/>
+		<xs:attribute name="verStretch" type="xs:boolean"/>
+		<xs:attribute name="autoMaxWidth" type="xs:boolean"/>
+		<xs:attribute name="maxWidth" type="xs:decimal"/>
+		<xs:attribute name="minWidth" type="xs:decimal"/>
+		<xs:attribute name="autoMaxHeight" type="xs:boolean"/>
+		<xs:attribute name="maxHeight" type="xs:decimal"/>
+		<xs:attribute name="minVal" type="xs:decimal"/>
+		<xs:attribute name="maxVal" type="xs:decimal"/>
+		<xs:attribute name="step" type="xs:decimal"/>
+		<xs:attribute name="pageSize" type="xs:decimal"/>
+		<xs:attribute name="markingStep" type="xs:decimal"/>
+		<xs:attribute name="orientation" type="tns:FormElementOrientation"/>
+		<xs:attribute name="marking" type="tns:MarkingStyle"/>
+	</xs:complexType>
+	<xs:complexType name="UsualGroupData">
+		<xs:sequence>
+			<xs:element name="backPic" type="ns2:Picture" minOccurs="0"/>
+			<xs:element name="prop" type="tns:DataPath" minOccurs="0"/>
+			<xs:element name="propName" type="xs:string" minOccurs="0"/>
+			<xs:element name="tdp" type="ns1:TypeDescription" minOccurs="0"/>
+			<xs:element name="bkClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="hiddenStateTitleBkClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="event" type="tns:Event" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="grouping" type="tns:FormChildrenGroup"/>
+		<xs:attribute name="align" type="tns:FormChildrenAlign"/>
+		<xs:attribute name="horizontalSpacing" type="tns:FormItemSpacing"/>
+		<xs:attribute name="verticalSpacing" type="tns:FormItemSpacing"/>
+		<xs:attribute name="hAlign" type="tns:ItemHorizontalAlignment"/>
+		<xs:attribute name="vAlign" type="tns:ItemVerticalAlignment"/>
+		<xs:attribute name="childrenWidth" type="tns:FormChildrenWidth"/>
+		<xs:attribute name="childrenTitleLocation" type="tns:ChildrenTitleLocation"/>
+		<xs:attribute name="repres" type="tns:UsualGroupRepresentation"/>
+		<xs:attribute name="bhv" type="tns:UsualGroupBehavior"/>
+		<xs:attribute name="mngRepres" type="tns:UsualGroupControlRepresentation"/>
+		<xs:attribute name="throughAlign" type="tns:UsualGroupThroughAlign"/>
+		<xs:attribute name="showTitle" type="tns:BWAValue"/>
+		<xs:attribute name="collapsed" type="xs:boolean"/>
+		<xs:attribute name="leftMargin" type="xs:boolean"/>
+		<xs:attribute name="united" type="xs:boolean"/>
+		<xs:attribute name="format" type="xs:string"/>
+		<xs:attribute name="clsTitle" type="xs:string"/>
+		<xs:attribute name="collapsedRepresentationItemId" type="xs:decimal"/>
+		<xs:attribute name="currentRowUse" type="tns:CurrentRowUse"/>
+		<xs:attribute name="associatedTableElementId" type="xs:decimal"/>
+		<xs:attribute name="showAsCard" type="xs:boolean"/>
+		<xs:attribute name="backPictRepresEffect" type="tns:PictureRepresentationEffect"/>
+		<xs:attribute name="cardRepresType" type="tns:CardRepresentationType"/>
+		<xs:attribute name="hyperlink" type="xs:boolean"/>
+		<xs:attribute name="scrollOnCompress" type="tns:BWAValue"/>
+		<xs:attribute name="clearEvents" type="xs:boolean"/>
+	</xs:complexType>
+	<xs:complexType name="ViewStatusData">
+		<xs:sequence>
+			<xs:element name="bkClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="btnClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="txtClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="titleTxtClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="brdClr" type="ns2:Color" minOccurs="0"/>
+			<xs:element name="fnt" type="ns2:Font" minOccurs="0"/>
+			<xs:element name="titleFnt" type="ns2:Font" minOccurs="0"/>
+			<xs:element name="brd" type="ns2:Border" minOccurs="0"/>
+			<xs:element name="event" type="tns:Event" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="width" type="xs:decimal"/>
+		<xs:attribute name="autoMaxWidth" type="xs:boolean"/>
+		<xs:attribute name="maxWidth" type="xs:decimal"/>
+		<xs:attribute name="minWidth" type="xs:decimal"/>
+		<xs:attribute name="horStretch" type="tns:BWAValue"/>
+		<xs:attribute name="hAlign" type="tns:ItemHorizontalAlignment"/>
+	</xs:complexType>
+</xs:schema>

--- a/src/main/xsd/v8.5/v8.1c.ru-8.2-managed-application-modules.xsd
+++ b/src/main/xsd/v8.5/v8.1c.ru-8.2-managed-application-modules.xsd
@@ -1,0 +1,71 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:ns1="http://v8.1c.ru/8.1/data/core" xmlns:ns2="http://v8.1c.ru/8.2/managed-application/core" xmlns:ns3="http://v8.1c.ru/8.2/data/bsl" xmlns:tns="http://v8.1c.ru/8.2/managed-application/modules" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://v8.1c.ru/8.2/managed-application/modules" attributeFormDefault="unqualified" elementFormDefault="qualified">
+	<xs:import namespace="http://v8.1c.ru/8.1/data/core"/>
+	<xs:import namespace="http://v8.1c.ru/8.2/managed-application/core"/>
+	<xs:import namespace="http://v8.1c.ru/8.2/data/bsl"/>
+	<xs:simpleType name="ParamDirection">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="InOut"/>
+			<xs:enumeration value="In"/>
+			<xs:enumeration value="Out"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="MethodCall">
+		<xs:sequence>
+			<xs:element name="ret" nillable="true" minOccurs="0"/>
+			<xs:element name="param" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="pfc" type="tns:ProcessFormsCloseParam" nillable="true" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="name" type="xs:Name"/>
+	</xs:complexType>
+	<xs:complexType name="MethodDef">
+		<xs:choice>
+			<xs:element name="param" type="tns:ParamDef" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:choice>
+		<xs:attribute name="name" type="xs:Name"/>
+		<xs:attribute name="exp" type="xs:boolean" default="false"/>
+		<xs:attribute name="params" type="xs:decimal"/>
+	</xs:complexType>
+	<xs:complexType name="MethodDefs">
+		<xs:choice>
+			<xs:element name="proc" type="tns:MethodDef" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="func" type="tns:MethodDef" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="ModuleContentDef">
+		<xs:sequence>
+			<xs:element name="moduleMethods" type="tns:MethodDefs" minOccurs="0"/>
+			<xs:element name="moduleImage" type="ns3:BSLModuleImage" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ModuleDef">
+		<xs:sequence>
+			<xs:element name="image" type="ns3:BSLModuleImage" minOccurs="0"/>
+			<xs:element name="extension" type="tns:ModuleDef" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="securityInfo" type="xs:string"/>
+		</xs:sequence>
+		<xs:attribute name="id" type="xs:string"/>
+		<xs:attribute name="code" type="xs:Name"/>
+		<xs:attribute name="name" type="xs:Name"/>
+		<xs:attribute name="cached" type="xs:integer"/>
+	</xs:complexType>
+	<xs:complexType name="ModulesDef">
+		<xs:sequence>
+			<xs:element name="main" type="tns:ModuleDef"/>
+			<xs:element name="global" type="tns:ModuleDef" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="client" type="tns:ModuleDef" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="server" type="tns:ModuleDef" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="alias" type="ns2:Alias" default="en"/>
+	</xs:complexType>
+	<xs:complexType name="ParamDef">
+		<xs:attribute name="dir" type="tns:ParamDirection" default="InOut"/>
+		<xs:attribute name="pos" type="xs:decimal"/>
+		<xs:attribute name="def" type="xs:boolean" default="false"/>
+	</xs:complexType>
+	<xs:complexType name="ProcessFormsCloseParam">
+		<xs:sequence>
+			<xs:element name="id" type="ns1:UUID" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+</xs:schema>

--- a/src/main/xsd/v8.5/v8.1c.ru-8.2-uobjects.xsd
+++ b/src/main/xsd/v8.5/v8.1c.ru-8.2-uobjects.xsd
@@ -1,0 +1,379 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:ns1="http://v8.1c.ru/8.1/data/core" xmlns:tns="http://v8.1c.ru/8.2/uobjects" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://v8.1c.ru/8.2/uobjects" attributeFormDefault="unqualified" elementFormDefault="qualified">
+	<xs:import namespace="http://v8.1c.ru/8.1/data/core"/>
+	<xs:simpleType name="AccessMode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="rw"/>
+			<xs:enumeration value="r"/>
+			<xs:enumeration value="none"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CollectionIds">
+		<xs:list itemType="xs:long"/>
+	</xs:simpleType>
+	<xs:simpleType name="RemoteKey">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="StructureFields">
+		<xs:list itemType="xs:unsignedInt"/>
+	</xs:simpleType>
+	<xs:simpleType name="TypeList">
+		<xs:list itemType="ns1:UUID"/>
+	</xs:simpleType>
+	<xs:complexType name="BaseDescription"/>
+	<xs:complexType name="BaseStructure">
+		<xs:sequence>
+			<xs:element name="v" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="fields" type="tns:StructureFields"/>
+		<xs:attribute name="fixedFields" type="tns:StructureFields"/>
+	</xs:complexType>
+	<xs:complexType name="Changes">
+		<xs:choice>
+			<xs:element name="structure" type="tns:StructureChanges" minOccurs="0"/>
+			<xs:element name="collection" type="tns:CollectionChanges" minOccurs="0"/>
+			<xs:element name="structureAndCollection" type="tns:StructureAndCollectionChanges" minOccurs="0"/>
+			<xs:element name="tree" type="tns:TreeChanges" minOccurs="0"/>
+		</xs:choice>
+		<xs:attribute name="sinDesc" type="xs:unsignedInt"/>
+		<xs:attribute name="sin" type="xs:unsignedInt"/>
+		<xs:attribute name="seq" type="xs:unsignedInt"/>
+	</xs:complexType>
+	<xs:complexType name="Collection">
+		<xs:sequence>
+			<xs:element name="column" type="tns:CollectionColumn" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="item" type="tns:CollectionItem" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="count" type="xs:unsignedInt" use="required"/>
+		<xs:attribute name="lastId" type="xs:long" use="required"/>
+		<xs:attribute name="ids" type="tns:CollectionIds"/>
+		<xs:attribute name="fullChanged" type="xs:boolean"/>
+		<xs:attribute name="firstAddedLine" type="xs:integer"/>
+	</xs:complexType>
+	<xs:complexType name="CollectionChanges">
+		<xs:sequence>
+			<xs:element name="operations" type="tns:CollectionOperations" minOccurs="0"/>
+			<xs:element name="items" type="tns:CollectionItemChangesList" minOccurs="0"/>
+			<xs:element name="column" type="tns:CollectionColumn" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="count" type="xs:unsignedInt" use="required"/>
+		<xs:attribute name="lastId" type="xs:long" use="required"/>
+		<xs:attribute name="fullChanged" type="xs:boolean"/>
+		<xs:attribute name="firstAddedLine" type="xs:integer"/>
+		<xs:attribute name="dropOld" type="xs:boolean" default="false"/>
+	</xs:complexType>
+	<xs:complexType name="CollectionColumn">
+		<xs:attribute name="id" type="ns1:CompositeID" use="required"/>
+		<xs:attribute name="total" type="xs:decimal" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="CollectionFragment">
+		<xs:choice>
+			<xs:element name="item" type="tns:CollectionFragmentItem" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="CollectionFragmentItem">
+		<xs:complexContent>
+			<xs:extension base="tns:BaseStructure">
+				<xs:attribute name="id" type="xs:long" use="required"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="CollectionItem">
+		<xs:complexContent>
+			<xs:extension base="tns:BaseStructure">
+				<xs:attribute name="index" type="xs:unsignedInt" use="required"/>
+				<xs:attribute name="id" type="xs:long" use="required"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="CollectionItemChanges">
+		<xs:sequence>
+			<xs:element name="structure" type="tns:StructureChanges" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="index" type="xs:unsignedInt" use="required"/>
+		<xs:attribute name="id" type="xs:long" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="CollectionItemChangesList">
+		<xs:choice>
+			<xs:element name="item" type="tns:CollectionItemChanges" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="CollectionOperationAdd">
+		<xs:attribute name="index" type="xs:unsignedInt" use="required"/>
+		<xs:attribute name="id" type="xs:long" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="CollectionOperationAddRange">
+		<xs:attribute name="index1" type="xs:unsignedInt" use="required"/>
+		<xs:attribute name="index2" type="xs:unsignedInt" use="required"/>
+		<xs:attribute name="startId" type="xs:long" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="CollectionOperationClear"/>
+	<xs:complexType name="CollectionOperationMove">
+		<xs:attribute name="index" type="xs:unsignedInt" use="required"/>
+		<xs:attribute name="delta" type="xs:integer" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="CollectionOperationRemove">
+		<xs:attribute name="index" type="xs:unsignedInt" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="CollectionOperationRemoveRange">
+		<xs:attribute name="index1" type="xs:unsignedInt" use="required"/>
+		<xs:attribute name="index2" type="xs:unsignedInt" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="CollectionOperationSwap">
+		<xs:attribute name="index1" type="xs:unsignedInt" use="required"/>
+		<xs:attribute name="index2" type="xs:unsignedInt" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="CollectionOperations">
+		<xs:choice>
+			<xs:element name="add" type="tns:CollectionOperationAdd" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="addRange" type="tns:CollectionOperationAddRange" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="remove" type="tns:CollectionOperationRemove" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="removeRange" type="tns:CollectionOperationRemoveRange" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="swap" type="tns:CollectionOperationSwap" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="move" type="tns:CollectionOperationMove" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="clear" type="tns:CollectionOperationClear" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="FormDataCollection">
+		<xs:sequence>
+			<xs:element name="descriptions" type="tns:FormDataDescriptions"/>
+			<xs:element name="type" type="xs:string"/>
+			<xs:element name="data" type="tns:Collection"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="FormDataCollectionDescription">
+		<xs:complexContent>
+			<xs:extension base="tns:BaseDescription">
+				<xs:attribute name="name" type="xs:string" use="required"/>
+				<xs:attribute name="maxCount" type="xs:decimal" default="0"/>
+				<xs:attribute name="fixed" type="xs:boolean" default="false"/>
+				<xs:attribute name="itemType" type="xs:string" use="required"/>
+				<xs:attribute name="lineNoFieldId" type="ns1:CompositeID"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="FormDataDescriptionChanges">
+		<xs:choice>
+			<xs:element name="added" type="tns:FormDataDescriptions" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="removed" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="changed" type="tns:FormDataStructureChanges" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:choice>
+		<xs:attribute name="sin" type="xs:decimal" use="required"/>
+		<xs:attribute name="seq" type="xs:decimal" use="required"/>
+		<xs:attribute name="sinUo" type="xs:decimal" use="required"/>
+		<xs:attribute name="seqUo" type="xs:decimal" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="FormDataDescriptions">
+		<xs:choice>
+			<xs:element name="structure" type="tns:FormDataStructureDescription" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="collection" type="tns:FormDataCollectionDescription" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="structureAndCollection" type="tns:FormDataStructureAndCollectionDescription" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="tree" type="tns:FormDataTreeDescription" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:choice>
+		<xs:attribute name="remoteKey" type="tns:RemoteKey" use="required"/>
+		<xs:attribute name="trackChanges" type="xs:boolean" use="required"/>
+		<xs:attribute name="sinDe" type="xs:unsignedInt" use="required"/>
+		<xs:attribute name="seqDe" type="xs:unsignedInt" use="required"/>
+		<xs:attribute name="sinUo" type="xs:unsignedInt" use="required"/>
+		<xs:attribute name="seqUo" type="xs:unsignedInt" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="FormDataFieldDescription">
+		<xs:sequence>
+			<xs:element name="type" type="tns:FormDataTypeDescription"/>
+		</xs:sequence>
+		<xs:attribute name="id" type="ns1:CompositeID" use="required"/>
+		<xs:attribute name="name" type="xs:string" use="required"/>
+		<xs:attribute name="nameRu" type="xs:string" default=""/>
+		<xs:attribute name="mode" type="tns:AccessMode" default="rw"/>
+		<xs:attribute name="imode" type="tns:AccessMode" default="rw"/>
+		<xs:attribute name="fromCntx" type="xs:boolean" default="false"/>
+	</xs:complexType>
+	<xs:complexType name="FormDataStructure">
+		<xs:sequence>
+			<xs:element name="descriptions" type="tns:FormDataDescriptions"/>
+			<xs:element name="type" type="xs:string"/>
+			<xs:element name="data" type="tns:Structure"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="FormDataStructureAndCollection">
+		<xs:sequence>
+			<xs:element name="descriptions" type="tns:FormDataDescriptions"/>
+			<xs:element name="type" type="xs:string"/>
+			<xs:element name="data" type="tns:StructureAndCollection"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="FormDataStructureAndCollectionDescription">
+		<xs:complexContent>
+			<xs:extension base="tns:BaseDescription">
+				<xs:sequence>
+					<xs:element name="structure" type="tns:FormDataStructureDescription"/>
+					<xs:element name="collection" type="tns:FormDataCollectionDescription"/>
+				</xs:sequence>
+				<xs:attribute name="name" type="xs:string" use="required"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="FormDataStructureChanges">
+		<xs:choice>
+			<xs:element name="added" type="tns:FormDataFieldDescription" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="removed" type="ns1:CompositeID" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="changed" type="tns:FormDataFieldDescription" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:choice>
+		<xs:attribute name="name" type="xs:string" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="FormDataStructureDescription">
+		<xs:complexContent>
+			<xs:extension base="tns:BaseDescription">
+				<xs:sequence>
+					<xs:element name="field" type="tns:FormDataFieldDescription" minOccurs="0" maxOccurs="unbounded"/>
+				</xs:sequence>
+				<xs:attribute name="name" type="xs:string" use="required"/>
+				<xs:attribute name="value" type="xs:boolean" default="false"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="FormDataTree">
+		<xs:sequence>
+			<xs:element name="descriptions" type="tns:FormDataDescriptions"/>
+			<xs:element name="type" type="xs:string"/>
+			<xs:element name="data" type="tns:Tree"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="FormDataTreeDescription">
+		<xs:complexContent>
+			<xs:extension base="tns:BaseDescription">
+				<xs:attribute name="name" type="xs:string" use="required"/>
+				<xs:attribute name="itemType" type="xs:string" use="required"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="FormDataTypeDescription">
+		<xs:simpleContent>
+			<xs:extension base="tns:TypeList">
+				<xs:attribute name="object" type="xs:boolean" default="false"/>
+				<xs:attribute name="digits" type="xs:decimal" default="10"/>
+				<xs:attribute name="precision" type="xs:decimal" default="0"/>
+				<xs:attribute name="unsigned" type="xs:boolean" default="false"/>
+				<xs:attribute name="length" type="xs:decimal" default="10"/>
+				<xs:attribute name="fixed" type="xs:boolean" default="false"/>
+				<xs:attribute name="dateFraction" type="ns1:DateFractions" default="DateTime"/>
+				<xs:attribute name="binaryLength" type="xs:decimal" default="0"/>
+				<xs:attribute name="binaryFixed" type="xs:boolean" default="false"/>
+				<xs:attribute name="name" type="xs:string"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:complexType name="Fragment">
+		<xs:choice>
+			<xs:element name="collection" type="tns:CollectionFragment" minOccurs="0"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="Structure">
+		<xs:complexContent>
+			<xs:extension base="tns:BaseStructure"/>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="StructureAndCollection">
+		<xs:sequence>
+			<xs:element name="structure" type="tns:BaseStructure"/>
+			<xs:element name="collection" type="tns:Collection"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="StructureAndCollectionChanges">
+		<xs:sequence>
+			<xs:element name="structure" type="tns:StructureChanges" minOccurs="0"/>
+			<xs:element name="collection" type="tns:CollectionChanges" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="StructureChanges">
+		<xs:choice>
+			<xs:element name="v" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:choice>
+		<xs:attribute name="fields" type="tns:StructureFields"/>
+		<xs:attribute name="fixedFields" type="tns:StructureFields"/>
+	</xs:complexType>
+	<xs:complexType name="Tree">
+		<xs:choice>
+			<xs:element name="item" type="tns:TreeItem" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="TreeChanges">
+		<xs:sequence>
+			<xs:element name="operations" type="tns:TreeOperations" minOccurs="0"/>
+			<xs:element name="items" type="tns:TreeItemChangesList" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TreeItem">
+		<xs:complexContent>
+			<xs:extension base="tns:BaseStructure">
+				<xs:choice>
+					<xs:element name="item" type="tns:TreeItem" minOccurs="0" maxOccurs="unbounded"/>
+				</xs:choice>
+				<xs:attribute name="id" type="xs:long" use="required"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="TreeItemChanges">
+		<xs:sequence>
+			<xs:element name="structure" type="tns:StructureChanges" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="id" type="xs:long" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TreeItemChangesList">
+		<xs:choice>
+			<xs:element name="item" type="tns:TreeItemChanges" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="TreeOperationAdd">
+		<xs:attribute name="parentId" type="xs:long"/>
+		<xs:attribute name="index" type="xs:unsignedInt" use="required"/>
+		<xs:attribute name="id" type="xs:long" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TreeOperationAddRange">
+		<xs:attribute name="parentId" type="xs:long"/>
+		<xs:attribute name="index1" type="xs:unsignedInt" use="required"/>
+		<xs:attribute name="index2" type="xs:unsignedInt" use="required"/>
+		<xs:attribute name="startId" type="xs:long" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TreeOperationClear">
+		<xs:attribute name="parentId" type="xs:long"/>
+	</xs:complexType>
+	<xs:complexType name="TreeOperationMove">
+		<xs:attribute name="parentId" type="xs:long"/>
+		<xs:attribute name="index" type="xs:unsignedInt" use="required"/>
+		<xs:attribute name="delta" type="xs:integer" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TreeOperationRemove">
+		<xs:attribute name="parentId" type="xs:long"/>
+		<xs:attribute name="index" type="xs:unsignedInt" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TreeOperationRemoveRange">
+		<xs:attribute name="parentId" type="xs:long"/>
+		<xs:attribute name="index1" type="xs:unsignedInt" use="required"/>
+		<xs:attribute name="index2" type="xs:unsignedInt" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TreeOperationSwap">
+		<xs:attribute name="parentId" type="xs:long"/>
+		<xs:attribute name="index1" type="xs:unsignedInt" use="required"/>
+		<xs:attribute name="index2" type="xs:unsignedInt" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TreeOperations">
+		<xs:choice>
+			<xs:element name="add" type="tns:TreeOperationAdd" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="addRange" type="tns:TreeOperationAddRange" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="remove" type="tns:TreeOperationRemove" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="removeRange" type="tns:TreeOperationRemoveRange" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="swap" type="tns:TreeOperationSwap" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="move" type="tns:TreeOperationMove" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="clear" type="tns:TreeOperationClear" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="UObject">
+		<xs:sequence>
+			<xs:element name="descriptions" type="tns:FormDataDescriptions" minOccurs="0"/>
+			<xs:element name="name" type="xs:string" minOccurs="0"/>
+			<xs:element name="data"/>
+		</xs:sequence>
+		<xs:attribute name="mode" type="xs:string" use="required"/>
+	</xs:complexType>
+</xs:schema>

--- a/src/main/xsd/v8.5/v8.1c.ru-8.3-MDClasses.xsd
+++ b/src/main/xsd/v8.5/v8.1c.ru-8.3-MDClasses.xsd
@@ -1,0 +1,2899 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:ns1="http://v8.1c.ru/8.1/data/core" xmlns:ns2="http://v8.1c.ru/8.1/data/enterprise" xmlns:ns3="http://v8.1c.ru/8.1/data/ui" xmlns:ns4="http://v8.1c.ru/8.2/managed-application/core" xmlns:ns5="http://v8.1c.ru/8.2/managed-application/cmi" xmlns:ns6="http://v8.1c.ru/8.2/managed-application/logform" xmlns:ns7="http://v8.1c.ru/8.3/xcf/enums" xmlns:ns8="http://v8.1c.ru/8.3/xcf/readable" xmlns:ns9="http://v8.1c.ru/8.3/xcf/predef" xmlns:tns="http://v8.1c.ru/8.3/MDClasses" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://v8.1c.ru/8.3/MDClasses" attributeFormDefault="unqualified" elementFormDefault="qualified">
+	<xs:import namespace="http://v8.1c.ru/8.1/data/core"/>
+	<xs:import namespace="http://v8.1c.ru/8.1/data/enterprise"/>
+	<xs:import namespace="http://v8.1c.ru/8.1/data/ui"/>
+	<xs:import namespace="http://v8.1c.ru/8.2/managed-application/core"/>
+	<xs:import namespace="http://v8.1c.ru/8.2/managed-application/cmi"/>
+	<xs:import namespace="http://v8.1c.ru/8.2/managed-application/logform"/>
+	<xs:import namespace="http://v8.1c.ru/8.3/xcf/enums"/>
+	<xs:import namespace="http://v8.1c.ru/8.3/xcf/readable"/>
+	<xs:import namespace="http://v8.1c.ru/8.3/xcf/predef"/>
+	<xs:element name="MetaDataObject" type="tns:MetaDataObject"/>
+	<xs:complexType name="AccountingFlag">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:AccountingFlagProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="AccountingFlagProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Type" type="ns1:TypeDescription"/>
+			<xs:element name="PasswordMode" type="xs:boolean"/>
+			<xs:element name="Format" type="ns1:LocalStringType"/>
+			<xs:element name="EditFormat" type="ns1:LocalStringType"/>
+			<xs:element name="ToolTip" type="ns1:LocalStringType"/>
+			<xs:element name="MarkNegatives" type="xs:boolean"/>
+			<xs:element name="Mask" type="xs:string"/>
+			<xs:element name="MultiLine" type="xs:boolean"/>
+			<xs:element name="ExtendedEdit" type="xs:boolean"/>
+			<xs:element name="MinValue"/>
+			<xs:element name="MaxValue"/>
+			<xs:element name="FillFromFillingValue" type="xs:boolean"/>
+			<xs:element name="FillValue"/>
+			<xs:element name="FillChecking" type="ns1:FillChecking"/>
+			<xs:element name="ChoiceFoldersAndItems" type="ns2:FoldersAndItemsUse"/>
+			<xs:element name="ChoiceParameterLinks" type="ns8:ChoiceParameterLinks"/>
+			<xs:element name="ChoiceParameters" type="ns4:ChoiceParameters"/>
+			<xs:element name="QuickChoice" type="ns7:UseQuickChoice"/>
+			<xs:element name="CreateOnInput" type="ns7:CreateOnInput"/>
+			<xs:element name="ChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="LinkByType" type="ns8:TypeLink"/>
+			<xs:element name="ChoiceHistoryOnInput" type="ns6:ChoiceHistoryOnInput"/>
+			<xs:element name="DataHistory" type="ns7:DataHistoryUse"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="AccountingRegister">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:AccountingRegisterProperties"/>
+					<xs:element name="ChildObjects" type="tns:AccountingRegisterChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="AccountingRegisterChildObjects">
+		<xs:sequence>
+			<xs:element name="Dimension" type="tns:Dimension" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Resource" type="tns:Resource" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Attribute" type="tns:Attribute" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Form" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Template" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Command" type="tns:Command" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="AccountingRegisterProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="UseStandardCommands" type="xs:boolean"/>
+			<xs:element name="IncludeHelpInContents" type="xs:boolean"/>
+			<xs:element name="Help" type="ns8:ExternalProperty"/>
+			<xs:element name="ChartOfAccounts" type="ns8:MDObjectRef"/>
+			<xs:element name="Correspondence" type="xs:boolean"/>
+			<xs:element name="PeriodAdjustmentLength" type="xs:decimal"/>
+			<xs:element name="DefaultListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="RecordSetModule" type="ns8:ExternalProperty"/>
+			<xs:element name="ManagerModule" type="ns8:ExternalProperty"/>
+			<xs:element name="StandardAttributes" type="ns8:StandardAttributeDescriptions"/>
+			<xs:element name="DataLockControlMode" type="ns7:DefaultDataLockControlMode"/>
+			<xs:element name="EnableTotalsSplitting" type="xs:boolean"/>
+			<xs:element name="FullTextSearch" type="ns7:FullTextSearchUsing"/>
+			<xs:element name="ListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="Explanation" type="ns1:LocalStringType"/>
+			<xs:element name="AdditionalIndexes" type="ns8:ExternalProperty"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="AccumulationRegister">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:AccumulationRegisterProperties"/>
+					<xs:element name="ChildObjects" type="tns:AccumulationRegisterChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="AccumulationRegisterChildObjects">
+		<xs:sequence>
+			<xs:element name="Resource" type="tns:Resource" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Attribute" type="tns:Attribute" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Dimension" type="tns:Dimension" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Form" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Template" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Command" type="tns:Command" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="AccumulationRegisterProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="UseStandardCommands" type="xs:boolean"/>
+			<xs:element name="DefaultListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="RegisterType" type="ns7:AccumulationRegisterType"/>
+			<xs:element name="IncludeHelpInContents" type="xs:boolean"/>
+			<xs:element name="Help" type="ns8:ExternalProperty"/>
+			<xs:element name="RecordSetModule" type="ns8:ExternalProperty"/>
+			<xs:element name="ManagerModule" type="ns8:ExternalProperty"/>
+			<xs:element name="StandardAttributes" type="ns8:StandardAttributeDescriptions"/>
+			<xs:element name="DataLockControlMode" type="ns7:DefaultDataLockControlMode"/>
+			<xs:element name="FullTextSearch" type="ns7:FullTextSearchUsing"/>
+			<xs:element name="EnableTotalsSplitting" type="xs:boolean"/>
+			<xs:element name="Aggregates" type="ns8:ExternalProperty"/>
+			<xs:element name="ListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="Explanation" type="ns1:LocalStringType"/>
+			<xs:element name="AdditionalIndexes" type="ns8:ExternalProperty"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="AddressingAttribute">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:AddressingAttributeProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="AddressingAttributeProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Type" type="ns1:TypeDescription"/>
+			<xs:element name="PasswordMode" type="xs:boolean"/>
+			<xs:element name="Format" type="ns1:LocalStringType"/>
+			<xs:element name="EditFormat" type="ns1:LocalStringType"/>
+			<xs:element name="ToolTip" type="ns1:LocalStringType"/>
+			<xs:element name="MarkNegatives" type="xs:boolean"/>
+			<xs:element name="Mask" type="xs:string"/>
+			<xs:element name="MultiLine" type="xs:boolean"/>
+			<xs:element name="ExtendedEdit" type="xs:boolean"/>
+			<xs:element name="MinValue"/>
+			<xs:element name="MaxValue"/>
+			<xs:element name="FillFromFillingValue" type="xs:boolean"/>
+			<xs:element name="FillValue"/>
+			<xs:element name="FillChecking" type="ns1:FillChecking"/>
+			<xs:element name="ChoiceFoldersAndItems" type="ns2:FoldersAndItemsUse"/>
+			<xs:element name="ChoiceParameterLinks" type="ns8:ChoiceParameterLinks"/>
+			<xs:element name="ChoiceParameters" type="ns4:ChoiceParameters"/>
+			<xs:element name="QuickChoice" type="ns7:UseQuickChoice"/>
+			<xs:element name="CreateOnInput" type="ns7:CreateOnInput"/>
+			<xs:element name="ChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="LinkByType" type="ns8:TypeLink"/>
+			<xs:element name="ChoiceHistoryOnInput" type="ns6:ChoiceHistoryOnInput"/>
+			<xs:element name="Indexing" type="ns7:Indexing"/>
+			<xs:element name="AddressingDimension" type="ns8:MDObjectRef"/>
+			<xs:element name="FullTextSearch" type="ns7:FullTextSearchUsing"/>
+			<xs:element name="DataHistory" type="ns7:DataHistoryUse"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Attribute">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:AttributeProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="AttributeProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string" minOccurs="0"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="Comment" type="xs:string" minOccurs="0"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging" minOccurs="0"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Type" type="ns1:TypeDescription" minOccurs="0"/>
+			<xs:element name="PasswordMode" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="Format" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="EditFormat" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="ToolTip" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="MarkNegatives" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="Mask" type="xs:string" minOccurs="0"/>
+			<xs:element name="MultiLine" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="ExtendedEdit" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="MinValue" minOccurs="0"/>
+			<xs:element name="MaxValue" minOccurs="0"/>
+			<xs:element name="FillChecking" type="ns1:FillChecking" minOccurs="0"/>
+			<xs:element name="ChoiceFoldersAndItems" type="ns2:FoldersAndItemsUse" minOccurs="0"/>
+			<xs:element name="ChoiceParameterLinks" type="ns8:ChoiceParameterLinks" minOccurs="0"/>
+			<xs:element name="ChoiceParameters" type="ns4:ChoiceParameters" minOccurs="0"/>
+			<xs:element name="QuickChoice" type="ns7:UseQuickChoice" minOccurs="0"/>
+			<xs:element name="CreateOnInput" type="ns7:CreateOnInput" minOccurs="0"/>
+			<xs:element name="ChoiceForm" type="ns8:MDObjectRef" minOccurs="0"/>
+			<xs:element name="LinkByType" type="ns8:TypeLink" minOccurs="0"/>
+			<xs:element name="ChoiceHistoryOnInput" type="ns6:ChoiceHistoryOnInput" minOccurs="0"/>
+			<xs:element name="Indexing" type="ns7:Indexing" minOccurs="0"/>
+			<xs:element name="FullTextSearch" type="ns7:FullTextSearchUsing" minOccurs="0"/>
+			<xs:element name="DataHistory" type="ns7:DataHistoryUse" minOccurs="0"/>
+			<xs:element name="FillFromFillingValue" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="FillValue" minOccurs="0"/>
+			<xs:element name="Use" type="ns7:AttributeUse" minOccurs="0"/>
+			<xs:element name="ScheduleLink" type="ns8:MDObjectRef" minOccurs="0"/>
+			<xs:element name="BinaryDataStorageLocationUse" type="ns7:BinaryDataStorageLocationUse" minOccurs="0"/>
+			<xs:element name="BinaryDataStorageLocationUseField" type="ns8:MDObjectRef" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Bot">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:BotProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="BotProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Predefined" type="xs:boolean"/>
+			<xs:element name="Picture" type="ns8:Picture" minOccurs="0"/>
+			<xs:element name="Module" type="ns8:ExternalProperty"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="BusinessProcess">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:BusinessProcessProperties"/>
+					<xs:element name="ChildObjects" type="tns:BusinessProcessChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="BusinessProcessChildObjects">
+		<xs:sequence>
+			<xs:element name="Attribute" type="tns:Attribute" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="TabularSection" type="tns:TabularSection" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Form" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Template" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Command" type="tns:Command" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="BusinessProcessProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="UseStandardCommands" type="xs:boolean"/>
+			<xs:element name="ObjectModule" type="ns8:ExternalProperty"/>
+			<xs:element name="ManagerModule" type="ns8:ExternalProperty"/>
+			<xs:element name="Flowchart" type="ns8:ExternalProperty"/>
+			<xs:element name="EditType" type="ns7:EditType"/>
+			<xs:element name="InputByString" type="ns8:FieldList"/>
+			<xs:element name="CreateOnInput" type="ns7:CreateOnInput"/>
+			<xs:element name="SearchStringModeOnInputByString" type="ns6:SearchStringModeOnInputByString"/>
+			<xs:element name="ChoiceDataGetModeOnInputByString" type="ns6:ChoiceDataGetModeOnInputByString"/>
+			<xs:element name="FullTextSearchOnInputByString" type="ns6:FullTextSearchOnInputByString"/>
+			<xs:element name="DefaultObjectForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryObjectForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="ChoiceHistoryOnInput" type="ns6:ChoiceHistoryOnInput"/>
+			<xs:element name="NumberType" type="ns7:BusinessProcessNumberType"/>
+			<xs:element name="NumberLength" type="xs:decimal"/>
+			<xs:element name="NumberAllowedLength" type="ns1:AllowedLength"/>
+			<xs:element name="CheckUnique" type="xs:boolean"/>
+			<xs:element name="StandardAttributes" type="ns8:StandardAttributeDescriptions"/>
+			<xs:element name="Characteristics" type="ns8:CharacteristicsDescriptions"/>
+			<xs:element name="Autonumbering" type="xs:boolean"/>
+			<xs:element name="BasedOn" type="ns8:MDListType"/>
+			<xs:element name="NumberPeriodicity" type="ns7:BusinessProcessNumberPeriodicity"/>
+			<xs:element name="Task" type="ns8:MDObjectRef"/>
+			<xs:element name="CreateTaskInPrivilegedMode" type="xs:boolean"/>
+			<xs:element name="DataLockFields" type="ns8:FieldList"/>
+			<xs:element name="DataLockControlMode" type="ns7:DefaultDataLockControlMode"/>
+			<xs:element name="IncludeHelpInContents" type="xs:boolean"/>
+			<xs:element name="Help" type="ns8:ExternalProperty"/>
+			<xs:element name="FullTextSearch" type="ns7:FullTextSearchUsing"/>
+			<xs:element name="ObjectPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedObjectPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="Explanation" type="ns1:LocalStringType"/>
+			<xs:element name="DataHistory" type="ns7:DataHistoryUse"/>
+			<xs:element name="UpdateDataHistoryImmediatelyAfterWrite" type="xs:boolean"/>
+			<xs:element name="ExecuteAfterWriteDataHistoryVersionProcessing" type="xs:boolean"/>
+			<xs:element name="AdditionalIndexes" type="ns8:ExternalProperty"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CalculationRegister">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:CalculationRegisterProperties"/>
+					<xs:element name="ChildObjects" type="tns:CalculationRegisterChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="CalculationRegisterChildObjects">
+		<xs:sequence>
+			<xs:element name="Resource" type="tns:Resource" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Attribute" type="tns:Attribute" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Dimension" type="tns:Dimension" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Recalculation" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Form" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Template" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Command" type="tns:Command" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CalculationRegisterProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="UseStandardCommands" type="xs:boolean"/>
+			<xs:element name="DefaultListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="Periodicity" type="ns7:CalculationRegisterPeriodicity"/>
+			<xs:element name="ActionPeriod" type="xs:boolean"/>
+			<xs:element name="BasePeriod" type="xs:boolean"/>
+			<xs:element name="Schedule" type="ns8:MDObjectRef"/>
+			<xs:element name="ScheduleValue" type="ns8:MDObjectRef"/>
+			<xs:element name="ScheduleDate" type="ns8:MDObjectRef"/>
+			<xs:element name="ChartOfCalculationTypes" type="ns8:MDObjectRef"/>
+			<xs:element name="RecordSetModule" type="ns8:ExternalProperty"/>
+			<xs:element name="ManagerModule" type="ns8:ExternalProperty"/>
+			<xs:element name="IncludeHelpInContents" type="xs:boolean"/>
+			<xs:element name="Help" type="ns8:ExternalProperty"/>
+			<xs:element name="StandardAttributes" type="ns8:StandardAttributeDescriptions"/>
+			<xs:element name="DataLockControlMode" type="ns7:DefaultDataLockControlMode"/>
+			<xs:element name="FullTextSearch" type="ns7:FullTextSearchUsing"/>
+			<xs:element name="ListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="Explanation" type="ns1:LocalStringType"/>
+			<xs:element name="AdditionalIndexes" type="ns8:ExternalProperty"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Catalog">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:CatalogProperties"/>
+					<xs:element name="ChildObjects" type="tns:CatalogChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="CatalogChildObjects">
+		<xs:sequence>
+			<xs:element name="Attribute" type="tns:Attribute" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="TabularSection" type="tns:TabularSection" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Form" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Template" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Command" type="tns:Command" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CatalogProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Hierarchical" type="xs:boolean"/>
+			<xs:element name="HierarchyType" type="ns7:HierarchyType"/>
+			<xs:element name="LimitLevelCount" type="xs:boolean"/>
+			<xs:element name="LevelCount" type="xs:decimal"/>
+			<xs:element name="FoldersOnTop" type="xs:boolean"/>
+			<xs:element name="UseStandardCommands" type="xs:boolean"/>
+			<xs:element name="Owners" type="ns8:MDListType"/>
+			<xs:element name="SubordinationUse" type="ns7:SubordinationUse"/>
+			<xs:element name="CodeLength" type="xs:decimal"/>
+			<xs:element name="DescriptionLength" type="xs:decimal"/>
+			<xs:element name="CodeType" type="ns7:CatalogCodeType"/>
+			<xs:element name="CodeAllowedLength" type="ns1:AllowedLength"/>
+			<xs:element name="CodeSeries" type="ns7:CatalogCodesSeries"/>
+			<xs:element name="CheckUnique" type="xs:boolean"/>
+			<xs:element name="Autonumbering" type="xs:boolean"/>
+			<xs:element name="DefaultPresentation" type="ns7:CatalogMainPresentation"/>
+			<xs:element name="StandardAttributes" type="ns8:StandardAttributeDescriptions"/>
+			<xs:element name="Characteristics" type="ns8:CharacteristicsDescriptions"/>
+			<xs:element name="Predefined" type="ns8:ExternalProperty"/>
+			<xs:element name="PredefinedDataUpdate" type="ns7:PredefinedDataUpdate"/>
+			<xs:element name="EditType" type="ns7:EditType"/>
+			<xs:element name="QuickChoice" type="xs:boolean"/>
+			<xs:element name="ChoiceMode" type="ns7:ChoiceMode"/>
+			<xs:element name="InputByString" type="ns8:FieldList"/>
+			<xs:element name="SearchStringModeOnInputByString" type="ns6:SearchStringModeOnInputByString"/>
+			<xs:element name="FullTextSearchOnInputByString" type="ns6:FullTextSearchOnInputByString"/>
+			<xs:element name="ChoiceDataGetModeOnInputByString" type="ns6:ChoiceDataGetModeOnInputByString"/>
+			<xs:element name="DefaultObjectForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultFolderForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultFolderChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryObjectForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryFolderForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryFolderChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="ObjectModule" type="ns8:ExternalProperty"/>
+			<xs:element name="ManagerModule" type="ns8:ExternalProperty"/>
+			<xs:element name="IncludeHelpInContents" type="xs:boolean"/>
+			<xs:element name="Help" type="ns8:ExternalProperty"/>
+			<xs:element name="BasedOn" type="ns8:MDListType"/>
+			<xs:element name="DataLockFields" type="ns8:FieldList"/>
+			<xs:element name="DataLockControlMode" type="ns7:DefaultDataLockControlMode"/>
+			<xs:element name="FullTextSearch" type="ns7:FullTextSearchUsing"/>
+			<xs:element name="ObjectPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedObjectPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="Explanation" type="ns1:LocalStringType"/>
+			<xs:element name="CreateOnInput" type="ns7:CreateOnInput"/>
+			<xs:element name="ChoiceHistoryOnInput" type="ns6:ChoiceHistoryOnInput"/>
+			<xs:element name="DataHistory" type="ns7:DataHistoryUse"/>
+			<xs:element name="UpdateDataHistoryImmediatelyAfterWrite" type="xs:boolean"/>
+			<xs:element name="ExecuteAfterWriteDataHistoryVersionProcessing" type="xs:boolean"/>
+			<xs:element name="AdditionalIndexes" type="ns8:ExternalProperty"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ChartOfAccounts">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:ChartOfAccountsProperties"/>
+					<xs:element name="ChildObjects" type="tns:ChartOfAccountsChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="ChartOfAccountsChildObjects">
+		<xs:sequence>
+			<xs:element name="Attribute" type="tns:Attribute" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="TabularSection" type="tns:TabularSection" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="AccountingFlag" type="tns:AccountingFlag" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="ExtDimensionAccountingFlag" type="tns:ExtDimensionAccountingFlag" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Form" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Template" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Command" type="tns:Command" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ChartOfAccountsProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="UseStandardCommands" type="xs:boolean"/>
+			<xs:element name="IncludeHelpInContents" type="xs:boolean"/>
+			<xs:element name="Help" type="ns8:ExternalProperty"/>
+			<xs:element name="BasedOn" type="ns8:MDListType"/>
+			<xs:element name="ExtDimensionTypes" type="ns8:MDObjectRef"/>
+			<xs:element name="MaxExtDimensionCount" type="xs:decimal"/>
+			<xs:element name="CodeMask" type="xs:string"/>
+			<xs:element name="CodeLength" type="xs:decimal"/>
+			<xs:element name="DescriptionLength" type="xs:decimal"/>
+			<xs:element name="CodeSeries" type="ns7:CharOfAccountCodeSeries"/>
+			<xs:element name="CheckUnique" type="xs:boolean"/>
+			<xs:element name="DefaultPresentation" type="ns7:AccountMainPresentation"/>
+			<xs:element name="StandardAttributes" type="ns8:StandardAttributeDescriptions"/>
+			<xs:element name="Characteristics" type="ns8:CharacteristicsDescriptions"/>
+			<xs:element name="StandardTabularSections" type="ns8:StandardTabularSectionDescriptions"/>
+			<xs:element name="Predefined" type="ns8:ExternalProperty"/>
+			<xs:element name="PredefinedDataUpdate" type="ns7:PredefinedDataUpdate"/>
+			<xs:element name="EditType" type="ns7:EditType"/>
+			<xs:element name="QuickChoice" type="xs:boolean"/>
+			<xs:element name="ChoiceMode" type="ns7:ChoiceMode"/>
+			<xs:element name="InputByString" type="ns8:FieldList"/>
+			<xs:element name="SearchStringModeOnInputByString" type="ns6:SearchStringModeOnInputByString"/>
+			<xs:element name="FullTextSearchOnInputByString" type="ns6:FullTextSearchOnInputByString"/>
+			<xs:element name="ChoiceDataGetModeOnInputByString" type="ns6:ChoiceDataGetModeOnInputByString"/>
+			<xs:element name="CreateOnInput" type="ns7:CreateOnInput"/>
+			<xs:element name="ChoiceHistoryOnInput" type="ns6:ChoiceHistoryOnInput"/>
+			<xs:element name="DefaultObjectForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryObjectForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="ObjectModule" type="ns8:ExternalProperty"/>
+			<xs:element name="ManagerModule" type="ns8:ExternalProperty"/>
+			<xs:element name="AutoOrderByCode" type="xs:boolean"/>
+			<xs:element name="OrderLength" type="xs:decimal"/>
+			<xs:element name="DataLockFields" type="ns8:FieldList"/>
+			<xs:element name="DataLockControlMode" type="ns7:DefaultDataLockControlMode"/>
+			<xs:element name="FullTextSearch" type="ns7:FullTextSearchUsing"/>
+			<xs:element name="DataHistory" type="ns7:DataHistoryUse"/>
+			<xs:element name="ObjectPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedObjectPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="Explanation" type="ns1:LocalStringType"/>
+			<xs:element name="UpdateDataHistoryImmediatelyAfterWrite" type="xs:boolean"/>
+			<xs:element name="ExecuteAfterWriteDataHistoryVersionProcessing" type="xs:boolean"/>
+			<xs:element name="AdditionalIndexes" type="ns8:ExternalProperty"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ChartOfCalculationTypes">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:ChartOfCalculationTypesProperties"/>
+					<xs:element name="ChildObjects" type="tns:ChartOfCalculationTypesChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="ChartOfCalculationTypesChildObjects">
+		<xs:sequence>
+			<xs:element name="Attribute" type="tns:Attribute" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="TabularSection" type="tns:TabularSection" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Form" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Template" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Command" type="tns:Command" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ChartOfCalculationTypesProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="UseStandardCommands" type="xs:boolean"/>
+			<xs:element name="CodeLength" type="xs:decimal"/>
+			<xs:element name="DescriptionLength" type="xs:decimal"/>
+			<xs:element name="CodeType" type="ns7:ChartOfCalculationTypesCodeType"/>
+			<xs:element name="CodeAllowedLength" type="ns1:AllowedLength"/>
+			<xs:element name="DefaultPresentation" type="ns7:CalculationTypeMainPresentation"/>
+			<xs:element name="EditType" type="ns7:EditType"/>
+			<xs:element name="QuickChoice" type="xs:boolean"/>
+			<xs:element name="ChoiceMode" type="ns7:ChoiceMode"/>
+			<xs:element name="InputByString" type="ns8:FieldList"/>
+			<xs:element name="SearchStringModeOnInputByString" type="ns6:SearchStringModeOnInputByString"/>
+			<xs:element name="FullTextSearchOnInputByString" type="ns6:FullTextSearchOnInputByString"/>
+			<xs:element name="ChoiceDataGetModeOnInputByString" type="ns6:ChoiceDataGetModeOnInputByString"/>
+			<xs:element name="CreateOnInput" type="ns7:CreateOnInput"/>
+			<xs:element name="ChoiceHistoryOnInput" type="ns6:ChoiceHistoryOnInput"/>
+			<xs:element name="DefaultObjectForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryObjectForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="ObjectModule" type="ns8:ExternalProperty"/>
+			<xs:element name="ManagerModule" type="ns8:ExternalProperty"/>
+			<xs:element name="BasedOn" type="ns8:MDListType"/>
+			<xs:element name="DependenceOnCalculationTypes" type="ns7:ChartOfCalculationTypesBaseUse"/>
+			<xs:element name="BaseCalculationTypes" type="ns8:MDListType"/>
+			<xs:element name="ActionPeriodUse" type="xs:boolean"/>
+			<xs:element name="StandardAttributes" type="ns8:StandardAttributeDescriptions"/>
+			<xs:element name="Characteristics" type="ns8:CharacteristicsDescriptions"/>
+			<xs:element name="StandardTabularSections" type="ns8:StandardTabularSectionDescriptions"/>
+			<xs:element name="Predefined" type="ns8:ExternalProperty"/>
+			<xs:element name="PredefinedDataUpdate" type="ns7:PredefinedDataUpdate"/>
+			<xs:element name="IncludeHelpInContents" type="xs:boolean"/>
+			<xs:element name="Help" type="ns8:ExternalProperty"/>
+			<xs:element name="DataLockFields" type="ns8:FieldList"/>
+			<xs:element name="DataLockControlMode" type="ns7:DefaultDataLockControlMode"/>
+			<xs:element name="FullTextSearch" type="ns7:FullTextSearchUsing"/>
+			<xs:element name="ObjectPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedObjectPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="Explanation" type="ns1:LocalStringType"/>
+			<xs:element name="DataHistory" type="ns7:DataHistoryUse"/>
+			<xs:element name="UpdateDataHistoryImmediatelyAfterWrite" type="xs:boolean"/>
+			<xs:element name="ExecuteAfterWriteDataHistoryVersionProcessing" type="xs:boolean"/>
+			<xs:element name="AdditionalIndexes" type="ns8:ExternalProperty"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ChartOfCharacteristicTypes">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:ChartOfCharacteristicTypesProperties"/>
+					<xs:element name="ChildObjects" type="tns:ChartOfCharacteristicTypesChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="ChartOfCharacteristicTypesChildObjects">
+		<xs:sequence>
+			<xs:element name="Attribute" type="tns:Attribute" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="TabularSection" type="tns:TabularSection" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Form" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Template" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Command" type="tns:Command" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ChartOfCharacteristicTypesProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="UseStandardCommands" type="xs:boolean"/>
+			<xs:element name="IncludeHelpInContents" type="xs:boolean"/>
+			<xs:element name="Help" type="ns8:ExternalProperty"/>
+			<xs:element name="CharacteristicExtValues" type="ns8:MDObjectRef"/>
+			<xs:element name="Type" type="ns1:TypeDescription"/>
+			<xs:element name="Hierarchical" type="xs:boolean"/>
+			<xs:element name="FoldersOnTop" type="xs:boolean"/>
+			<xs:element name="CodeLength" type="xs:decimal"/>
+			<xs:element name="CodeAllowedLength" type="ns1:AllowedLength"/>
+			<xs:element name="DescriptionLength" type="xs:decimal"/>
+			<xs:element name="CodeSeries" type="ns7:CharacteristicKindCodesSeries"/>
+			<xs:element name="CheckUnique" type="xs:boolean"/>
+			<xs:element name="Autonumbering" type="xs:boolean"/>
+			<xs:element name="DefaultPresentation" type="ns7:CharacteristicTypeMainPresentation"/>
+			<xs:element name="StandardAttributes" type="ns8:StandardAttributeDescriptions"/>
+			<xs:element name="Characteristics" type="ns8:CharacteristicsDescriptions"/>
+			<xs:element name="Predefined" type="ns8:ExternalProperty"/>
+			<xs:element name="PredefinedDataUpdate" type="ns7:PredefinedDataUpdate"/>
+			<xs:element name="EditType" type="ns7:EditType"/>
+			<xs:element name="QuickChoice" type="xs:boolean"/>
+			<xs:element name="ChoiceMode" type="ns7:ChoiceMode"/>
+			<xs:element name="InputByString" type="ns8:FieldList"/>
+			<xs:element name="CreateOnInput" type="ns7:CreateOnInput"/>
+			<xs:element name="SearchStringModeOnInputByString" type="ns6:SearchStringModeOnInputByString"/>
+			<xs:element name="ChoiceDataGetModeOnInputByString" type="ns6:ChoiceDataGetModeOnInputByString"/>
+			<xs:element name="FullTextSearchOnInputByString" type="ns6:FullTextSearchOnInputByString"/>
+			<xs:element name="ChoiceHistoryOnInput" type="ns6:ChoiceHistoryOnInput"/>
+			<xs:element name="DefaultObjectForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultFolderForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultFolderChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryObjectForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryFolderForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryFolderChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="ObjectModule" type="ns8:ExternalProperty"/>
+			<xs:element name="ManagerModule" type="ns8:ExternalProperty"/>
+			<xs:element name="BasedOn" type="ns8:MDListType"/>
+			<xs:element name="DataLockFields" type="ns8:FieldList"/>
+			<xs:element name="DataLockControlMode" type="ns7:DefaultDataLockControlMode"/>
+			<xs:element name="FullTextSearch" type="ns7:FullTextSearchUsing"/>
+			<xs:element name="ObjectPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedObjectPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="Explanation" type="ns1:LocalStringType"/>
+			<xs:element name="DataHistory" type="ns7:DataHistoryUse"/>
+			<xs:element name="UpdateDataHistoryImmediatelyAfterWrite" type="xs:boolean"/>
+			<xs:element name="ExecuteAfterWriteDataHistoryVersionProcessing" type="xs:boolean"/>
+			<xs:element name="AdditionalIndexes" type="ns8:ExternalProperty"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Column">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:ColumnProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="ColumnProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Indexing" type="ns7:Indexing"/>
+			<xs:element name="References" type="ns8:MDListType"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Command">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:CommandProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="CommandGroup">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:CommandGroupProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="CommandGroupProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Representation" type="ns6:ButtonRepresentation"/>
+			<xs:element name="ToolTip" type="ns1:LocalStringType"/>
+			<xs:element name="Picture" type="ns8:Picture"/>
+			<xs:element name="Category" type="ns4:CommandGroupCategory"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CommandProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string" minOccurs="0"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="Comment" type="xs:string" minOccurs="0"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging" minOccurs="0"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Group" type="ns8:IncludeInCommandCategoriesType" minOccurs="0"/>
+			<xs:element name="CommandParameterType" type="ns1:TypeDescription" minOccurs="0"/>
+			<xs:element name="ParameterUseMode" type="ns5:CommandParameterUseMode" minOccurs="0"/>
+			<xs:element name="ModifiesData" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="Representation" type="ns6:ButtonRepresentation" minOccurs="0"/>
+			<xs:element name="ToolTip" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="Picture" type="ns8:Picture" minOccurs="0"/>
+			<xs:element name="Shortcut" type="ns8:ShortCutType" minOccurs="0"/>
+			<xs:element name="CommandModule" type="ns8:ExternalProperty" minOccurs="0"/>
+			<xs:element name="OnMainServerUnavalableBehavior" type="ns6:OnMainServerUnavalableBehavior"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CommonAttribute">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:CommonAttributeProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="CommonAttributeProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Type" type="ns1:TypeDescription"/>
+			<xs:element name="PasswordMode" type="xs:boolean"/>
+			<xs:element name="Format" type="ns1:LocalStringType"/>
+			<xs:element name="EditFormat" type="ns1:LocalStringType"/>
+			<xs:element name="ToolTip" type="ns1:LocalStringType"/>
+			<xs:element name="MarkNegatives" type="xs:boolean"/>
+			<xs:element name="Mask" type="xs:string"/>
+			<xs:element name="MultiLine" type="xs:boolean"/>
+			<xs:element name="ExtendedEdit" type="xs:boolean"/>
+			<xs:element name="MinValue"/>
+			<xs:element name="MaxValue"/>
+			<xs:element name="FillFromFillingValue" type="xs:boolean"/>
+			<xs:element name="FillValue"/>
+			<xs:element name="FillChecking" type="ns1:FillChecking"/>
+			<xs:element name="ChoiceFoldersAndItems" type="ns2:FoldersAndItemsUse"/>
+			<xs:element name="ChoiceParameterLinks" type="ns8:ChoiceParameterLinks"/>
+			<xs:element name="ChoiceParameters" type="ns4:ChoiceParameters"/>
+			<xs:element name="QuickChoice" type="ns7:UseQuickChoice"/>
+			<xs:element name="CreateOnInput" type="ns7:CreateOnInput"/>
+			<xs:element name="ChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="LinkByType" type="ns8:TypeLink"/>
+			<xs:element name="ChoiceHistoryOnInput" type="ns6:ChoiceHistoryOnInput"/>
+			<xs:element name="Content" type="ns8:CommonAttributeContent"/>
+			<xs:element name="AutoUse" type="ns7:CommonAttributeAutoUse"/>
+			<xs:element name="DataSeparation" type="ns7:CommonAttributeDataSeparation"/>
+			<xs:element name="SeparatedDataUse" type="ns7:CommonAttributeSeparatedDataUse"/>
+			<xs:element name="DataSeparationValue" type="ns8:MDObjectRef"/>
+			<xs:element name="DataSeparationUse" type="ns8:MDObjectRef"/>
+			<xs:element name="ConditionalSeparation" type="ns8:MDObjectRef"/>
+			<xs:element name="UsersSeparation" type="ns7:CommonAttributeUsersSeparation"/>
+			<xs:element name="AuthenticationSeparation" type="ns7:CommonAttributeAuthenticationSeparation"/>
+			<xs:element name="ConfigurationExtensionsSeparation" type="ns7:CommonAttributeConfigurationExtensionsSeparation"/>
+			<xs:element name="Indexing" type="ns7:Indexing"/>
+			<xs:element name="FullTextSearch" type="ns7:FullTextSearchUsing"/>
+			<xs:element name="DataHistory" type="ns7:DataHistoryUse"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CommonCommand">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:CommonCommandProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="CommonCommandProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Group" type="ns8:IncludeInCommandCategoriesType"/>
+			<xs:element name="Representation" type="ns6:ButtonRepresentation"/>
+			<xs:element name="ToolTip" type="ns1:LocalStringType"/>
+			<xs:element name="Picture" type="ns8:Picture"/>
+			<xs:element name="Shortcut" type="ns8:ShortCutType"/>
+			<xs:element name="CommandModule" type="ns8:ExternalProperty"/>
+			<xs:element name="IncludeHelpInContents" type="xs:boolean"/>
+			<xs:element name="Help" type="ns8:ExternalProperty"/>
+			<xs:element name="CommandParameterType" type="ns1:TypeDescription"/>
+			<xs:element name="ParameterUseMode" type="ns5:CommandParameterUseMode"/>
+			<xs:element name="ModifiesData" type="xs:boolean"/>
+			<xs:element name="OnMainServerUnavalableBehavior" type="ns6:OnMainServerUnavalableBehavior"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CommonForm">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:CommonFormProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="CommonFormProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Form" type="ns8:ExternalProperty"/>
+			<xs:element name="FormType" type="ns7:FormType"/>
+			<xs:element name="IncludeHelpInContents" type="xs:boolean"/>
+			<xs:element name="Help" type="ns8:ExternalProperty"/>
+			<xs:element name="UsePurposes" type="ns1:FixedArray"/>
+			<xs:element name="UseStandardCommands" type="xs:boolean"/>
+			<xs:element name="ExtendedPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="Explanation" type="ns1:LocalStringType"/>
+			<xs:element name="UseInInterfaceCompatibilityMode" type="ns7:UseInInterfaceCompatibilityMode"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CommonModule">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:CommonModuleProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="CommonModuleProperties">
+		<xs:choice>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Module" type="ns8:ExternalProperty"/>
+			<xs:element name="Global" type="xs:boolean"/>
+			<xs:element name="ClientManagedApplication" type="xs:boolean"/>
+			<xs:element name="Server" type="xs:boolean"/>
+			<xs:element name="ExternalConnection" type="xs:boolean"/>
+			<xs:element name="ClientOrdinaryApplication" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="Client" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="ServerCall" type="xs:boolean"/>
+			<xs:element name="Privileged" type="xs:boolean"/>
+			<xs:element name="ReturnValuesReuse" type="ns7:ReturnValuesReuse"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="CommonPicture">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:CommonPictureProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="CommonPictureProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Picture" type="ns8:ExternalProperty"/>
+			<xs:element name="AvailabilityForChoice" type="xs:boolean"/>
+			<xs:element name="AvailabilityForAppearance" type="xs:boolean"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CommonTemplate">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:CommonTemplateProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="CommonTemplateProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="TemplateType" type="ns7:TemplateType"/>
+			<xs:element name="Template" type="ns8:ExternalProperty"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Configuration">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:ConfigurationProperties"/>
+					<xs:element name="ChildObjects" type="tns:ConfigurationChildObjects"/>
+				</xs:sequence>
+				<xs:attribute name="formatVersion" type="xs:string" use="required"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="ConfigurationChildObjects">
+		<xs:sequence>
+			<xs:element name="Language" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Subsystem" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="StyleItem" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Style" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="CommonPicture" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Interface" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="SessionParameter" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Role" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="CommonTemplate" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="FilterCriterion" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="CommonModule" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="CommonAttribute" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="ExchangePlan" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="XDTOPackage" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="WebService" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="HTTPService" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="WSReference" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="EventSubscription" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="ScheduledJob" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="SettingsStorage" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="FunctionalOption" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="FunctionalOptionsParameter" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="DefinedType" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="CommonCommand" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="CommandGroup" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Constant" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="CommonForm" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Catalog" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Document" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="DocumentNumerator" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Sequence" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="DocumentJournal" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Enum" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Report" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="DataProcessor" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="InformationRegister" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="AccumulationRegister" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="ChartOfCharacteristicTypes" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="ChartOfAccounts" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="AccountingRegister" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="ChartOfCalculationTypes" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="CalculationRegister" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="BusinessProcess" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Task" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="ExternalDataSource" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="IntegrationService" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Bot" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="WebSocketClient" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="PaletteColor" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ConfigurationProperties">
+		<xs:choice>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ConfigurationExtensionPurpose" type="ns7:ConfigurationExtensionPurpose"/>
+			<xs:element name="KeepMappingToExtendedConfigurationObjectsByIDs" type="xs:boolean"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="NamePrefix" type="xs:string"/>
+			<xs:element name="ConfigurationExtensionCompatibilityMode" type="ns7:CompatibilityMode"/>
+			<xs:element name="DefaultRunMode" type="ns4:ClientRunMode"/>
+			<xs:element name="UsePurposes" type="ns1:FixedArray"/>
+			<xs:element name="ScriptVariant" type="ns7:ScriptVariant"/>
+			<xs:element name="DefaultRoles" type="ns8:MDListType"/>
+			<xs:element name="Vendor" type="xs:string"/>
+			<xs:element name="Version" type="xs:string"/>
+			<xs:element name="UpdateCatalogAddress" type="xs:string"/>
+			<xs:element name="ParentConfigurations" type="ns8:ExternalProperty"/>
+			<xs:element name="ManagedApplicationModule" type="ns8:ExternalProperty"/>
+			<xs:element name="SessionModule" type="ns8:ExternalProperty"/>
+			<xs:element name="ExternalConnectionModule" type="ns8:ExternalProperty"/>
+			<xs:element name="OrdinaryApplicationModule" type="ns8:ExternalProperty" minOccurs="0"/>
+			<xs:element name="ApplicationModule" type="ns8:ExternalProperty" minOccurs="0"/>
+			<xs:element name="IncludeHelpInContents" type="xs:boolean"/>
+			<xs:element name="Help" type="ns8:ExternalProperty"/>
+			<xs:element name="UseManagedFormInOrdinaryApplication" type="xs:boolean"/>
+			<xs:element name="UseOrdinaryFormInManagedApplication" type="xs:boolean"/>
+			<xs:element name="AdditionalFullTextSearchDictionaries" type="ns8:MDListType"/>
+			<xs:element name="CommonSettingsStorage" type="ns8:MDObjectRef"/>
+			<xs:element name="ReportsUserSettingsStorage" type="ns8:MDObjectRef"/>
+			<xs:element name="ReportsVariantsStorage" type="ns8:MDObjectRef"/>
+			<xs:element name="FormDataSettingsStorage" type="ns8:MDObjectRef"/>
+			<xs:element name="DynamicListsUserSettingsStorage" type="ns8:MDObjectRef"/>
+			<xs:element name="URLExternalDataStorage" type="ns8:MDObjectRef"/>
+			<xs:element name="Content" type="ns8:MDListType"/>
+			<xs:element name="DefaultReportForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultReportVariantForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultReportSettingsForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultDynamicListSettingsForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultSearchForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultDataHistoryChangeHistoryForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultDataHistoryVersionDataForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultDataHistoryVersionDifferencesForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultCollaborationSystemUsersChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryReportForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryReportVariantForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryReportSettingsForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryDynamicListSettingsForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryDataHistoryChangeHistoryForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryDataHistoryVersionDataForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryDataHistoryVersionDifferencesForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryCollaborationSystemUsersChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultReportAppearanceTemplate" type="xs:string"/>
+			<xs:element name="RequiredMobileApplicationPermissions" type="ns4:RequiredPermissions"/>
+			<xs:element name="UsedMobileApplicationFunctionalities" type="ns4:UsedFunctionality"/>
+			<xs:element name="MobileApplicationURLs" type="ns1:FixedArray"/>
+			<xs:element name="AllowedIncomingShareRequestTypes" type="ns1:FixedArray"/>
+			<xs:element name="MobileClientSignature" type="ns8:ExternalProperty" minOccurs="0"/>
+			<xs:element name="MobileClientSign" type="ns8:ExternalProperty" minOccurs="0"/>
+			<xs:element name="CommandInterface" type="ns8:ExternalProperty"/>
+			<xs:element name="HomePageWorkArea" type="ns8:ExternalProperty" minOccurs="0"/>
+			<xs:element name="StartPageWorkingArea" type="ns8:ExternalProperty" minOccurs="0"/>
+			<xs:element name="MainSectionCommandInterface" type="ns8:ExternalProperty"/>
+			<xs:element name="MainSectionPicture" type="ns8:ExternalProperty"/>
+			<xs:element name="ClientApplicationInterface" type="ns8:ExternalProperty"/>
+			<xs:element name="ClientApplicationTheme" type="ns2:ClientApplicationTheme"/>
+			<xs:element name="MainClientApplicationWindowMode" type="ns1:MainClientApplicationWindowMode"/>
+			<xs:element name="DefaultInterface" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultStyle" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultLanguage" type="ns8:MDObjectRef"/>
+			<xs:element name="BriefInformation" type="ns1:LocalStringType"/>
+			<xs:element name="DetailedInformation" type="ns1:LocalStringType"/>
+			<xs:element name="Logo" type="ns8:ExternalProperty"/>
+			<xs:element name="Splash" type="ns8:ExternalProperty"/>
+			<xs:element name="Copyright" type="ns1:LocalStringType"/>
+			<xs:element name="VendorInformationAddress" type="ns1:LocalStringType"/>
+			<xs:element name="ConfigurationInformationAddress" type="ns1:LocalStringType"/>
+			<xs:element name="DataLockControlMode" type="ns7:DefaultDataLockControlMode"/>
+			<xs:element name="BinaryDataStorageMode" type="ns7:BinaryDataStorageMode"/>
+			<xs:element name="BinaryDataBlockStorageUseMode" type="ns7:BinaryDataBlockStorageUseMode"/>
+			<xs:element name="ObjectAutonumerationMode" type="ns7:ObjectAutonumerationMode"/>
+			<xs:element name="ModalityUseMode" type="ns7:ModalityUseMode"/>
+			<xs:element name="SynchronousPlatformExtensionAndAddInCallUseMode" type="ns7:SynchronousPlatformExtensionAndAddInCallUseMode" minOccurs="0"/>
+			<xs:element name="SynchronousExtensionAndAddInCallUseMode" type="ns7:SynchronousPlatformExtensionAndAddInCallUseMode" minOccurs="0"/>
+			<xs:element name="InterfaceCompatibilityMode" type="ns7:InterfaceCompatibilityMode"/>
+			<xs:element name="Version85InterfaceMigrationMode" type="ns7:Version85InterfaceMigrationMode"/>
+			<xs:element name="CompatibilityMode" type="ns7:CompatibilityMode"/>
+			<xs:element name="DefaultConstantsForm" type="ns8:MDObjectRef" minOccurs="0"/>
+			<xs:element name="DefaultConstantForm" type="ns8:MDObjectRef" minOccurs="0"/>
+			<xs:element name="StandaloneConfigurationRestrictionRoles" type="ns8:MDListType"/>
+			<xs:element name="DatabaseTablespacesUseMode" type="ns7:DatabaseTablespacesUseMode"/>
+			<xs:element name="Caption" type="ns1:LocalStringType"/>
+			<xs:element name="ShortCaption" type="ns1:LocalStringType"/>
+			<xs:element name="MainClientApplicationWindowInterfaceVariant" type="ns2:MainClientApplicationWindowInterfaceVariant"/>
+			<xs:element name="ClientApplicationWindowsOpenVariant" type="ns2:ClientApplicationWindowsOpenVariant"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="Constant">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:ConstantProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="ConstantProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Type" type="ns1:TypeDescription"/>
+			<xs:element name="UseStandardCommands" type="xs:boolean"/>
+			<xs:element name="DefaultForm" type="ns8:MDObjectRef"/>
+			<xs:element name="ExtendedPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="Explanation" type="ns1:LocalStringType"/>
+			<xs:element name="PasswordMode" type="xs:boolean"/>
+			<xs:element name="Format" type="ns1:LocalStringType"/>
+			<xs:element name="EditFormat" type="ns1:LocalStringType"/>
+			<xs:element name="ToolTip" type="ns1:LocalStringType"/>
+			<xs:element name="MarkNegatives" type="xs:boolean"/>
+			<xs:element name="Mask" type="xs:string"/>
+			<xs:element name="MultiLine" type="xs:boolean"/>
+			<xs:element name="ExtendedEdit" type="xs:boolean"/>
+			<xs:element name="MinValue"/>
+			<xs:element name="MaxValue"/>
+			<xs:element name="FillChecking" type="ns1:FillChecking"/>
+			<xs:element name="ChoiceFoldersAndItems" type="ns2:FoldersAndItemsUse"/>
+			<xs:element name="ChoiceParameterLinks" type="ns8:ChoiceParameterLinks"/>
+			<xs:element name="ChoiceParameters" type="ns4:ChoiceParameters"/>
+			<xs:element name="QuickChoice" type="ns7:UseQuickChoice"/>
+			<xs:element name="ChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="LinkByType" type="ns8:TypeLink"/>
+			<xs:element name="ChoiceHistoryOnInput" type="ns6:ChoiceHistoryOnInput"/>
+			<xs:element name="ValueManagerModule" type="ns8:ExternalProperty"/>
+			<xs:element name="ManagerModule" type="ns8:ExternalProperty"/>
+			<xs:element name="DataLockControlMode" type="ns7:DefaultDataLockControlMode"/>
+			<xs:element name="DataHistory" type="ns7:DataHistoryUse"/>
+			<xs:element name="UpdateDataHistoryImmediatelyAfterWrite" type="xs:boolean"/>
+			<xs:element name="ExecuteAfterWriteDataHistoryVersionProcessing" type="xs:boolean"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Cube">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:CubeProperties"/>
+					<xs:element name="ChildObjects" type="tns:CubeChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="CubeChildObjects">
+		<xs:sequence>
+			<xs:element name="DimensionTable" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Dimension" type="tns:Dimension" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Resource" type="tns:Resource" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Form" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Command" type="tns:Command" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Template" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CubeProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="NameInDataSource" type="xs:string"/>
+			<xs:element name="Characteristics" type="ns8:CharacteristicsDescriptions"/>
+			<xs:element name="UseStandardCommands" type="xs:boolean"/>
+			<xs:element name="DefaultRecordForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="RecordPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedRecordPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="Explanation" type="ns1:LocalStringType"/>
+			<xs:element name="RecordSetModule" type="ns8:ExternalProperty"/>
+			<xs:element name="ManagerModule" type="ns8:ExternalProperty"/>
+			<xs:element name="IncludeHelpInContents" type="xs:boolean"/>
+			<xs:element name="Help" type="ns8:ExternalProperty"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DataProcessor">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:DataProcessorProperties"/>
+					<xs:element name="ChildObjects" type="tns:DataProcessorChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="DataProcessorChildObjects">
+		<xs:sequence>
+			<xs:element name="Attribute" type="tns:Attribute" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="TabularSection" type="tns:TabularSection" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Form" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Template" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Command" type="tns:Command" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DataProcessorProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="UseStandardCommands" type="xs:boolean"/>
+			<xs:element name="DefaultForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryForm" type="ns8:MDObjectRef"/>
+			<xs:element name="ObjectModule" type="ns8:ExternalProperty"/>
+			<xs:element name="ManagerModule" type="ns8:ExternalProperty"/>
+			<xs:element name="IncludeHelpInContents" type="xs:boolean"/>
+			<xs:element name="Help" type="ns8:ExternalProperty"/>
+			<xs:element name="ExtendedPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="Explanation" type="ns1:LocalStringType"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DefinedType">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:DefinedTypeProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="DefinedTypeProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Type" type="ns1:TypeDescription"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Dimension">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:DimensionProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="DimensionProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string" minOccurs="0"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="Comment" type="xs:string" minOccurs="0"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging" minOccurs="0"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Type" type="ns1:TypeDescription" minOccurs="0"/>
+			<xs:element name="DocumentMap" type="ns8:MDListType" minOccurs="0"/>
+			<xs:element name="RegisterRecordsMap" type="ns8:MDListType" minOccurs="0"/>
+			<xs:element name="RegisterDimension" type="ns8:MDObjectRef" minOccurs="0"/>
+			<xs:element name="LeadingRegisterData" type="ns8:MDListType" minOccurs="0"/>
+			<xs:element name="PasswordMode" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="Format" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="EditFormat" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="ToolTip" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="MarkNegatives" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="Mask" type="xs:string" minOccurs="0"/>
+			<xs:element name="MultiLine" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="ExtendedEdit" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="MinValue" minOccurs="0"/>
+			<xs:element name="MaxValue" minOccurs="0"/>
+			<xs:element name="FillChecking" type="ns1:FillChecking" minOccurs="0"/>
+			<xs:element name="ChoiceFoldersAndItems" type="ns2:FoldersAndItemsUse" minOccurs="0"/>
+			<xs:element name="ChoiceParameterLinks" type="ns8:ChoiceParameterLinks" minOccurs="0"/>
+			<xs:element name="ChoiceParameters" type="ns4:ChoiceParameters" minOccurs="0"/>
+			<xs:element name="QuickChoice" type="ns7:UseQuickChoice" minOccurs="0"/>
+			<xs:element name="CreateOnInput" type="ns7:CreateOnInput" minOccurs="0"/>
+			<xs:element name="ChoiceForm" type="ns8:MDObjectRef" minOccurs="0"/>
+			<xs:element name="LinkByType" type="ns8:TypeLink" minOccurs="0"/>
+			<xs:element name="ChoiceHistoryOnInput" type="ns6:ChoiceHistoryOnInput" minOccurs="0"/>
+			<xs:element name="DenyIncompleteValues" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="BaseDimension" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="ScheduleLink" type="ns8:MDObjectRef" minOccurs="0"/>
+			<xs:element name="Indexing" type="ns7:Indexing" minOccurs="0"/>
+			<xs:element name="FullTextSearch" type="ns7:FullTextSearchUsing" minOccurs="0"/>
+			<xs:element name="UseInTotals" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="FillFromFillingValue" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="FillValue" minOccurs="0"/>
+			<xs:element name="Master" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="MainFilter" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="DataHistory" type="ns7:DataHistoryUse" minOccurs="0"/>
+			<xs:element name="Balance" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="AccountingFlag" type="ns8:MDObjectRef" minOccurs="0"/>
+			<xs:element name="TypeReductionMode" type="ns7:TypeReductionMode" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DimensionTable">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:DimensionTableProperties"/>
+					<xs:element name="ChildObjects" type="tns:DimensionTableChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="DimensionTableChildObjects">
+		<xs:sequence>
+			<xs:element name="Field" type="tns:Field" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Form" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Command" type="tns:Command" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Template" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DimensionTableProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="NameInDataSource" type="xs:string"/>
+			<xs:element name="PresentationField" type="ns8:MDObjectRef"/>
+			<xs:element name="HierarchyNameInDataSource" type="xs:string"/>
+			<xs:element name="LevelNumber" type="xs:decimal"/>
+			<xs:element name="Hierarchical" type="xs:boolean"/>
+			<xs:element name="UnfilledParentValue"/>
+			<xs:element name="UseStandardCommands" type="xs:boolean"/>
+			<xs:element name="QuickChoice" type="xs:boolean"/>
+			<xs:element name="DefaultObjectForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="ObjectPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedObjectPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="Explanation" type="ns1:LocalStringType"/>
+			<xs:element name="ObjectModule" type="ns8:ExternalProperty"/>
+			<xs:element name="ManagerModule" type="ns8:ExternalProperty"/>
+			<xs:element name="IncludeHelpInContents" type="xs:boolean"/>
+			<xs:element name="Help" type="ns8:ExternalProperty"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Document">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:DocumentProperties"/>
+					<xs:element name="ChildObjects" type="tns:DocumentChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="DocumentChildObjects">
+		<xs:sequence>
+			<xs:element name="Attribute" type="tns:Attribute" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Form" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="TabularSection" type="tns:TabularSection" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Template" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Command" type="tns:Command" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DocumentJournal">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:DocumentJournalProperties"/>
+					<xs:element name="ChildObjects" type="tns:DocumentJournalChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="DocumentJournalChildObjects">
+		<xs:sequence>
+			<xs:element name="Column" type="tns:Column" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Form" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Template" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Command" type="tns:Command" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DocumentJournalProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="DefaultForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryForm" type="ns8:MDObjectRef"/>
+			<xs:element name="UseStandardCommands" type="xs:boolean"/>
+			<xs:element name="RegisteredDocuments" type="ns8:MDListType"/>
+			<xs:element name="IncludeHelpInContents" type="xs:boolean"/>
+			<xs:element name="Help" type="ns8:ExternalProperty"/>
+			<xs:element name="ManagerModule" type="ns8:ExternalProperty"/>
+			<xs:element name="StandardAttributes" type="ns8:StandardAttributeDescriptions"/>
+			<xs:element name="ListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="Explanation" type="ns1:LocalStringType"/>
+			<xs:element name="AdditionalIndexes" type="ns8:ExternalProperty"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DocumentNumerator">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:DocumentNumeratorProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="DocumentNumeratorProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="NumberType" type="ns7:DocumentNumberType"/>
+			<xs:element name="NumberLength" type="xs:decimal"/>
+			<xs:element name="NumberAllowedLength" type="ns1:AllowedLength"/>
+			<xs:element name="NumberPeriodicity" type="ns7:DocumentNumberPeriodicity"/>
+			<xs:element name="CheckUnique" type="xs:boolean"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DocumentProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="UseStandardCommands" type="xs:boolean"/>
+			<xs:element name="Numerator" type="ns8:MDObjectRef"/>
+			<xs:element name="NumberType" type="ns7:DocumentNumberType"/>
+			<xs:element name="NumberLength" type="xs:decimal"/>
+			<xs:element name="NumberAllowedLength" type="ns1:AllowedLength"/>
+			<xs:element name="NumberPeriodicity" type="ns7:DocumentNumberPeriodicity"/>
+			<xs:element name="CheckUnique" type="xs:boolean"/>
+			<xs:element name="Autonumbering" type="xs:boolean"/>
+			<xs:element name="StandardAttributes" type="ns8:StandardAttributeDescriptions"/>
+			<xs:element name="Characteristics" type="ns8:CharacteristicsDescriptions"/>
+			<xs:element name="BasedOn" type="ns8:MDListType"/>
+			<xs:element name="InputByString" type="ns8:FieldList"/>
+			<xs:element name="CreateOnInput" type="ns7:CreateOnInput"/>
+			<xs:element name="SearchStringModeOnInputByString" type="ns6:SearchStringModeOnInputByString"/>
+			<xs:element name="FullTextSearchOnInputByString" type="ns6:FullTextSearchOnInputByString"/>
+			<xs:element name="ChoiceDataGetModeOnInputByString" type="ns6:ChoiceDataGetModeOnInputByString"/>
+			<xs:element name="DefaultObjectForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryObjectForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="ObjectModule" type="ns8:ExternalProperty"/>
+			<xs:element name="ManagerModule" type="ns8:ExternalProperty"/>
+			<xs:element name="Posting" type="ns7:Posting"/>
+			<xs:element name="RealTimePosting" type="ns7:RealTimePosting"/>
+			<xs:element name="RegisterRecordsDeletion" type="ns7:RegisterRecordsDeletion"/>
+			<xs:element name="RegisterRecordsWritingOnPost" type="ns7:RegisterRecordsWritingOnPost"/>
+			<xs:element name="SequenceFilling" type="ns7:SequenceFilling"/>
+			<xs:element name="RegisterRecords" type="ns8:MDListType"/>
+			<xs:element name="PostInPrivilegedMode" type="xs:boolean"/>
+			<xs:element name="UnpostInPrivilegedMode" type="xs:boolean"/>
+			<xs:element name="IncludeHelpInContents" type="xs:boolean"/>
+			<xs:element name="Help" type="ns8:ExternalProperty"/>
+			<xs:element name="DataLockFields" type="ns8:FieldList"/>
+			<xs:element name="DataLockControlMode" type="ns7:DefaultDataLockControlMode"/>
+			<xs:element name="FullTextSearch" type="ns7:FullTextSearchUsing"/>
+			<xs:element name="ObjectPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedObjectPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="Explanation" type="ns1:LocalStringType"/>
+			<xs:element name="ChoiceHistoryOnInput" type="ns6:ChoiceHistoryOnInput"/>
+			<xs:element name="DataHistory" type="ns7:DataHistoryUse"/>
+			<xs:element name="UpdateDataHistoryImmediatelyAfterWrite" type="xs:boolean"/>
+			<xs:element name="ExecuteAfterWriteDataHistoryVersionProcessing" type="xs:boolean"/>
+			<xs:element name="AdditionalIndexes" type="ns8:ExternalProperty"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Enum">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:EnumProperties"/>
+					<xs:element name="ChildObjects" type="tns:EnumChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="EnumChildObjects">
+		<xs:sequence>
+			<xs:element name="EnumValue" type="tns:EnumValue" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Form" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Template" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Command" type="tns:Command" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="EnumProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="UseStandardCommands" type="xs:boolean"/>
+			<xs:element name="StandardAttributes" type="ns8:StandardAttributeDescriptions"/>
+			<xs:element name="Characteristics" type="ns8:CharacteristicsDescriptions"/>
+			<xs:element name="QuickChoice" type="xs:boolean"/>
+			<xs:element name="ChoiceMode" type="ns7:ChoiceMode"/>
+			<xs:element name="DefaultListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="ManagerModule" type="ns8:ExternalProperty"/>
+			<xs:element name="ListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="Explanation" type="ns1:LocalStringType"/>
+			<xs:element name="ChoiceHistoryOnInput" type="ns6:ChoiceHistoryOnInput"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="EnumValue">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:EnumValueProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="EnumValueProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Color" type="ns3:Color" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="EventSubscription">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:EventSubscriptionProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="EventSubscriptionProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Source" type="ns1:TypeDescription"/>
+			<xs:element name="Event" type="ns8:AliasedStringType"/>
+			<xs:element name="Handler" type="ns8:MDMethodRef"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ExchangePlan">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:ExchangePlanProperties"/>
+					<xs:element name="ChildObjects" type="tns:ExchangePlanChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="ExchangePlanChildObjects">
+		<xs:sequence>
+			<xs:element name="Attribute" type="tns:Attribute" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="TabularSection" type="tns:TabularSection" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Form" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Template" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Command" type="tns:Command" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ExchangePlanProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="UseStandardCommands" type="xs:boolean"/>
+			<xs:element name="CodeLength" type="xs:decimal"/>
+			<xs:element name="CodeAllowedLength" type="ns1:AllowedLength"/>
+			<xs:element name="DescriptionLength" type="xs:decimal"/>
+			<xs:element name="Content" type="ns8:ExternalProperty"/>
+			<xs:element name="DefaultPresentation" type="ns7:DataExchangeMainPresentation"/>
+			<xs:element name="EditType" type="ns7:EditType"/>
+			<xs:element name="QuickChoice" type="xs:boolean"/>
+			<xs:element name="ChoiceMode" type="ns7:ChoiceMode"/>
+			<xs:element name="InputByString" type="ns8:FieldList"/>
+			<xs:element name="SearchStringModeOnInputByString" type="ns6:SearchStringModeOnInputByString"/>
+			<xs:element name="FullTextSearchOnInputByString" type="ns6:FullTextSearchOnInputByString"/>
+			<xs:element name="ChoiceDataGetModeOnInputByString" type="ns6:ChoiceDataGetModeOnInputByString"/>
+			<xs:element name="DefaultObjectForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryObjectForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="ObjectModule" type="ns8:ExternalProperty"/>
+			<xs:element name="ManagerModule" type="ns8:ExternalProperty"/>
+			<xs:element name="StandardAttributes" type="ns8:StandardAttributeDescriptions"/>
+			<xs:element name="Characteristics" type="ns8:CharacteristicsDescriptions"/>
+			<xs:element name="BasedOn" type="ns8:MDListType"/>
+			<xs:element name="DistributedInfoBase" type="xs:boolean"/>
+			<xs:element name="IncludeConfigurationExtensions" type="xs:boolean"/>
+			<xs:element name="CreateOnInput" type="ns7:CreateOnInput"/>
+			<xs:element name="ChoiceHistoryOnInput" type="ns6:ChoiceHistoryOnInput"/>
+			<xs:element name="IncludeHelpInContents" type="xs:boolean"/>
+			<xs:element name="Help" type="ns8:ExternalProperty"/>
+			<xs:element name="DataLockFields" type="ns8:FieldList"/>
+			<xs:element name="DataLockControlMode" type="ns7:DefaultDataLockControlMode"/>
+			<xs:element name="FullTextSearch" type="ns7:FullTextSearchUsing"/>
+			<xs:element name="ObjectPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedObjectPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="Explanation" type="ns1:LocalStringType"/>
+			<xs:element name="DataHistory" type="ns7:DataHistoryUse"/>
+			<xs:element name="UpdateDataHistoryImmediatelyAfterWrite" type="xs:boolean"/>
+			<xs:element name="ExecuteAfterWriteDataHistoryVersionProcessing" type="xs:boolean"/>
+			<xs:element name="AdditionalIndexes" type="ns8:ExternalProperty"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ExtDimensionAccountingFlag">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:ExtDimensionAccountingFlagProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="ExtDimensionAccountingFlagProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Type" type="ns1:TypeDescription"/>
+			<xs:element name="PasswordMode" type="xs:boolean"/>
+			<xs:element name="Format" type="ns1:LocalStringType"/>
+			<xs:element name="EditFormat" type="ns1:LocalStringType"/>
+			<xs:element name="ToolTip" type="ns1:LocalStringType"/>
+			<xs:element name="MarkNegatives" type="xs:boolean"/>
+			<xs:element name="Mask" type="xs:string"/>
+			<xs:element name="MultiLine" type="xs:boolean"/>
+			<xs:element name="ExtendedEdit" type="xs:boolean"/>
+			<xs:element name="MinValue"/>
+			<xs:element name="MaxValue"/>
+			<xs:element name="FillFromFillingValue" type="xs:boolean"/>
+			<xs:element name="FillValue"/>
+			<xs:element name="FillChecking" type="ns1:FillChecking"/>
+			<xs:element name="ChoiceFoldersAndItems" type="ns2:FoldersAndItemsUse"/>
+			<xs:element name="ChoiceParameterLinks" type="ns8:ChoiceParameterLinks"/>
+			<xs:element name="ChoiceParameters" type="ns4:ChoiceParameters"/>
+			<xs:element name="QuickChoice" type="ns7:UseQuickChoice"/>
+			<xs:element name="CreateOnInput" type="ns7:CreateOnInput"/>
+			<xs:element name="ChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="LinkByType" type="ns8:TypeLink"/>
+			<xs:element name="ChoiceHistoryOnInput" type="ns6:ChoiceHistoryOnInput"/>
+			<xs:element name="DataHistory" type="ns7:DataHistoryUse"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ExternalDataProcessor">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:ExternalDataProcessorProperties"/>
+					<xs:element name="ChildObjects" type="tns:ExternalDataProcessorChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="ExternalDataProcessorChildObjects">
+		<xs:sequence>
+			<xs:element name="Attribute" type="tns:Attribute" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="TabularSection" type="tns:TabularSection" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Form" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Template" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ExternalDataProcessorProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string" minOccurs="0"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="Comment" type="xs:string" minOccurs="0"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging" minOccurs="0"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="DefaultForm" type="ns8:MDObjectRef" minOccurs="0"/>
+			<xs:element name="AuxiliaryForm" type="ns8:MDObjectRef" minOccurs="0"/>
+			<xs:element name="ObjectModule" type="ns8:ExternalProperty" minOccurs="0"/>
+			<xs:element name="Help" type="ns8:ExternalProperty" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ExternalDataSource">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:ExternalDataSourceProperties"/>
+					<xs:element name="ChildObjects" type="tns:ExternalDataSourceChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="ExternalDataSourceChildObjects">
+		<xs:sequence>
+			<xs:element name="Table" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Cube" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Function" type="tns:Function" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ExternalDataSourceProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="DataLockControlMode" type="ns7:DefaultDataLockControlMode"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ExternalReport">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:ExternalReportProperties"/>
+					<xs:element name="ChildObjects" type="tns:ExternalReportChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="ExternalReportChildObjects">
+		<xs:sequence>
+			<xs:element name="Attribute" type="tns:Attribute" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="TabularSection" type="tns:TabularSection" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Form" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Template" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ExternalReportProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string" minOccurs="0"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="Comment" type="xs:string" minOccurs="0"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging" minOccurs="0"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="DefaultForm" type="ns8:MDObjectRef" minOccurs="0"/>
+			<xs:element name="AuxiliaryForm" type="ns8:MDObjectRef" minOccurs="0"/>
+			<xs:element name="MainDataCompositionSchema" type="ns8:MDObjectRef" minOccurs="0"/>
+			<xs:element name="DefaultSettingsForm" type="ns8:MDObjectRef" minOccurs="0"/>
+			<xs:element name="AuxiliarySettingsForm" type="ns8:MDObjectRef" minOccurs="0"/>
+			<xs:element name="DefaultVariantForm" type="ns8:MDObjectRef" minOccurs="0"/>
+			<xs:element name="AuxiliaryVariantForm" type="ns8:MDObjectRef" minOccurs="0"/>
+			<xs:element name="VariantsStorage" type="ns8:MDObjectRef" minOccurs="0"/>
+			<xs:element name="SettingsStorage" type="ns8:MDObjectRef" minOccurs="0"/>
+			<xs:element name="ObjectModule" type="ns8:ExternalProperty" minOccurs="0"/>
+			<xs:element name="Help" type="ns8:ExternalProperty" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Field">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:FieldProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="FieldProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Type" type="ns1:TypeDescription"/>
+			<xs:element name="PasswordMode" type="xs:boolean"/>
+			<xs:element name="Format" type="ns1:LocalStringType"/>
+			<xs:element name="EditFormat" type="ns1:LocalStringType"/>
+			<xs:element name="ToolTip" type="ns1:LocalStringType"/>
+			<xs:element name="MarkNegatives" type="xs:boolean"/>
+			<xs:element name="Mask" type="xs:string"/>
+			<xs:element name="MultiLine" type="xs:boolean"/>
+			<xs:element name="ExtendedEdit" type="xs:boolean"/>
+			<xs:element name="MinValue"/>
+			<xs:element name="MaxValue"/>
+			<xs:element name="FillFromFillingValue" type="xs:boolean"/>
+			<xs:element name="FillValue"/>
+			<xs:element name="FillChecking" type="ns1:FillChecking"/>
+			<xs:element name="ChoiceParameterLinks" type="ns8:ChoiceParameterLinks"/>
+			<xs:element name="ChoiceParameters" type="ns4:ChoiceParameters"/>
+			<xs:element name="QuickChoice" type="ns7:UseQuickChoice"/>
+			<xs:element name="CreateOnInput" type="ns7:CreateOnInput"/>
+			<xs:element name="ChoiceHistoryOnInput" type="ns6:ChoiceHistoryOnInput"/>
+			<xs:element name="ChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="NameInDataSource" type="xs:string"/>
+			<xs:element name="ReadOnly" type="xs:boolean"/>
+			<xs:element name="AllowNull" type="xs:boolean"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="FilterCriterion">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:FilterCriterionProperties"/>
+					<xs:element name="ChildObjects" type="tns:FilterCriterionChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="FilterCriterionChildObjects">
+		<xs:sequence>
+			<xs:element name="Form" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Command" type="tns:Command" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="FilterCriterionProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Type" type="ns1:TypeDescription"/>
+			<xs:element name="UseStandardCommands" type="xs:boolean"/>
+			<xs:element name="Content" type="ns8:MDListType"/>
+			<xs:element name="DefaultForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryForm" type="ns8:MDObjectRef"/>
+			<xs:element name="ManagerModule" type="ns8:ExternalProperty"/>
+			<xs:element name="ListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="Explanation" type="ns1:LocalStringType"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Form">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:FormProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="FormProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string" minOccurs="0"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="Comment" type="xs:string" minOccurs="0"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging" minOccurs="0"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Form" type="ns8:ExternalProperty" minOccurs="0"/>
+			<xs:element name="FormType" type="ns7:FormType" minOccurs="0"/>
+			<xs:element name="IncludeHelpInContents" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="Help" type="ns8:ExternalProperty" minOccurs="0"/>
+			<xs:element name="UsePurposes" type="ns1:FixedArray" minOccurs="0"/>
+			<xs:element name="ExtendedPresentation" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="UseInInterfaceCompatibilityMode" type="ns7:UseInInterfaceCompatibilityMode" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Function">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:FunctionProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="FunctionProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="ReturnValue" type="xs:boolean"/>
+			<xs:element name="Type" type="ns1:TypeDescription"/>
+			<xs:element name="ExpressionInDataSource" type="xs:string"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="FunctionalOption">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:FunctionalOptionProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="FunctionalOptionProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Location" type="ns8:MDObjectRef"/>
+			<xs:element name="PrivilegedGetMode" type="xs:boolean"/>
+			<xs:element name="Content" type="ns8:FuncOptionContentType"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="FunctionalOptionsParameter">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:FunctionalOptionsParameterProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="FunctionalOptionsParameterProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Use" type="ns8:MDListType"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="HTTPService">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:HTTPServiceProperties"/>
+					<xs:element name="ChildObjects" type="tns:HTTPServiceChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="HTTPServiceChildObjects">
+		<xs:sequence>
+			<xs:element name="URLTemplate" type="tns:URLTemplate" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="HTTPServiceProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="RootURL" type="xs:string"/>
+			<xs:element name="Module" type="ns8:ExternalProperty"/>
+			<xs:element name="ReuseSessions" type="ns7:SessionReuseMode"/>
+			<xs:element name="SessionMaxAge" type="xs:decimal"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="InformationRegister">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:InformationRegisterProperties"/>
+					<xs:element name="ChildObjects" type="tns:InformationRegisterChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="InformationRegisterChildObjects">
+		<xs:sequence>
+			<xs:element name="Resource" type="tns:Resource" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Attribute" type="tns:Attribute" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Dimension" type="tns:Dimension" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Form" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Template" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Command" type="tns:Command" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="InformationRegisterProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="UseStandardCommands" type="xs:boolean"/>
+			<xs:element name="EditType" type="ns7:EditType"/>
+			<xs:element name="DefaultRecordForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryRecordForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="StandardAttributes" type="ns8:StandardAttributeDescriptions"/>
+			<xs:element name="InformationRegisterPeriodicity" type="ns7:InformationRegisterPeriodicity"/>
+			<xs:element name="WriteMode" type="ns7:RegisterWriteMode"/>
+			<xs:element name="MainFilterOnPeriod" type="xs:boolean"/>
+			<xs:element name="IncludeHelpInContents" type="xs:boolean"/>
+			<xs:element name="Help" type="ns8:ExternalProperty"/>
+			<xs:element name="RecordSetModule" type="ns8:ExternalProperty"/>
+			<xs:element name="ManagerModule" type="ns8:ExternalProperty"/>
+			<xs:element name="DataLockControlMode" type="ns7:DefaultDataLockControlMode"/>
+			<xs:element name="FullTextSearch" type="ns7:FullTextSearchUsing"/>
+			<xs:element name="EnableTotalsSliceFirst" type="xs:boolean"/>
+			<xs:element name="EnableTotalsSliceLast" type="xs:boolean"/>
+			<xs:element name="RecordPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedRecordPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="Explanation" type="ns1:LocalStringType"/>
+			<xs:element name="DataHistory" type="ns7:DataHistoryUse"/>
+			<xs:element name="UpdateDataHistoryImmediatelyAfterWrite" type="xs:boolean"/>
+			<xs:element name="ExecuteAfterWriteDataHistoryVersionProcessing" type="xs:boolean"/>
+			<xs:element name="AdditionalIndexes" type="ns8:ExternalProperty"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="IntegrationService">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:IntegrationServiceProperties"/>
+					<xs:element name="ChildObjects" type="tns:IntegrationServiceChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="IntegrationServiceChannel">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:IntegrationServiceChannelProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="IntegrationServiceChannelProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="ExternalIntegrationServiceChannelName" type="xs:string"/>
+			<xs:element name="ReceiveMessageProcessing" type="xs:string"/>
+			<xs:element name="MessageDirection" type="ns7:IntegrationServiceChannelMessageDirection" minOccurs="0"/>
+			<xs:element name="Transactioned" type="xs:boolean"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="IntegrationServiceChildObjects">
+		<xs:sequence>
+			<xs:element name="IntegrationServiceChannel" type="tns:IntegrationServiceChannel" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="IntegrationServiceProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="ExternalIntegrationServiceAddress" type="xs:string"/>
+			<xs:element name="Module" type="ns8:ExternalProperty"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Interface">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:InterfaceProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="InterfaceProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Interface" type="ns8:ExternalProperty"/>
+			<xs:element name="Switchable" type="xs:boolean"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Language">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:LanguageProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="LanguageProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="LanguageCode" type="xs:string"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="MDObjectBase">
+		<xs:sequence>
+			<xs:element name="InternalInfo" type="ns8:InternalInfo" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="uuid" type="ns1:UUID" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="MetaDataObject">
+		<xs:complexContent>
+			<xs:extension base="ns8:EntityWithVersion">
+				<xs:choice>
+					<xs:element name="AccountingRegister" type="tns:AccountingRegister" minOccurs="0"/>
+					<xs:element name="AccumulationRegister" type="tns:AccumulationRegister" minOccurs="0"/>
+					<xs:element name="BusinessProcess" type="tns:BusinessProcess" minOccurs="0"/>
+					<xs:element name="CalculationRegister" type="tns:CalculationRegister" minOccurs="0"/>
+					<xs:element name="Catalog" type="tns:Catalog" minOccurs="0"/>
+					<xs:element name="ChartOfAccounts" type="tns:ChartOfAccounts" minOccurs="0"/>
+					<xs:element name="ChartOfCalculationTypes" type="tns:ChartOfCalculationTypes" minOccurs="0"/>
+					<xs:element name="ChartOfCharacteristicTypes" type="tns:ChartOfCharacteristicTypes" minOccurs="0"/>
+					<xs:element name="CommandGroup" type="tns:CommandGroup" minOccurs="0"/>
+					<xs:element name="CommonAttribute" type="tns:CommonAttribute" minOccurs="0"/>
+					<xs:element name="CommonCommand" type="tns:CommonCommand" minOccurs="0"/>
+					<xs:element name="CommonForm" type="tns:CommonForm" minOccurs="0"/>
+					<xs:element name="CommonModule" type="tns:CommonModule" minOccurs="0"/>
+					<xs:element name="CommonPicture" type="tns:CommonPicture" minOccurs="0"/>
+					<xs:element name="CommonTemplate" type="tns:CommonTemplate" minOccurs="0"/>
+					<xs:element name="Configuration" type="tns:Configuration" minOccurs="0"/>
+					<xs:element name="Constant" type="tns:Constant" minOccurs="0"/>
+					<xs:element name="Cube" type="tns:Cube" minOccurs="0"/>
+					<xs:element name="DataProcessor" type="tns:DataProcessor" minOccurs="0"/>
+					<xs:element name="DefinedType" type="tns:DefinedType" minOccurs="0"/>
+					<xs:element name="DimensionTable" type="tns:DimensionTable" minOccurs="0"/>
+					<xs:element name="Document" type="tns:Document" minOccurs="0"/>
+					<xs:element name="DocumentJournal" type="tns:DocumentJournal" minOccurs="0"/>
+					<xs:element name="DocumentNumerator" type="tns:DocumentNumerator" minOccurs="0"/>
+					<xs:element name="Enum" type="tns:Enum" minOccurs="0"/>
+					<xs:element name="EventSubscription" type="tns:EventSubscription" minOccurs="0"/>
+					<xs:element name="ExchangePlan" type="tns:ExchangePlan" minOccurs="0"/>
+					<xs:element name="ExternalDataProcessor" type="tns:ExternalDataProcessor" minOccurs="0"/>
+					<xs:element name="ExternalDataSource" type="tns:ExternalDataSource" minOccurs="0"/>
+					<xs:element name="ExternalReport" type="tns:ExternalReport" minOccurs="0"/>
+					<xs:element name="FilterCriterion" type="tns:FilterCriterion" minOccurs="0"/>
+					<xs:element name="Form" type="tns:Form" minOccurs="0"/>
+					<xs:element name="FunctionalOption" type="tns:FunctionalOption" minOccurs="0"/>
+					<xs:element name="FunctionalOptionsParameter" type="tns:FunctionalOptionsParameter" minOccurs="0"/>
+					<xs:element name="HTTPService" type="tns:HTTPService" minOccurs="0"/>
+					<xs:element name="InformationRegister" type="tns:InformationRegister" minOccurs="0"/>
+					<xs:element name="IntegrationService" type="tns:IntegrationService" minOccurs="0"/>
+					<xs:element name="Interface" type="tns:Interface" minOccurs="0"/>
+					<xs:element name="Language" type="tns:Language" minOccurs="0"/>
+					<xs:element name="Recalculation" type="tns:Recalculation" minOccurs="0"/>
+					<xs:element name="Report" type="tns:Report" minOccurs="0"/>
+					<xs:element name="Role" type="tns:Role" minOccurs="0"/>
+					<xs:element name="ScheduledJob" type="tns:ScheduledJob" minOccurs="0"/>
+					<xs:element name="Sequence" type="tns:Sequence" minOccurs="0"/>
+					<xs:element name="SessionParameter" type="tns:SessionParameter" minOccurs="0"/>
+					<xs:element name="SettingsStorage" type="tns:SettingsStorage" minOccurs="0"/>
+					<xs:element name="Style" type="tns:Style" minOccurs="0"/>
+					<xs:element name="StyleItem" type="tns:StyleItem" minOccurs="0"/>
+					<xs:element name="Subsystem" type="tns:Subsystem" minOccurs="0"/>
+					<xs:element name="Table" type="tns:Table" minOccurs="0"/>
+					<xs:element name="Task" type="tns:Task" minOccurs="0"/>
+					<xs:element name="Template" type="tns:Template" minOccurs="0"/>
+					<xs:element name="WSReference" type="tns:WSReference" minOccurs="0"/>
+					<xs:element name="WebService" type="tns:WebService" minOccurs="0"/>
+					<xs:element name="XDTOPackage" type="tns:XDTOPackage" minOccurs="0"/>
+					<xs:element name="Bot" type="tns:Bot" minOccurs="0"/>
+					<xs:element name="WebSocketClient" type="tns:WebSocketClient" minOccurs="0"/>
+					<xs:element name="PaletteColor" type="tns:PaletteColor" minOccurs="0"/>
+				</xs:choice>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="Method">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:MethodProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="MethodProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="HTTPMethod" type="ns7:HTTPMethod"/>
+			<xs:element name="Handler" type="xs:string"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Operation">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:OperationProperties"/>
+					<xs:element name="ChildObjects" type="tns:OperationChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="OperationChildObjects">
+		<xs:sequence>
+			<xs:element name="Parameter" type="tns:Parameter" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="OperationProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="XDTOReturningValueType" type="xs:QName"/>
+			<xs:element name="Nillable" type="xs:boolean"/>
+			<xs:element name="Transactioned" type="xs:boolean"/>
+			<xs:element name="ProcedureName" type="xs:string"/>
+			<xs:element name="DataLockControlMode" type="ns7:DefaultDataLockControlMode"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PaletteColor">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:PaletteColorProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="PaletteColorProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Color" type="ns3:Color"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Parameter">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:ParameterProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="ParameterProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="XDTOValueType" type="xs:QName"/>
+			<xs:element name="Nillable" type="xs:boolean"/>
+			<xs:element name="TransferDirection" type="ns7:TransferDirection"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Recalculation">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:RecalculationProperties"/>
+					<xs:element name="ChildObjects" type="tns:RecalculationChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="RecalculationChildObjects">
+		<xs:sequence>
+			<xs:element name="Dimension" type="tns:Dimension" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="RecalculationProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="RecordSetModule" type="ns8:ExternalProperty"/>
+			<xs:element name="DataLockControlMode" type="ns7:DefaultDataLockControlMode"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Report">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:ReportProperties"/>
+					<xs:element name="ChildObjects" type="tns:ReportChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="ReportChildObjects">
+		<xs:sequence>
+			<xs:element name="Attribute" type="tns:Attribute" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="TabularSection" type="tns:TabularSection" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Form" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Template" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Command" type="tns:Command" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ReportProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="UseStandardCommands" type="xs:boolean"/>
+			<xs:element name="DefaultForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryForm" type="ns8:MDObjectRef"/>
+			<xs:element name="MainDataCompositionSchema" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultSettingsForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliarySettingsForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultVariantForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryVariantForm" type="ns8:MDObjectRef"/>
+			<xs:element name="VariantsStorage" type="ns8:MDObjectRef"/>
+			<xs:element name="SettingsStorage" type="ns8:MDObjectRef"/>
+			<xs:element name="ObjectModule" type="ns8:ExternalProperty"/>
+			<xs:element name="ManagerModule" type="ns8:ExternalProperty"/>
+			<xs:element name="IncludeHelpInContents" type="xs:boolean"/>
+			<xs:element name="Help" type="ns8:ExternalProperty"/>
+			<xs:element name="ExtendedPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="Explanation" type="ns1:LocalStringType"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Resource">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:ResourceProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="ResourceProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string" minOccurs="0"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="Comment" type="xs:string" minOccurs="0"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging" minOccurs="0"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Type" type="ns1:TypeDescription" minOccurs="0"/>
+			<xs:element name="PasswordMode" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="Format" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="EditFormat" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="ToolTip" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="MarkNegatives" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="Mask" type="xs:string" minOccurs="0"/>
+			<xs:element name="MultiLine" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="ExtendedEdit" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="MinValue" minOccurs="0"/>
+			<xs:element name="MaxValue" minOccurs="0"/>
+			<xs:element name="FillChecking" type="ns1:FillChecking" minOccurs="0"/>
+			<xs:element name="ChoiceFoldersAndItems" type="ns2:FoldersAndItemsUse" minOccurs="0"/>
+			<xs:element name="ChoiceParameterLinks" type="ns8:ChoiceParameterLinks" minOccurs="0"/>
+			<xs:element name="ChoiceParameters" type="ns4:ChoiceParameters" minOccurs="0"/>
+			<xs:element name="QuickChoice" type="ns7:UseQuickChoice" minOccurs="0"/>
+			<xs:element name="CreateOnInput" type="ns7:CreateOnInput" minOccurs="0"/>
+			<xs:element name="ChoiceForm" type="ns8:MDObjectRef" minOccurs="0"/>
+			<xs:element name="LinkByType" type="ns8:TypeLink" minOccurs="0"/>
+			<xs:element name="ChoiceHistoryOnInput" type="ns6:ChoiceHistoryOnInput" minOccurs="0"/>
+			<xs:element name="Balance" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="AccountingFlag" type="ns8:MDObjectRef" minOccurs="0"/>
+			<xs:element name="ExtDimensionAccountingFlag" type="ns8:MDObjectRef" minOccurs="0"/>
+			<xs:element name="FullTextSearch" type="ns7:FullTextSearchUsing" minOccurs="0"/>
+			<xs:element name="FillFromFillingValue" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="FillValue" minOccurs="0"/>
+			<xs:element name="Indexing" type="ns7:Indexing" minOccurs="0"/>
+			<xs:element name="DataHistory" type="ns7:DataHistoryUse" minOccurs="0"/>
+			<xs:element name="NameInDataSource" type="xs:string" minOccurs="0"/>
+			<xs:element name="BinaryDataStorageLocationUse" type="ns7:BinaryDataStorageLocationUse" minOccurs="0"/>
+			<xs:element name="BinaryDataStorageLocationUseField" type="ns8:MDObjectRef" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Role">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:RoleProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="RoleProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Rights" type="ns8:ExternalProperty"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ScheduledJob">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:ScheduledJobProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="ScheduledJobProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="MethodName" type="ns8:MDMethodRef"/>
+			<xs:element name="Description" type="xs:string"/>
+			<xs:element name="Key" type="xs:string"/>
+			<xs:element name="Schedule" type="ns8:ExternalProperty"/>
+			<xs:element name="Use" type="xs:boolean"/>
+			<xs:element name="Predefined" type="xs:boolean"/>
+			<xs:element name="RestartCountOnFailure" type="xs:decimal"/>
+			<xs:element name="RestartIntervalOnFailure" type="xs:decimal"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Sequence">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:SequenceProperties"/>
+					<xs:element name="ChildObjects" type="tns:SequenceChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="SequenceChildObjects">
+		<xs:sequence>
+			<xs:element name="Dimension" type="tns:Dimension" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="SequenceProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="MoveBoundaryOnPosting" type="ns7:MoveBoundaryOnPosting"/>
+			<xs:element name="Documents" type="ns8:MDListType"/>
+			<xs:element name="RegisterRecords" type="ns8:MDListType"/>
+			<xs:element name="RecordSetModule" type="ns8:ExternalProperty"/>
+			<xs:element name="DataLockControlMode" type="ns7:DefaultDataLockControlMode"/>
+			<xs:element name="AdditionalIndexes" type="ns8:ExternalProperty"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="SessionParameter">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:SessionParameterProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="SessionParameterProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Type" type="ns1:TypeDescription"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="SettingsStorage">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:SettingsStorageProperties"/>
+					<xs:element name="ChildObjects" type="tns:SettingsStorageChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="SettingsStorageChildObjects">
+		<xs:sequence>
+			<xs:element name="Form" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Template" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="SettingsStorageProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="DefaultSaveForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultLoadForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliarySaveForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryLoadForm" type="ns8:MDObjectRef"/>
+			<xs:element name="ManagerModule" type="ns8:ExternalProperty"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Style">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:StyleProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="StyleItem">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:StyleItemProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="StyleItemProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Type" type="ns7:StyleElementType"/>
+			<xs:element name="Value"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="StyleProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Style" type="ns8:ExternalProperty"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Subsystem">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:SubsystemProperties"/>
+					<xs:element name="ChildObjects" type="tns:SubsystemChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="SubsystemChildObjects">
+		<xs:sequence>
+			<xs:element name="Subsystem" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="SubsystemProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="IncludeHelpInContents" type="xs:boolean"/>
+			<xs:element name="UseOneCommand" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="Help" type="ns8:ExternalProperty"/>
+			<xs:element name="IncludeInCommandInterface" type="xs:boolean"/>
+			<xs:element name="CommandInterface" type="ns8:ExternalProperty"/>
+			<xs:element name="Explanation" type="ns1:LocalStringType"/>
+			<xs:element name="Picture" type="ns8:Picture"/>
+			<xs:element name="Content" type="ns8:MDListType"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Table">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:TableProperties"/>
+					<xs:element name="ChildObjects" type="tns:TableChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="TableChildObjects">
+		<xs:sequence>
+			<xs:element name="Field" type="tns:Field" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Form" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Command" type="tns:Command" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Template" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TableProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="TableType" type="ns7:ExternalDataSourceTableType"/>
+			<xs:element name="NameInDataSource" type="xs:string"/>
+			<xs:element name="ExpressionInDataSource" type="xs:string"/>
+			<xs:element name="TableDataType" type="ns7:ExternalDataSourceTableDataType"/>
+			<xs:element name="KeyFields" type="ns8:FieldList"/>
+			<xs:element name="PresentationField" type="ns8:MDObjectRef"/>
+			<xs:element name="ParentField" type="ns8:MDObjectRef"/>
+			<xs:element name="UnfilledParentValue"/>
+			<xs:element name="Characteristics" type="ns8:CharacteristicsDescriptions"/>
+			<xs:element name="UseStandardCommands" type="xs:boolean"/>
+			<xs:element name="QuickChoice" type="xs:boolean"/>
+			<xs:element name="InputByString" type="ns8:FieldList"/>
+			<xs:element name="CreateOnInput" type="ns7:CreateOnInput"/>
+			<xs:element name="SearchStringModeOnInputByString" type="ns6:SearchStringModeOnInputByString"/>
+			<xs:element name="ChoiceDataGetModeOnInputByString" type="ns6:ChoiceDataGetModeOnInputByString"/>
+			<xs:element name="ChoiceHistoryOnInput" type="ns6:ChoiceHistoryOnInput"/>
+			<xs:element name="DefaultObjectForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultRecordForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="ObjectPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedObjectPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="RecordPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedRecordPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="Explanation" type="ns1:LocalStringType"/>
+			<xs:element name="ObjectModule" type="ns8:ExternalProperty"/>
+			<xs:element name="RecordSetModule" type="ns8:ExternalProperty"/>
+			<xs:element name="ManagerModule" type="ns8:ExternalProperty"/>
+			<xs:element name="IncludeHelpInContents" type="xs:boolean"/>
+			<xs:element name="Help" type="ns8:ExternalProperty"/>
+			<xs:element name="ReadOnly" type="xs:boolean"/>
+			<xs:element name="TransactionsIsolationLevel" type="ns2:TransactionsIsolationLevel"/>
+			<xs:element name="DataVersionField" type="ns8:MDObjectRef"/>
+			<xs:element name="EditType" type="ns7:EditType"/>
+			<xs:element name="BasedOn" type="ns8:MDListType"/>
+			<xs:element name="DataLockFields" type="ns8:FieldList"/>
+			<xs:element name="DataLockControlMode" type="ns7:DefaultDataLockControlMode"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TabularSection">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:TabularSectionProperties"/>
+					<xs:element name="ChildObjects" type="tns:TabularSectionChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="TabularSectionChildObjects">
+		<xs:sequence>
+			<xs:element name="Attribute" type="tns:Attribute" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TabularSectionProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string" minOccurs="0"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="Comment" type="xs:string" minOccurs="0"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging" minOccurs="0"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="ToolTip" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="FillChecking" type="ns1:FillChecking" minOccurs="0"/>
+			<xs:element name="StandardAttributes" type="ns8:StandardAttributeDescriptions" minOccurs="0"/>
+			<xs:element name="Use" type="ns7:AttributeUse" minOccurs="0"/>
+			<xs:element name="LineNumberLength" type="xs:decimal" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Task">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:TaskProperties"/>
+					<xs:element name="ChildObjects" type="tns:TaskChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="TaskChildObjects">
+		<xs:sequence>
+			<xs:element name="Attribute" type="tns:Attribute" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="TabularSection" type="tns:TabularSection" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Form" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Template" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="AddressingAttribute" type="tns:AddressingAttribute" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Command" type="tns:Command" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TaskProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="UseStandardCommands" type="xs:boolean"/>
+			<xs:element name="ObjectModule" type="ns8:ExternalProperty"/>
+			<xs:element name="ManagerModule" type="ns8:ExternalProperty"/>
+			<xs:element name="NumberType" type="ns7:TaskNumberType"/>
+			<xs:element name="NumberLength" type="xs:decimal"/>
+			<xs:element name="NumberAllowedLength" type="ns1:AllowedLength"/>
+			<xs:element name="CheckUnique" type="xs:boolean"/>
+			<xs:element name="Autonumbering" type="xs:boolean"/>
+			<xs:element name="TaskNumberAutoPrefix" type="ns7:TaskNumberAutoPrefix"/>
+			<xs:element name="DescriptionLength" type="xs:decimal"/>
+			<xs:element name="Addressing" type="ns8:MDObjectRef"/>
+			<xs:element name="MainAddressingAttribute" type="ns8:MDObjectRef"/>
+			<xs:element name="CurrentPerformer" type="ns8:MDObjectRef"/>
+			<xs:element name="BasedOn" type="ns8:MDListType"/>
+			<xs:element name="StandardAttributes" type="ns8:StandardAttributeDescriptions"/>
+			<xs:element name="Characteristics" type="ns8:CharacteristicsDescriptions"/>
+			<xs:element name="DefaultPresentation" type="ns7:TaskMainPresentation"/>
+			<xs:element name="EditType" type="ns7:EditType"/>
+			<xs:element name="InputByString" type="ns8:FieldList"/>
+			<xs:element name="SearchStringModeOnInputByString" type="ns6:SearchStringModeOnInputByString"/>
+			<xs:element name="FullTextSearchOnInputByString" type="ns6:FullTextSearchOnInputByString"/>
+			<xs:element name="ChoiceDataGetModeOnInputByString" type="ns6:ChoiceDataGetModeOnInputByString"/>
+			<xs:element name="CreateOnInput" type="ns7:CreateOnInput"/>
+			<xs:element name="DefaultObjectForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="DefaultChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryObjectForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryListForm" type="ns8:MDObjectRef"/>
+			<xs:element name="AuxiliaryChoiceForm" type="ns8:MDObjectRef"/>
+			<xs:element name="ChoiceHistoryOnInput" type="ns6:ChoiceHistoryOnInput"/>
+			<xs:element name="IncludeHelpInContents" type="xs:boolean"/>
+			<xs:element name="Help" type="ns8:ExternalProperty"/>
+			<xs:element name="DataLockFields" type="ns8:FieldList"/>
+			<xs:element name="DataLockControlMode" type="ns7:DefaultDataLockControlMode"/>
+			<xs:element name="FullTextSearch" type="ns7:FullTextSearchUsing"/>
+			<xs:element name="ObjectPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedObjectPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="ExtendedListPresentation" type="ns1:LocalStringType"/>
+			<xs:element name="Explanation" type="ns1:LocalStringType"/>
+			<xs:element name="DataHistory" type="ns7:DataHistoryUse"/>
+			<xs:element name="UpdateDataHistoryImmediatelyAfterWrite" type="xs:boolean"/>
+			<xs:element name="ExecuteAfterWriteDataHistoryVersionProcessing" type="xs:boolean"/>
+			<xs:element name="AdditionalIndexes" type="ns8:ExternalProperty"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Template">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:TemplateProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="TemplateProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="TemplateType" type="ns7:TemplateType"/>
+			<xs:element name="Template" type="ns8:ExternalProperty"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="URLTemplate">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:URLTemplateProperties"/>
+					<xs:element name="ChildObjects" type="tns:URLTemplateChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="URLTemplateChildObjects">
+		<xs:sequence>
+			<xs:element name="Method" type="tns:Method" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="URLTemplateProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Template" type="xs:string"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="WSReference">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:WSReferenceProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="WSReferenceProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="LocationURL" type="xs:string"/>
+			<xs:element name="WSDefinition" type="ns8:ExternalProperty"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="WebService">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:WebServiceProperties"/>
+					<xs:element name="ChildObjects" type="tns:WebServiceChildObjects"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="WebServiceChildObjects">
+		<xs:sequence>
+			<xs:element name="Operation" type="tns:Operation" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="WebServiceProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Namespace" type="xs:string"/>
+			<xs:element name="Module" type="ns8:ExternalProperty"/>
+			<xs:element name="XDTOPackages" type="ns8:ValueList"/>
+			<xs:element name="DescriptorFileName" type="xs:string"/>
+			<xs:element name="ReuseSessions" type="ns7:SessionReuseMode"/>
+			<xs:element name="SessionMaxAge" type="xs:decimal"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="WebSocketClient">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:WebSocketClientProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="WebSocketClientProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Predefined" type="xs:boolean"/>
+			<xs:element name="Module" type="ns8:ExternalProperty"/>
+			<xs:element name="ServerURL" type="xs:string"/>
+			<xs:element name="User" type="xs:string"/>
+			<xs:element name="Password" type="xs:string"/>
+			<xs:element name="Headers"/>
+			<xs:element name="UseOSProxy" type="xs:boolean"/>
+			<xs:element name="UseOSAuthentication" type="xs:boolean"/>
+			<xs:element name="Timeout" type="xs:decimal"/>
+			<xs:element name="AutoConnect" type="xs:boolean"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="XDTOPackage">
+		<xs:complexContent>
+			<xs:extension base="tns:MDObjectBase">
+				<xs:sequence>
+					<xs:element name="Properties" type="tns:XDTOPackageProperties"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="XDTOPackageProperties">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Synonym" type="ns1:LocalStringType"/>
+			<xs:element name="Comment" type="xs:string"/>
+			<xs:element name="ObjectBelonging" type="ns7:ObjectBelonging"/>
+			<xs:element name="ExtendedConfigurationObject" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="Namespace" type="xs:string"/>
+			<xs:element name="Package" type="ns8:ExternalProperty"/>
+		</xs:sequence>
+	</xs:complexType>
+</xs:schema>

--- a/src/main/xsd/v8.5/v8.1c.ru-8.3-xcf-enums.xsd
+++ b/src/main/xsd/v8.5/v8.1c.ru-8.3-xcf-enums.xsd
@@ -1,0 +1,608 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:tns="http://v8.1c.ru/8.3/xcf/enums" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://v8.1c.ru/8.3/xcf/enums" attributeFormDefault="unqualified" elementFormDefault="qualified">
+	<xs:simpleType name="AccountMainPresentation">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="AsCode"/>
+			<xs:enumeration value="AsDescription"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="AccumulationRegisterType">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Balance"/>
+			<xs:enumeration value="Turnovers"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="AttributeUse">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="ForItem"/>
+			<xs:enumeration value="ForFolder"/>
+			<xs:enumeration value="ForFolderAndItem"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="BaseEnumType">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="BinaryDataBlockStorageUseMode">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Use"/>
+			<xs:enumeration value="DontUse"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="BinaryDataStorageLocationUse">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Use"/>
+			<xs:enumeration value="DontUse"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="BinaryDataStorageMode">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="DontUse"/>
+			<xs:enumeration value="Use"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="BusinessProcessNumberPeriodicity">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Nonperiodical"/>
+			<xs:enumeration value="Year"/>
+			<xs:enumeration value="Quarter"/>
+			<xs:enumeration value="Month"/>
+			<xs:enumeration value="Day"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="BusinessProcessNumberType">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Number"/>
+			<xs:enumeration value="String"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CalculationRegisterPeriodicity">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Year"/>
+			<xs:enumeration value="Quarter"/>
+			<xs:enumeration value="Month"/>
+			<xs:enumeration value="Day"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CalculationTypeMainPresentation">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="AsCode"/>
+			<xs:enumeration value="AsDescription"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CatalogCodeType">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Number"/>
+			<xs:enumeration value="String"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CatalogCodesSeries">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="WholeCatalog"/>
+			<xs:enumeration value="WithinSubordination"/>
+			<xs:enumeration value="WithinOwnerSubordination"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CatalogMainPresentation">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="AsCode"/>
+			<xs:enumeration value="AsDescription"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CharOfAccountCodeSeries">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="WholeChartOfAccounts"/>
+			<xs:enumeration value="WithinSubordination"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CharacteristicKindCodesSeries">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="WholeCharacteristicKind"/>
+			<xs:enumeration value="WithinSubordination"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CharacteristicTypeMainPresentation">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="AsCode"/>
+			<xs:enumeration value="AsDescription"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ChartOfCalculationTypesBaseUse">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="DontUse"/>
+			<xs:enumeration value="OnActionPeriod"/>
+			<xs:enumeration value="OnRegistrationPeriod"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ChartOfCalculationTypesCodeType">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Number"/>
+			<xs:enumeration value="String"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ChoiceDataGetModeOnInputByString">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Directly"/>
+			<xs:enumeration value="Background"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ChoiceMode">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="FromForm"/>
+			<xs:enumeration value="QuickChoice"/>
+			<xs:enumeration value="BothWays"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CommonAttributeAuthenticationSeparation">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Separate"/>
+			<xs:enumeration value="DontUse"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CommonAttributeAutoUse">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Use"/>
+			<xs:enumeration value="DontUse"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CommonAttributeConfigurationExtensionsSeparation">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Separate"/>
+			<xs:enumeration value="DontUse"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CommonAttributeDataSeparation">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Separate"/>
+			<xs:enumeration value="DontUse"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CommonAttributeSeparatedDataUse">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Independently"/>
+			<xs:enumeration value="IndependentlyAndSimultaneously"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CommonAttributeUse">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Use"/>
+			<xs:enumeration value="DontUse"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CommonAttributeUsersSeparation">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Separate"/>
+			<xs:enumeration value="DontUse"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CompatibilityMode">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="DontUse"/>
+			<xs:enumeration value="Version8_3_12"/>
+			<xs:enumeration value="Version8_3_11"/>
+			<xs:enumeration value="Version8_3_10"/>
+			<xs:enumeration value="Version8_3_9"/>
+			<xs:enumeration value="Version8_3_8"/>
+			<xs:enumeration value="Version8_3_7"/>
+			<xs:enumeration value="Version8_3_6"/>
+			<xs:enumeration value="Version8_3_5"/>
+			<xs:enumeration value="Version8_3_4"/>
+			<xs:enumeration value="Version8_3_3"/>
+			<xs:enumeration value="Version8_3_2"/>
+			<xs:enumeration value="Version8_3_1"/>
+			<xs:enumeration value="Version8_2_16"/>
+			<xs:enumeration value="Version8_2_13"/>
+			<xs:enumeration value="Version8_1"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ConfigurationExtensionPurpose">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Patch"/>
+			<xs:enumeration value="Customization"/>
+			<xs:enumeration value="AddOn"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CreateOnInput">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="DontUse"/>
+			<xs:enumeration value="Use"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DataExchangeMainPresentation">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="AsCode"/>
+			<xs:enumeration value="AsDescription"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DataHistoryUse">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="DontUse"/>
+			<xs:enumeration value="Use"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DatabaseTablespacesUseMode">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Use"/>
+			<xs:enumeration value="DontUse"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DefaultDataLockControlMode">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Automatic"/>
+			<xs:enumeration value="Managed"/>
+			<xs:enumeration value="AutomaticAndManaged"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DocumentNumberPeriodicity">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Nonperiodical"/>
+			<xs:enumeration value="Year"/>
+			<xs:enumeration value="Quarter"/>
+			<xs:enumeration value="Month"/>
+			<xs:enumeration value="Day"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DocumentNumberType">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Number"/>
+			<xs:enumeration value="String"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="EditType">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="InList"/>
+			<xs:enumeration value="InDialog"/>
+			<xs:enumeration value="BothWays"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ExternalDataSourceTableDataType">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="ObjectData"/>
+			<xs:enumeration value="NonobjectData"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ExternalDataSourceTableType">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Table"/>
+			<xs:enumeration value="Expression"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FormType">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Ordinary"/>
+			<xs:enumeration value="Managed"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FormatVersion">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="1.0"/>
+			<xs:enumeration value="2.0"/>
+			<xs:enumeration value="2.1"/>
+			<xs:enumeration value="2.2"/>
+			<xs:enumeration value="2.3"/>
+			<xs:enumeration value="2.4"/>
+			<xs:enumeration value="2.5"/>
+			<xs:enumeration value="2.6"/>
+			<xs:enumeration value="2.7"/>
+			<xs:enumeration value="2.8"/>
+			<xs:enumeration value="2.9"/>
+			<xs:enumeration value="2.9.1"/>
+			<xs:enumeration value="2.10"/>
+			<xs:enumeration value="2.11"/>
+			<xs:enumeration value="2.12"/>
+			<xs:enumeration value="2.13"/>
+			<xs:enumeration value="2.14"/>
+			<xs:enumeration value="2.15"/>
+			<xs:enumeration value="2.16"/>
+			<xs:enumeration value="2.17"/>
+			<xs:enumeration value="2.18"/>
+			<xs:enumeration value="2.19"/>
+			<xs:enumeration value="2.20"/>
+			<xs:enumeration value="2.21"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FullTextSearchOnInputByString">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Use"/>
+			<xs:enumeration value="DontUse"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FullTextSearchUsing">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="DontUse"/>
+			<xs:enumeration value="Use"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="HTTPMethod">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="GET"/>
+			<xs:enumeration value="HEAD"/>
+			<xs:enumeration value="PUT"/>
+			<xs:enumeration value="POST"/>
+			<xs:enumeration value="DELETE"/>
+			<xs:enumeration value="PATCH"/>
+			<xs:enumeration value="MERGE"/>
+			<xs:enumeration value="OPTIONS"/>
+			<xs:enumeration value="TRACE"/>
+			<xs:enumeration value="CONNECT"/>
+			<xs:enumeration value="PROPFIND"/>
+			<xs:enumeration value="PROPPATCH"/>
+			<xs:enumeration value="MOVE"/>
+			<xs:enumeration value="COPY"/>
+			<xs:enumeration value="LOCK"/>
+			<xs:enumeration value="UNLOCK"/>
+			<xs:enumeration value="MKCOL"/>
+			<xs:enumeration value="Any"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="HierarchyType">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="HierarchyFoldersAndItems"/>
+			<xs:enumeration value="HierarchyOfItems"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Indexing">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="DontIndex"/>
+			<xs:enumeration value="Index"/>
+			<xs:enumeration value="IndexWithAdditionalOrder"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="InformationRegisterPeriodicity">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Nonperiodical"/>
+			<xs:enumeration value="RecorderPosition"/>
+			<xs:enumeration value="Second"/>
+			<xs:enumeration value="Day"/>
+			<xs:enumeration value="Month"/>
+			<xs:enumeration value="Quarter"/>
+			<xs:enumeration value="Year"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="IntegrationServiceChannelMessageDirection">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Send"/>
+			<xs:enumeration value="Receive"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="InterfaceCompatibilityMode">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Version8_5"/>
+			<xs:enumeration value="Taxi"/>
+			<xs:enumeration value="TaxiEnableVersion8_2"/>
+			<xs:enumeration value="Version8_2EnableTaxi"/>
+			<xs:enumeration value="Version8_2"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ModalityUseMode">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Use"/>
+			<xs:enumeration value="UseWithWarnings"/>
+			<xs:enumeration value="DontUse"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="MoveBoundaryOnPosting">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Move"/>
+			<xs:enumeration value="DontMove"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ObjectAutonumerationMode">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="AutoFree"/>
+			<xs:enumeration value="NotAutoFree"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ObjectBelonging">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Native"/>
+			<xs:enumeration value="Adopted"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Posting">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Allow"/>
+			<xs:enumeration value="Deny"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="PredefinedDataUpdate">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="AutoUpdate"/>
+			<xs:enumeration value="DontAutoUpdate"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="PropertyState">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="NotSet"/>
+			<xs:enumeration value="Checked"/>
+			<xs:enumeration value="Extended"/>
+			<xs:enumeration value="Notify"/>
+			<xs:enumeration value="MultiState"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="RealTimePosting">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Allow"/>
+			<xs:enumeration value="Deny"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="RegisterRecordsDeletion">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="AutoDeleteOnUnpost"/>
+			<xs:enumeration value="AutoDelete"/>
+			<xs:enumeration value="AutoDeleteOff"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="RegisterRecordsWritingOnPost">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="WriteSelected"/>
+			<xs:enumeration value="WriteModified"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="RegisterWriteMode">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Independent"/>
+			<xs:enumeration value="RecorderSubordinate"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ReturnValuesReuse">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="DontUse"/>
+			<xs:enumeration value="DuringRequest"/>
+			<xs:enumeration value="DuringSession"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ScriptVariant">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="English"/>
+			<xs:enumeration value="Russian"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SearchStringModeOnInputByString">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Begin"/>
+			<xs:enumeration value="AnyPart"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SequenceFilling">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="AutoFill"/>
+			<xs:enumeration value="AutoFillOff"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SessionReuseMode">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="DontUse"/>
+			<xs:enumeration value="Use"/>
+			<xs:enumeration value="AutoUse"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="StyleElementType">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Color"/>
+			<xs:enumeration value="Font"/>
+			<xs:enumeration value="Border"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SubordinationUse">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="ToItems"/>
+			<xs:enumeration value="ToFolders"/>
+			<xs:enumeration value="ToFoldersAndItems"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SynchronousPlatformExtensionAndAddInCallUseMode">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Use"/>
+			<xs:enumeration value="UseWithWarnings"/>
+			<xs:enumeration value="DontUse"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TaskMainPresentation">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="AsNumber"/>
+			<xs:enumeration value="AsDescription"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TaskNumberAutoPrefix">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="BusinessProcessNumber"/>
+			<xs:enumeration value="DontUse"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TaskNumberType">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Number"/>
+			<xs:enumeration value="String"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TemplateType">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="SpreadsheetDocument"/>
+			<xs:enumeration value="BinaryData"/>
+			<xs:enumeration value="ActiveDocument"/>
+			<xs:enumeration value="HTMLDocument"/>
+			<xs:enumeration value="TextDocument"/>
+			<xs:enumeration value="GeographicalSchema"/>
+			<xs:enumeration value="GraphicalSchema"/>
+			<xs:enumeration value="DataCompositionSchema"/>
+			<xs:enumeration value="DataCompositionAppearanceTemplate"/>
+			<xs:enumeration value="AddIn"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TransferDirection">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="In"/>
+			<xs:enumeration value="Out"/>
+			<xs:enumeration value="InOut"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TypeCategories">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="TabularSectionRow"/>
+			<xs:enumeration value="Object"/>
+			<xs:enumeration value="Ref"/>
+			<xs:enumeration value="Selection"/>
+			<xs:enumeration value="List"/>
+			<xs:enumeration value="Manager"/>
+			<xs:enumeration value="ValueManager"/>
+			<xs:enumeration value="RecordManager"/>
+			<xs:enumeration value="RecordSet"/>
+			<xs:enumeration value="RecordKey"/>
+			<xs:enumeration value="Characteristic"/>
+			<xs:enumeration value="ExtDimensions"/>
+			<xs:enumeration value="ExtDimensionTypesRow"/>
+			<xs:enumeration value="DisplacingCalculationTypes"/>
+			<xs:enumeration value="DisplacingCalculationTypesRow"/>
+			<xs:enumeration value="BaseCalculationTypes"/>
+			<xs:enumeration value="BaseCalculationTypesRow"/>
+			<xs:enumeration value="LeadingCalculationTypes"/>
+			<xs:enumeration value="LeadingCalculationTypesRow"/>
+			<xs:enumeration value="Recalcs"/>
+			<xs:enumeration value="RoutePointRef"/>
+			<xs:enumeration value="TablesManager"/>
+			<xs:enumeration value="Record"/>
+			<xs:enumeration value="TabularSection"/>
+			<xs:enumeration value="ExtDimensionTypes"/>
+			<xs:enumeration value="CubesManager"/>
+			<xs:enumeration value="DimensionTables"/>
+			<xs:enumeration value="DefinedType"/>
+			<xs:enumeration value="ValueKey"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TypeReductionMode">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="TransformValues"/>
+			<xs:enumeration value="DeleteData"/>
+			<xs:enumeration value="Deny"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="UseInInterfaceCompatibilityMode">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Any"/>
+			<xs:enumeration value="Taxi"/>
+			<xs:enumeration value="Version85"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="UseQuickChoice">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Auto"/>
+			<xs:enumeration value="Use"/>
+			<xs:enumeration value="DontUse"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Version85InterfaceMigrationMode">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Use"/>
+			<xs:enumeration value="DontUse"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="XCFFormat">
+		<xs:restriction base="tns:BaseEnumType">
+			<xs:enumeration value="Hierarchical"/>
+			<xs:enumeration value="Plain"/>
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>

--- a/src/main/xsd/v8.5/v8.1c.ru-8.3-xcf-predef.xsd
+++ b/src/main/xsd/v8.5/v8.1c.ru-8.3-xcf-predef.xsd
@@ -1,0 +1,128 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:ns1="http://v8.1c.ru/8.1/data/core" xmlns:ns2="http://v8.1c.ru/8.1/data/enterprise" xmlns:ns3="http://v8.1c.ru/8.3/xcf/readable" xmlns:tns="http://v8.1c.ru/8.3/xcf/predef" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://v8.1c.ru/8.3/xcf/predef" attributeFormDefault="unqualified" elementFormDefault="qualified">
+	<xs:import namespace="http://v8.1c.ru/8.1/data/core"/>
+	<xs:import namespace="http://v8.1c.ru/8.1/data/enterprise"/>
+	<xs:import namespace="http://v8.1c.ru/8.3/xcf/readable"/>
+	<xs:element name="PredefinedData"/>
+	<xs:simpleType name="PredefinedItemExtensionState">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Native"/>
+			<xs:enumeration value="AdoptedCheck"/>
+			<xs:enumeration value="AdoptedNotify"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="AccountingFlags">
+		<xs:sequence>
+			<xs:element name="Flag" type="ns3:FlagType"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CalculationTypeList">
+		<xs:sequence>
+			<xs:element name="CalculationType" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CalculationTypePredefinedItem">
+		<xs:complexContent>
+			<xs:extension base="tns:PredefinedItemBase">
+				<xs:sequence>
+					<xs:element name="ActionPeriodIsBase" type="xs:boolean"/>
+					<xs:element name="Displaced" type="tns:CalculationTypeList" minOccurs="0"/>
+					<xs:element name="Base" type="tns:CalculationTypeList" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="Leading" type="tns:CalculationTypeList" minOccurs="0" maxOccurs="unbounded"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="CalculationTypePredefinedItems">
+		<xs:complexContent>
+			<xs:extension base="ns3:EntityWithVersion">
+				<xs:sequence>
+					<xs:element name="Item" type="tns:CalculationTypePredefinedItem"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="CatalogPredefinedItem">
+		<xs:complexContent>
+			<xs:extension base="tns:PredefinedItemBase">
+				<xs:sequence>
+					<xs:element name="IsFolder" type="xs:boolean"/>
+					<xs:element name="ChildItems" type="tns:CatalogPredefinedItems" minOccurs="0" maxOccurs="unbounded"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="CatalogPredefinedItems">
+		<xs:complexContent>
+			<xs:extension base="ns3:EntityWithVersion">
+				<xs:sequence>
+					<xs:element name="Item" type="tns:CatalogPredefinedItem" maxOccurs="unbounded"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="ChartOfAccountsPredefinedItem">
+		<xs:complexContent>
+			<xs:extension base="tns:PredefinedItemBase">
+				<xs:sequence>
+					<xs:element name="AccountType" type="ns2:AccountType"/>
+					<xs:element name="OffBalance" type="xs:boolean"/>
+					<xs:element name="Order" type="xs:string"/>
+					<xs:element name="AccountingFlags" type="tns:AccountingFlags" minOccurs="0"/>
+					<xs:element name="ExtDimensionTypes" type="tns:ExtDimensionTypes" minOccurs="0"/>
+					<xs:element name="ChildItems" type="tns:ChartOfAccountsPredefinedItems" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="ChartOfAccountsPredefinedItems">
+		<xs:complexContent>
+			<xs:extension base="ns3:EntityWithVersion">
+				<xs:sequence>
+					<xs:element name="Item" type="tns:ChartOfAccountsPredefinedItem" minOccurs="0" maxOccurs="unbounded"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="ExtDimensionType">
+		<xs:sequence>
+			<xs:element name="Turnover" type="xs:boolean"/>
+			<xs:element name="AccountingFlags" type="tns:AccountingFlags" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="name" type="xs:string"/>
+	</xs:complexType>
+	<xs:complexType name="ExtDimensionTypes">
+		<xs:sequence>
+			<xs:element name="ExtDimensionType" type="tns:ExtDimensionType" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PlanOfCharacteristicKindPredefinedItem">
+		<xs:complexContent>
+			<xs:extension base="tns:PredefinedItemBase">
+				<xs:sequence>
+					<xs:element name="Type" type="ns1:TypeDescription"/>
+					<xs:element name="IsFolder" type="xs:boolean"/>
+					<xs:element name="ChildItems" type="tns:PlanOfCharacteristicKindPredefinedItems" minOccurs="0" maxOccurs="unbounded"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="PlanOfCharacteristicKindPredefinedItems">
+		<xs:complexContent>
+			<xs:extension base="ns3:EntityWithVersion">
+				<xs:sequence>
+					<xs:element name="Item" type="tns:PlanOfCharacteristicKindPredefinedItem"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="PredefinedItemBase">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string"/>
+			<xs:element name="Code" type="xs:string"/>
+			<xs:element name="Description" type="xs:string"/>
+			<xs:element name="ExtensionState" type="tns:PredefinedItemExtensionState"/>
+		</xs:sequence>
+		<xs:attribute name="id" type="ns1:UUID"/>
+	</xs:complexType>
+</xs:schema>

--- a/src/main/xsd/v8.5/v8.1c.ru-8.3-xcf-readable.xsd
+++ b/src/main/xsd/v8.5/v8.1c.ru-8.3-xcf-readable.xsd
@@ -1,0 +1,271 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:ns1="http://v8.1c.ru/8.1/data/core" xmlns:ns2="http://v8.1c.ru/8.1/data/enterprise" xmlns:ns3="http://v8.1c.ru/8.2/managed-application/core" xmlns:ns4="http://v8.1c.ru/8.3/xcf/enums" xmlns:ns5="http://v8.1c.ru/8.2/managed-application/logform" xmlns:tns="http://v8.1c.ru/8.3/xcf/readable" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://v8.1c.ru/8.3/xcf/readable" attributeFormDefault="unqualified" elementFormDefault="qualified">
+	<xs:import namespace="http://v8.1c.ru/8.1/data/core"/>
+	<xs:import namespace="http://v8.1c.ru/8.1/data/enterprise"/>
+	<xs:import namespace="http://v8.1c.ru/8.2/managed-application/core"/>
+	<xs:import namespace="http://v8.1c.ru/8.3/xcf/enums"/>
+	<xs:import namespace="http://v8.1c.ru/8.2/managed-application/logform"/>
+	<xs:simpleType name="AliasedStringType">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="DataPath">
+		<xs:restriction base="tns:ReferenceType"/>
+	</xs:simpleType>
+	<xs:simpleType name="DesignTimeRef">
+		<xs:restriction base="tns:ReferenceType"/>
+	</xs:simpleType>
+	<xs:simpleType name="EventName">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="ExternalProperty">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="FiedlRef">
+		<xs:restriction base="tns:ReferenceType"/>
+	</xs:simpleType>
+	<xs:simpleType name="IncludeInCommandCategoriesType">
+		<xs:restriction base="tns:ReferenceType"/>
+	</xs:simpleType>
+	<xs:simpleType name="MDMethodRef">
+		<xs:restriction base="tns:ReferenceType"/>
+	</xs:simpleType>
+	<xs:simpleType name="MDObjectRef">
+		<xs:restriction base="tns:ReferenceType"/>
+	</xs:simpleType>
+	<xs:simpleType name="ReferenceType">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="([A-Za-z0-9_])*"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ShortCutType">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:complexType name="AdjustableBoolean">
+		<xs:sequence>
+			<xs:element name="Common" type="xs:boolean"/>
+			<xs:element name="Value" type="tns:AdjustableBooleanItemType" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="AdjustableBooleanItemType">
+		<xs:simpleContent>
+			<xs:extension base="xs:boolean">
+				<xs:attribute name="name" type="tns:MDObjectRef"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:complexType name="CharacteristicTypes">
+		<xs:sequence>
+			<xs:element name="KeyField" type="tns:FiedlRef"/>
+			<xs:element name="TypesFilterField" type="tns:FiedlRef"/>
+			<xs:element name="TypesFilterValue"/>
+			<xs:element name="DataPathField" type="tns:FiedlRef"/>
+			<xs:element name="MultipleValuesUseField" type="tns:FiedlRef"/>
+		</xs:sequence>
+		<xs:attribute name="from" type="tns:MDObjectRef"/>
+	</xs:complexType>
+	<xs:complexType name="CharacteristicValues">
+		<xs:sequence>
+			<xs:element name="ObjectField" type="tns:FiedlRef"/>
+			<xs:element name="TypeField" type="tns:FiedlRef"/>
+			<xs:element name="ValueField" type="tns:FiedlRef"/>
+			<xs:element name="MultipleValuesKeyField" type="tns:FiedlRef"/>
+			<xs:element name="MultipleValuesOrderField" type="tns:FiedlRef"/>
+		</xs:sequence>
+		<xs:attribute name="from" type="tns:MDObjectRef"/>
+	</xs:complexType>
+	<xs:complexType name="CharacteristicsDescription">
+		<xs:sequence>
+			<xs:element name="CharacteristicTypes" type="tns:CharacteristicTypes"/>
+			<xs:element name="CharacteristicValues" type="tns:CharacteristicValues"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CharacteristicsDescriptions">
+		<xs:sequence>
+			<xs:element name="Characteristic" type="tns:CharacteristicsDescription" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ChoiceParameterLink">
+		<xs:sequence>
+			<xs:element name="Name" type="xs:string" maxOccurs="unbounded"/>
+			<xs:element name="DataPath" type="tns:DataPath" maxOccurs="unbounded"/>
+			<xs:element name="ValueChange" type="ns2:LinkedValueChangeMode" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ChoiceParameterLinks">
+		<xs:sequence>
+			<xs:element name="Link" type="tns:ChoiceParameterLink" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CommonAttributeContent">
+		<xs:sequence>
+			<xs:element name="Item" type="tns:CommonAttributeContentItem" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CommonAttributeContentItem">
+		<xs:sequence>
+			<xs:element name="Metadata" type="tns:MDObjectRef"/>
+			<xs:element name="Use" type="ns4:CommonAttributeUse"/>
+			<xs:element name="ConditionalSeparation" type="tns:MDObjectRef"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ContainedObject">
+		<xs:sequence>
+			<xs:element name="ClassId" type="ns1:UUID"/>
+			<xs:element name="ObjectId" type="ns1:UUID"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="EntityWithVersion">
+		<xs:attribute name="version" type="ns4:FormatVersion"/>
+	</xs:complexType>
+	<xs:complexType name="ExtendedProperty">
+		<xs:sequence>
+			<xs:element name="CheckValue" nillable="true" minOccurs="0"/>
+			<xs:element name="ExtendValue" nillable="true" minOccurs="0"/>
+			<xs:element name="NotifyValue" nillable="true" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="FieldList">
+		<xs:sequence>
+			<xs:element name="Field" type="tns:FiedlRef" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="FlagType">
+		<xs:simpleContent>
+			<xs:extension base="xs:boolean">
+				<xs:attribute name="ref" type="tns:MDObjectRef"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:complexType name="FormattedStringType">
+		<xs:complexContent>
+			<xs:extension base="ns1:LocalStringType">
+				<xs:attribute name="formatted" type="xs:boolean"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="FuncOptionContentType">
+		<xs:sequence>
+			<xs:element name="Object" type="tns:MDObjectRef" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="GeneratedType">
+		<xs:sequence>
+			<xs:element name="TypeId" type="ns1:UUID"/>
+			<xs:element name="ValueId" type="ns1:UUID"/>
+		</xs:sequence>
+		<xs:attribute name="category" type="ns4:TypeCategories"/>
+		<xs:attribute name="name" type="xs:string"/>
+	</xs:complexType>
+	<xs:complexType name="InternalInfo">
+		<xs:sequence>
+			<xs:element name="ThisNode" type="ns1:UUID" minOccurs="0"/>
+			<xs:element name="GeneratedType" type="tns:GeneratedType" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="ContainedObject" type="tns:ContainedObject" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="PropertyState" type="tns:PropertyState" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="MDListType">
+		<xs:choice>
+			<xs:element name="Item" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="Picture">
+		<xs:choice>
+			<xs:element name="Ref" type="xs:string" minOccurs="0"/>
+			<xs:element name="Url" type="xs:string" minOccurs="0"/>
+			<xs:element name="Abs" type="xs:string" minOccurs="0"/>
+			<xs:element name="LoadTransparent" type="xs:boolean"/>
+			<xs:element name="TransparentPixel" type="tns:Point" minOccurs="0"/>
+			<xs:element name="GlyphPoint" type="tns:Point" minOccurs="0"/>
+			<xs:element name="ZipEntryParams" type="xs:string" minOccurs="0"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="Point">
+		<xs:attribute name="x" type="xs:decimal"/>
+		<xs:attribute name="y" type="xs:decimal"/>
+	</xs:complexType>
+	<xs:complexType name="PropertyState">
+		<xs:sequence>
+			<xs:element name="Property" type="xs:string"/>
+			<xs:element name="State" type="ns4:PropertyState"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Rect">
+		<xs:attribute name="top" type="xs:decimal"/>
+		<xs:attribute name="left" type="xs:decimal"/>
+		<xs:attribute name="bottom" type="xs:decimal"/>
+		<xs:attribute name="right" type="xs:decimal"/>
+	</xs:complexType>
+	<xs:complexType name="Size">
+		<xs:attribute name="cx" type="xs:decimal"/>
+		<xs:attribute name="cy" type="xs:decimal"/>
+	</xs:complexType>
+	<xs:complexType name="StandardAttributeDescription">
+		<xs:choice>
+			<xs:element name="Synonym" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="Comment" type="xs:string" minOccurs="0"/>
+			<xs:element name="ToolTip" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="QuickChoice" type="ns4:UseQuickChoice" minOccurs="0"/>
+			<xs:element name="FillChecking" type="ns1:FillChecking" minOccurs="0"/>
+			<xs:element name="FillValue" minOccurs="0"/>
+			<xs:element name="FillFromFillingValue" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="ChoiceParameterLinks" type="tns:ChoiceParameterLinks" minOccurs="0"/>
+			<xs:element name="ChoiceParameters" type="ns3:ChoiceParameters" minOccurs="0"/>
+			<xs:element name="LinkByType" type="tns:TypeLink" minOccurs="0"/>
+			<xs:element name="FullTextSearch" type="ns4:FullTextSearchUsing" minOccurs="0"/>
+			<xs:element name="PasswordMode" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="Format" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="EditFormat" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="Mask" type="xs:string" minOccurs="0"/>
+			<xs:element name="MultiLine" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="ExtendedEdit" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="MinValue" minOccurs="0"/>
+			<xs:element name="MaxValue" minOccurs="0"/>
+			<xs:element name="MarkNegatives" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="ChoiceForm" type="tns:MDObjectRef" minOccurs="0"/>
+			<xs:element name="CreateOnInput" type="ns4:CreateOnInput" minOccurs="0"/>
+			<xs:element name="ChoiceHistoryOnInput" type="ns5:ChoiceHistoryOnInput" minOccurs="0"/>
+			<xs:element name="DataHistory" type="ns4:DataHistoryUse" minOccurs="0"/>
+			<xs:element name="TypeReductionMode" type="ns4:TypeReductionMode" minOccurs="0"/>
+		</xs:choice>
+		<xs:attribute name="name" type="xs:string" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="StandardAttributeDescriptions">
+		<xs:sequence>
+			<xs:element name="StandardAttribute" type="tns:StandardAttributeDescription" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="StandardTabularSectionDescription">
+		<xs:sequence>
+			<xs:element name="Synonym" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="Comment" type="xs:string" minOccurs="0"/>
+			<xs:element name="ToolTip" type="ns1:LocalStringType" minOccurs="0"/>
+			<xs:element name="FillChecking" type="ns1:FillChecking" minOccurs="0"/>
+			<xs:element name="StandardAttributes" type="tns:StandardAttributeDescriptions"/>
+		</xs:sequence>
+		<xs:attribute name="name" type="xs:string" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="StandardTabularSectionDescriptions">
+		<xs:sequence>
+			<xs:element name="StandardTabularSection" type="tns:StandardTabularSectionDescription" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TypeLink">
+		<xs:sequence>
+			<xs:element name="DataPath" type="tns:DataPath" maxOccurs="unbounded"/>
+			<xs:element name="LinkItem" type="xs:decimal" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ValueList">
+		<xs:sequence>
+			<xs:element name="Item" type="tns:ValueListItem"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ValueListItem">
+		<xs:sequence>
+			<xs:element name="Presentation" type="xs:string"/>
+			<xs:element name="CheckState" type="xs:decimal"/>
+			<xs:element name="Value"/>
+		</xs:sequence>
+	</xs:complexType>
+</xs:schema>

--- a/src/test/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/DesignerJaxbWriterTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/DesignerJaxbWriterTest.java
@@ -1,0 +1,149 @@
+/*
+ * This file is a part of MDClasses.
+ *
+ * Copyright (c) 2019 - 2026
+ * Tymko Oleg <olegtymko@yandex.ru>, Maximov Valery <maximovvalery@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * MDClasses is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * MDClasses is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with MDClasses.
+ */
+package com.github._1c_syntax.bsl.mdclasses.jaxb.write;
+
+import com.github._1c_syntax.bsl.mdo.Catalog;
+import com.github._1c_syntax.bsl.mdo.MD;
+import com.github._1c_syntax.bsl.mdo.Role;
+import com.github._1c_syntax.bsl.mdo.Subsystem;
+import com.github._1c_syntax.bsl.types.MDOType;
+import com.github._1c_syntax.bsl.mdclasses.Configuration;
+import com.github._1c_syntax.bsl.mdclasses.MDCReadSettings;
+import com.github._1c_syntax.bsl.mdclasses.MDClasses;
+import com.github._1c_syntax.bsl.reader.MDOReader;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class DesignerJaxbWriterTest {
+
+  private static final Path DESIGNER_CF = Path.of("src/test/resources/ext/designer/mdclasses/src/cf");
+
+  @Test
+  void writeSubsystemRoundTrip(@TempDir Path tempDir) throws Exception {
+    MD mdo = (MD) MDOReader.read(DESIGNER_CF, "Subsystems.ПерваяПодсистема", MDCReadSettings.DEFAULT);
+    assertThat(mdo).isInstanceOf(Subsystem.class);
+
+    Path out = tempDir.resolve("Subsystems.ПерваяПодсистема.xml");
+    MDClassesJaxbWriter.writeObjectJaxb(out, mdo);
+
+    assertThat(out).exists();
+    String xml = Files.readString(out);
+    assertThat(xml).contains("MetaDataObject");
+    assertThat(xml).contains("Subsystem");
+    assertThat(xml).contains("http://v8.1c.ru/8.3/MDClasses");
+    assertThat(xml).contains("version=\"" + JaxbWriteDefaults.DEFAULT_FORMAT_VERSION + "\"");
+    assertThat(xml).contains("ПерваяПодсистема");
+  }
+
+  @Test
+  void writeCatalogRoundTrip(@TempDir Path tempDir) throws Exception {
+    MD mdo = (MD) MDOReader.read(DESIGNER_CF, "Catalogs.Справочник1", MDCReadSettings.DEFAULT);
+    assertThat(mdo).isInstanceOf(Catalog.class);
+
+    Path out = tempDir.resolve("Catalogs.Справочник1.xml");
+    MDClassesJaxbWriter.writeObjectJaxb(out, mdo);
+
+    assertThat(out).exists();
+    String xml = Files.readString(out);
+    assertThat(xml).contains("MetaDataObject");
+    assertThat(xml).contains("Catalog");
+    assertThat(xml).contains("http://v8.1c.ru/8.3/MDClasses");
+    assertThat(xml).contains("Справочник1");
+  }
+
+  @Test
+  void writeConfigurationRoundTrip(@TempDir Path tempDir) throws Exception {
+    var mdc = MDClasses.createConfiguration(DESIGNER_CF, MDCReadSettings.DEFAULT);
+    assertThat(mdc).isInstanceOf(Configuration.class);
+    Configuration cf = (Configuration) mdc;
+
+    Path out = tempDir.resolve("Configuration.xml");
+    MDClassesJaxbWriter.writeConfigurationJaxb(out, cf);
+
+    assertThat(out).exists();
+    String xml = Files.readString(out);
+    assertThat(xml).contains("MetaDataObject");
+    assertThat(xml).contains("Configuration");
+    assertThat(xml).contains("http://v8.1c.ru/8.3/MDClasses");
+  }
+
+  @Test
+  void writeUnsupportedTypeThrows() {
+    // Use a type not yet supported by JAXB writer (e.g. Constant, SessionParameter)
+    MD mdo = (MD) MDOReader.read(DESIGNER_CF, "Constants.Константа1", MDCReadSettings.DEFAULT);
+    assertThat(mdo).isNotNull();
+
+    assertThatThrownBy(() -> MDClassesJaxbWriter.writeObjectJaxb(Path.of("out.xml"), mdo))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("does not support type");
+  }
+
+  @Test
+  void writeRoleRoundTrip(@TempDir Path tempDir) throws Exception {
+    MD mdo = (MD) MDOReader.read(DESIGNER_CF, "Roles.Роль1", MDCReadSettings.DEFAULT);
+    assertThat(mdo).isInstanceOf(Role.class);
+
+    Path out = tempDir.resolve("Roles").resolve("Роль1.xml");
+    Files.createDirectories(out.getParent());
+    MDClassesJaxbWriter.writeObjectJaxb(out, mdo);
+
+    assertThat(out).exists();
+    String xml = Files.readString(out);
+    assertThat(xml).contains("MetaDataObject");
+    assertThat(xml).contains("Role");
+    assertThat(xml).contains("Роль1");
+  }
+
+  @Test
+  void writeConfigurationToFolderWithTypeFilter(@TempDir Path tempDir) throws Exception {
+    Configuration cf = (Configuration) MDClasses.createConfiguration(DESIGNER_CF, MDCReadSettings.DEFAULT);
+    WriteOptions options = WriteOptions.builder()
+      .typeFilter(Set.of(MDOType.CATALOG, MDOType.DOCUMENT))
+      .build();
+
+    MDClassesJaxbWriter.writeConfigurationToFolder(tempDir, cf, options);
+
+    assertThat(tempDir.resolve("Configuration.xml")).exists();
+    assertThat(tempDir.resolve("Catalogs").resolve("Справочник1.xml")).exists();
+    assertThat(tempDir.resolve("Documents").resolve("Документ1.xml")).exists();
+    assertThat(tempDir.resolve("Subsystems")).doesNotExist();
+  }
+
+  @Test
+  void writeConfigurationToFolderFull(@TempDir Path tempDir) throws Exception {
+    Configuration cf = (Configuration) MDClasses.createConfiguration(DESIGNER_CF, MDCReadSettings.DEFAULT);
+    MDClassesJaxbWriter.writeConfigurationToFolder(tempDir, cf);
+
+    assertThat(tempDir.resolve("Configuration.xml")).exists();
+    assertThat(tempDir.resolve("Subsystems")).isDirectory();
+    assertThat(tempDir.resolve("Catalogs")).isDirectory();
+    assertThat(tempDir.resolve("Documents")).isDirectory();
+    assertThat(tempDir.resolve("Roles").resolve("Роль1.xml")).exists();
+  }
+}

--- a/src/test/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/DesignerPathResolverTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/DesignerPathResolverTest.java
@@ -1,0 +1,75 @@
+/*
+ * This file is a part of MDClasses.
+ *
+ * Copyright (c) 2019 - 2026
+ * Tymko Oleg <olegtymko@yandex.ru>, Maximov Valery <maximovvalery@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+package com.github._1c_syntax.bsl.mdclasses.jaxb.write;
+
+import com.github._1c_syntax.bsl.mdo.MD;
+import com.github._1c_syntax.bsl.mdo.Subsystem;
+import com.github._1c_syntax.bsl.mdclasses.MDCReadSettings;
+import com.github._1c_syntax.bsl.reader.MDOReader;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DesignerPathResolverTest {
+
+  private static final Path DESIGNER_CF = Path.of("src/test/resources/ext/designer/mdclasses/src/cf");
+  private static final Path ROOT = Path.of("out");
+
+  @Test
+  void configurationPath() {
+    Path p = DesignerPathResolver.configurationPath(ROOT);
+    assertThat(p).isEqualTo(ROOT.resolve("Configuration.xml"));
+  }
+
+  @Test
+  void pathForObjectSubsystemTopLevel() {
+    MD mdo = (MD) MDOReader.read(DESIGNER_CF, "Subsystems.ПерваяПодсистема", MDCReadSettings.DEFAULT);
+    assertThat(mdo).isNotNull();
+
+    Path p = DesignerPathResolver.pathForObject(ROOT, mdo);
+    assertThat(p).isEqualTo(ROOT.resolve("Subsystems").resolve("ПерваяПодсистема.xml"));
+  }
+
+  @Test
+  void pathForObjectCatalog() {
+    MD mdo = (MD) MDOReader.read(DESIGNER_CF, "Catalogs.Справочник1", MDCReadSettings.DEFAULT);
+    assertThat(mdo).isNotNull();
+
+    Path p = DesignerPathResolver.pathForObject(ROOT, mdo);
+    assertThat(p).isEqualTo(ROOT.resolve("Catalogs").resolve("Справочник1.xml"));
+  }
+
+  @Test
+  void pathForObjectNestedSubsystem() {
+    MD parent = (MD) MDOReader.read(DESIGNER_CF, "Subsystems.ПерваяПодсистема", MDCReadSettings.DEFAULT);
+    assertThat(parent).isInstanceOf(Subsystem.class);
+    Subsystem parentSub = (Subsystem) parent;
+    var children = parentSub.getSubsystems();
+    if (children == null || children.isEmpty()) {
+      return;
+    }
+    MD child = children.get(0);
+    Path parentPath = ROOT.resolve("Subsystems").resolve("ПерваяПодсистема.xml");
+
+    Path childPath = DesignerPathResolver.pathForObject(ROOT, child, parentPath);
+    assertThat(childPath).isEqualTo(ROOT.resolve("Subsystems").resolve("ПерваяПодсистема")
+      .resolve("Subsystems").resolve(child.getName() + ".xml"));
+  }
+
+  @Test
+  void getPathForObjectViaFacade() {
+    MD mdo = (MD) MDOReader.read(DESIGNER_CF, "Documents.Документ1", MDCReadSettings.DEFAULT);
+    assertThat(mdo).isNotNull();
+
+    Path p = MDClassesJaxbWriter.getPathForObject(ROOT, mdo);
+    assertThat(p).isEqualTo(ROOT.resolve("Documents").resolve("Документ1.xml"));
+  }
+}

--- a/src/test/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/JaxbWriterExampleTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdclasses/jaxb/write/JaxbWriterExampleTest.java
@@ -1,0 +1,64 @@
+/*
+ * This file is a part of MDClasses.
+ *
+ * Copyright (c) 2019 - 2026
+ * Tymko Oleg <olegtymko@yandex.ru>, Maximov Valery <maximovvalery@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * MDClasses is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * MDClasses is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with MDClasses.
+ */
+package com.github._1c_syntax.bsl.mdclasses.jaxb.write;
+
+import com.github._1c_syntax.bsl.mdclasses.Configuration;
+import com.github._1c_syntax.bsl.mdclasses.MDCReadSettings;
+import com.github._1c_syntax.bsl.mdclasses.MDClasses;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Пример полной записи конфигурации в папку для ручной проверки в Конфигураторе 1С.
+ * Результат в {@code build/jaxb-example-output/}: Configuration.xml, Languages/, Subsystems/ (в т.ч. вложенные),
+ * Catalogs/, и прочие объекты по дереву конфигурации.
+ * <p>
+ * Формы справочников записываются в отдельные файлы Catalogs/Имя/Forms/ИмяФормы.xml.
+ * <p>
+ * Запуск: {@code ./gradlew test --tests "com.github._1c_syntax.bsl.mdclasses.jaxb.write.JaxbWriterExampleTest.writeExampleToBuildDir"}
+ */
+class JaxbWriterExampleTest {
+
+  private static final Path DESIGNER_CF = Path.of("src/test/resources/ext/designer/mdclasses/src/cf");
+  private static final Path OUTPUT_DIR = Path.of("build/jaxb-example-output");
+
+  @Test
+  void writeExampleToBuildDir() throws Exception {
+    Configuration cf = (Configuration) MDClasses.createConfiguration(DESIGNER_CF, MDCReadSettings.DEFAULT);
+    MDClassesJaxbWriter.writeConfigurationToFolder(OUTPUT_DIR, cf);
+
+    Path configPath = OUTPUT_DIR.resolve("Configuration.xml");
+    assert Files.exists(configPath) : "Configuration.xml";
+    assert Files.exists(OUTPUT_DIR.resolve("Languages").resolve("Русский.xml")) : "Languages/Русский.xml";
+    assert Files.exists(OUTPUT_DIR.resolve("Subsystems").resolve("ПерваяПодсистема.xml")) : "Subsystems/ПерваяПодсистема.xml";
+    assert Files.exists(OUTPUT_DIR.resolve("Subsystems").resolve("ВтораяПодсистема.xml")) : "Subsystems/ВтораяПодсистема.xml";
+    Path nestedSub = OUTPUT_DIR.resolve("Subsystems").resolve("ПерваяПодсистема").resolve("Subsystems").resolve("ПодчиненнаяПодсистема.xml");
+    assert Files.exists(nestedSub) : "Subsystems/ПерваяПодсистема/Subsystems/ПодчиненнаяПодсистема.xml";
+    assert Files.exists(OUTPUT_DIR.resolve("Catalogs").resolve("Справочник1.xml")) : "Catalogs/Справочник1.xml";
+    Path formsDir = OUTPUT_DIR.resolve("Catalogs").resolve("Справочник1").resolve("Forms");
+    assert Files.exists(formsDir.resolve("ФормаЭлемента.xml")) : "Catalogs/Справочник1/Forms/ФормаЭлемента.xml";
+    assert Files.exists(formsDir.resolve("ФормаСписка.xml")) : "Catalogs/Справочник1/Forms/ФормаСписка.xml";
+    assert Files.exists(formsDir.resolve("ФормаВыбора.xml")) : "Catalogs/Справочник1/Forms/ФормаВыбора.xml";
+  }
+}


### PR DESCRIPTION
## Описание

TODO 

## Связанные задачи

Closes #158 

## Чеклист

### Общие

- [x] Ветка PR обновлена из develop
- [ ] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [ ] Изменения покрыты тестами
- [ ] Обязательные действия перед коммитом выполнены (запускал команду `gradlew precommit`)

## Дополнительно


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for writing 1C metadata objects in Designer XML format
  * New capability to export entire configuration to folder structure with automatic path resolution
  * Optional filtering of metadata types during export
  * Support for serializing multiple metadata object types including configuration, catalogs, documents, roles, and subsystems

* **Dependencies**
  * Added Jakarta JAXB support for XML serialization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->