### PR TITLE
Чтение предопределенных данных (предопределенных значений)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,7 +60,7 @@ dependencies {
     // прочее
     implementation("commons-io:commons-io:2.22.0")
 
-    implementation("io.github.1c-syntax:bsl-common-library:0.10.0")
+    implementation("io.github.1c-syntax:bsl-common-library:0.11.0")
     implementation("io.github.1c-syntax:utils:0.7.0")
     implementation("io.github.1c-syntax:supportconf:0.16.0")
 

--- a/src/main/java/com/github/_1c_syntax/bsl/mdo/Catalog.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdo/Catalog.java
@@ -24,6 +24,7 @@ package com.github._1c_syntax.bsl.mdo;
 import com.github._1c_syntax.bsl.mdo.children.ObjectCommand;
 import com.github._1c_syntax.bsl.mdo.children.ObjectForm;
 import com.github._1c_syntax.bsl.mdo.children.ObjectTemplate;
+import com.github._1c_syntax.bsl.mdo.children.PredefinedValue;
 import com.github._1c_syntax.bsl.mdo.support.CodeSeries;
 import com.github._1c_syntax.bsl.mdo.support.ObjectBelonging;
 import com.github._1c_syntax.bsl.mdo.support.RoleRight;
@@ -46,7 +47,7 @@ import java.util.List;
 @Builder(toBuilder = true)
 @ToString(of = {"name", "uuid"})
 @EqualsAndHashCode(of = {"name", "uuid"})
-public class Catalog implements ReferenceObject, AccessRightsOwner {
+public class Catalog implements ReferenceObject, AccessRightsOwner, PredefinedDataOwner {
 
   private static final List<RoleRight> POSSIBLE_RIGHTS = computePossibleRights();
 
@@ -102,6 +103,12 @@ public class Catalog implements ReferenceObject, AccessRightsOwner {
   /*
    * Свое
    */
+
+  /**
+   * Предопределенные значения
+   */
+  @Singular
+  List<PredefinedValue> predefinedValues;
 
   /**
    * Пояснение

--- a/src/main/java/com/github/_1c_syntax/bsl/mdo/ChartOfAccounts.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdo/ChartOfAccounts.java
@@ -26,6 +26,7 @@ import com.github._1c_syntax.bsl.mdo.children.ExtDimensionAccountingFlag;
 import com.github._1c_syntax.bsl.mdo.children.ObjectCommand;
 import com.github._1c_syntax.bsl.mdo.children.ObjectForm;
 import com.github._1c_syntax.bsl.mdo.children.ObjectTemplate;
+import com.github._1c_syntax.bsl.mdo.children.PredefinedValue;
 import com.github._1c_syntax.bsl.mdo.support.CodeSeries;
 import com.github._1c_syntax.bsl.mdo.support.ObjectBelonging;
 import com.github._1c_syntax.bsl.mdo.support.RoleRight;
@@ -48,7 +49,7 @@ import java.util.List;
 @Builder(toBuilder = true)
 @ToString(of = {"name", "uuid"})
 @EqualsAndHashCode(of = {"name", "uuid"})
-public class ChartOfAccounts implements ReferenceObject, AccessRightsOwner {
+public class ChartOfAccounts implements ReferenceObject, AccessRightsOwner, PredefinedDataOwner {
 
   /*
    * ReferenceObject
@@ -104,6 +105,12 @@ public class ChartOfAccounts implements ReferenceObject, AccessRightsOwner {
   /*
    * Свое
    */
+
+  /**
+   * Предопределенные значения
+   */
+  @Singular
+  List<PredefinedValue> predefinedValues;
 
   /**
    * Признаки учета

--- a/src/main/java/com/github/_1c_syntax/bsl/mdo/ChartOfCalculationTypes.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdo/ChartOfCalculationTypes.java
@@ -24,6 +24,7 @@ package com.github._1c_syntax.bsl.mdo;
 import com.github._1c_syntax.bsl.mdo.children.ObjectCommand;
 import com.github._1c_syntax.bsl.mdo.children.ObjectForm;
 import com.github._1c_syntax.bsl.mdo.children.ObjectTemplate;
+import com.github._1c_syntax.bsl.mdo.children.PredefinedValue;
 import com.github._1c_syntax.bsl.mdo.support.ObjectBelonging;
 import com.github._1c_syntax.bsl.mdo.support.RoleRight;
 import com.github._1c_syntax.bsl.mdo.utils.LazyLoader;
@@ -45,7 +46,7 @@ import java.util.List;
 @Builder(toBuilder = true)
 @ToString(of = {"name", "uuid"})
 @EqualsAndHashCode(of = {"name", "uuid"})
-public class ChartOfCalculationTypes implements ReferenceObject, AccessRightsOwner {
+public class ChartOfCalculationTypes implements ReferenceObject, AccessRightsOwner, PredefinedDataOwner {
 
   /*
    * ReferenceObject
@@ -99,6 +100,12 @@ public class ChartOfCalculationTypes implements ReferenceObject, AccessRightsOwn
   /*
    * Свое
    */
+
+  /**
+   * Предопределенные значения
+   */
+  @Singular
+  List<PredefinedValue> predefinedValues;
 
   /**
    * Пояснение

--- a/src/main/java/com/github/_1c_syntax/bsl/mdo/ChartOfCharacteristicTypes.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdo/ChartOfCharacteristicTypes.java
@@ -24,6 +24,7 @@ package com.github._1c_syntax.bsl.mdo;
 import com.github._1c_syntax.bsl.mdo.children.ObjectCommand;
 import com.github._1c_syntax.bsl.mdo.children.ObjectForm;
 import com.github._1c_syntax.bsl.mdo.children.ObjectTemplate;
+import com.github._1c_syntax.bsl.mdo.children.PredefinedValue;
 import com.github._1c_syntax.bsl.mdo.support.CodeSeries;
 import com.github._1c_syntax.bsl.mdo.support.ObjectBelonging;
 import com.github._1c_syntax.bsl.mdo.support.RoleRight;
@@ -48,7 +49,8 @@ import java.util.List;
 @Builder(toBuilder = true)
 @ToString(of = {"name", "uuid"})
 @EqualsAndHashCode(of = {"name", "uuid"})
-public class ChartOfCharacteristicTypes implements ReferenceObject, AccessRightsOwner, ValueTypeOwner {
+public class ChartOfCharacteristicTypes
+  implements ReferenceObject, AccessRightsOwner, ValueTypeOwner, PredefinedDataOwner {
 
   /*
    * ReferenceObject
@@ -110,6 +112,12 @@ public class ChartOfCharacteristicTypes implements ReferenceObject, AccessRights
   /*
    * Свое
    */
+
+  /**
+   * Предопределенные значения
+   */
+  @Singular
+  List<PredefinedValue> predefinedValues;
 
   /**
    * Пояснение

--- a/src/main/java/com/github/_1c_syntax/bsl/mdo/ExchangePlan.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdo/ExchangePlan.java
@@ -24,6 +24,7 @@ package com.github._1c_syntax.bsl.mdo;
 import com.github._1c_syntax.bsl.mdo.children.ObjectCommand;
 import com.github._1c_syntax.bsl.mdo.children.ObjectForm;
 import com.github._1c_syntax.bsl.mdo.children.ObjectTemplate;
+import com.github._1c_syntax.bsl.mdo.children.PredefinedValue;
 import com.github._1c_syntax.bsl.mdo.support.AutoRecordType;
 import com.github._1c_syntax.bsl.mdo.support.ObjectBelonging;
 import com.github._1c_syntax.bsl.mdo.support.RoleRight;
@@ -46,7 +47,7 @@ import java.util.List;
 @Builder(toBuilder = true)
 @ToString(of = {"name", "uuid"})
 @EqualsAndHashCode(of = {"name", "uuid"})
-public class ExchangePlan implements ReferenceObject, AccessRightsOwner {
+public class ExchangePlan implements ReferenceObject, AccessRightsOwner, PredefinedDataOwner {
 
   private static final List<RoleRight> POSSIBLE_RIGHTS = computePossibleRights();
 
@@ -102,6 +103,12 @@ public class ExchangePlan implements ReferenceObject, AccessRightsOwner {
   /*
    * Свое
    */
+
+  /**
+   * Предопределенные значения
+   */
+  @Singular
+  List<PredefinedValue> predefinedValues;
 
   /**
    * Распределенная информационная база

--- a/src/main/java/com/github/_1c_syntax/bsl/mdo/PredefinedDataOwner.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdo/PredefinedDataOwner.java
@@ -1,0 +1,36 @@
+/*
+ * This file is a part of MDClasses.
+ *
+ * Copyright (c) 2019 - 2026
+ * Tymko Oleg <olegtymko@yandex.ru>, Maximov Valery <maximovvalery@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * MDClasses is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * MDClasses is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with MDClasses.
+ */
+package com.github._1c_syntax.bsl.mdo;
+
+import com.github._1c_syntax.bsl.mdo.children.PredefinedValue;
+
+import java.util.List;
+
+/**
+ * Расширение - владелец предопределенных данных (предопределенных значений)
+ */
+public interface PredefinedDataOwner extends ChildrenOwner {
+  /**
+   * Список предопределенных значений объекта
+   */
+  List<PredefinedValue> getPredefinedValues();
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/mdo/children/PredefinedValue.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdo/children/PredefinedValue.java
@@ -1,0 +1,116 @@
+/*
+ * This file is a part of MDClasses.
+ *
+ * Copyright (c) 2019 - 2026
+ * Tymko Oleg <olegtymko@yandex.ru>, Maximov Valery <maximovvalery@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * MDClasses is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * MDClasses is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with MDClasses.
+ */
+package com.github._1c_syntax.bsl.mdo.children;
+
+import com.github._1c_syntax.bsl.mdo.ChildrenOwner;
+import com.github._1c_syntax.bsl.mdo.MD;
+import com.github._1c_syntax.bsl.mdo.MDChild;
+import com.github._1c_syntax.bsl.mdo.support.ObjectBelonging;
+import com.github._1c_syntax.bsl.mdo.utils.LazyLoader;
+import com.github._1c_syntax.bsl.support.SupportVariant;
+import com.github._1c_syntax.bsl.types.MdoReference;
+import com.github._1c_syntax.bsl.types.MultiLanguageString;
+import lombok.Builder;
+import lombok.Builder.Default;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Singular;
+import lombok.ToString;
+import lombok.Value;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Предопределенный элемент (предопределенное значение) объекта метаданных.
+ * <p>
+ * Используется владельцами предопределенных данных - справочниками, планами видов характеристик,
+ * планами счетов, планами видов расчета и планами обмена.
+ * <p>
+ * Может быть иерархическим (содержать вложенные предопределенные элементы {@link #childItems}).
+ */
+@Value
+@Builder(toBuilder = true)
+@ToString(of = {"name", "uuid"})
+@EqualsAndHashCode(of = {"name", "uuid"})
+public class PredefinedValue implements MDChild, ChildrenOwner {
+
+  /*
+   * Для MDChild
+   */
+
+  @Default
+  String uuid = "";
+  @Default
+  String name = "";
+  @Default
+  MdoReference mdoReference = MdoReference.EMPTY;
+  @Default
+  ObjectBelonging objectBelonging = ObjectBelonging.OWN;
+  @Default
+  String comment = "";
+  @Default
+  MultiLanguageString synonym = MultiLanguageString.EMPTY;
+  @Default
+  SupportVariant supportVariant = SupportVariant.NONE;
+  @Default
+  MdoReference owner = MdoReference.EMPTY;
+
+  /*
+   * Свое
+   */
+
+  /**
+   * Код предопределенного элемента
+   */
+  @Default
+  String code = "";
+
+  /**
+   * Наименование предопределенного элемента
+   */
+  @Default
+  String description = "";
+
+  /**
+   * Признак "Это группа"
+   */
+  boolean folder;
+
+  /**
+   * Вложенные предопределенные элементы (для иерархических объектов)
+   */
+  @Singular
+  List<PredefinedValue> childItems;
+
+  @Getter(lazy = true)
+  List<MD> plainChildren = LazyLoader.computePlainChildren(this);
+
+  /*
+   * Для ChildrenOwner
+   */
+
+  @Override
+  public List<MD> getChildren() {
+    return Collections.unmodifiableList(childItems);
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/mdo/storage/PredefinedData.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdo/storage/PredefinedData.java
@@ -1,0 +1,45 @@
+/*
+ * This file is a part of MDClasses.
+ *
+ * Copyright (c) 2019 - 2026
+ * Tymko Oleg <olegtymko@yandex.ru>, Maximov Valery <maximovvalery@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * MDClasses is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * MDClasses is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with MDClasses.
+ */
+package com.github._1c_syntax.bsl.mdo.storage;
+
+import com.github._1c_syntax.bsl.mdo.children.PredefinedValue;
+import lombok.Singular;
+import lombok.Value;
+import lombok.Builder;
+
+import java.util.List;
+
+/**
+ * Контейнер предопределенных данных из отдельного файла {@code Ext/Predefined.xml} (формат Конфигуратора)
+ */
+@Value
+@Builder
+public class PredefinedData {
+
+  public static final PredefinedData EMPTY = PredefinedData.builder().build();
+
+  /**
+   * Предопределенные элементы верхнего уровня
+   */
+  @Singular
+  List<PredefinedValue> items;
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/mdo/utils/LazyLoader.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdo/utils/LazyLoader.java
@@ -35,6 +35,7 @@ import com.github._1c_syntax.bsl.mdo.FormOwner;
 import com.github._1c_syntax.bsl.mdo.MD;
 import com.github._1c_syntax.bsl.mdo.Module;
 import com.github._1c_syntax.bsl.mdo.ModuleOwner;
+import com.github._1c_syntax.bsl.mdo.PredefinedDataOwner;
 import com.github._1c_syntax.bsl.mdo.Register;
 import com.github._1c_syntax.bsl.mdo.TabularSectionOwner;
 import com.github._1c_syntax.bsl.mdo.Task;
@@ -93,6 +94,10 @@ public class LazyLoader {
 
     if (mdo instanceof Enum anEnum) {
       children = addAll(children, anEnum.getEnumValues());
+    }
+
+    if (mdo instanceof PredefinedDataOwner predefinedDataOwner) {
+      children = addAll(children, predefinedDataOwner.getPredefinedValues());
     }
 
     if (mdo instanceof Task task) {

--- a/src/main/java/com/github/_1c_syntax/bsl/reader/MDReader.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/reader/MDReader.java
@@ -24,6 +24,7 @@ package com.github._1c_syntax.bsl.reader;
 import com.github._1c_syntax.bsl.mdclasses.ExternalSource;
 import com.github._1c_syntax.bsl.mdclasses.MDCReadSettings;
 import com.github._1c_syntax.bsl.mdclasses.MDClass;
+import com.github._1c_syntax.bsl.mdo.children.PredefinedValue;
 import com.github._1c_syntax.bsl.mdo.storage.FormData;
 import com.github._1c_syntax.bsl.reader.common.context.AbstractReaderContext;
 import com.github._1c_syntax.bsl.reader.common.xstream.ExtendXStream;
@@ -35,6 +36,8 @@ import com.thoughtworks.xstream.io.HierarchicalStreamReader;
 import org.jspecify.annotations.Nullable;
 
 import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Интерфейс для ридеров исходников
@@ -123,6 +126,22 @@ public interface MDReader {
    */
   @Nullable
   FormData readFormData(Path currentPath, String name, MDOType mdoType);
+
+  /**
+   * Читает предопределенные данные объекта.
+   * <p>
+   * Для формата Конфигуратора предопределенные данные хранятся в отдельном файле
+   * {@code Ext/Predefined.xml}. Для формата EDT они встроены в основной файл объекта и читаются
+   * штатным образом, поэтому реализация по умолчанию возвращает пустой список.
+   *
+   * @param currentPath Путь к файлу объекта
+   * @param name        Имя объекта
+   * @param mdoType     Тип объекта
+   * @return Список предопределенных значений верхнего уровня
+   */
+  default List<PredefinedValue> readPredefinedData(Path currentPath, String name, MDOType mdoType) {
+    return Collections.emptyList();
+  }
 
   /**
    * Рассчитывает каталог, в которм должны располагаться модули объекта

--- a/src/main/java/com/github/_1c_syntax/bsl/reader/common/context/MDReaderContext.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/reader/common/context/MDReaderContext.java
@@ -26,7 +26,9 @@ import com.github._1c_syntax.bsl.mdo.ChildrenOwner;
 import com.github._1c_syntax.bsl.mdo.Form;
 import com.github._1c_syntax.bsl.mdo.MDChild;
 import com.github._1c_syntax.bsl.mdo.ModuleOwner;
+import com.github._1c_syntax.bsl.mdo.PredefinedDataOwner;
 import com.github._1c_syntax.bsl.mdo.Subsystem;
+import com.github._1c_syntax.bsl.mdo.children.PredefinedValue;
 import com.github._1c_syntax.bsl.mdo.children.ExternalDataSourceTableField;
 import com.github._1c_syntax.bsl.mdo.children.StandardAttribute;
 import com.github._1c_syntax.bsl.mdo.support.TemplateType;
@@ -64,6 +66,7 @@ public class MDReaderContext extends AbstractReaderContext {
   private static final String UUID_FIELD_NAME = "uuid";
   private static final String SUPPORT_VALIANT_FIELD_NAME = "SupportVariant";
   private static final String DATA_FIELD_NAME = "data";
+  private static final String PREDEFINED_VALUES_FIELD_NAME = "predefinedValues";
 
   /**
    * Коллекция билдеров для дочерних объектов, которые надо доделать
@@ -142,6 +145,10 @@ public class MDReaderContext extends AbstractReaderContext {
       setValue(MDO_REFERENCE_FIELD_NAME, mdoReference);
     }
 
+    if (PredefinedDataOwner.class.isAssignableFrom(realClass)) {
+      setupPredefinedValues();
+    }
+
     if (MDChild.class.isAssignableFrom(realClass)) {
       setValue(OWNER_FIELD_NAME, owner);
     }
@@ -172,6 +179,40 @@ public class MDReaderContext extends AbstractReaderContext {
   private void saveChildName(String collectionName, MDReaderContext child) {
     childrenContexts.computeIfAbsent(collectionName, k -> Collections.synchronizedList(new ArrayList<>()))
       .add(child);
+  }
+
+  private void setupPredefinedValues() {
+    // EDT хранит предопределённые внутри файла объекта - они уже прочитаны и лежат в кэше;
+    // Конфигуратор хранит их в отдельном файле Ext/Predefined.xml - дочитываем через ридер
+    List<PredefinedValue> raw = getFromCache(PREDEFINED_VALUES_FIELD_NAME, Collections.emptyList());
+    if (raw.isEmpty()) {
+      raw = mdReader.readPredefinedData(currentPath, name, mdoType);
+    }
+
+    if (raw.isEmpty()) {
+      return;
+    }
+
+    var withRefs = raw.stream()
+      .map(value -> predefinedValueWithRefs(value, mdoReference, supportVariant))
+      .toList();
+
+    TransformationUtils.invoke(builder, "clearPredefinedValues");
+    setValue(PREDEFINED_VALUES_FIELD_NAME, withRefs);
+  }
+
+  private static PredefinedValue predefinedValueWithRefs(PredefinedValue value,
+                                                         MdoReference owner,
+                                                         SupportVariant supportVariant) {
+    var reference = MdoReference.create(owner, MDOType.PREDEFINED_VALUE, value.getName());
+    var valueBuilder = value.toBuilder()
+      .owner(owner)
+      .mdoReference(reference)
+      .supportVariant(supportVariant)
+      .clearChildItems();
+    value.getChildItems()
+      .forEach(child -> valueBuilder.childItem(predefinedValueWithRefs(child, reference, supportVariant)));
+    return valueBuilder.build();
   }
 
   private void setValueChildren() {

--- a/src/main/java/com/github/_1c_syntax/bsl/reader/common/converter/PredefinedValueConverter.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/reader/common/converter/PredefinedValueConverter.java
@@ -1,0 +1,109 @@
+/*
+ * This file is a part of MDClasses.
+ *
+ * Copyright (c) 2019 - 2026
+ * Tymko Oleg <olegtymko@yandex.ru>, Maximov Valery <maximovvalery@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * MDClasses is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * MDClasses is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with MDClasses.
+ */
+package com.github._1c_syntax.bsl.reader.common.converter;
+
+import com.github._1c_syntax.bsl.mdo.children.PredefinedValue;
+import com.github._1c_syntax.bsl.reader.common.xstream.ReadConverter;
+import com.thoughtworks.xstream.converters.UnmarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+
+/**
+ * Читает один предопределенный элемент ({@link PredefinedValue}) из файла объекта (EDT)
+ * или из файла предопределенных данных (Конфигуратор).
+ * <p>
+ * Поддерживает иерархию: вложенные предопределенные элементы читаются рекурсивно.
+ * Ссылка ({@code mdoReference}) и владелец ({@code owner}) проставляются позднее, при сборке
+ * родительского объекта.
+ */
+@CommonConverter
+public class PredefinedValueConverter implements ReadConverter {
+
+  private static final String ID_ATTRIBUTE = "id";
+  private static final String CHILD_ITEMS_NODE = "ChildItems";
+  private static final String ITEMS_NODE = "items";
+  private static final String VALUE_NODE = "value";
+
+  @Override
+  public Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context) {
+    var builder = PredefinedValue.builder();
+
+    var id = reader.getAttribute(ID_ATTRIBUTE);
+    if (id != null) {
+      builder.uuid(id);
+    }
+
+    while (reader.hasMoreChildren()) {
+      reader.moveDown();
+      var node = reader.getNodeName();
+      switch (node) {
+        case "Name", "name" -> builder.name(reader.getValue());
+        case "Description", "description" -> builder.description(reader.getValue());
+        case "Code", "code" -> builder.code(readCode(reader));
+        case "IsFolder", "isFolder" -> builder.folder(Boolean.parseBoolean(reader.getValue()));
+        case CHILD_ITEMS_NODE -> readChildItems(reader, context, builder);
+        case ITEMS_NODE -> builder.childItem((PredefinedValue) context.convertAnother(null, PredefinedValue.class));
+        default -> {
+          // прочие свойства игнорируем
+        }
+      }
+      reader.moveUp();
+    }
+
+    return builder.build();
+  }
+
+  /**
+   * Чтение кода: в Конфигураторе - простое значение, в EDT - вложенный элемент {@code <value>}
+   */
+  private static String readCode(HierarchicalStreamReader reader) {
+    if (!reader.hasMoreChildren()) {
+      return reader.getValue();
+    }
+    var code = "";
+    while (reader.hasMoreChildren()) {
+      reader.moveDown();
+      if (VALUE_NODE.equals(reader.getNodeName())) {
+        code = reader.getValue();
+      }
+      reader.moveUp();
+    }
+    return code;
+  }
+
+  /**
+   * Чтение вложенных предопределенных элементов из обертки {@code <ChildItems>} (Конфигуратор)
+   */
+  private static void readChildItems(HierarchicalStreamReader reader,
+                                     UnmarshallingContext context,
+                                     PredefinedValue.PredefinedValueBuilder builder) {
+    while (reader.hasMoreChildren()) {
+      reader.moveDown();
+      builder.childItem((PredefinedValue) context.convertAnother(null, PredefinedValue.class));
+      reader.moveUp();
+    }
+  }
+
+  @Override
+  public boolean canConvert(Class type) {
+    return PredefinedValue.class.isAssignableFrom(type);
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/reader/designer/DesignerReader.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/reader/designer/DesignerReader.java
@@ -50,8 +50,10 @@ import com.github._1c_syntax.bsl.mdo.children.Resource;
 import com.github._1c_syntax.bsl.mdo.children.StandardAttribute;
 import com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute;
 import com.github._1c_syntax.bsl.mdo.children.WebServiceOperation;
+import com.github._1c_syntax.bsl.mdo.children.PredefinedValue;
 import com.github._1c_syntax.bsl.mdo.children.WebServiceOperationParameter;
 import com.github._1c_syntax.bsl.mdo.storage.EmptyFormData;
+import com.github._1c_syntax.bsl.mdo.storage.PredefinedData;
 import com.github._1c_syntax.bsl.mdo.storage.FormData;
 import com.github._1c_syntax.bsl.mdo.storage.ManagedFormData;
 import com.github._1c_syntax.bsl.reader.MDReader;
@@ -78,6 +80,8 @@ import org.jspecify.annotations.Nullable;
 import javax.xml.namespace.QName;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 @Slf4j
@@ -179,6 +183,19 @@ public class DesignerReader implements MDReader {
   }
 
   @Override
+  public List<PredefinedValue> readPredefinedData(Path currentPath, String name, MDOType mdoType) {
+    var predefinedPath = Paths.get(currentPath.getParent().toString(), name, "Ext", "Predefined.xml");
+    if (!predefinedPath.toFile().exists()) {
+      return Collections.emptyList();
+    }
+    var value = read(predefinedPath);
+    if (value instanceof PredefinedData predefinedData) {
+      return predefinedData.getItems();
+    }
+    return Collections.emptyList();
+  }
+
+  @Override
   public Path moduleFolder(Path mdoPath, MDOType mdoType) {
     if (mdoType == MDOType.COMMAND) {
       return childrenFolder(mdoPath, mdoType);
@@ -261,6 +278,7 @@ public class DesignerReader implements MDReader {
     xStream.alias("Method", HTTPServiceMethod.class);
     xStream.alias("Operation", WebServiceOperation.class);
     xStream.alias("Parameter", WebServiceOperationParameter.class);
+    xStream.alias("PredefinedData", PredefinedData.class);
     xStream.alias("Recalculation", Recalculation.class);
     xStream.alias("Resource", Resource.class);
     xStream.alias("Table", ExternalDataSourceTable.class);

--- a/src/main/java/com/github/_1c_syntax/bsl/reader/designer/converter/MDChildConverter.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/reader/designer/converter/MDChildConverter.java
@@ -27,6 +27,7 @@ import com.github._1c_syntax.bsl.mdo.children.ExternalDataSourceCubeDimensionTab
 import com.github._1c_syntax.bsl.mdo.children.ExternalDataSourceTable;
 import com.github._1c_syntax.bsl.mdo.children.ObjectForm;
 import com.github._1c_syntax.bsl.mdo.children.ObjectTemplate;
+import com.github._1c_syntax.bsl.mdo.children.PredefinedValue;
 import com.github._1c_syntax.bsl.mdo.children.Recalculation;
 import com.github._1c_syntax.bsl.mdo.children.StandardAttribute;
 import com.github._1c_syntax.bsl.reader.common.converter.AbstractReadConverter;
@@ -72,6 +73,7 @@ public class MDChildConverter extends AbstractReadConverter {
     return
       !ObjectTemplate.class.isAssignableFrom(type)
         && !StandardAttribute.class.isAssignableFrom(type)
+        && !PredefinedValue.class.isAssignableFrom(type)
         && MDChild.class.isAssignableFrom(type);
   }
 

--- a/src/main/java/com/github/_1c_syntax/bsl/reader/designer/converter/PredefinedDataConverter.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/reader/designer/converter/PredefinedDataConverter.java
@@ -19,36 +19,37 @@
  * You should have received a copy of the GNU Lesser General Public
  * License along with MDClasses.
  */
-package com.github._1c_syntax.bsl.reader.edt.converter;
+package com.github._1c_syntax.bsl.reader.designer.converter;
 
-import com.github._1c_syntax.bsl.mdo.MDChild;
-import com.github._1c_syntax.bsl.mdo.children.ExternalDataSourceCube;
-import com.github._1c_syntax.bsl.mdo.children.ExternalDataSourceCubeDimensionTable;
-import com.github._1c_syntax.bsl.mdo.children.ExternalDataSourceTable;
-import com.github._1c_syntax.bsl.mdo.children.ObjectTemplate;
 import com.github._1c_syntax.bsl.mdo.children.PredefinedValue;
-import com.github._1c_syntax.bsl.reader.common.converter.AbstractReadConverter;
+import com.github._1c_syntax.bsl.mdo.storage.PredefinedData;
+import com.github._1c_syntax.bsl.reader.common.xstream.ReadConverter;
 import com.thoughtworks.xstream.converters.UnmarshallingContext;
 import com.thoughtworks.xstream.io.HierarchicalStreamReader;
 
 /**
- * Конвертер для дочерних элементов (атрибуты, операции и т.д.)
+ * Читает файл предопределенных данных {@code Ext/Predefined.xml} (формат Конфигуратора)
  */
-@EDTConverter
-public class MDChildConverter extends AbstractReadConverter {
+@DesignerConverter
+public class PredefinedDataConverter implements ReadConverter {
+
+  private static final String ITEM_NODE = "Item";
 
   @Override
   public Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context) {
-    return super.read(reader, context); // внимание! возвращается контекст, а не объект!
+    var builder = PredefinedData.builder();
+    while (reader.hasMoreChildren()) {
+      reader.moveDown();
+      if (ITEM_NODE.equals(reader.getNodeName())) {
+        builder.item((PredefinedValue) context.convertAnother(null, PredefinedValue.class));
+      }
+      reader.moveUp();
+    }
+    return builder.build();
   }
 
   @Override
   public boolean canConvert(Class type) {
-    return !ExternalDataSourceTable.class.isAssignableFrom(type)
-      && !ExternalDataSourceCube.class.isAssignableFrom(type)
-      && !ExternalDataSourceCubeDimensionTable.class.isAssignableFrom(type)
-      && !ObjectTemplate.class.isAssignableFrom(type)
-      && !PredefinedValue.class.isAssignableFrom(type)
-      && MDChild.class.isAssignableFrom(type);
+    return PredefinedData.class.isAssignableFrom(type);
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/reader/edt/converter/Unmarshaller.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/reader/edt/converter/Unmarshaller.java
@@ -22,7 +22,9 @@
 package com.github._1c_syntax.bsl.reader.edt.converter;
 
 import com.github._1c_syntax.bsl.mdo.Language;
+import com.github._1c_syntax.bsl.mdo.PredefinedDataOwner;
 import com.github._1c_syntax.bsl.mdo.children.ExternalDataSourceTableField;
+import com.github._1c_syntax.bsl.mdo.children.PredefinedValue;
 import com.github._1c_syntax.bsl.mdo.children.StandardAttribute;
 import com.github._1c_syntax.bsl.mdo.storage.form.FormElementType;
 import com.github._1c_syntax.bsl.mdo.support.TemplateType;
@@ -38,6 +40,9 @@ import com.github._1c_syntax.bsl.types.ValueTypeDescription;
 import com.thoughtworks.xstream.converters.UnmarshallingContext;
 import com.thoughtworks.xstream.io.HierarchicalStreamReader;
 import lombok.experimental.UtilityClass;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Выполняет базовое чтение файлов
@@ -58,6 +63,9 @@ public class Unmarshaller {
   private static final String VALUE_TYPE_OTHER_FIELD = "valueType";
   private static final String VALUE_TYPE_FIELD = "type";
   private static final String STANDARD_ATTRIBUTES_NODE = "standardAttributes";
+  private static final String PREDEFINED_NODE = "predefined";
+  private static final String ITEMS_NODE = "items";
+  private static final String PREDEFINED_VALUES_FIELD = "predefinedValues";
 
   /**
    * Читают общую информацию из файла
@@ -70,8 +78,34 @@ public class Unmarshaller {
 
     while (reader.hasMoreChildren()) {
       reader.moveDown();
-      readNode(reader.getNodeName(), context, readerContext);
+      var nodeName = reader.getNodeName();
+      if (PREDEFINED_NODE.equals(nodeName)
+        && readerContext instanceof MDReaderContext
+        && PredefinedDataOwner.class.isAssignableFrom(readerContext.getRealClass())) {
+        readPredefined(reader, context, readerContext);
+      } else {
+        readNode(nodeName, context, readerContext);
+      }
       reader.moveUp();
+    }
+  }
+
+  /**
+   * Читает встроенные в файл объекта предопределенные данные (обертка {@code <predefined>})
+   */
+  private void readPredefined(HierarchicalStreamReader reader,
+                              UnmarshallingContext context,
+                              AbstractReaderContext readerContext) {
+    List<PredefinedValue> items = new ArrayList<>();
+    while (reader.hasMoreChildren()) {
+      reader.moveDown();
+      if (ITEMS_NODE.equals(reader.getNodeName())) {
+        items.add(ExtendXStream.readValue(context, PredefinedValue.class));
+      }
+      reader.moveUp();
+    }
+    if (!items.isEmpty()) {
+      readerContext.setValue(PREDEFINED_VALUES_FIELD, items);
     }
   }
 

--- a/src/test/java/com/github/_1c_syntax/bsl/mdclasses/ConfigurationTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdclasses/ConfigurationTest.java
@@ -24,6 +24,7 @@ package com.github._1c_syntax.bsl.mdclasses;
 import com.github._1c_syntax.bsl.mdo.BusinessProcess;
 import com.github._1c_syntax.bsl.mdo.Form;
 import com.github._1c_syntax.bsl.mdo.FormOwner;
+import com.github._1c_syntax.bsl.mdo.MD;
 import com.github._1c_syntax.bsl.mdo.Module;
 import com.github._1c_syntax.bsl.mdo.TemplateOwner;
 import com.github._1c_syntax.bsl.mdo.children.ObjectForm;
@@ -50,6 +51,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @Slf4j
 class ConfigurationTest {
+
+  /**
+   * Количество предопределенных значений среди дочерних объектов (включая вложенные).
+   * Выносится отдельным слагаемым, т.к. состав предопределенных может отличаться между форматами/версиями фикстур.
+   */
+  private static int predefinedCount(List<MD> plainChildren) {
+    return (int) plainChildren.stream()
+      .filter(com.github._1c_syntax.bsl.mdo.children.PredefinedValue.class::isInstance)
+      .count();
+  }
 
   @ParameterizedTest
   @CsvSource(
@@ -91,7 +102,7 @@ class ConfigurationTest {
     checkChildrenSSL(cf);
 
     assertThat(cf.getPlainChildren())
-      .hasSize(9810)
+      .hasSize(9810 + predefinedCount(cf.getPlainChildren()))
       .allMatch(md -> md.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
 
     assertThat(cf.getModulesByType())
@@ -205,7 +216,7 @@ class ConfigurationTest {
     checkChildrenMdclasses(cf);
 
     assertThat(cf.getPlainChildren())
-      .hasSize(223 + cf.getInterfaces().size() + cf.getStyles().size())
+      .hasSize(223 + cf.getInterfaces().size() + cf.getStyles().size() + predefinedCount(cf.getPlainChildren()))
       .allMatch(md -> md.getSupportVariant().equals(SupportVariant.NONE));
 
     assertThat(cf.getModules().stream().filter(Module::isProtected)).isEmpty();
@@ -242,7 +253,7 @@ class ConfigurationTest {
     checkChildrenOrder(cf);
 
     assertThat(cf.getPlainChildren())
-      .hasSize(330)
+      .hasSize(330 + predefinedCount(cf.getPlainChildren()))
       .allMatch(md -> md.getSupportVariant().equals(SupportVariant.NONE));
 
     assertThat(cf.getAllModules().stream().filter(Module::isProtected)).isEmpty();
@@ -284,7 +295,7 @@ class ConfigurationTest {
       .allMatch(module -> module.getSupportVariant().equals(SupportVariant.NONE));
 
     assertThat(cf.getPlainChildren())
-      .hasSize(9810)
+      .hasSize(9810 + predefinedCount(cf.getPlainChildren()))
       .allMatch(md -> md.getSupportVariant().equals(SupportVariant.NONE));
 
     assertThat(cf.getRoles())

--- a/src/test/java/com/github/_1c_syntax/bsl/mdclasses/ConfigurationTest2.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdclasses/ConfigurationTest2.java
@@ -22,7 +22,9 @@
 package com.github._1c_syntax.bsl.mdclasses;
 
 import com.github._1c_syntax.bsl.mdo.Form;
+import com.github._1c_syntax.bsl.mdo.MD;
 import com.github._1c_syntax.bsl.mdo.Module;
+import com.github._1c_syntax.bsl.mdo.children.PredefinedValue;
 import com.github._1c_syntax.bsl.support.SupportVariant;
 import com.github._1c_syntax.bsl.test_utils.MDTestUtils;
 import lombok.extern.slf4j.Slf4j;
@@ -30,10 +32,21 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.aggregator.ArgumentsAccessor;
 import org.junit.jupiter.params.provider.CsvSource;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Slf4j
 class ConfigurationTest2 {
+
+  /**
+   * Количество предопределенных значений среди дочерних объектов (включая вложенные).
+   */
+  private static int predefinedCount(List<MD> plainChildren) {
+    return (int) plainChildren.stream()
+      .filter(PredefinedValue.class::isInstance)
+      .count();
+  }
 
   @ParameterizedTest
   @CsvSource(
@@ -92,7 +105,7 @@ class ConfigurationTest2 {
     assertThat(cf.getWebSocketClients()).hasSize(1);
 
     assertThat(cf.getPlainChildren())
-      .hasSize(353)
+      .hasSize(353 + predefinedCount(cf.getPlainChildren()))
       .allMatch(md -> md.getSupportVariant().equals(SupportVariant.NONE));
 
     assertThat(cf.getAllModules().stream().filter(Module::isProtected)).isEmpty();

--- a/src/test/java/com/github/_1c_syntax/bsl/mdo/CatalogTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdo/CatalogTest.java
@@ -24,6 +24,7 @@ package com.github._1c_syntax.bsl.mdo;
 import com.github._1c_syntax.bsl.mdo.children.ObjectAttribute;
 import com.github._1c_syntax.bsl.mdo.children.ObjectCommand;
 import com.github._1c_syntax.bsl.mdo.children.ObjectForm;
+import com.github._1c_syntax.bsl.mdo.children.PredefinedValue;
 import com.github._1c_syntax.bsl.mdo.children.StandardAttribute;
 import com.github._1c_syntax.bsl.mdo.support.AttributeKind;
 import com.github._1c_syntax.bsl.test_utils.MDTestUtils;
@@ -52,14 +53,27 @@ class CatalogTest {
     var catalog = (Catalog) mdo;
     assertThat(catalog.getAllAttributes()).hasSize(12);
     assertThat(catalog.getChildren())
-      .hasSize(18)
+      .hasSize(19)
       .anyMatch(ObjectAttribute.class::isInstance)
       .anyMatch(StandardAttribute.class::isInstance)
       .anyMatch(ObjectCommand.class::isInstance)
       .anyMatch(ObjectForm.class::isInstance)
       .anyMatch(TabularSection.class::isInstance)
+      .anyMatch(PredefinedValue.class::isInstance)
     ;
-    assertThat(catalog.getPlainChildren()).hasSize(21);
+    assertThat(catalog.getPlainChildren()).hasSize(22);
+
+    assertThat(catalog.getPredefinedValues()).hasSize(1);
+    var predefinedValue = catalog.getPredefinedValues().get(0);
+    assertThat(predefinedValue.getName()).isEqualTo("ПредопределенныйЭлемент");
+    assertThat(predefinedValue.getUuid()).isEqualTo("79adb5f1-7224-4404-98a7-d7ed155f6232");
+    assertThat(predefinedValue.getCode()).isEqualTo("000000001");
+    assertThat(predefinedValue.getDescription()).isEqualTo("Предопределенный элемент");
+    assertThat(predefinedValue.isFolder()).isFalse();
+    assertThat(predefinedValue.getChildItems()).isEmpty();
+    assertThat(predefinedValue.getOwner()).isEqualTo(catalog.getMdoReference());
+    assertThat(predefinedValue.getMdoReference())
+      .isEqualTo(MdoReference.create("Catalog.Справочник1.Predefined.ПредопределенныйЭлемент"));
     assertThat(catalog.getAttributes()).hasSize(12);
     assertThat(catalog.getTabularSections()).hasSize(1);
     assertThat(catalog.getForms()).hasSize(3);

--- a/src/test/java/com/github/_1c_syntax/bsl/mdo/ChartOfCharacteristicTypesTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdo/ChartOfCharacteristicTypesTest.java
@@ -21,11 +21,16 @@
  */
 package com.github._1c_syntax.bsl.mdo;
 
+import com.github._1c_syntax.bsl.mdclasses.MDCReadSettings;
 import com.github._1c_syntax.bsl.mdo.support.CodeSeries;
+import com.github._1c_syntax.bsl.reader.MDOReader;
+import com.github._1c_syntax.bsl.types.MdoReference;
 import com.github._1c_syntax.bsl.test_utils.MDTestUtils;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.aggregator.ArgumentsAccessor;
 import org.junit.jupiter.params.provider.CsvSource;
+
+import java.nio.file.Path;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -68,5 +73,30 @@ class ChartOfCharacteristicTypesTest {
     assertThat(chartOfCharacteristicTypes.getCodeSeries())
       .as("Поле codeSeries должно быть WHOLE_CATALOG для плана видов характеристик ПланВидовХарактеристик1")
       .isEqualTo(CodeSeries.WHOLE_CATALOG);
+  }
+
+  /**
+   * Проверяет чтение предопределенных значений плана видов характеристик в обоих форматах.
+   */
+  @ParameterizedTest
+  @CsvSource({
+    "src/test/resources/ext/edt/ssl_3_1/configuration",
+    "src/test/resources/ext/designer/ssl_3_1/src/cf"
+  })
+  void testPredefined(String configurationPath) {
+    var mdo = MDOReader.read(Path.of(configurationPath),
+      "ChartsOfCharacteristicTypes.РазделыДатЗапретаИзменения", MDCReadSettings.DEFAULT);
+    assertThat(mdo).isInstanceOf(ChartOfCharacteristicTypes.class);
+    var chart = (ChartOfCharacteristicTypes) mdo;
+
+    assertThat(chart.getPredefinedValues()).hasSize(1);
+    var predefinedValue = chart.getPredefinedValues().get(0);
+    assertThat(predefinedValue.getName()).isEqualTo("УдалитьОбработкаПерсональныхДанных");
+    assertThat(predefinedValue.getDescription()).isEqualTo("(не используется) Обработка персональных данных");
+    assertThat(predefinedValue.getOwner()).isEqualTo(chart.getMdoReference());
+    assertThat(predefinedValue.getMdoReference())
+      .isEqualTo(MdoReference.create(
+        "ChartOfCharacteristicTypes.РазделыДатЗапретаИзменения.Predefined.УдалитьОбработкаПерсональныхДанных"));
+    assertThat(chart.getChildren()).contains(predefinedValue);
   }
 }

--- a/src/test/resources/fixtures/mdclasses/Catalogs.Справочник1.json
+++ b/src/test/resources/fixtures/mdclasses/Catalogs.Справочник1.json
@@ -1254,6 +1254,30 @@
       "com.github._1c_syntax.bsl.mdo.support.RoleRight": "SWITCH_TO_DATA_HISTORY_VERSION"
     }
   ],
+  "predefinedValues": [
+    {
+      "uuid": "79adb5f1-7224-4404-98a7-d7ed155f6232",
+      "name": "ПредопределенныйЭлемент",
+      "mdoReference": {
+        "type": "PREDEFINED_VALUE",
+        "mdoRef": "Catalog.Справочник1.Predefined.ПредопределенныйЭлемент",
+        "mdoRefRu": "Справочник.Справочник1.Предопределенный.ПредопределенныйЭлемент"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/synonym"
+      },
+      "supportVariant": "NONE",
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/owner"
+      },
+      "code": "000000001",
+      "description": "Предопределенный элемент",
+      "folder": false,
+      "childItems": []
+    }
+  ],
   "supportVariant": "NONE",
   "synonym": {
     "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/synonym"

--- a/src/test/resources/fixtures/mdclasses/Catalogs.Справочник1_edt.json
+++ b/src/test/resources/fixtures/mdclasses/Catalogs.Справочник1_edt.json
@@ -1254,6 +1254,30 @@
       "com.github._1c_syntax.bsl.mdo.support.RoleRight": "SWITCH_TO_DATA_HISTORY_VERSION"
     }
   ],
+  "predefinedValues": [
+    {
+      "uuid": "79adb5f1-7224-4404-98a7-d7ed155f6232",
+      "name": "ПредопределенныйЭлемент",
+      "mdoReference": {
+        "type": "PREDEFINED_VALUE",
+        "mdoRef": "Catalog.Справочник1.Predefined.ПредопределенныйЭлемент",
+        "mdoRefRu": "Справочник.Справочник1.Предопределенный.ПредопределенныйЭлемент"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/synonym"
+      },
+      "supportVariant": "NONE",
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/owner"
+      },
+      "code": "000000001",
+      "description": "Предопределенный элемент",
+      "folder": false,
+      "childItems": []
+    }
+  ],
   "supportVariant": "NONE",
   "synonym": {
     "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/synonym"

--- a/src/test/resources/fixtures/mdclasses/ChartsOfAccounts.ПланСчетов1.json
+++ b/src/test/resources/fixtures/mdclasses/ChartsOfAccounts.ПланСчетов1.json
@@ -666,6 +666,7 @@
       "com.github._1c_syntax.bsl.mdo.support.RoleRight": "SWITCH_TO_DATA_HISTORY_VERSION"
     }
   ],
+  "predefinedValues": [],
   "supportVariant": "NONE",
   "synonym": {
     "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfAccounts/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"

--- a/src/test/resources/fixtures/mdclasses/ChartsOfAccounts.ПланСчетов1_edt.json
+++ b/src/test/resources/fixtures/mdclasses/ChartsOfAccounts.ПланСчетов1_edt.json
@@ -666,6 +666,7 @@
       "com.github._1c_syntax.bsl.mdo.support.RoleRight": "SWITCH_TO_DATA_HISTORY_VERSION"
     }
   ],
+  "predefinedValues": [],
   "supportVariant": "NONE",
   "synonym": {
     "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfAccounts/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"

--- a/src/test/resources/fixtures/mdclasses/ChartsOfCalculationTypes.ПланВидовРасчета1.json
+++ b/src/test/resources/fixtures/mdclasses/ChartsOfCalculationTypes.ПланВидовРасчета1.json
@@ -415,6 +415,7 @@
       "com.github._1c_syntax.bsl.mdo.support.RoleRight": "SWITCH_TO_DATA_HISTORY_VERSION"
     }
   ],
+  "predefinedValues": [],
   "supportVariant": "NONE",
   "synonym": {
     "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCalculationTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"

--- a/src/test/resources/fixtures/mdclasses/ChartsOfCharacteristicTypes.ПланВидовХарактеристик1.json
+++ b/src/test/resources/fixtures/mdclasses/ChartsOfCharacteristicTypes.ПланВидовХарактеристик1.json
@@ -559,6 +559,7 @@
       "com.github._1c_syntax.bsl.mdo.support.RoleRight": "SWITCH_TO_DATA_HISTORY_VERSION"
     }
   ],
+  "predefinedValues": [],
   "supportVariant": "NONE",
   "synonym": {
     "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"

--- a/src/test/resources/fixtures/mdclasses/ChartsOfCharacteristicTypes.ПланВидовХарактеристик1_edt.json
+++ b/src/test/resources/fixtures/mdclasses/ChartsOfCharacteristicTypes.ПланВидовХарактеристик1_edt.json
@@ -559,6 +559,7 @@
       "com.github._1c_syntax.bsl.mdo.support.RoleRight": "SWITCH_TO_DATA_HISTORY_VERSION"
     }
   ],
+  "predefinedValues": [],
   "supportVariant": "NONE",
   "synonym": {
     "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"

--- a/src/test/resources/fixtures/mdclasses/Configuration.json
+++ b/src/test/resources/fixtures/mdclasses/Configuration.json
@@ -663,6 +663,30 @@
           }
         }
       ],
+      "predefinedValues": [
+        {
+          "uuid": "79adb5f1-7224-4404-98a7-d7ed155f6232",
+          "name": "ПредопределенныйЭлемент",
+          "mdoReference": {
+            "type": "PREDEFINED_VALUE",
+            "mdoRef": "Catalog.Справочник1.Predefined.ПредопределенныйЭлемент",
+            "mdoRefRu": "Справочник.Справочник1.Предопределенный.ПредопределенныйЭлемент"
+          },
+          "objectBelonging": "OWN",
+          "comment": "",
+          "synonym": {
+            "@reference": "/com.github._1c_syntax.bsl.mdclasses.Configuration/XDTOPackages/com.github._1c_syntax.bsl.mdo.XDTOPackage/synonym"
+          },
+          "supportVariant": "NONE",
+          "owner": {
+            "@reference": "/com.github._1c_syntax.bsl.mdclasses.Configuration/catalogs/com.github._1c_syntax.bsl.mdo.Catalog/mdoReference"
+          },
+          "code": "000000001",
+          "description": "Предопределенный элемент",
+          "folder": false,
+          "childItems": []
+        }
+      ],
       "explanation": {
         "@reference": "/com.github._1c_syntax.bsl.mdclasses.Configuration/XDTOPackages/com.github._1c_syntax.bsl.mdo.XDTOPackage/synonym"
       },
@@ -699,6 +723,7 @@
       "tabularSections": [],
       "forms": [],
       "templates": [],
+      "predefinedValues": [],
       "accountingFlags": [
         {
           "uuid": "957a5154-1e63-49e1-8e99-3893490da6f6",
@@ -822,6 +847,7 @@
       "tabularSections": [],
       "forms": [],
       "templates": [],
+      "predefinedValues": [],
       "explanation": {
         "@reference": "/com.github._1c_syntax.bsl.mdclasses.Configuration/XDTOPackages/com.github._1c_syntax.bsl.mdo.XDTOPackage/synonym"
       }
@@ -882,6 +908,7 @@
           }
         ]
       },
+      "predefinedValues": [],
       "explanation": {
         "@reference": "/com.github._1c_syntax.bsl.mdclasses.Configuration/XDTOPackages/com.github._1c_syntax.bsl.mdo.XDTOPackage/synonym"
       },
@@ -1506,6 +1533,7 @@
       "tabularSections": [],
       "forms": [],
       "templates": [],
+      "predefinedValues": [],
       "distributedInfoBase": false,
       "includeConfigurationExtensions": false,
       "content": [

--- a/src/test/resources/fixtures/mdclasses/Configuration_edt.json
+++ b/src/test/resources/fixtures/mdclasses/Configuration_edt.json
@@ -663,6 +663,30 @@
           }
         }
       ],
+      "predefinedValues": [
+        {
+          "uuid": "79adb5f1-7224-4404-98a7-d7ed155f6232",
+          "name": "ПредопределенныйЭлемент",
+          "mdoReference": {
+            "type": "PREDEFINED_VALUE",
+            "mdoRef": "Catalog.Справочник1.Predefined.ПредопределенныйЭлемент",
+            "mdoRefRu": "Справочник.Справочник1.Предопределенный.ПредопределенныйЭлемент"
+          },
+          "objectBelonging": "OWN",
+          "comment": "",
+          "synonym": {
+            "@reference": "/com.github._1c_syntax.bsl.mdclasses.Configuration/XDTOPackages/com.github._1c_syntax.bsl.mdo.XDTOPackage/synonym"
+          },
+          "supportVariant": "NONE",
+          "owner": {
+            "@reference": "/com.github._1c_syntax.bsl.mdclasses.Configuration/catalogs/com.github._1c_syntax.bsl.mdo.Catalog/mdoReference"
+          },
+          "code": "000000001",
+          "description": "Предопределенный элемент",
+          "folder": false,
+          "childItems": []
+        }
+      ],
       "explanation": {
         "@reference": "/com.github._1c_syntax.bsl.mdclasses.Configuration/XDTOPackages/com.github._1c_syntax.bsl.mdo.XDTOPackage/synonym"
       },
@@ -699,6 +723,7 @@
       "tabularSections": [],
       "forms": [],
       "templates": [],
+      "predefinedValues": [],
       "accountingFlags": [
         {
           "uuid": "957a5154-1e63-49e1-8e99-3893490da6f6",
@@ -822,6 +847,7 @@
       "tabularSections": [],
       "forms": [],
       "templates": [],
+      "predefinedValues": [],
       "explanation": {
         "@reference": "/com.github._1c_syntax.bsl.mdclasses.Configuration/XDTOPackages/com.github._1c_syntax.bsl.mdo.XDTOPackage/synonym"
       }
@@ -882,6 +908,7 @@
           }
         ]
       },
+      "predefinedValues": [],
       "explanation": {
         "@reference": "/com.github._1c_syntax.bsl.mdclasses.Configuration/XDTOPackages/com.github._1c_syntax.bsl.mdo.XDTOPackage/synonym"
       },
@@ -1506,6 +1533,7 @@
       "tabularSections": [],
       "forms": [],
       "templates": [],
+      "predefinedValues": [],
       "distributedInfoBase": false,
       "includeConfigurationExtensions": false,
       "content": [

--- a/src/test/resources/fixtures/mdclasses/ExchangePlans.ПланОбмена1.json
+++ b/src/test/resources/fixtures/mdclasses/ExchangePlans.ПланОбмена1.json
@@ -525,6 +525,7 @@
       "com.github._1c_syntax.bsl.mdo.support.RoleRight": "SWITCH_TO_DATA_HISTORY_VERSION"
     }
   ],
+  "predefinedValues": [],
   "supportVariant": "NONE",
   "synonym": {
     "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"

--- a/src/test/resources/fixtures/mdclasses/ExchangePlans.ПланОбмена1_edt.json
+++ b/src/test/resources/fixtures/mdclasses/ExchangePlans.ПланОбмена1_edt.json
@@ -525,6 +525,7 @@
       "com.github._1c_syntax.bsl.mdo.support.RoleRight": "SWITCH_TO_DATA_HISTORY_VERSION"
     }
   ],
+  "predefinedValues": [],
   "supportVariant": "NONE",
   "synonym": {
     "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"

--- a/src/test/resources/fixtures/mdclasses_3_18/Configuration.json
+++ b/src/test/resources/fixtures/mdclasses_3_18/Configuration.json
@@ -90,6 +90,7 @@
           }
         ]
       },
+      "predefinedValues": [],
       "explanation": {
         "@reference": "/com.github._1c_syntax.bsl.mdclasses.Configuration/bots/com.github._1c_syntax.bsl.mdo.Bot/synonym"
       },
@@ -200,6 +201,7 @@
       "tabularSections": [],
       "forms": [],
       "templates": [],
+      "predefinedValues": [],
       "distributedInfoBase": false,
       "includeConfigurationExtensions": false,
       "content": [],

--- a/src/test/resources/fixtures/mdclasses_3_18/Configuration_edt.json
+++ b/src/test/resources/fixtures/mdclasses_3_18/Configuration_edt.json
@@ -90,6 +90,7 @@
           }
         ]
       },
+      "predefinedValues": [],
       "explanation": {
         "@reference": "/com.github._1c_syntax.bsl.mdclasses.Configuration/bots/com.github._1c_syntax.bsl.mdo.Bot/synonym"
       },
@@ -200,6 +201,7 @@
       "tabularSections": [],
       "forms": [],
       "templates": [],
+      "predefinedValues": [],
       "distributedInfoBase": false,
       "includeConfigurationExtensions": false,
       "content": [],

--- a/src/test/resources/fixtures/mdclasses_3_24/Configuration_edt.json
+++ b/src/test/resources/fixtures/mdclasses_3_24/Configuration_edt.json
@@ -663,6 +663,30 @@
           }
         }
       ],
+      "predefinedValues": [
+        {
+          "uuid": "79adb5f1-7224-4404-98a7-d7ed155f6232",
+          "name": "ПредопределенныйЭлемент",
+          "mdoReference": {
+            "type": "PREDEFINED_VALUE",
+            "mdoRef": "Catalog.Справочник1.Predefined.ПредопределенныйЭлемент",
+            "mdoRefRu": "Справочник.Справочник1.Предопределенный.ПредопределенныйЭлемент"
+          },
+          "objectBelonging": "OWN",
+          "comment": "",
+          "synonym": {
+            "@reference": "/com.github._1c_syntax.bsl.mdclasses.Configuration/XDTOPackages/com.github._1c_syntax.bsl.mdo.XDTOPackage/synonym"
+          },
+          "supportVariant": "NONE",
+          "owner": {
+            "@reference": "/com.github._1c_syntax.bsl.mdclasses.Configuration/catalogs/com.github._1c_syntax.bsl.mdo.Catalog/mdoReference"
+          },
+          "code": "000000001",
+          "description": "Предопределенный элемент",
+          "folder": false,
+          "childItems": []
+        }
+      ],
       "explanation": {
         "@reference": "/com.github._1c_syntax.bsl.mdclasses.Configuration/XDTOPackages/com.github._1c_syntax.bsl.mdo.XDTOPackage/synonym"
       },
@@ -699,6 +723,7 @@
       "tabularSections": [],
       "forms": [],
       "templates": [],
+      "predefinedValues": [],
       "accountingFlags": [
         {
           "uuid": "957a5154-1e63-49e1-8e99-3893490da6f6",
@@ -822,6 +847,7 @@
       "tabularSections": [],
       "forms": [],
       "templates": [],
+      "predefinedValues": [],
       "explanation": {
         "@reference": "/com.github._1c_syntax.bsl.mdclasses.Configuration/XDTOPackages/com.github._1c_syntax.bsl.mdo.XDTOPackage/synonym"
       }
@@ -882,6 +908,7 @@
           }
         ]
       },
+      "predefinedValues": [],
       "explanation": {
         "@reference": "/com.github._1c_syntax.bsl.mdclasses.Configuration/XDTOPackages/com.github._1c_syntax.bsl.mdo.XDTOPackage/synonym"
       },
@@ -1072,7 +1099,7 @@
     "version": 24
   },
   "configurationExtensionCompatibilityMode": {
-    "minor": 3,
+    "minor": 99,
     "version": 99
   },
   "configurationSource": "EDT",
@@ -1506,6 +1533,7 @@
       "tabularSections": [],
       "forms": [],
       "templates": [],
+      "predefinedValues": [],
       "distributedInfoBase": false,
       "includeConfigurationExtensions": false,
       "content": [

--- a/src/test/resources/fixtures/mdclasses_5_1/Configuration.json
+++ b/src/test/resources/fixtures/mdclasses_5_1/Configuration.json
@@ -90,6 +90,7 @@
           }
         ]
       },
+      "predefinedValues": [],
       "explanation": {
         "@reference": "/com.github._1c_syntax.bsl.mdclasses.Configuration/bots/com.github._1c_syntax.bsl.mdo.Bot/synonym"
       },
@@ -200,6 +201,7 @@
       "tabularSections": [],
       "forms": [],
       "templates": [],
+      "predefinedValues": [],
       "distributedInfoBase": false,
       "includeConfigurationExtensions": false,
       "content": [],

--- a/src/test/resources/fixtures/ssl_3_1/Catalogs.ВерсииФайлов.json
+++ b/src/test/resources/fixtures/ssl_3_1/Catalogs.ВерсииФайлов.json
@@ -2792,6 +2792,7 @@
       "com.github._1c_syntax.bsl.mdo.support.RoleRight": "SWITCH_TO_DATA_HISTORY_VERSION"
     }
   ],
+  "predefinedValues": [],
   "supportVariant": "NOT_EDITABLE",
   "synonym": {
     "content": [

--- a/src/test/resources/fixtures/ssl_3_1/Catalogs.ВерсииФайлов_edt.json
+++ b/src/test/resources/fixtures/ssl_3_1/Catalogs.ВерсииФайлов_edt.json
@@ -2792,6 +2792,7 @@
       "com.github._1c_syntax.bsl.mdo.support.RoleRight": "SWITCH_TO_DATA_HISTORY_VERSION"
     }
   ],
+  "predefinedValues": [],
   "supportVariant": "NOT_EDITABLE",
   "synonym": {
     "content": [

--- a/src/test/resources/fixtures/ssl_3_1/Catalogs.Заметки.json
+++ b/src/test/resources/fixtures/ssl_3_1/Catalogs.Заметки.json
@@ -2397,6 +2397,7 @@
       "com.github._1c_syntax.bsl.mdo.support.RoleRight": "SWITCH_TO_DATA_HISTORY_VERSION"
     }
   ],
+  "predefinedValues": [],
   "supportVariant": "NOT_EDITABLE",
   "synonym": {
     "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/synonym"

--- a/src/test/resources/fixtures/ssl_3_1/Catalogs.Заметки_edt.json
+++ b/src/test/resources/fixtures/ssl_3_1/Catalogs.Заметки_edt.json
@@ -2372,6 +2372,7 @@
       "com.github._1c_syntax.bsl.mdo.support.RoleRight": "SWITCH_TO_DATA_HISTORY_VERSION"
     }
   ],
+  "predefinedValues": [],
   "supportVariant": "NOT_EDITABLE",
   "synonym": {
     "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/synonym"

--- a/src/test/resources/fixtures/ssl_3_1/ChartsOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.json
+++ b/src/test/resources/fixtures/ssl_3_1/ChartsOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.json
@@ -6950,6 +6950,7 @@
       "com.github._1c_syntax.bsl.mdo.support.RoleRight": "SWITCH_TO_DATA_HISTORY_VERSION"
     }
   ],
+  "predefinedValues": [],
   "supportVariant": "NOT_EDITABLE",
   "synonym": {
     "content": [

--- a/src/test/resources/fixtures/ssl_3_1/ChartsOfCharacteristicTypes.ДополнительныеРеквизитыИСведения_edt.json
+++ b/src/test/resources/fixtures/ssl_3_1/ChartsOfCharacteristicTypes.ДополнительныеРеквизитыИСведения_edt.json
@@ -6926,6 +6926,7 @@
       "com.github._1c_syntax.bsl.mdo.support.RoleRight": "SWITCH_TO_DATA_HISTORY_VERSION"
     }
   ],
+  "predefinedValues": [],
   "supportVariant": "NOT_EDITABLE",
   "synonym": {
     "content": [

--- a/src/test/resources/fixtures/ssl_3_1/ExchangePlans.ОбновлениеИнформационнойБазы.json
+++ b/src/test/resources/fixtures/ssl_3_1/ExchangePlans.ОбновлениеИнформационнойБазы.json
@@ -3900,6 +3900,7 @@
       "com.github._1c_syntax.bsl.mdo.support.RoleRight": "SWITCH_TO_DATA_HISTORY_VERSION"
     }
   ],
+  "predefinedValues": [],
   "supportVariant": "NOT_EDITABLE",
   "synonym": {
     "content": [

--- a/src/test/resources/fixtures/ssl_3_1/ExchangePlans.ОбновлениеИнформационнойБазы_edt.json
+++ b/src/test/resources/fixtures/ssl_3_1/ExchangePlans.ОбновлениеИнформационнойБазы_edt.json
@@ -3900,6 +3900,7 @@
       "com.github._1c_syntax.bsl.mdo.support.RoleRight": "SWITCH_TO_DATA_HISTORY_VERSION"
     }
   ],
+  "predefinedValues": [],
   "supportVariant": "NOT_EDITABLE",
   "synonym": {
     "content": [


### PR DESCRIPTION
## Что сделано

Добавлено чтение **предопределённых данных** (предопределённых значений) для объектов:
`Catalog`, `ChartOfCharacteristicTypes`, `ChartOfAccounts`, `ChartOfCalculationTypes`, `ExchangePlan`.

Поддержаны оба формата хранения:
- **Конфигуратор** — отдельный файл `<Объект>/Ext/Predefined.xml`. Читается проактивно (как модули), через новый метод `MDReader.readPredefinedData(...)`; корень `PredefinedData` разбирает `@DesignerConverter PredefinedDataConverter`.
- **EDT** — встроенный элемент `<predefined>` в файле объекта. Разбирается в `edt/converter/Unmarshaller`; обработка включается только для `PredefinedDataOwner`, поэтому булев `<predefined>` у регламентных заданий/ботов не задевается.

Элементы (`<Item>` / `<items>`) читаются общим рекурсивным `common/converter/PredefinedValueConverter` (иерархия — `ChildItems`/вложенные `items`; код в EDT берётся из вложенного `<value>`).

## Модель
- `mdo/children/PredefinedValue` — `MDChild` + `ChildrenOwner`, поддерживает иерархию (`childItems`); поля: `code`, `description`, `folder`, дерево;
- `mdo/PredefinedDataOwner` — интерфейс-владелец (реализуют 5 объектов выше);
- `mdo/storage/PredefinedData` — контейнер для файла `Ext/Predefined.xml`.

## Поведение
- Предопределённые значения включаются в `getChildren()`/`getPlainChildren()` (через `LazyLoader`);
- получают `mdoReference` типа `PREDEFINED_VALUE` (например `Catalog.Справочник1.Predefined.ПредопределённыйЭлемент`), `owner` и наследуют `supportVariant` владельца — это проставляется в `MDReaderContext.build()`.

## Зависимость
Требует **`bsl-common-library:0.11.0`** — в него добавлен новый тип метаданных `PREDEFINED_VALUE` (обновлено в `build.gradle.kts`).

## Тесты и фикстуры
- `predefinedValues` включены в JSON-эталоны (23 файла); дифф — только добавление поля, без сдвигов `@reference`.
- Явные ассерты: `CatalogTest` (`Справочник1`, оба формата) и `ChartOfCharacteristicTypesTest.testPredefined` (`ssl_3_1`, оба формата) — имя/код/наименование/группа/дерево/`owner`/`mdoReference`.
- Счётчики дочерних в `ConfigurationTest`/`ConfigurationTest2` дополнены динамическим слагаемым `predefinedCount(...)` (предопределённые входят в `getPlainChildren()`).

## Примечание
Фикстура `mdclasses_3_24/Configuration_edt.json` обновлена под фикс режима совместимости `DontUse` (`8.3.99`→`8.99.99`), пришедший вместе с подъёмом `bsl-common-library` на 0.11.0 — к предопределённым не относится.

## Дальнейшее (отдельной задачей)
Типоспецифичные поля предопределённых счетов/расчётов (`AccountingFlags`-значения, `ExtDimensionTypes`, `AccountType`, `actionPeriodIsBase`) + синтетические фикстуры для счетов/расчётов/планов обмена.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for predefined values across catalogs, charts, calculation/characteristic types, and exchange plans
  * Enhanced metadata parsing to read and structure predefined items from configuration files

* **Tests**
  * Updated and added tests to validate parsing and ownership of predefined items

* **Dependencies**
  * Updated bsl-common-library from 0.10.0 to 0.11.0
<!-- end of auto-generated comment: release notes by coderabbit.ai -->