### PR TITLE
perf(mdo): LRU-мемоизация findCommonModule

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/mdo/utils/LazyLoader.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdo/utils/LazyLoader.java
@@ -317,7 +317,19 @@ public class LazyLoader {
   public static Map<String, CommonModule> computeCommonModulesByName(ConfigurationTree cf) {
     Map<String, CommonModule> result = new CaseInsensitiveMap<>();
     cf.getCommonModules().forEach(commonModule -> result.put(commonModule.getName(), commonModule));
-    return Collections.unmodifiableMap(result);
+    // CaseInsensitiveMap.get сворачивает регистр запроса на каждый вызов, а findCommonModule
+    // дёргается десятки тысяч раз (на каждый идентификатор при разрешении ссылок). Оборачиваем в
+    // кэширующий по запросу декоратор с ограниченным LRU, чтобы не сворачивать одно и то же имя
+    // повторно и не дать кэшу расти неограниченно на промахах.
+    return new LookupCachingMap<>(Collections.unmodifiableMap(result), lookupCacheSize(result.size()));
+  }
+
+  /**
+   * Размер LRU-кэша обращений к карте общих модулей: вмещает все имеющиеся модули (чтобы
+   * положительные попадания не вытеснялись) плюс запас под кэширование промахов.
+   */
+  private static int lookupCacheSize(int moduleCount) {
+    return Math.max(2048, moduleCount * 2);
   }
 
   private <T> List<T> addAll(List<T> result, List<? extends T> source) {

--- a/src/main/java/com/github/_1c_syntax/bsl/mdo/utils/LookupCachingMap.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdo/utils/LookupCachingMap.java
@@ -1,0 +1,74 @@
+/*
+ * This file is a part of MDClasses.
+ *
+ * Copyright (c) 2019 - 2026
+ * Tymko Oleg <olegtymko@yandex.ru>, Maximov Valery <maximovvalery@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * MDClasses is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * MDClasses is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with MDClasses.
+ */
+package com.github._1c_syntax.bsl.mdo.utils;
+
+import org.apache.commons.collections4.map.AbstractMapDecorator;
+import org.apache.commons.collections4.map.LRUMap;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Декоратор read-only карты, мемоизирующий результаты {@link #get(Object)} (включая
+ * отрицательные — отсутствие ключа) в ограниченном по размеру LRU.
+ * <p>
+ * Нужен для карт с дорогим {@code get}. В частности
+ * {@link org.apache.commons.collections4.map.CaseInsensitiveMap} сворачивает регистр
+ * ключа-запроса на каждый вызов (посимвольный {@code toLowerCase} + аллокация строки),
+ * что заметно при десятках тысяч обращений. Ключи-запросы приходят из исходного кода и
+ * сильно повторяются, поэтому memo резко снижает стоимость повторных обращений, а LRU не
+ * даёт кэшу расти неограниченно на «промахах» (имена, которых в карте нет).
+ * <p>
+ * Потокобезопасен: внутренний LRU обёрнут в {@link Collections#synchronizedMap}. Сама
+ * декорируемая карта при этом не модифицируется — декоратор рассчитан на неизменяемые
+ * (read-only) карты; запись/итерация делегируются как есть, кэшируется только {@code get}.
+ *
+ * @param <V> тип значения
+ */
+public final class LookupCachingMap<V> extends AbstractMapDecorator<String, V> {
+
+  /** Маркер закэшированного отрицательного результата (ключ в карте отсутствует). */
+  private static final Object MISS = new Object();
+
+  private final Map<Object, Object> cache;
+
+  /**
+   * @param map          декорируемая read-only карта
+   * @param maxCacheSize максимальный размер LRU-кэша обращений
+   */
+  public LookupCachingMap(Map<String, V> map, int maxCacheSize) {
+    super(map);
+    this.cache = Collections.synchronizedMap(new LRUMap<>(maxCacheSize));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public V get(Object key) {
+    var cached = cache.get(key);
+    if (cached != null) {
+      return cached == MISS ? null : (V) cached;
+    }
+    var value = decorated().get(key);
+    cache.put(key, value == null ? MISS : value);
+    return value;
+  }
+}


### PR DESCRIPTION
CF.findCommonModule(name) — тонкая обёртка над
getCommonModulesByName().get(name). Карта мемоизируется, но её тип —
CaseInsensitiveMap, у которой каждый get() сворачивает регистр
ключа-запроса посимвольно (Character.toLowerCase + аллокация строки).

В потребителях (заполнитель индекса ссылок bsl-language-server)
findCommonModule вызывается на каждый идентификатор исходного кода —
десятки тысяч раз на ребилд документа, в основном промахи.

Добавлен LookupCachingMap — декоратор read-only карты поверх
commons-collections4 (новых зависимостей нет), мемоизирующий результаты
get() (включая отрицательные через маркер MISS) в ограниченном по
размеру потокобезопасном LRU. computeCommonModulesByName оборачивает
карту общих модулей; размер кэша max(2048, 2×count) гарантирует, что
положительные попадания не вытесняются.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Lsui6HwTYazwFSPSB6Wt5k

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Enhanced lookup performance for common module discovery through the implementation of efficient caching with automatic memory management, reducing computational overhead during frequent access operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->