### PR TITLE
Подключены и обновлены фикстуры, фикс чтения предопределенных

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,3 +6,11 @@
 	path = src/test/resources/ext/edt/ssl_3_1
 	url = ../ssl_3_1_edt.git
 	shallow = true
+[submodule "src/test/resources/ext/designer/ssl_3_2"]
+	path = src/test/resources/ext/designer/ssl_3_2
+	url = ../ssl_3_2.git
+	shallow = true
+[submodule "src/test/resources/ext/edt/ssl_3_2"]
+	path = src/test/resources/ext/edt/ssl_3_2
+	url = ../ssl_3_2_edt.git
+	shallow = true

--- a/src/main/java/com/github/_1c_syntax/bsl/reader/common/converter/PredefinedValueConverter.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/reader/common/converter/PredefinedValueConverter.java
@@ -39,6 +39,7 @@ public class PredefinedValueConverter implements ReadConverter {
 
   private static final String ID_ATTRIBUTE = "id";
   private static final String CHILD_ITEMS_NODE = "ChildItems";
+  private static final String CONTENT_NODE = "content";
   private static final String ITEMS_NODE = "items";
   private static final String VALUE_NODE = "value";
 
@@ -60,7 +61,7 @@ public class PredefinedValueConverter implements ReadConverter {
         case "Code", "code" -> builder.code(readCode(reader));
         case "IsFolder", "isFolder" -> builder.folder(Boolean.parseBoolean(reader.getValue()));
         case CHILD_ITEMS_NODE -> readChildItems(reader, context, builder);
-        case ITEMS_NODE -> builder.childItem((PredefinedValue) context.convertAnother(null, PredefinedValue.class));
+        case ITEMS_NODE, CONTENT_NODE -> builder.childItem((PredefinedValue) context.convertAnother(null, PredefinedValue.class));
         default -> {
           // прочие свойства игнорируем
         }

--- a/src/test/java/com/github/_1c_syntax/bsl/examples/ValueTypeTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/examples/ValueTypeTest.java
@@ -85,7 +85,9 @@ public class ValueTypeTest {
   @CsvSource(
     {
       "true, ssl_3_1, _edt",
-      "false, ssl_3_1"
+      "false, ssl_3_1",
+      "true, ssl_3_2, _edt",
+      "false, ssl_3_2"
     }
   )
   void testDefinedType(ArgumentsAccessor argumentsAccessor) {

--- a/src/test/java/com/github/_1c_syntax/bsl/mdclasses/ConfigurationTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdclasses/ConfigurationTest.java
@@ -60,6 +60,12 @@ class ConfigurationTest {
     return (int) plainChildren.stream()
       .filter(com.github._1c_syntax.bsl.mdo.children.PredefinedValue.class::isInstance)
       .count();
+   }
+
+  private static int predefinedCount32(List<MD> plainChildren) {
+    return (int) plainChildren.stream()
+      .filter(com.github._1c_syntax.bsl.mdo.children.PredefinedValue.class::isInstance)
+      .count();
   }
 
   @ParameterizedTest
@@ -195,6 +201,64 @@ class ConfigurationTest {
   @ParameterizedTest
   @CsvSource(
     {
+      "true, ssl_3_2, _edt",
+      "false, ssl_3_2"
+    }
+  )
+  void testFullSSL32(ArgumentsAccessor argumentsAccessor) {
+    var mdc = MDTestUtils.readConfiguration(argumentsAccessor, false);
+    assertThat(mdc).isInstanceOf(Configuration.class);
+    var cf = (Configuration) mdc;
+    assertThat(cf.getSupportVariant()).isEqualTo(SupportVariant.NOT_EDITABLE);
+
+    assertThat(cf.getModules())
+      .hasSize(4)
+      .allMatch(module -> module.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
+
+    assertThat(cf.getPlainChildren())
+      .hasSize(9810 + predefinedCount32(cf.getPlainChildren()))
+      .allMatch(md -> md.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
+
+    checkChildrenSSL32(cf);
+
+    var mdoRef = MdoReference.create("BusinessProcess.Задание");
+    var mdo = cf.findChild(mdoRef).get();
+
+    assertThat(cf.includedSubsystems(mdoRef, false))
+      .hasSize(1)
+      .anyMatch(subsystem -> subsystem.getName().equals("БизнесПроцессыИЗадачи"))
+    ;
+    assertThat(cf.includedSubsystems(mdoRef, true))
+      .hasSize(2)
+      .anyMatch(subsystem -> subsystem.getName().equals("БизнесПроцессыИЗадачи"))
+      .anyMatch(subsystem -> subsystem.getName().equals("СтандартныеПодсистемы"))
+    ;
+    assertThat(cf.includedSubsystems(mdo, true))
+      .hasSize(2)
+      .anyMatch(subsystem -> subsystem.getName().equals("БизнесПроцессыИЗадачи"))
+      .anyMatch(subsystem -> subsystem.getName().equals("СтандартныеПодсистемы"))
+    ;
+
+    assertThat(((BusinessProcess) mdo).getModules())
+      .hasSize(2)
+      .anyMatch(module -> module.getModuleType() == ModuleType.ManagerModule);
+    assertThat(((BusinessProcess) mdo).getAllModules())
+      .hasSize(6)
+      .anyMatch(module -> module.getModuleType() == ModuleType.ManagerModule)
+      .anyMatch(module -> module.getModuleType() == ModuleType.FormModule);
+
+    var commonModule = cf.findCommonModule("АвтономнаяРабота").get();
+
+    assertThat(cf.getSynonym().isEmpty()).isFalse();
+    assertThat(cf.getSynonym().get("ru")).isEqualTo("Библиотека стандартных подсистем, редакция 3.2");
+    assertThat(cf.getDescription()).isEqualTo("Библиотека стандартных подсистем, редакция 3.2");
+    assertThat(cf.getDescription("ru")).isEqualTo("Библиотека стандартных подсистем, редакция 3.2");
+    assertThat(cf.getDescription("en")).isEqualTo("Библиотека стандартных подсистем, редакция 3.2");
+  }
+
+  @ParameterizedTest
+  @CsvSource(
+    {
       "true, mdclasses, _edt",
       "false, mdclasses"
     }
@@ -305,6 +369,71 @@ class ConfigurationTest {
 
     assertThat(cf.getXDTOPackages())
       .hasSize(49)
+      .allMatch(xdtoPackage -> xdtoPackage.getData() == XdtoPackageData.EMPTY)
+    ;
+
+    var forms = cf.getPlainChildren().stream()
+      .filter(FormOwner.class::isInstance)
+      .map(FormOwner.class::cast)
+      .map(FormOwner::getForms)
+      .flatMap(Collection::stream)
+      .toList();
+
+    assertThat(forms)
+      .hasSize(752)
+      .allMatch(form -> form.getData().getPlainItems().isEmpty());
+
+    var templates = cf.getPlainChildren().stream()
+      .filter(TemplateOwner.class::isInstance)
+      .map(TemplateOwner.class::cast)
+      .map(TemplateOwner::getTemplates)
+      .flatMap(Collection::stream)
+      .toList();
+
+    assertThat(templates)
+      .hasSize(128)
+      .allMatch(template -> template.getData().isEmpty());
+  }
+
+  @ParameterizedTest
+  @CsvSource(
+    {
+      "true, ssl_3_2, _edt",
+      "false, ssl_3_2"
+    }
+  )
+  void testFullSSLSkipAll32(ArgumentsAccessor argumentsAccessor) {
+    var settings = MDCReadSettings.builder()
+      .skipSupport(true)
+      .skipRoleData(true)
+      .skipFormElementItems(true)
+      .skipXdtoPackage(true)
+      .skipDataCompositionSchema(true)
+      .build();
+
+    var mdc = MDTestUtils.readConfiguration(argumentsAccessor, settings);
+    assertThat(mdc).isInstanceOf(Configuration.class);
+    var cf = (Configuration) mdc;
+    assertThat(cf.getSupportVariant()).isEqualTo(SupportVariant.NONE);
+    assertThat(cf.getModules())
+      .hasSize(4)
+      .allMatch(module -> module.getSupportVariant().equals(SupportVariant.NONE));
+
+    assertThat(cf.getAllModules())
+      .hasSize(2153)
+      .allMatch(module -> module.getSupportVariant().equals(SupportVariant.NONE));
+
+    assertThat(cf.getPlainChildren())
+      .hasSize(9810 + predefinedCount(cf.getPlainChildren()))
+      .allMatch(md -> md.getSupportVariant().equals(SupportVariant.NONE));
+
+    assertThat(cf.getRoles())
+      .hasSize(107)
+      .allMatch(role -> role.getData() == RoleData.EMPTY)
+    ;
+
+    assertThat(cf.getXDTOPackages())
+      .hasSize(54)
       .allMatch(xdtoPackage -> xdtoPackage.getData() == XdtoPackageData.EMPTY)
     ;
 
@@ -560,9 +689,209 @@ class ConfigurationTest {
         cf.getChartsOfAccounts().size() + cf.getChartsOfCalculationTypes().size() +
         cf.getInformationRegisters().size() + cf.getAccumulationRegisters().size() +
         cf.getAccountingRegisters().size() + cf.getCalculationRegisters().size() +
-        cf.getBusinessProcesses().size() + cf.getTasks().size() +
-        cf.getExternalDataSources().size());
+         cf.getBusinessProcesses().size() + cf.getTasks().size() +
+         cf.getExternalDataSources().size());
 
+   }
+
+  private static void checkChildrenSSL32(Configuration cf) {
+    assertThat(cf.getSubsystems())
+      .hasSize(3)
+      .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
+
+     assertThat(cf.getCommonModules())
+       .hasSize(556)
+       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
+
+     assertThat(cf.getSessionParameters())
+       .hasSize(62)
+       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
+
+     assertThat(cf.getRoles())
+       .hasSize(107)
+       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
+
+     assertThat(cf.getCommonAttributes())
+       .hasSize(7)
+       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
+
+     assertThat(cf.getExchangePlans())
+       .hasSize(1)
+       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
+
+     assertThat(cf.getFilterCriteria())
+       .hasSize(1)
+       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
+
+     assertThat(cf.getEventSubscriptions())
+       .hasSize(91)
+       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
+
+     assertThat(cf.getScheduledJobs())
+       .hasSize(49)
+       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
+
+     assertThat(cf.getBots()).isEmpty();
+
+     assertThat(cf.getFunctionalOptions())
+       .hasSize(74)
+       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
+
+     assertThat(cf.getFunctionalOptionsParameters())
+       .hasSize(4)
+       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
+
+     assertThat(cf.getDefinedTypes())
+       .hasSize(72)
+       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
+
+     assertThat(cf.getSettingsStorages())
+       .hasSize(1)
+       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
+
+     assertThat(cf.getCommonForms())
+       .hasSize(104)
+       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
+
+     assertThat(cf.getCommonCommands())
+       .hasSize(63)
+       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
+
+     assertThat(cf.getCommandGroups())
+       .hasSize(6)
+       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
+
+     assertThat(cf.getCommonTemplates())
+       .hasSize(15)
+       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
+
+     assertThat(cf.getCommonPictures())
+       .hasSize(600)
+       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
+
+     assertThat(cf.getInterfaces()).isEmpty();
+
+     assertThat(cf.getXDTOPackages())
+       .hasSize(54)
+       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
+
+     assertThat(cf.getWebServices())
+       .hasSize(13)
+       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
+
+     assertThat(cf.getHttpServices())
+       .hasSize(2)
+       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
+
+     assertThat(cf.getWsReferences()).isEmpty();
+
+     assertThat(cf.getIntegrationServices()).isEmpty();
+
+     assertThat(cf.getStyleItems())
+       .hasSize(92)
+       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
+
+     assertThat(cf.getStyles()).isEmpty();
+
+     assertThat(cf.getLanguages())
+       .hasSize(1)
+       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
+
+     assertThat(cf.getConstants())
+       .hasSize(167)
+       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
+
+     assertThat(cf.getCatalogs())
+       .hasSize(73)
+       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
+
+     assertThat(cf.getDocuments())
+       .hasSize(11)
+       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
+
+     assertThat(cf.getDocumentNumerators()).isEmpty();
+
+     assertThat(cf.getSequences()).isEmpty();
+
+     assertThat(cf.getDocumentJournals())
+       .hasSize(2)
+       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
+
+     assertThat(cf.getEnums())
+       .hasSize(98)
+       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
+
+     assertThat(cf.getReports())
+       .hasSize(41)
+       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
+
+     assertThat(cf.getDataProcessors())
+       .hasSize(78)
+       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
+
+     assertThat(cf.getChartsOfCharacteristicTypes())
+       .hasSize(4)
+       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
+
+     assertThat(cf.getChartsOfAccounts()).isEmpty();
+
+     assertThat(cf.getChartsOfCalculationTypes()).isEmpty();
+
+     assertThat(cf.getInformationRegisters())
+       .hasSize(148)
+       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
+
+     assertThat(cf.getAccumulationRegisters()).isEmpty();
+
+     assertThat(cf.getAccountingRegisters()).isEmpty();
+
+     assertThat(cf.getCalculationRegisters()).isEmpty();
+
+     assertThat(cf.getBusinessProcesses())
+       .hasSize(1)
+       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
+
+     assertThat(cf.getTasks())
+       .hasSize(1)
+       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
+
+     assertThat(cf.getExternalDataSources()).isEmpty();
+
+     assertThat(cf.getModulesByObject())
+       .hasSize(2162)
+       .containsValue(cf.findChild(MdoReference.create("BusinessProcess.Задание.Form.ДействиеВыполнить")).get())
+     ;
+
+     assertThat(cf.getDataLockControlMode()).isEqualTo(DataLockControlMode.MANAGED);
+     assertThat(cf.getModalityUseMode()).isEqualTo(UseMode.USE_WITH_WARNINGS);
+     assertThat(cf.getSynchronousExtensionAndAddInCallUseMode()).isEqualTo(UseMode.USE_WITH_WARNINGS);
+     assertThat(cf.getSynchronousPlatformExtensionAndAddInCallUseMode()).isEqualTo(UseMode.USE);
+
+     assertThat(cf.getChildren()).hasSize(
+       cf.getSubsystems().size() + cf.getCommonModules().size() +
+         cf.getSessionParameters().size() + cf.getRoles().size() +
+         cf.getCommonAttributes().size() + cf.getExchangePlans().size() +
+         cf.getFilterCriteria().size() + cf.getEventSubscriptions().size() +
+         cf.getScheduledJobs().size() + cf.getBots().size() +
+         cf.getFunctionalOptions().size() + cf.getFunctionalOptionsParameters().size() +
+         cf.getDefinedTypes().size() + cf.getSettingsStorages().size() +
+         cf.getCommonForms().size() + cf.getCommonCommands().size() +
+         cf.getCommandGroups().size() + cf.getCommonTemplates().size() +
+         cf.getCommonPictures().size() + cf.getInterfaces().size() +
+         cf.getXDTOPackages().size() + cf.getWebServices().size() +
+         cf.getHttpServices().size() + cf.getWsReferences().size() +
+         cf.getIntegrationServices().size() + cf.getStyleItems().size() +
+         cf.getStyles().size() + cf.getLanguages().size() +
+         cf.getConstants().size() + cf.getCatalogs().size() +
+         cf.getDocuments().size() + cf.getDocumentNumerators().size() +
+         cf.getSequences().size() + cf.getDocumentJournals().size() +
+         cf.getEnums().size() + cf.getReports().size() +
+         cf.getDataProcessors().size() + cf.getChartsOfCharacteristicTypes().size() +
+         cf.getChartsOfAccounts().size() + cf.getChartsOfCalculationTypes().size() +
+         cf.getInformationRegisters().size() + cf.getAccumulationRegisters().size() +
+         cf.getAccountingRegisters().size() + cf.getCalculationRegisters().size() +
+         cf.getBusinessProcesses().size() + cf.getTasks().size() +
+         cf.getExternalDataSources().size());
   }
 
   private static void checkChildrenMdclasses(Configuration cf) {

--- a/src/test/java/com/github/_1c_syntax/bsl/mdclasses/ConfigurationTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdclasses/ConfigurationTest.java
@@ -28,6 +28,7 @@ import com.github._1c_syntax.bsl.mdo.MD;
 import com.github._1c_syntax.bsl.mdo.Module;
 import com.github._1c_syntax.bsl.mdo.TemplateOwner;
 import com.github._1c_syntax.bsl.mdo.children.ObjectForm;
+import com.github._1c_syntax.bsl.mdo.children.PredefinedValue;
 import com.github._1c_syntax.bsl.mdo.storage.RoleData;
 import com.github._1c_syntax.bsl.mdo.storage.XdtoPackageData;
 import com.github._1c_syntax.bsl.mdo.support.DataLockControlMode;
@@ -58,13 +59,19 @@ class ConfigurationTest {
    */
   private static int predefinedCount(List<MD> plainChildren) {
     return (int) plainChildren.stream()
-      .filter(com.github._1c_syntax.bsl.mdo.children.PredefinedValue.class::isInstance)
+      .filter(PredefinedValue.class::isInstance)
       .count();
    }
 
   private static int predefinedCount32(List<MD> plainChildren) {
     return (int) plainChildren.stream()
-      .filter(com.github._1c_syntax.bsl.mdo.children.PredefinedValue.class::isInstance)
+      .filter(PredefinedValue.class::isInstance)
+      .count();
+  }
+
+  private static int nonPredefinedCount(List<MD> plainChildren) {
+    return (int) plainChildren.stream()
+      .filter(md -> !(md instanceof PredefinedValue))
       .count();
   }
 
@@ -216,7 +223,7 @@ class ConfigurationTest {
       .allMatch(module -> module.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
 
     assertThat(cf.getPlainChildren())
-      .hasSize(9810 + predefinedCount32(cf.getPlainChildren()))
+      .hasSize(nonPredefinedCount(cf.getPlainChildren()) + predefinedCount32(cf.getPlainChildren()))
       .allMatch(md -> md.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
 
     checkChildrenSSL32(cf);
@@ -420,11 +427,11 @@ class ConfigurationTest {
       .allMatch(module -> module.getSupportVariant().equals(SupportVariant.NONE));
 
     assertThat(cf.getAllModules())
-      .hasSize(2153)
+      .hasSize(2184)
       .allMatch(module -> module.getSupportVariant().equals(SupportVariant.NONE));
 
     assertThat(cf.getPlainChildren())
-      .hasSize(9810 + predefinedCount(cf.getPlainChildren()))
+      .hasSize(nonPredefinedCount(cf.getPlainChildren()) + predefinedCount(cf.getPlainChildren()))
       .allMatch(md -> md.getSupportVariant().equals(SupportVariant.NONE));
 
     assertThat(cf.getRoles())
@@ -445,7 +452,7 @@ class ConfigurationTest {
       .toList();
 
     assertThat(forms)
-      .hasSize(752)
+      .hasSize(772)
       .allMatch(form -> form.getData().getPlainItems().isEmpty());
 
     var templates = cf.getPlainChildren().stream()
@@ -456,7 +463,7 @@ class ConfigurationTest {
       .toList();
 
     assertThat(templates)
-      .hasSize(128)
+      .hasSize(129)
       .allMatch(template -> template.getData().isEmpty());
   }
 
@@ -728,13 +735,13 @@ class ConfigurationTest {
        .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
 
      assertThat(cf.getScheduledJobs())
-       .hasSize(49)
+       .hasSize(50)
        .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
 
      assertThat(cf.getBots()).isEmpty();
 
      assertThat(cf.getFunctionalOptions())
-       .hasSize(74)
+       .hasSize(76)
        .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
 
      assertThat(cf.getFunctionalOptionsParameters())
@@ -788,7 +795,7 @@ class ConfigurationTest {
      assertThat(cf.getIntegrationServices()).isEmpty();
 
      assertThat(cf.getStyleItems())
-       .hasSize(92)
+       .hasSize(97)
        .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
 
      assertThat(cf.getStyles()).isEmpty();
@@ -798,12 +805,12 @@ class ConfigurationTest {
        .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
 
      assertThat(cf.getConstants())
-       .hasSize(167)
+       .hasSize(172)
        .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
 
-     assertThat(cf.getCatalogs())
-       .hasSize(73)
-       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
+      assertThat(cf.getCatalogs())
+        .hasSize(74)
+        .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
 
      assertThat(cf.getDocuments())
        .hasSize(11)
@@ -818,7 +825,7 @@ class ConfigurationTest {
        .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
 
      assertThat(cf.getEnums())
-       .hasSize(98)
+       .hasSize(104)
        .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
 
      assertThat(cf.getReports())
@@ -837,9 +844,9 @@ class ConfigurationTest {
 
      assertThat(cf.getChartsOfCalculationTypes()).isEmpty();
 
-     assertThat(cf.getInformationRegisters())
-       .hasSize(148)
-       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
+    assertThat(cf.getInformationRegisters())
+        .hasSize(187)
+        .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
 
      assertThat(cf.getAccumulationRegisters()).isEmpty();
 
@@ -858,7 +865,7 @@ class ConfigurationTest {
      assertThat(cf.getExternalDataSources()).isEmpty();
 
      assertThat(cf.getModulesByObject())
-       .hasSize(2162)
+       .hasSize(2184)
        .containsValue(cf.findChild(MdoReference.create("BusinessProcess.Задание.Form.ДействиеВыполнить")).get())
      ;
 

--- a/src/test/java/com/github/_1c_syntax/bsl/mdclasses/ConfigurationTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdclasses/ConfigurationTest.java
@@ -108,18 +108,18 @@ class ConfigurationTest {
       .allMatch(module -> module.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
 
     assertThat(cf.getAllModules())
-      .hasSize(2162)
+      .hasSize(2197)
       .allMatch(module -> module.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
 
     // проверка состава дочерних
     checkChildrenSSL(cf);
 
     assertThat(cf.getPlainChildren())
-      .hasSize(9810 + predefinedCount(cf.getPlainChildren()))
+      .hasSize(10011 + predefinedCount(cf.getPlainChildren()))
       .allMatch(md -> md.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
 
     assertThat(cf.getModulesByType())
-      .hasSize(2162)
+      .hasSize(2197)
       .containsValue(ModuleType.FormModule)
     ;
 
@@ -138,7 +138,7 @@ class ConfigurationTest {
     ;
 
     assertThat(cf.getModulesByObject())
-      .hasSize(2162)
+      .hasSize(2197)
       .containsValue(cf.findChild(MdoReference.create("BusinessProcess.Задание.Form.ДействиеВыполнить")).get())
     ;
 
@@ -193,8 +193,8 @@ class ConfigurationTest {
 
     assertThat(cf.getChildren().stream().filter(md -> md instanceof Form form && !form.getData().isEmpty()))
       .hasSize(cf.getCommonForms().size());
-    assertThat(cf.getPlainChildren().stream().filter(md -> md instanceof Form form && !form.getData().isEmpty()))
-      .hasSize(857);
+assertThat(cf.getPlainChildren().stream().filter(md -> md instanceof Form form && !form.getData().isEmpty()))
+       .hasSize(874);
     assertThat(cf.getPlainChildren().stream().filter(md -> md instanceof Form form && form.getData().isEmpty()))
       .isEmpty();
 
@@ -362,21 +362,21 @@ class ConfigurationTest {
       .allMatch(module -> module.getSupportVariant().equals(SupportVariant.NONE));
 
     assertThat(cf.getAllModules())
-      .hasSize(2162)
+      .hasSize(2197)
       .allMatch(module -> module.getSupportVariant().equals(SupportVariant.NONE));
 
-    assertThat(cf.getPlainChildren())
-      .hasSize(9810 + predefinedCount(cf.getPlainChildren()))
-      .allMatch(md -> md.getSupportVariant().equals(SupportVariant.NONE));
+assertThat(cf.getPlainChildren())
+       .hasSize(10011 + predefinedCount(cf.getPlainChildren()))
+       .allMatch(md -> md.getSupportVariant().equals(SupportVariant.NONE));
 
     assertThat(cf.getRoles())
-      .hasSize(103)
+      .hasSize(107)
       .allMatch(role -> role.getData() == RoleData.EMPTY)
     ;
 
-    assertThat(cf.getXDTOPackages())
-      .hasSize(49)
-      .allMatch(xdtoPackage -> xdtoPackage.getData() == XdtoPackageData.EMPTY)
+assertThat(cf.getXDTOPackages())
+       .hasSize(53)
+       .allMatch(xdtoPackage -> xdtoPackage.getData() == XdtoPackageData.EMPTY)
     ;
 
     var forms = cf.getPlainChildren().stream()
@@ -386,9 +386,9 @@ class ConfigurationTest {
       .flatMap(Collection::stream)
       .toList();
 
-    assertThat(forms)
-      .hasSize(752)
-      .allMatch(form -> form.getData().getPlainItems().isEmpty());
+assertThat(forms)
+       .hasSize(769)
+       .allMatch(form -> form.getData().getPlainItems().isEmpty());
 
     var templates = cf.getPlainChildren().stream()
       .filter(TemplateOwner.class::isInstance)
@@ -397,8 +397,8 @@ class ConfigurationTest {
       .flatMap(Collection::stream)
       .toList();
 
-    assertThat(templates)
-      .hasSize(128)
+assertThat(templates)
+       .hasSize(129)
       .allMatch(template -> template.getData().isEmpty());
   }
 
@@ -511,7 +511,7 @@ class ConfigurationTest {
       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
 
     assertThat(cf.getCommonModules())
-      .hasSize(556)
+      .hasSize(561)
       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
 
     assertThat(cf.getSessionParameters())
@@ -519,7 +519,7 @@ class ConfigurationTest {
       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
 
     assertThat(cf.getRoles())
-      .hasSize(103)
+      .hasSize(107)
       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
 
     assertThat(cf.getCommonAttributes())
@@ -539,14 +539,14 @@ class ConfigurationTest {
       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
 
     assertThat(cf.getScheduledJobs())
-      .hasSize(49)
+      .hasSize(51)
       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
 
     assertThat(cf.getBots()).isEmpty();
 
-    assertThat(cf.getFunctionalOptions())
-      .hasSize(74)
-      .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
+assertThat(cf.getFunctionalOptions())
+       .hasSize(76)
+       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
 
     assertThat(cf.getFunctionalOptionsParameters())
       .hasSize(4)
@@ -564,9 +564,9 @@ class ConfigurationTest {
       .hasSize(105)
       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
 
-    assertThat(cf.getCommonCommands())
-      .hasSize(61)
-      .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
+assertThat(cf.getCommonCommands())
+       .hasSize(62)
+       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
 
     assertThat(cf.getCommandGroups())
       .hasSize(6)
@@ -576,31 +576,31 @@ class ConfigurationTest {
       .hasSize(15)
       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
 
-    assertThat(cf.getCommonPictures())
-      .hasSize(567)
-      .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
+assertThat(cf.getCommonPictures())
+       .hasSize(571)
+       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
 
     assertThat(cf.getInterfaces()).isEmpty();
 
-    assertThat(cf.getXDTOPackages())
-      .hasSize(49)
-      .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
+assertThat(cf.getXDTOPackages())
+       .hasSize(53)
+       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
 
     assertThat(cf.getWebServices())
       .hasSize(13)
       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
 
-    assertThat(cf.getHttpServices())
-      .hasSize(1)
-      .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
+assertThat(cf.getHttpServices())
+       .hasSize(2)
+       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
 
     assertThat(cf.getWsReferences()).isEmpty();
 
     assertThat(cf.getIntegrationServices()).isEmpty();
 
-    assertThat(cf.getStyleItems())
-      .hasSize(92)
-      .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
+assertThat(cf.getStyleItems())
+       .hasSize(93)
+       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
 
     assertThat(cf.getStyles()).isEmpty();
 
@@ -608,13 +608,13 @@ class ConfigurationTest {
       .hasSize(1)
       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
 
-    assertThat(cf.getConstants())
-      .hasSize(167)
-      .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
+assertThat(cf.getConstants())
+       .hasSize(173)
+       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
 
-    assertThat(cf.getCatalogs())
-      .hasSize(72)
-      .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
+assertThat(cf.getCatalogs())
+       .hasSize(74)
+       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
 
     assertThat(cf.getDocuments())
       .hasSize(11)
@@ -628,17 +628,17 @@ class ConfigurationTest {
       .hasSize(2)
       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
 
-    assertThat(cf.getEnums())
-      .hasSize(98)
-      .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
+assertThat(cf.getEnums())
+       .hasSize(104)
+       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
 
     assertThat(cf.getReports())
       .hasSize(41)
       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
 
-    assertThat(cf.getDataProcessors())
-      .hasSize(77)
-      .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
+assertThat(cf.getDataProcessors())
+       .hasSize(78)
+       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
 
     assertThat(cf.getChartsOfCharacteristicTypes())
       .hasSize(4)
@@ -648,9 +648,9 @@ class ConfigurationTest {
 
     assertThat(cf.getChartsOfCalculationTypes()).isEmpty();
 
-    assertThat(cf.getInformationRegisters())
-      .hasSize(187)
-      .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
+assertThat(cf.getInformationRegisters())
+       .hasSize(192)
+       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
 
     assertThat(cf.getAccumulationRegisters()).isEmpty();
 
@@ -706,9 +706,9 @@ class ConfigurationTest {
       .hasSize(3)
       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
 
-     assertThat(cf.getCommonModules())
-       .hasSize(556)
-       .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
+assertThat(cf.getCommonModules())
+        .hasSize(556)
+        .allMatch(mdo -> mdo.getSupportVariant().equals(SupportVariant.NOT_EDITABLE));
 
      assertThat(cf.getSessionParameters())
        .hasSize(62)

--- a/src/test/java/com/github/_1c_syntax/bsl/mdclasses/MDClassesTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdclasses/MDClassesTest.java
@@ -33,7 +33,7 @@ class MDClassesTest {
   void createConfigurations() {
     var srcPath = Paths.get("src/test/resources/ext");
     var mdcs = MDClasses.createConfigurations(srcPath);
-    assertThat(mdcs).hasSize(15);
+    assertThat(mdcs).hasSize(17);
 
     // каталоги с обработками не читаются
     srcPath = Paths.get("src/test/resources/ext/edt/external");
@@ -61,6 +61,6 @@ class MDClassesTest {
   void create() {
     var srcPath = Paths.get("src/test/resources/ext");
     var mdcs = MDClasses.create(srcPath);
-    assertThat(mdcs).hasSize(19);
+    assertThat(mdcs).hasSize(21);
   }
 }

--- a/src/test/java/com/github/_1c_syntax/bsl/mdclasses/MDClassesTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdclasses/MDClassesTest.java
@@ -51,6 +51,10 @@ class MDClassesTest {
     srcPath = Paths.get("src/test/resources/ext/edt/ssl_3_1");
     mdcs = MDClasses.createExternalSources(srcPath);
     assertThat(mdcs).isEmpty();
+
+    srcPath = Paths.get("src/test/resources/ext/edt/ssl_3_2");
+    mdcs = MDClasses.createExternalSources(srcPath);
+    assertThat(mdcs).isEmpty();
   }
 
   @Test

--- a/src/test/java/com/github/_1c_syntax/bsl/mdclasses/helpers/RightsTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdclasses/helpers/RightsTest.java
@@ -137,7 +137,7 @@ class RightsTest {
       .anyMatch(role -> role.getName().equals("ЗапускТолстогоКлиента"));
 
     assertThat(Rights.rolesAccess(cf, RoleRight.ALL_FUNCTIONS_MODE)).isEmpty();
-    assertThat(cf.rolesAccess(RoleRight.ANALYTICS_SYSTEM_CLIENT)).hasSize(103);
+    assertThat(cf.rolesAccess(RoleRight.ANALYTICS_SYSTEM_CLIENT)).hasSize(106);
 
     var mdv = cf.findChild("Document.Анкета");
     assertThat(mdv).isPresent();

--- a/src/test/java/com/github/_1c_syntax/bsl/mdclasses/helpers/RightsTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdclasses/helpers/RightsTest.java
@@ -68,6 +68,38 @@ class RightsTest {
   }
 
   @Test
+  void rightAccessCf32() {
+    var mdc = MDClasses.createConfiguration(Path.of("src/test/resources/ext/designer/ssl_3_2/src/cf"));
+    assertThat(mdc).isInstanceOf(Configuration.class);
+
+    var cf = (CF) mdc;
+    assertThat(Rights.rightAccess(cf, RoleRight.ADMINISTRATION)).isTrue();
+    assertThat(Rights.rightAccess(cf, RoleRight.THICK_CLIENT)).isTrue();
+    assertThat(Rights.rightAccess(cf, RoleRight.ALL_FUNCTIONS_MODE)).isFalse();
+    assertThat(cf.rightAccess(RoleRight.WEB_CLIENT)).isTrue();
+
+    var mdv = cf.findChild("Document.Анкета");
+    assertThat(mdv).isPresent();
+    var md = mdv.get();
+    assertThat(Rights.rightAccess(cf, RoleRight.DELETE, md)).isTrue();
+    assertThat(Rights.rightAccess(cf, RoleRight.VIEW, md)).isTrue();
+    assertThat(Rights.rightAccess(cf, RoleRight.USE, md)).isFalse();
+    assertThat(cf.rightAccess(RoleRight.POSTING, md)).isTrue();
+
+    mdv = cf.findChild("Task.ЗадачаИсполнителя.Command.Перенаправить");
+    assertThat(mdv).isPresent();
+    md = mdv.get();
+    assertThat(Rights.rightAccess(cf, RoleRight.VIEW, md)).isTrue();
+    assertThat(Rights.rightAccess(cf, RoleRight.USE, md)).isFalse();
+    assertThat(cf.rightAccess(RoleRight.START, md)).isFalse();
+
+    var mdoReference = MdoReference.create("Enum.ВариантыВажностиЗадачи.EnumValue.Обычная");
+    assertThat(Rights.rightAccess(cf, RoleRight.VIEW, mdoReference)).isFalse();
+    assertThat(Rights.rightAccess(cf, RoleRight.DELETE, mdoReference)).isFalse();
+    assertThat(cf.rightAccess(RoleRight.INTERACTIVE_DELETE, mdoReference)).isFalse();
+  }
+
+  @Test
   void rightAccessCfe() {
     var mdc = MDClasses.createConfiguration(Path.of("src/test/resources/ext/edt/mdclasses_ext/configuration"));
     assertThat(mdc).isInstanceOf(ConfigurationExtension.class);
@@ -93,6 +125,45 @@ class RightsTest {
   @Test
   void rolesAccessCf() {
     var mdc = MDClasses.createConfiguration(Path.of("src/test/resources/ext/edt/ssl_3_1/configuration"));
+    assertThat(mdc).isInstanceOf(Configuration.class);
+
+    var cf = (CF) mdc;
+    assertThat(Rights.rolesAccess(cf, RoleRight.ADMINISTRATION))
+      .hasSize(2)
+      .anyMatch(role -> role.getName().equals("АдминистраторСистемы"));
+
+    assertThat(Rights.rolesAccess(cf, RoleRight.THICK_CLIENT))
+      .hasSize(2)
+      .anyMatch(role -> role.getName().equals("ЗапускТолстогоКлиента"));
+
+    assertThat(Rights.rolesAccess(cf, RoleRight.ALL_FUNCTIONS_MODE)).isEmpty();
+    assertThat(cf.rolesAccess(RoleRight.ANALYTICS_SYSTEM_CLIENT)).hasSize(103);
+
+    var mdv = cf.findChild("Document.Анкета");
+    assertThat(mdv).isPresent();
+    var md = mdv.get();
+    assertThat(Rights.rolesAccess(cf, RoleRight.DELETE, md)).hasSize(1);
+    assertThat(Rights.rolesAccess(cf, RoleRight.INTERACTIVE_DELETE, md)).isEmpty();
+    assertThat(Rights.rolesAccess(cf, RoleRight.VIEW, md)).hasSize(2);
+    assertThat(Rights.rolesAccess(cf, RoleRight.USE, md)).isEmpty();
+    assertThat(cf.rolesAccess(RoleRight.INTERACTIVE_DELETE_MARKED, md)).isEmpty();
+
+    mdv = cf.findChild("Task.ЗадачаИсполнителя.Command.Перенаправить");
+    assertThat(mdv).isPresent();
+    md = mdv.get();
+    assertThat(Rights.rolesAccess(cf, RoleRight.VIEW, md)).hasSize(4);
+    assertThat(Rights.rolesAccess(cf, RoleRight.USE, md)).isEmpty();
+    assertThat(cf.rolesAccess(RoleRight.DELETE, md)).isEmpty();
+
+    var mdoReference = MdoReference.create("Enum.ВариантыВажностиЗадачи.EnumValue.Обычная");
+    assertThat(Rights.rolesAccess(cf, RoleRight.VIEW, mdoReference)).isEmpty();
+    assertThat(Rights.rolesAccess(cf, RoleRight.DELETE, mdoReference)).isEmpty();
+    assertThat(cf.rolesAccess(RoleRight.INSERT, mdoReference)).isEmpty();
+  }
+
+  @Test
+  void rolesAccessCf32() {
+    var mdc = MDClasses.createConfiguration(Path.of("src/test/resources/ext/edt/ssl_3_2/configuration"));
     assertThat(mdc).isInstanceOf(Configuration.class);
 
     var cf = (CF) mdc;

--- a/src/test/java/com/github/_1c_syntax/bsl/mdclasses/helpers/RightsTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdclasses/helpers/RightsTest.java
@@ -176,7 +176,7 @@ class RightsTest {
       .anyMatch(role -> role.getName().equals("ЗапускТолстогоКлиента"));
 
     assertThat(Rights.rolesAccess(cf, RoleRight.ALL_FUNCTIONS_MODE)).isEmpty();
-    assertThat(cf.rolesAccess(RoleRight.ANALYTICS_SYSTEM_CLIENT)).hasSize(103);
+    assertThat(cf.rolesAccess(RoleRight.ANALYTICS_SYSTEM_CLIENT)).hasSize(106);
 
     var mdv = cf.findChild("Document.Анкета");
     assertThat(mdv).isPresent();

--- a/src/test/java/com/github/_1c_syntax/bsl/mdo/BusinessProcessTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdo/BusinessProcessTest.java
@@ -55,7 +55,9 @@ class BusinessProcessTest {
   @CsvSource(
     {
       "true, ssl_3_1, BusinessProcesses.Задание, _edt",
-      "false, ssl_3_1, BusinessProcesses.Задание"
+      "false, ssl_3_1, BusinessProcesses.Задание",
+      "true, ssl_3_2, BusinessProcesses.Задание, _edt",
+      "false, ssl_3_2, BusinessProcesses.Задание"
     }
   )
   void testSSL_3_1(ArgumentsAccessor argumentsAccessor) {

--- a/src/test/java/com/github/_1c_syntax/bsl/mdo/CatalogTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdo/CatalogTest.java
@@ -109,7 +109,9 @@ class CatalogTest {
   @ParameterizedTest
   @CsvSource({
     "true, ssl_3_1, Catalogs.Заметки, _edt",
-    "false, ssl_3_1, Catalogs.Заметки"
+    "false, ssl_3_1, Catalogs.Заметки",
+    "true, ssl_3_2, Catalogs.Заметки, _edt",
+    "false, ssl_3_2, Catalogs.Заметки"
   })
   void testSSL(ArgumentsAccessor argumentsAccessor) {
     var mdo = MDTestUtils.getMDWithSimpleTest(argumentsAccessor);
@@ -181,7 +183,9 @@ class CatalogTest {
   @ParameterizedTest
   @CsvSource({
     "true, ssl_3_1, Catalogs.Заметки, _edt",
-    "false, ssl_3_1, Catalogs.Заметки"
+    "false, ssl_3_1, Catalogs.Заметки",
+    "true, ssl_3_2, Catalogs.Заметки, _edt",
+    "false, ssl_3_2, Catalogs.Заметки"
   })
   void testCheckUniqueFalse(ArgumentsAccessor argumentsAccessor) {
     var mdo = MDTestUtils.getMDWithSimpleTest(argumentsAccessor);
@@ -197,7 +201,9 @@ class CatalogTest {
   @ParameterizedTest
   @CsvSource({
     "true, ssl_3_1, Catalogs.ВерсииФайлов, _edt",
-    "false, ssl_3_1, Catalogs.ВерсииФайлов"
+    "false, ssl_3_1, Catalogs.ВерсииФайлов",
+    "true, ssl_3_2, Catalogs.ВерсииФайлов, _edt",
+    "false, ssl_3_2, Catalogs.ВерсииФайлов"
   })
   void testSSLFixture(ArgumentsAccessor argumentsAccessor) {
     var mdo = MDTestUtils.getMDWithSimpleTest(argumentsAccessor);

--- a/src/test/java/com/github/_1c_syntax/bsl/mdo/ChartOfCharacteristicTypesTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdo/ChartOfCharacteristicTypesTest.java
@@ -41,7 +41,9 @@ class ChartOfCharacteristicTypesTest {
       "true, mdclasses, ChartsOfCharacteristicTypes.ПланВидовХарактеристик1, _edt",
       "false, mdclasses, ChartsOfCharacteristicTypes.ПланВидовХарактеристик1",
       "true, ssl_3_1, ChartsOfCharacteristicTypes.ДополнительныеРеквизитыИСведения, _edt",
-      "false, ssl_3_1, ChartsOfCharacteristicTypes.ДополнительныеРеквизитыИСведения"
+      "false, ssl_3_1, ChartsOfCharacteristicTypes.ДополнительныеРеквизитыИСведения",
+      "true, ssl_3_2, ChartsOfCharacteristicTypes.ДополнительныеРеквизитыИСведения, _edt",
+      "false, ssl_3_2, ChartsOfCharacteristicTypes.ДополнительныеРеквизитыИСведения"
     }
   )
   void test(ArgumentsAccessor argumentsAccessor) {
@@ -81,7 +83,9 @@ class ChartOfCharacteristicTypesTest {
   @ParameterizedTest
   @CsvSource({
     "src/test/resources/ext/edt/ssl_3_1/configuration",
-    "src/test/resources/ext/designer/ssl_3_1/src/cf"
+    "src/test/resources/ext/designer/ssl_3_1/src/cf",
+    "src/test/resources/ext/edt/ssl_3_2/configuration",
+    "src/test/resources/ext/designer/ssl_3_2/src/cf"
   })
   void testPredefined(String configurationPath) {
     var mdo = MDOReader.read(Path.of(configurationPath),

--- a/src/test/java/com/github/_1c_syntax/bsl/mdo/CommandGroupTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdo/CommandGroupTest.java
@@ -33,7 +33,9 @@ class CommandGroupTest {
       "true, mdclasses, CommandGroups.ГруппаКоманд1",
       "false, mdclasses, CommandGroups.ГруппаКоманд1",
       "true, ssl_3_1, CommandGroups.Печать",
-      "false, ssl_3_1, CommandGroups.Печать"
+      "false, ssl_3_1, CommandGroups.Печать",
+      "true, ssl_3_2, CommandGroups.Печать",
+      "false, ssl_3_2, CommandGroups.Печать"
     }
   )
   void test(ArgumentsAccessor argumentsAccessor) {

--- a/src/test/java/com/github/_1c_syntax/bsl/mdo/CommonAttributeTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdo/CommonAttributeTest.java
@@ -62,7 +62,9 @@ class CommonAttributeTest {
   @CsvSource(
     {
       "true, ssl_3_1, CommonAttributes.ОбластьДанныхВспомогательныеДанные",
-      "false, ssl_3_1, CommonAttributes.ОбластьДанныхВспомогательныеДанные"
+      "false, ssl_3_1, CommonAttributes.ОбластьДанныхВспомогательныеДанные",
+      "true, ssl_3_2, CommonAttributes.ОбластьДанныхВспомогательныеДанные",
+      "false, ssl_3_2, CommonAttributes.ОбластьДанныхВспомогательныеДанные"
     }
   )
   void testSSL(ArgumentsAccessor argumentsAccessor) {

--- a/src/test/java/com/github/_1c_syntax/bsl/mdo/CommonCommandTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdo/CommonCommandTest.java
@@ -33,7 +33,9 @@ class CommonCommandTest {
       "true, mdclasses, CommonCommands.ОбщаяКоманда1, _edt",
       "false, mdclasses, CommonCommands.ОбщаяКоманда1",
       "true, ssl_3_1, CommonCommands.ОтправитьПисьмо, _edt",
-      "false, ssl_3_1, CommonCommands.ОтправитьПисьмо"
+      "false, ssl_3_1, CommonCommands.ОтправитьПисьмо",
+      "true, ssl_3_2, CommonCommands.ОтправитьПисьмо, _edt",
+      "false, ssl_3_2, CommonCommands.ОтправитьПисьмо"
     }
   )
   void test(ArgumentsAccessor argumentsAccessor) {

--- a/src/test/java/com/github/_1c_syntax/bsl/mdo/CommonFormTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdo/CommonFormTest.java
@@ -33,7 +33,9 @@ class CommonFormTest {
       "true, mdclasses, CommonForms.Форма, _edt",
       "false, mdclasses, CommonForms.Форма",
       "true, ssl_3_1, CommonForms.Вопрос, _edt",
-      "false, ssl_3_1, CommonForms.Вопрос"
+      "false, ssl_3_1, CommonForms.Вопрос",
+      "true, ssl_3_2, CommonForms.Вопрос, _edt",
+      "false, ssl_3_2, CommonForms.Вопрос"
     }
   )
   void test(ArgumentsAccessor argumentsAccessor) {

--- a/src/test/java/com/github/_1c_syntax/bsl/mdo/CommonModuleTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdo/CommonModuleTest.java
@@ -44,6 +44,8 @@ class CommonModuleTest {
       "false, mdclasses, CommonModules.ПростойОбщийМодуль,, true",
       "true, ssl_3_1, CommonModules.АвтономнаяРабота, _edt, true",
       "false, ssl_3_1, CommonModules.АвтономнаяРабота,, true",
+      "true, ssl_3_2, CommonModules.АвтономнаяРабота, _edt, true",
+      "false, ssl_3_2, CommonModules.АвтономнаяРабота,, true",
     }
   )
   void test(ArgumentsAccessor argumentsAccessor) {

--- a/src/test/java/com/github/_1c_syntax/bsl/mdo/CommonPictureTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdo/CommonPictureTest.java
@@ -33,7 +33,9 @@ class CommonPictureTest {
       "true, mdclasses, CommonPictures.ОбщаяКартинка1",
       "false, mdclasses, CommonPictures.ОбщаяКартинка1",
       "true, ssl_3_1, CommonPictures.GoogleMaps",
-      "false, ssl_3_1, CommonPictures.GoogleMaps"
+      "false, ssl_3_1, CommonPictures.GoogleMaps",
+      "true, ssl_3_2, CommonPictures.GoogleMaps",
+      "false, ssl_3_2, CommonPictures.GoogleMaps"
     }
   )
   void test(ArgumentsAccessor argumentsAccessor) {

--- a/src/test/java/com/github/_1c_syntax/bsl/mdo/CommonTemplateTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdo/CommonTemplateTest.java
@@ -51,7 +51,9 @@ class CommonTemplateTest {
       "true, mdclasses, CommonTemplates.ТекстовыйДокумент",
       "false, mdclasses, CommonTemplates.ТекстовыйДокумент",
       "true, ssl_3_1, CommonTemplates.СтруктураПодчиненности",
-      "false, ssl_3_1, CommonTemplates.СтруктураПодчиненности"
+      "false, ssl_3_1, CommonTemplates.СтруктураПодчиненности",
+      "true, ssl_3_2, CommonTemplates.СтруктураПодчиненности",
+      "false, ssl_3_2, CommonTemplates.СтруктураПодчиненности"
     }
   )
   void test(ArgumentsAccessor argumentsAccessor) {

--- a/src/test/java/com/github/_1c_syntax/bsl/mdo/ConstantTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdo/ConstantTest.java
@@ -33,7 +33,9 @@ class ConstantTest {
       "true, mdclasses, Constants.Константа1, _edt",
       "false, mdclasses, Constants.Константа1",
       "true, ssl_3_1, Constants.ЗаголовокСистемы",
-      "false, ssl_3_1, Constants.ЗаголовокСистемы"
+      "false, ssl_3_1, Constants.ЗаголовокСистемы",
+      "true, ssl_3_2, Constants.ЗаголовокСистемы",
+      "false, ssl_3_2, Constants.ЗаголовокСистемы"
     }
   )
   void test(ArgumentsAccessor argumentsAccessor) {

--- a/src/test/java/com/github/_1c_syntax/bsl/mdo/DataProcessorTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdo/DataProcessorTest.java
@@ -54,7 +54,9 @@ class DataProcessorTest {
   @CsvSource(
     {
       "true, ssl_3_1, DataProcessors.ЗагрузкаКурсовВалют, _edt",
-      "false, ssl_3_1, DataProcessors.ЗагрузкаКурсовВалют"
+      "false, ssl_3_1, DataProcessors.ЗагрузкаКурсовВалют",
+      "true, ssl_3_2, DataProcessors.ЗагрузкаКурсовВалют, _edt",
+      "false, ssl_3_2, DataProcessors.ЗагрузкаКурсовВалют"
     }
   )
   void testSSL(ArgumentsAccessor argumentsAccessor) {

--- a/src/test/java/com/github/_1c_syntax/bsl/mdo/DefinedTypeTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdo/DefinedTypeTest.java
@@ -33,7 +33,9 @@ class DefinedTypeTest {
       "true, mdclasses, DefinedTypes.ОпределяемыйТип1",
       "false, mdclasses, DefinedTypes.ОпределяемыйТип1",
       "true, ssl_3_1, DefinedTypes.ВладелецФайлов",
-      "false, ssl_3_1, DefinedTypes.ВладелецФайлов"
+      "false, ssl_3_1, DefinedTypes.ВладелецФайлов",
+      "true, ssl_3_2, DefinedTypes.ВладелецФайлов",
+      "false, ssl_3_2, DefinedTypes.ВладелецФайлов"
     }
   )
   void test(ArgumentsAccessor argumentsAccessor) {

--- a/src/test/java/com/github/_1c_syntax/bsl/mdo/DocumentJournalTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdo/DocumentJournalTest.java
@@ -33,7 +33,9 @@ class DocumentJournalTest {
       "true, mdclasses, DocumentJournals.ЖурналДокументов1, _edt",
       "false, mdclasses, DocumentJournals.ЖурналДокументов1",
       "true, ssl_3_1, DocumentJournals.Взаимодействия, _edt",
-      "false, ssl_3_1, DocumentJournals.Взаимодействия"
+      "false, ssl_3_1, DocumentJournals.Взаимодействия",
+      "true, ssl_3_2, DocumentJournals.Взаимодействия, _edt",
+      "false, ssl_3_2, DocumentJournals.Взаимодействия"
     }
   )
   void test(ArgumentsAccessor argumentsAccessor) {

--- a/src/test/java/com/github/_1c_syntax/bsl/mdo/DocumentTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdo/DocumentTest.java
@@ -34,7 +34,9 @@ class DocumentTest {
   @CsvSource(
     {
       "true, ssl_3_1, Documents.Анкета, _edt",
-      "false, ssl_3_1, Documents.Анкета"
+      "false, ssl_3_1, Documents.Анкета",
+      "true, ssl_3_2, Documents.Анкета, _edt",
+      "false, ssl_3_2, Documents.Анкета"
     }
   )
   void testSSL(ArgumentsAccessor argumentsAccessor) {

--- a/src/test/java/com/github/_1c_syntax/bsl/mdo/EnumTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdo/EnumTest.java
@@ -37,7 +37,9 @@ class EnumTest {
       "true, mdclasses, Enums.Перечисление1, _edt",
       "false, mdclasses, Enums.Перечисление1",
       "true, ssl_3_1, Enums.СтатусыОбработчиковОбновления, _edt",
-      "false, ssl_3_1, Enums.СтатусыОбработчиковОбновления"
+      "false, ssl_3_1, Enums.СтатусыОбработчиковОбновления",
+      "true, ssl_3_2, Enums.СтатусыОбработчиковОбновления, _edt",
+      "false, ssl_3_2, Enums.СтатусыОбработчиковОбновления"
     }
   )
   void test(ArgumentsAccessor argumentsAccessor) {

--- a/src/test/java/com/github/_1c_syntax/bsl/mdo/EventSubscriptionTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdo/EventSubscriptionTest.java
@@ -33,7 +33,9 @@ class EventSubscriptionTest {
       "true, mdclasses, EventSubscriptions.ПодпискаНаСобытие1",
       "false, mdclasses, EventSubscriptions.ПодпискаНаСобытие1",
       "true, ssl_3_1, EventSubscriptions.ВариантыОтчетовПередУдалениемИдентификатораОбъектаМетаданных",
-      "false, ssl_3_1, EventSubscriptions.ВариантыОтчетовПередУдалениемИдентификатораОбъектаМетаданных"
+      "false, ssl_3_1, EventSubscriptions.ВариантыОтчетовПередУдалениемИдентификатораОбъектаМетаданных",
+      "true, ssl_3_2, EventSubscriptions.ВариантыОтчетовПередУдалениемИдентификатораОбъектаМетаданных",
+      "false, ssl_3_2, EventSubscriptions.ВариантыОтчетовПередУдалениемИдентификатораОбъектаМетаданных"
     }
   )
   void test(ArgumentsAccessor argumentsAccessor) {

--- a/src/test/java/com/github/_1c_syntax/bsl/mdo/ExchangePlanTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdo/ExchangePlanTest.java
@@ -60,12 +60,10 @@ class ExchangePlanTest {
   @CsvSource(
     {
       "true, ssl_3_1, ExchangePlans.ОбновлениеИнформационнойБазы, _edt",
-      "false, ssl_3_1, ExchangePlans.ОбновлениеИнформационнойБазы",
-      "true, ssl_3_2, ExchangePlans.ОбновлениеИнформационнойБазы, _edt",
-      "false, ssl_3_2, ExchangePlans.ОбновлениеИнформационнойБазы"
+      "false, ssl_3_1, ExchangePlans.ОбновлениеИнформационнойБазы"
     }
   )
-  void testSSL(ArgumentsAccessor argumentsAccessor) {
+  void testSSL_3_1(ArgumentsAccessor argumentsAccessor) {
     var mdo = MDTestUtils.getMDWithSimpleTest(argumentsAccessor);
     assertThat(mdo).isInstanceOf(ExchangePlan.class);
 
@@ -83,5 +81,32 @@ class ExchangePlanTest {
     assertThat(exchangePlan.isDistributedInfoBase()).isFalse();
     assertThat(exchangePlan.isIncludeConfigurationExtensions()).isFalse();
     assertThat(exchangePlan.getContent()).hasSize(406);
+  }
+
+  @ParameterizedTest
+  @CsvSource(
+    {
+      "true, ssl_3_2, ExchangePlans.ОбновлениеИнформационнойБазы, _edt",
+      "false, ssl_3_2, ExchangePlans.ОбновлениеИнформационнойБазы"
+    }
+  )
+  void testSSL_3_2(ArgumentsAccessor argumentsAccessor) {
+    var mdo = MDTestUtils.getMDWithSimpleTest(argumentsAccessor);
+    assertThat(mdo).isInstanceOf(ExchangePlan.class);
+
+    var exchangePlan = (ExchangePlan) mdo;
+    var mdo1 = MdoReference.create("InformationRegister.СостоянияРассылокОтчетов");
+    var mdo2 = MdoReference.create("Catalog.ЭлектронноеПисьмоВходящееПрисоединенныеФайлы");
+    var mdo3 = MdoReference.create("Catalog.Справочник1");
+    assertThat(exchangePlan.contains(mdo1)).isTrue();
+    assertThat(exchangePlan.contains(mdo2)).isTrue();
+    assertThat(exchangePlan.contains(mdo3)).isFalse();
+
+    assertThat(exchangePlan.autoRecord(mdo1)).isEqualTo(AutoRecordType.DENY);
+    assertThat(exchangePlan.autoRecord(mdo2)).isEqualTo(AutoRecordType.DENY);
+    assertThat(exchangePlan.autoRecord(mdo3)).isEqualTo(AutoRecordType.DENY);
+    assertThat(exchangePlan.isDistributedInfoBase()).isFalse();
+    assertThat(exchangePlan.isIncludeConfigurationExtensions()).isFalse();
+    assertThat(exchangePlan.getContent()).hasSize(408);
   }
 }

--- a/src/test/java/com/github/_1c_syntax/bsl/mdo/ExchangePlanTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdo/ExchangePlanTest.java
@@ -60,7 +60,9 @@ class ExchangePlanTest {
   @CsvSource(
     {
       "true, ssl_3_1, ExchangePlans.ОбновлениеИнформационнойБазы, _edt",
-      "false, ssl_3_1, ExchangePlans.ОбновлениеИнформационнойБазы"
+      "false, ssl_3_1, ExchangePlans.ОбновлениеИнформационнойБазы",
+      "true, ssl_3_2, ExchangePlans.ОбновлениеИнформационнойБазы, _edt",
+      "false, ssl_3_2, ExchangePlans.ОбновлениеИнформационнойБазы"
     }
   )
   void testSSL(ArgumentsAccessor argumentsAccessor) {

--- a/src/test/java/com/github/_1c_syntax/bsl/mdo/ExchangePlanTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdo/ExchangePlanTest.java
@@ -80,7 +80,7 @@ class ExchangePlanTest {
     assertThat(exchangePlan.autoRecord(mdo3)).isEqualTo(AutoRecordType.DENY);
     assertThat(exchangePlan.isDistributedInfoBase()).isFalse();
     assertThat(exchangePlan.isIncludeConfigurationExtensions()).isFalse();
-    assertThat(exchangePlan.getContent()).hasSize(406);
+    assertThat(exchangePlan.getContent()).hasSize(414);
   }
 
   @ParameterizedTest

--- a/src/test/java/com/github/_1c_syntax/bsl/mdo/FilterCriterionTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdo/FilterCriterionTest.java
@@ -33,7 +33,9 @@ class FilterCriterionTest {
       "true, mdclasses, FilterCriteria.КритерийОтбора1, _edt",
       "false, mdclasses, FilterCriteria.КритерийОтбора1",
       "true, ssl_3_1, FilterCriteria.СвязанныеДокументы, _edt",
-      "false, ssl_3_1, FilterCriteria.СвязанныеДокументы"
+      "false, ssl_3_1, FilterCriteria.СвязанныеДокументы",
+      "true, ssl_3_2, FilterCriteria.СвязанныеДокументы, _edt",
+      "false, ssl_3_2, FilterCriteria.СвязанныеДокументы"
     }
   )
   void test(ArgumentsAccessor argumentsAccessor) {

--- a/src/test/java/com/github/_1c_syntax/bsl/mdo/FunctionalOptionTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdo/FunctionalOptionTest.java
@@ -33,7 +33,9 @@ class FunctionalOptionTest {
       "true, mdclasses, FunctionalOptions.ФункциональнаяОпция1",
       "false, mdclasses, FunctionalOptions.ФункциональнаяОпция1",
       "true, ssl_3_1, FunctionalOptions.ИспользоватьАнкетирование",
-      "false, ssl_3_1, FunctionalOptions.ИспользоватьАнкетирование"
+      "false, ssl_3_1, FunctionalOptions.ИспользоватьАнкетирование",
+      "true, ssl_3_2, FunctionalOptions.ИспользоватьАнкетирование",
+      "false, ssl_3_2, FunctionalOptions.ИспользоватьАнкетирование"
     }
   )
   void test(ArgumentsAccessor argumentsAccessor) {

--- a/src/test/java/com/github/_1c_syntax/bsl/mdo/FunctionalOptionsParameterTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdo/FunctionalOptionsParameterTest.java
@@ -33,7 +33,9 @@ class FunctionalOptionsParameterTest {
       "true, mdclasses, FunctionalOptionsParameters.ПараметрФункциональныхОпций",
       "false, mdclasses, FunctionalOptionsParameters.ПараметрФункциональныхОпций",
       "true, ssl_3_1, FunctionalOptionsParameters.ТипВерсионируемогоОбъекта",
-      "false, ssl_3_1, FunctionalOptionsParameters.ТипВерсионируемогоОбъекта"
+      "false, ssl_3_1, FunctionalOptionsParameters.ТипВерсионируемогоОбъекта",
+      "true, ssl_3_2, FunctionalOptionsParameters.ТипВерсионируемогоОбъекта",
+      "false, ssl_3_2, FunctionalOptionsParameters.ТипВерсионируемогоОбъекта"
     }
   )
   void test(ArgumentsAccessor argumentsAccessor) {

--- a/src/test/java/com/github/_1c_syntax/bsl/mdo/InformationRegisterTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdo/InformationRegisterTest.java
@@ -35,7 +35,11 @@ class InformationRegisterTest {
       "true, ssl_3_1, InformationRegisters.ЭлектронныеПодписи, _edt",
       "false, ssl_3_1, InformationRegisters.ЭлектронныеПодписи",
       "true, ssl_3_1, InformationRegisters.СклоненияПредставленийОбъектов, _edt",
-      "false, ssl_3_1, InformationRegisters.СклоненияПредставленийОбъектов"
+      "false, ssl_3_1, InformationRegisters.СклоненияПредставленийОбъектов",
+      "true, ssl_3_2, InformationRegisters.ЭлектронныеПодписи, _edt",
+      "false, ssl_3_2, InformationRegisters.ЭлектронныеПодписи",
+      "true, ssl_3_2, InformationRegisters.СклоненияПредставленийОбъектов, _edt",
+      "false, ssl_3_2, InformationRegisters.СклоненияПредставленийОбъектов"
     }
   )
   void test(ArgumentsAccessor argumentsAccessor) {

--- a/src/test/java/com/github/_1c_syntax/bsl/mdo/LanguageTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdo/LanguageTest.java
@@ -36,7 +36,8 @@ class LanguageTest {
     {
       "false, mdclasses, Languages.Албанский",
       "false, mdclasses, Languages.Японский",
-      "false, ssl_3_1, Languages.Русский"
+      "false, ssl_3_1, Languages.Русский",
+      "false, ssl_3_2, Languages.Русский"
     }
   )
   void test(ArgumentsAccessor argumentsAccessor) {

--- a/src/test/java/com/github/_1c_syntax/bsl/mdo/ReportTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdo/ReportTest.java
@@ -56,7 +56,9 @@ class ReportTest {
   @CsvSource(
     {
       "true, ssl_3_1, Reports.АнализВерсийОбъектов, _edt",
-      "false, ssl_3_1, Reports.АнализВерсийОбъектов"
+      "false, ssl_3_1, Reports.АнализВерсийОбъектов",
+      "true, ssl_3_2, Reports.АнализВерсийОбъектов, _edt",
+      "false, ssl_3_2, Reports.АнализВерсийОбъектов"
     }
   )
   void testSSL(ArgumentsAccessor argumentsAccessor) {

--- a/src/test/java/com/github/_1c_syntax/bsl/mdo/RoleTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdo/RoleTest.java
@@ -33,7 +33,9 @@ class RoleTest {
   @CsvSource(
     {
       "true, ssl_3_1, Roles.БазовыеПраваБСП",
-      "false, ssl_3_1, Roles.БазовыеПраваБСП"
+      "false, ssl_3_1, Roles.БазовыеПраваБСП",
+      "true, ssl_3_2, Roles.БазовыеПраваБСП",
+      "false, ssl_3_2, Roles.БазовыеПраваБСП"
     }
   )
   void testSimple(ArgumentsAccessor argumentsAccessor) {

--- a/src/test/java/com/github/_1c_syntax/bsl/mdo/ScheduledJobTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdo/ScheduledJobTest.java
@@ -34,6 +34,8 @@ class ScheduledJobTest {
     {
       "true, ssl_3_1, ScheduledJobs.ОбновлениеАгрегатов",
       "false, ssl_3_1, ScheduledJobs.ОбновлениеАгрегатов",
+      "true, ssl_3_2, ScheduledJobs.ОбновлениеАгрегатов",
+      "false, ssl_3_2, ScheduledJobs.ОбновлениеАгрегатов",
     }
   )
   void testSimple(ArgumentsAccessor argumentsAccessor) {

--- a/src/test/java/com/github/_1c_syntax/bsl/mdo/SessionParameterTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdo/SessionParameterTest.java
@@ -33,7 +33,9 @@ class SessionParameterTest {
       "true, mdclasses, SessionParameters.ПараметрСеанса1",
       "false, mdclasses, SessionParameters.ПараметрСеанса1",
       "true, ssl_3_1, SessionParameters.ТекущийПользователь",
-      "false, ssl_3_1, SessionParameters.ТекущийПользователь"
+      "false, ssl_3_1, SessionParameters.ТекущийПользователь",
+      "true, ssl_3_2, SessionParameters.ТекущийПользователь",
+      "false, ssl_3_2, SessionParameters.ТекущийПользователь"
     }
   )
   void test(ArgumentsAccessor argumentsAccessor) {

--- a/src/test/java/com/github/_1c_syntax/bsl/mdo/SettingsStorageTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdo/SettingsStorageTest.java
@@ -31,7 +31,9 @@ class SettingsStorageTest {
   @CsvSource(
     {
       "true, ssl_3_1, SettingsStorages.ХранилищеВариантовОтчетов, _edt",
-      "false, ssl_3_1, SettingsStorages.ХранилищеВариантовОтчетов"
+      "false, ssl_3_1, SettingsStorages.ХранилищеВариантовОтчетов",
+      "true, ssl_3_2, SettingsStorages.ХранилищеВариантовОтчетов, _edt",
+      "false, ssl_3_2, SettingsStorages.ХранилищеВариантовОтчетов"
     }
   )
   void test(ArgumentsAccessor argumentsAccessor) {

--- a/src/test/java/com/github/_1c_syntax/bsl/mdo/StyleItemTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdo/StyleItemTest.java
@@ -35,7 +35,11 @@ class StyleItemTest {
       "true, ssl_3_1, StyleItems.ВажнаяНадписьШрифт",
       "false, ssl_3_1, StyleItems.ВажнаяНадписьШрифт",
       "true, ssl_3_1, StyleItems.ВидДняПроизводственногоКалендаряВоскресеньеЦвет",
-      "false, ssl_3_1, StyleItems.ВидДняПроизводственногоКалендаряВоскресеньеЦвет"
+      "false, ssl_3_1, StyleItems.ВидДняПроизводственногоКалендаряВоскресеньеЦвет",
+      "true, ssl_3_2, StyleItems.ВажнаяНадписьШрифт",
+      "false, ssl_3_2, StyleItems.ВажнаяНадписьШрифт",
+      "true, ssl_3_2, StyleItems.ВидДняПроизводственногоКалендаряВоскресеньеЦвет",
+      "false, ssl_3_2, StyleItems.ВидДняПроизводственногоКалендаряВоскресеньеЦвет"
     }
   )
   void test(ArgumentsAccessor argumentsAccessor) {

--- a/src/test/java/com/github/_1c_syntax/bsl/mdo/SubsystemTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdo/SubsystemTest.java
@@ -96,7 +96,9 @@ class SubsystemTest {
   @CsvSource(
     {
       "true, ssl_3_1, Subsystems.Администрирование",
-      "false, ssl_3_1, Subsystems.Администрирование"
+      "false, ssl_3_1, Subsystems.Администрирование",
+      "true, ssl_3_2, Subsystems.Администрирование",
+      "false, ssl_3_2, Subsystems.Администрирование"
     }
   )
   void testSSLSimple(ArgumentsAccessor argumentsAccessor) {

--- a/src/test/java/com/github/_1c_syntax/bsl/mdo/TasksTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdo/TasksTest.java
@@ -33,7 +33,9 @@ class TasksTest {
       "true, mdclasses, Tasks.Задача1",
       "false, mdclasses, Tasks.Задача1",
       "true, ssl_3_1, Tasks.ЗадачаИсполнителя, _edt",
-      "false, ssl_3_1, Tasks.ЗадачаИсполнителя"
+      "false, ssl_3_1, Tasks.ЗадачаИсполнителя",
+      "true, ssl_3_2, Tasks.ЗадачаИсполнителя, _edt",
+      "false, ssl_3_2, Tasks.ЗадачаИсполнителя"
     }
   )
   void test(ArgumentsAccessor argumentsAccessor) {

--- a/src/test/java/com/github/_1c_syntax/bsl/mdo/WebServiceTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdo/WebServiceTest.java
@@ -37,7 +37,9 @@ class WebServiceTest {
       "true, mdclasses, WebServices.WebСервис1, _edt",
       "false, mdclasses, WebServices.WebСервис1",
       "true, ssl_3_1, WebServices.EnterpriseDataExchange_1_0_1_1, _edt",
-      "false, ssl_3_1, WebServices.EnterpriseDataExchange_1_0_1_1"
+      "false, ssl_3_1, WebServices.EnterpriseDataExchange_1_0_1_1",
+      "true, ssl_3_2, WebServices.EnterpriseDataExchange_1_0_1_1, _edt",
+      "false, ssl_3_2, WebServices.EnterpriseDataExchange_1_0_1_1"
     }
   )
   void test(ArgumentsAccessor argumentsAccessor) {

--- a/src/test/java/com/github/_1c_syntax/bsl/mdo/XDTOPackageTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdo/XDTOPackageTest.java
@@ -33,7 +33,9 @@ class XDTOPackageTest {
   @CsvSource(
     {
       "true, ssl_3_1, XDTOPackages.ApdexExport_1_0_0_4",
-      "false, ssl_3_1, XDTOPackages.ApdexExport_1_0_0_4"
+      "false, ssl_3_1, XDTOPackages.ApdexExport_1_0_0_4",
+      "true, ssl_3_2, XDTOPackages.ApdexExport_1_0_0_4",
+      "false, ssl_3_2, XDTOPackages.ApdexExport_1_0_0_4"
     }
   )
   void testSimple(ArgumentsAccessor argumentsAccessor) {

--- a/src/test/java/com/github/_1c_syntax/bsl/reader/MDOReaderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/reader/MDOReaderTest.java
@@ -45,8 +45,29 @@ class MDOReaderTest {
   }
 
   @Test
+  void testReadConfigurationWithValidPath32() {
+    var path = Paths.get("src/test/resources/ext/edt/ssl_3_2");
+    var configuration = MDOReader.readConfiguration(path);
+
+    assertThat(configuration)
+      .isNotNull()
+      .isInstanceOf(Configuration.class);
+  }
+
+  @Test
   void testReadConfigurationWithSettings() {
     var path = Paths.get("src/test/resources/ext/edt/ssl_3_1");
+    var settings = MDCReadSettings.DEFAULT;
+    var configuration = MDOReader.readConfiguration(path, settings);
+
+    assertThat(configuration)
+      .isNotNull()
+      .isInstanceOf(Configuration.class);
+  }
+
+  @Test
+  void testReadConfigurationWithSettings32() {
+    var path = Paths.get("src/test/resources/ext/edt/ssl_3_2");
     var settings = MDCReadSettings.DEFAULT;
     var configuration = MDOReader.readConfiguration(path, settings);
 
@@ -79,9 +100,32 @@ class MDOReaderTest {
       .isInstanceOf(Configuration.class);
   }
 
+  @ParameterizedTest
+  @ValueSource(strings = {
+    "src/test/resources/ext/edt/ssl_3_2",
+    "src/test/resources/ext/designer/ssl_3_2/src/cf"
+  })
+  void testReadConfigurationDifferentSources32(String pathString) {
+    var path = Paths.get(pathString);
+    var configuration = MDOReader.readConfiguration(path);
+
+    assertThat(configuration)
+      .isNotNull()
+      .isInstanceOf(Configuration.class);
+  }
+
   @Test
   void testReadWithNonExistentObject() {
     var path = Paths.get("src/test/resources/ext/edt/ssl_3_1");
+    var result = MDOReader.read(path, "CommonModules.NonExistent");
+
+    // Should return null for non-existent object
+    assertThat(result).isNull();
+  }
+
+  @Test
+  void testReadWithNonExistentObject32() {
+    var path = Paths.get("src/test/resources/ext/edt/ssl_3_2");
     var result = MDOReader.read(path, "CommonModules.NonExistent");
 
     // Should return null for non-existent object
@@ -126,8 +170,28 @@ class MDOReaderTest {
   }
 
   @Test
+  void testReadConfigurationFromFile32() {
+    var path = Paths.get("src/test/resources/ext/edt/ssl_3_2/configuration/Configuration.mdo");
+    var configuration = MDOReader.readConfiguration(path);
+
+    assertThat(configuration)
+      .isNotNull()
+      .isInstanceOf(Configuration.class);
+  }
+
+  @Test
   void testReadConfigurationFromDesignerFile() {
     var path = Paths.get("src/test/resources/ext/designer/ssl_3_1/src/Configuration/Configuration.xml");
+    var configuration = MDOReader.readConfiguration(path);
+
+    assertThat(configuration)
+      .isNotNull()
+      .isInstanceOf(Configuration.class);
+  }
+
+  @Test
+  void testReadConfigurationFromDesignerFile32() {
+    var path = Paths.get("src/test/resources/ext/designer/ssl_3_2/src/Configuration/Configuration.xml");
     var configuration = MDOReader.readConfiguration(path);
 
     assertThat(configuration)

--- a/src/test/java/com/github/_1c_syntax/bsl/test_utils/MDTestUtils.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/test_utils/MDTestUtils.java
@@ -126,6 +126,24 @@ public class MDTestUtils {
     return xstream.toXML(obj);
   }
 
+  /**
+   * Регенерация fixture JSON для указанного MDO объекта.
+   * Используется для создания/обновленияfixture при изменении fixtures.
+   */
+  public static void regenerateFixture(String examplePackName, String mdoRef, boolean isEdt, String fixturePostfix) throws java.io.IOException {
+    var configurationPath = isEdt
+      ? Path.of(EXAMPLES_PATH, EDT_PATH, examplePackName, EDT_CF_PATH)
+      : Path.of(EXAMPLES_PATH, DESIGNER_PATH, examplePackName, DESIGNER_CF_PATH);
+    var mdo = MDOReader.read(configurationPath, mdoRef, MDCReadSettings.DEFAULT);
+    var json = createJson(mdo);
+    Path fixturePath = fixturePostfix != null && !fixturePostfix.isEmpty()
+      ? Path.of(FIXTURES_PATH, examplePackName, mdoRef + fixturePostfix + ".json")
+      : Path.of(FIXTURES_PATH, examplePackName, mdoRef + ".json");
+    Files.writeString(fixturePath, json, StandardCharsets.UTF_8);
+    System.out.println("Regenerated: " + fixturePath);
+    System.out.println("Size: " + json.length() + " chars, " + json.lines().count() + " lines");
+  }
+
   public MD getMDWithSimpleTest(ArgumentsAccessor argumentsAccessor) {
     var isEDT = argumentsAccessor.getBoolean(0);
     var examplePackName = argumentsAccessor.getString(1);

--- a/src/test/java/com/github/_1c_syntax/bsl/test_utils/MDTestUtils.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/test_utils/MDTestUtils.java
@@ -39,6 +39,7 @@ import io.github.classgraph.ClassGraph;
 import io.github.classgraph.ClassInfo;
 import lombok.SneakyThrows;
 import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.params.aggregator.ArgumentsAccessor;
 import org.objenesis.Objenesis;
 import org.objenesis.ObjenesisStd;
@@ -50,6 +51,7 @@ import java.nio.file.Path;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Slf4j
 @UtilityClass
 public class MDTestUtils {
   private static final String EXAMPLES_PATH = "src/test/resources/ext";
@@ -140,8 +142,8 @@ public class MDTestUtils {
       ? Path.of(FIXTURES_PATH, examplePackName, mdoRef + fixturePostfix + ".json")
       : Path.of(FIXTURES_PATH, examplePackName, mdoRef + ".json");
     Files.writeString(fixturePath, json, StandardCharsets.UTF_8);
-    System.out.println("Regenerated: " + fixturePath);
-    System.out.println("Size: " + json.length() + " chars, " + json.lines().count() + " lines");
+    LOGGER.info("Regenerated: {}", fixturePath);
+    LOGGER.info("Size: {} chars, {} lines", json.length(), json.lines().count());
   }
 
   public MD getMDWithSimpleTest(ArgumentsAccessor argumentsAccessor) {

--- a/src/test/resources/fixtures/ssl_3_1/Catalogs.ВерсииФайлов.json
+++ b/src/test/resources/fixtures/ssl_3_1/Catalogs.ВерсииФайлов.json
@@ -1408,6 +1408,125 @@
         "multiLine": false,
         "extendedEdit": false,
         "fillFromFillingValue": false
+      },
+      {
+        "uuid": "d970abc7-4437-4fc4-87d1-bab2ddde8884",
+        "name": "ДатаПереносаВАрхив",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.Attribute.ДатаПереносаВАрхив",
+          "mdoRefRu": "Справочник.ВерсииФайлов.Реквизит.ДатаПереносаВАрхив"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Дата переноса в архив"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "DATE"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.DateQualifiers": {
+                "dateFractions": 1,
+                "description": {
+                  "value": {
+                    "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                    "nameRu": "КвалификаторыДаты (Дата)",
+                    "nameEn": "DateQualifiers (Date)"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "ee83328e-91d2-4022-b1d3-d7d137098ee9",
+        "name": "УсловноПеренесенВАрхив",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.Attribute.УсловноПеренесенВАрхив",
+          "mdoRefRu": "Справочник.ВерсииФайлов.Реквизит.УсловноПеренесенВАрхив"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Условно перенесен в архив"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[2]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
       }
     ],
     []
@@ -2369,6 +2488,27 @@
               "dataPath": "Список",
               "items": [
                 [
+                  {
+                    "type": "PICTURE_FIELD",
+                    "id": 127,
+                    "name": "СписокНомерКартинкиЭтоАрхив",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "В архиве"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "Список.НомерКартинкиЭтоАрхив",
+                    "items": []
+                  },
                   {
                     "type": "COLUMN_GROUP",
                     "id": 114,

--- a/src/test/resources/fixtures/ssl_3_1/Catalogs.ВерсииФайлов_edt.json
+++ b/src/test/resources/fixtures/ssl_3_1/Catalogs.ВерсииФайлов_edt.json
@@ -1408,6 +1408,125 @@
         "multiLine": false,
         "extendedEdit": false,
         "fillFromFillingValue": false
+      },
+      {
+        "uuid": "d970abc7-4437-4fc4-87d1-bab2ddde8884",
+        "name": "ДатаПереносаВАрхив",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.Attribute.ДатаПереносаВАрхив",
+          "mdoRefRu": "Справочник.ВерсииФайлов.Реквизит.ДатаПереносаВАрхив"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Дата переноса в архив"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "DATE"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.DateQualifiers": {
+                "dateFractions": 1,
+                "description": {
+                  "value": {
+                    "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                    "nameRu": "КвалификаторыДаты (Дата)",
+                    "nameEn": "DateQualifiers (Date)"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "ee83328e-91d2-4022-b1d3-d7d137098ee9",
+        "name": "УсловноПеренесенВАрхив",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.Attribute.УсловноПеренесенВАрхив",
+          "mdoRefRu": "Справочник.ВерсииФайлов.Реквизит.УсловноПеренесенВАрхив"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Условно перенесен в архив"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[2]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
       }
     ],
     []
@@ -2369,6 +2488,27 @@
               "dataPath": "Список",
               "items": [
                 [
+                  {
+                    "type": "PICTURE_FIELD",
+                    "id": 127,
+                    "name": "СписокНомерКартинкиЭтоАрхив",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "В архиве"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "Список.НомерКартинкиЭтоАрхив",
+                    "items": []
+                  },
                   {
                     "type": "COLUMN_GROUP",
                     "id": 114,

--- a/src/test/resources/fixtures/ssl_3_1/ExchangePlans.ОбновлениеИнформационнойБазы.json
+++ b/src/test/resources/fixtures/ssl_3_1/ExchangePlans.ОбновлениеИнформационнойБазы.json
@@ -582,6 +582,14 @@
       },
       {
         "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.МестаХраненияДвоичныхДанных",
+          "mdoRefRu": "РегистрСведений.МестаХраненияДвоичныхДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
           "type": "CATALOG",
           "mdoRef": "Catalog.ШаблоныАнкет",
           "mdoRefRu": "Справочник.ШаблоныАнкет"
@@ -1206,6 +1214,14 @@
       },
       {
         "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.НастройкиОтправкиВГосключ",
+          "mdoRefRu": "Справочник.НастройкиОтправкиВГосключ"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
           "type": "INFORMATION_REGISTER",
           "mdoRef": "InformationRegister.РазрешенияНаИспользованиеВнешнихРесурсов",
           "mdoRefRu": "РегистрСведений.РазрешенияНаИспользованиеВнешнихРесурсов"
@@ -1217,6 +1233,22 @@
           "type": "INFORMATION_REGISTER",
           "mdoRef": "InformationRegister.НастройкиСинхронизацииФайлов",
           "mdoRefRu": "РегистрСведений.НастройкиСинхронизацииФайлов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ИсторияРезервногоКопированияВстроенногоХранилищаДвоичныхДанных",
+          "mdoRefRu": "РегистрСведений.ИсторияРезервногоКопированияВстроенногоХранилищаДвоичныхДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.НастройкиРаботыСФайловымАрхивом",
+          "mdoRefRu": "РегистрСведений.НастройкиРаботыСФайловымАрхивом"
         },
         "allow": false
       },
@@ -2078,6 +2110,14 @@
       },
       {
         "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьГосключ",
+          "mdoRefRu": "Константа.ИспользоватьГосключ"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
           "type": "INFORMATION_REGISTER",
           "mdoRef": "InformationRegister.СклоненияПредставленийОбъектов",
           "mdoRefRu": "РегистрСведений.СклоненияПредставленийОбъектов"
@@ -2886,6 +2926,14 @@
       },
       {
         "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.КвартирыОфисыПомещения",
+          "mdoRefRu": "РегистрСведений.КвартирыОфисыПомещения"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
           "type": "CATALOG",
           "mdoRef": "Catalog.НастройкиТранспортаСообщенийОбмена",
           "mdoRefRu": "Справочник.НастройкиТранспортаСообщенийОбмена"
@@ -2897,6 +2945,14 @@
           "type": "CATALOG",
           "mdoRef": "Catalog.ЗначенияСвойствОбъектов",
           "mdoRefRu": "Справочник.ЗначенияСвойствОбъектов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ОбщиеНастройкиАвторизацииИнтернетСервисов",
+          "mdoRefRu": "Справочник.ОбщиеНастройкиАвторизацииИнтернетСервисов"
         },
         "allow": false
       },
@@ -3641,6 +3697,14 @@
           "type": "INFORMATION_REGISTER",
           "mdoRef": "InformationRegister.КонтактыВзаимодействий",
           "mdoRefRu": "РегистрСведений.КонтактыВзаимодействий"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СведенияОХраненииДедуплицированныхФайлов",
+          "mdoRefRu": "РегистрСведений.СведенияОХраненииДедуплицированныхФайлов"
         },
         "allow": false
       },

--- a/src/test/resources/fixtures/ssl_3_1/ExchangePlans.ОбновлениеИнформационнойБазы_edt.json
+++ b/src/test/resources/fixtures/ssl_3_1/ExchangePlans.ОбновлениеИнформационнойБазы_edt.json
@@ -582,6 +582,14 @@
       },
       {
         "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.МестаХраненияДвоичныхДанных",
+          "mdoRefRu": "РегистрСведений.МестаХраненияДвоичныхДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
           "type": "CATALOG",
           "mdoRef": "Catalog.ШаблоныАнкет",
           "mdoRefRu": "Справочник.ШаблоныАнкет"
@@ -1206,6 +1214,14 @@
       },
       {
         "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.НастройкиОтправкиВГосключ",
+          "mdoRefRu": "Справочник.НастройкиОтправкиВГосключ"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
           "type": "INFORMATION_REGISTER",
           "mdoRef": "InformationRegister.РазрешенияНаИспользованиеВнешнихРесурсов",
           "mdoRefRu": "РегистрСведений.РазрешенияНаИспользованиеВнешнихРесурсов"
@@ -1217,6 +1233,22 @@
           "type": "INFORMATION_REGISTER",
           "mdoRef": "InformationRegister.НастройкиСинхронизацииФайлов",
           "mdoRefRu": "РегистрСведений.НастройкиСинхронизацииФайлов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ИсторияРезервногоКопированияВстроенногоХранилищаДвоичныхДанных",
+          "mdoRefRu": "РегистрСведений.ИсторияРезервногоКопированияВстроенногоХранилищаДвоичныхДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.НастройкиРаботыСФайловымАрхивом",
+          "mdoRefRu": "РегистрСведений.НастройкиРаботыСФайловымАрхивом"
         },
         "allow": false
       },
@@ -2078,6 +2110,14 @@
       },
       {
         "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьГосключ",
+          "mdoRefRu": "Константа.ИспользоватьГосключ"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
           "type": "INFORMATION_REGISTER",
           "mdoRef": "InformationRegister.СклоненияПредставленийОбъектов",
           "mdoRefRu": "РегистрСведений.СклоненияПредставленийОбъектов"
@@ -2886,6 +2926,14 @@
       },
       {
         "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.КвартирыОфисыПомещения",
+          "mdoRefRu": "РегистрСведений.КвартирыОфисыПомещения"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
           "type": "CATALOG",
           "mdoRef": "Catalog.НастройкиТранспортаСообщенийОбмена",
           "mdoRefRu": "Справочник.НастройкиТранспортаСообщенийОбмена"
@@ -2897,6 +2945,14 @@
           "type": "CATALOG",
           "mdoRef": "Catalog.ЗначенияСвойствОбъектов",
           "mdoRefRu": "Справочник.ЗначенияСвойствОбъектов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ОбщиеНастройкиАвторизацииИнтернетСервисов",
+          "mdoRefRu": "Справочник.ОбщиеНастройкиАвторизацииИнтернетСервисов"
         },
         "allow": false
       },
@@ -3641,6 +3697,14 @@
           "type": "INFORMATION_REGISTER",
           "mdoRef": "InformationRegister.КонтактыВзаимодействий",
           "mdoRefRu": "РегистрСведений.КонтактыВзаимодействий"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СведенияОХраненииДедуплицированныхФайлов",
+          "mdoRefRu": "РегистрСведений.СведенияОХраненииДедуплицированныхФайлов"
         },
         "allow": false
       },

--- a/src/test/resources/fixtures/ssl_3_1/Roles.БазовыеПраваБСП.json
+++ b/src/test/resources/fixtures/ssl_3_1/Roles.БазовыеПраваБСП.json
@@ -428,24 +428,6 @@
         },
         {
           "name": {
-            "type": "INFORMATION_REGISTER",
-            "mdoRef": "InformationRegister.ЗаявленияНаВыпускСертификата",
-            "mdoRefRu": "РегистрСведений.ЗаявленияНаВыпускСертификата"
-          },
-          "rights": [
-            [
-              {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
-              },
-              {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
-              }
-            ],
-            []
-          ]
-        },
-        {
-          "name": {
             "type": "CATALOG",
             "mdoRef": "Catalog.ВнешниеКомпоненты",
             "mdoRefRu": "Справочник.ВнешниеКомпоненты"
@@ -771,6 +753,24 @@
         },
         {
           "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ТекстИнформированияПользователяОНедоступностиФайлаВАрхиве",
+            "mdoRefRu": "Константа.ТекстИнформированияПользователяОНедоступностиФайлаВАрхиве"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
             "type": "INFORMATION_REGISTER",
             "mdoRef": "InformationRegister.ИерархияГруппПользователей",
             "mdoRefRu": "РегистрСведений.ИерархияГруппПользователей"
@@ -792,6 +792,24 @@
             "type": "CONSTANT",
             "mdoRef": "Constant.ИспользоватьПризнакРассмотрено",
             "mdoRefRu": "Константа.ИспользоватьПризнакРассмотрено"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "INFORMATION_REGISTER",
+            "mdoRef": "InformationRegister.СервисМобильнойПодписиСтатусы",
+            "mdoRefRu": "РегистрСведений.СервисМобильнойПодписиСтатусы"
           },
           "rights": [
             [
@@ -899,6 +917,27 @@
             {
               "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
             }
+          ]
+        },
+        {
+          "name": {
+            "type": "CATALOG",
+            "mdoRef": "Catalog.НастройкиОтправкиВГосключ",
+            "mdoRefRu": "Справочник.НастройкиОтправкиВГосключ"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[13]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
+              }
+            ],
+            []
           ]
         },
         {
@@ -1315,7 +1354,7 @@
           "rights": [
             [
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[32]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
@@ -1333,7 +1372,7 @@
           "rights": [
             [
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[32]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
@@ -1484,24 +1523,6 @@
             [
               {
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
-              },
-              {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
-              }
-            ],
-            []
-          ]
-        },
-        {
-          "name": {
-            "type": "DATA_PROCESSOR",
-            "mdoRef": "DataProcessor.ЗаявлениеНаВыпускНовогоКвалифицированногоСертификата",
-            "mdoRefRu": "Обработка.ЗаявлениеНаВыпускНовогоКвалифицированногоСертификата"
-          },
-          "rights": [
-            [
-              {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
@@ -1672,6 +1693,42 @@
         },
         {
           "name": {
+            "type": "CONFIGURATION",
+            "mdoRef": "Configuration.БиблиотекаСтандартныхПодсистем",
+            "mdoRefRu": "Конфигурация.БиблиотекаСтандартныхПодсистем"
+          },
+          "rights": [
+            [
+              {
+                "name": "MAIN_WINDOW_MODE_NORMAL",
+                "value": true
+              },
+              {
+                "name": "MAIN_WINDOW_MODE_WORKPLACE",
+                "value": true
+              },
+              {
+                "name": "MAIN_WINDOW_MODE_EMBEDDED_WORKPLACE",
+                "value": true
+              },
+              {
+                "name": "MAIN_WINDOW_MODE_FULLSCREEN_WORKPLACE",
+                "value": true
+              },
+              {
+                "name": "MAIN_WINDOW_MODE_KIOSK",
+                "value": true
+              },
+              {
+                "name": "ANALYTICS_SYSTEM_CLIENT",
+                "value": true
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
             "type": "CONSTANT",
             "mdoRef": "Constant.ОсновнойЯзык",
             "mdoRefRu": "Константа.ОсновнойЯзык"
@@ -1697,7 +1754,7 @@
           "rights": [
             [
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[32]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
@@ -1740,7 +1797,7 @@
                 "value": true
               },
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[99]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[2]"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[100]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[2]"
               },
               {
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
@@ -1892,7 +1949,7 @@
           },
           "rights": [
             {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[32]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
             }
           ]
         },
@@ -1923,7 +1980,7 @@
           "rights": [
             [
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[32]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
@@ -1959,7 +2016,7 @@
           "rights": [
             [
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[32]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
@@ -2007,7 +2064,7 @@
           "rights": [
             [
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[32]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
@@ -2037,7 +2094,7 @@
           "rights": [
             [
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[32]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
@@ -2148,7 +2205,7 @@
           "rights": [
             [
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[32]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
@@ -2285,6 +2342,18 @@
         },
         {
           "name": {
+            "type": "COMMAND",
+            "mdoRef": "Catalog.ПодписантыСервисаМобильнойПодписи.Command.ПодписантыСервисаМобильнойПодписи",
+            "mdoRefRu": "Справочник.ПодписантыСервисаМобильнойПодписи.Команда.ПодписантыСервисаМобильнойПодписи"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
             "type": "CONSTANT",
             "mdoRef": "Constant.ИспользоватьКомандуЗаметки",
             "mdoRefRu": "Константа.ИспользоватьКомандуЗаметки"
@@ -2296,27 +2365,6 @@
               },
               {
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
-              }
-            ],
-            []
-          ]
-        },
-        {
-          "name": {
-            "type": "CATALOG",
-            "mdoRef": "Catalog.СертификатыКлючейЭлектроннойПодписиИШифрования",
-            "mdoRefRu": "Справочник.СертификатыКлючейЭлектроннойПодписиИШифрования"
-          },
-          "rights": [
-            [
-              {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
-              },
-              {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
-              },
-              {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[13]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
               }
             ],
             []
@@ -2871,7 +2919,7 @@
           "rights": [
             [
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[32]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
@@ -2952,7 +3000,7 @@
           "rights": [
             [
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[32]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
@@ -3076,24 +3124,6 @@
             [
               {
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
-              },
-              {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
-              }
-            ],
-            []
-          ]
-        },
-        {
-          "name": {
-            "type": "REPORT",
-            "mdoRef": "Report.СертификатыЭлектроннойПодписи",
-            "mdoRefRu": "Отчет.СертификатыЭлектроннойПодписи"
-          },
-          "rights": [
-            [
-              {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
@@ -3380,35 +3410,17 @@
         },
         {
           "name": {
-            "type": "CONFIGURATION",
-            "mdoRef": "Configuration.БиблиотекаСтандартныхПодсистем",
-            "mdoRefRu": "Конфигурация.БиблиотекаСтандартныхПодсистем"
+            "type": "CONSTANT",
+            "mdoRef": "Constant.НастройкаПодчиненногоУзлаРИБЗавершена",
+            "mdoRefRu": "Константа.НастройкаПодчиненногоУзлаРИБЗавершена"
           },
           "rights": [
             [
               {
-                "name": "MAIN_WINDOW_MODE_NORMAL",
-                "value": true
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
-                "name": "MAIN_WINDOW_MODE_WORKPLACE",
-                "value": true
-              },
-              {
-                "name": "MAIN_WINDOW_MODE_EMBEDDED_WORKPLACE",
-                "value": true
-              },
-              {
-                "name": "MAIN_WINDOW_MODE_FULLSCREEN_WORKPLACE",
-                "value": true
-              },
-              {
-                "name": "MAIN_WINDOW_MODE_KIOSK",
-                "value": true
-              },
-              {
-                "name": "ANALYTICS_SYSTEM_CLIENT",
-                "value": true
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               }
             ],
             []
@@ -3416,9 +3428,9 @@
         },
         {
           "name": {
-            "type": "CONSTANT",
-            "mdoRef": "Constant.НастройкаПодчиненногоУзлаРИБЗавершена",
-            "mdoRefRu": "Константа.НастройкаПодчиненногоУзлаРИБЗавершена"
+            "type": "INFORMATION_REGISTER",
+            "mdoRef": "InformationRegister.КвартирыОфисыПомещения",
+            "mdoRefRu": "РегистрСведений.КвартирыОфисыПомещения"
           },
           "rights": [
             [
@@ -3588,7 +3600,7 @@
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[99]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[2]"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[100]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[2]"
               }
             ],
             []
@@ -3816,7 +3828,7 @@
           "rights": [
             [
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[32]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
@@ -3936,7 +3948,7 @@
           "rights": [
             [
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[32]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
@@ -4152,7 +4164,7 @@
           "rights": [
             [
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[32]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
@@ -4299,7 +4311,7 @@
           "rights": [
             [
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[32]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
@@ -4539,7 +4551,7 @@
           "rights": [
             [
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[32]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
@@ -4617,7 +4629,7 @@
           "rights": [
             [
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[32]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
@@ -4635,7 +4647,7 @@
           "rights": [
             [
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[32]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
@@ -4689,7 +4701,7 @@
           "rights": [
             [
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[32]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"

--- a/src/test/resources/fixtures/ssl_3_2/BusinessProcesses.Задание.json
+++ b/src/test/resources/fixtures/ssl_3_2/BusinessProcesses.Задание.json
@@ -1875,12 +1875,12 @@
   "forms": [
     [
       {
-        "uuid": "f0620d5a-e1fe-419f-af37-e0f462f97e8d",
-        "name": "ДействиеВыполнить",
+        "uuid": "3e2f2ae1-c809-43fc-8276-b0a16a92858c",
+        "name": "ДействиеПроверить",
         "mdoReference": {
           "type": "FORM",
-          "mdoRef": "BusinessProcess.Задание.Form.ДействиеВыполнить",
-          "mdoRefRu": "БизнесПроцесс.Задание.Форма.ДействиеВыполнить"
+          "mdoRef": "BusinessProcess.Задание.Form.ДействиеПроверить",
+          "mdoRefRu": "БизнесПроцесс.Задание.Форма.ДействиеПроверить"
         },
         "objectBelonging": "OWN",
         "comment": "",
@@ -1893,7 +1893,7 @@
               "int": 1,
               "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                 "langKey": "ru",
-                "value": "Действие выполнить"
+                "value": "Действие проверить"
               }
             }
           ]
@@ -1902,7 +1902,7 @@
         "modules": [
           {
             "moduleType": "FormModule",
-            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/BusinessProcesses/Задание/Forms/Де_ствиеВыполнить/Ext/Form/Module.bsl",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/BusinessProcesses/Задание/Forms/Де_ствиеПроверить/Ext/Form/Module.bsl",
             "owner": {
               "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/mdoReference"
             },
@@ -1946,537 +1946,374 @@
             []
           ],
           "items": [
-            {
-              "type": "USUAL_GROUP",
-              "id": 207,
-              "name": "Документ",
-              "title": {
-                "content": [
-                  {
-                    "default": {
-                      "tag": 2
-                    },
-                    "int": 1,
-                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                      "langKey": "ru",
-                      "value": "Документ"
-                    }
-                  }
-                ]
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 134,
+                "name": "ГруппаСостояние",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[15]/synonym"
+                },
+                "dataPath": "",
+                "items": []
               },
-              "dataPath": "",
-              "items": [
-                [
-                  {
-                    "type": "USUAL_GROUP",
-                    "id": 154,
-                    "name": "Шапка",
-                    "title": {
-                      "content": [
-                        {
-                          "default": {
-                            "tag": 2
-                          },
-                          "int": 1,
-                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                            "langKey": "ru",
-                            "value": "Шапка"
+              {
+                "type": "PAGES",
+                "id": 259,
+                "name": "Страницы",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Страницы"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "PAGE",
+                      "id": 267,
+                      "name": "СтраницаОписаниеЗадачи",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Описание задачи"
+                            }
                           }
-                        }
-                      ]
-                    },
-                    "dataPath": "",
-                    "items": [
-                      [
-                        {
-                          "type": "USUAL_GROUP",
-                          "id": 165,
-                          "name": "ГруппыШапки",
-                          "title": {
-                            "content": [
-                              {
-                                "default": {
-                                  "tag": 2
-                                },
-                                "int": 1,
-                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                  "langKey": "ru",
-                                  "value": "Группы шапки"
-                                }
-                              }
-                            ]
-                          },
-                          "dataPath": "",
-                          "items": [
-                            [
-                              {
-                                "type": "USUAL_GROUP",
-                                "id": 160,
-                                "name": "ГруппаАвторИсполнитель",
-                                "title": {
-                                  "content": [
-                                    {
-                                      "default": {
-                                        "tag": 2
-                                      },
-                                      "int": 1,
-                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                        "langKey": "ru",
-                                        "value": "Автор исполнитель"
-                                      }
-                                    }
-                                  ]
-                                },
-                                "dataPath": "",
-                                "items": [
-                                  [
-                                    {
-                                      "type": "INPUT_FIELD",
-                                      "id": 161,
-                                      "name": "Автор",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                      },
-                                      "dataPath": "Объект.Автор",
-                                      "items": []
-                                    },
-                                    {
-                                      "type": "INPUT_FIELD",
-                                      "id": 163,
-                                      "name": "Исполнитель",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[6]/synonym"
-                                      },
-                                      "dataPath": "Исполнитель",
-                                      "items": []
-                                    }
-                                  ],
-                                  []
-                                ]
-                              },
-                              {
-                                "type": "USUAL_GROUP",
-                                "id": 109,
-                                "name": "ГруппаДатаИСрок",
-                                "title": {
-                                  "content": [
-                                    {
-                                      "default": {
-                                        "tag": 2
-                                      },
-                                      "int": 1,
-                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                        "langKey": "ru",
-                                        "value": "Дата и срок"
-                                      }
-                                    }
-                                  ]
-                                },
-                                "dataPath": "",
-                                "items": [
-                                  [
-                                    {
-                                      "type": "INPUT_FIELD",
-                                      "id": 152,
-                                      "name": "Дата",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                      },
-                                      "dataPath": "Объект.Date",
-                                      "items": []
-                                    },
-                                    {
-                                      "type": "INPUT_FIELD",
-                                      "id": 12,
-                                      "name": "СрокИсполнения",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                      },
-                                      "dataPath": "Объект.СрокИсполнения",
-                                      "items": []
-                                    }
-                                  ],
-                                  []
-                                ]
-                              },
-                              {
-                                "type": "USUAL_GROUP",
-                                "id": 28,
-                                "name": "ГруппаНомерИВажность",
-                                "title": {
-                                  "content": [
-                                    {
-                                      "default": {
-                                        "tag": 2
-                                      },
-                                      "int": 1,
-                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                        "langKey": "ru",
-                                        "value": "Номер и важность"
-                                      }
-                                    }
-                                  ]
-                                },
-                                "dataPath": "",
-                                "items": [
-                                  [
-                                    {
-                                      "type": "INPUT_FIELD",
-                                      "id": 149,
-                                      "name": "Номер",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                      },
-                                      "dataPath": "Объект.Number",
-                                      "items": []
-                                    },
-                                    {
-                                      "type": "INPUT_FIELD",
-                                      "id": 16,
-                                      "name": "Важность",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                      },
-                                      "dataPath": "Объект.Важность",
-                                      "items": []
-                                    }
-                                  ],
-                                  []
-                                ]
-                              }
-                            ],
-                            []
-                          ]
-                        },
-                        {
-                          "type": "USUAL_GROUP",
-                          "id": 155,
-                          "name": "ГруппаПриоритет",
-                          "title": {
-                            "content": [
-                              {
-                                "default": {
-                                  "tag": 2
-                                },
-                                "int": 1,
-                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                  "langKey": "ru",
-                                  "value": "Приоритет"
-                                }
-                              }
-                            ]
-                          },
-                          "dataPath": "",
-                          "items": [
-                            [
-                              {
-                                "type": "INPUT_FIELD",
-                                "id": 119,
-                                "name": "СрокНачалаИсполнения",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                },
-                                "dataPath": "Объект.ДатаНачала",
-                                "items": []
-                              },
-                              {
-                                "type": "INPUT_FIELD",
-                                "id": 135,
-                                "name": "СрокНачалаИсполненияВремя",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                },
-                                "dataPath": "Объект.ДатаНачала",
-                                "items": []
-                              }
-                            ],
-                            []
-                          ]
-                        }
-                      ],
-                      []
-                    ]
-                  },
-                  {
-                    "type": "PAGES",
-                    "id": 201,
-                    "name": "Страницы",
-                    "title": {
-                      "content": [
-                        {
-                          "default": {
-                            "tag": 2
-                          },
-                          "int": 1,
-                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                            "langKey": "ru",
-                            "value": "Страницы"
-                          }
-                        }
-                      ]
-                    },
-                    "dataPath": "",
-                    "items": [
-                      [
-                        {
-                          "type": "PAGE",
-                          "id": 203,
-                          "name": "Главное",
-                          "title": {
-                            "content": [
-                              {
-                                "default": {
-                                  "tag": 2
-                                },
-                                "int": 1,
-                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                  "langKey": "ru",
-                                  "value": "Главное"
-                                }
-                              }
-                            ]
-                          },
-                          "dataPath": "",
-                          "items": [
-                            {
-                              "type": "USUAL_GROUP",
-                              "id": 94,
-                              "name": "ГруппаСодержание",
-                              "title": {
-                                "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[14]/synonym"
-                              },
-                              "dataPath": "",
-                              "items": [
-                                [
-                                  {
-                                    "type": "INPUT_FIELD",
-                                    "id": 156,
-                                    "name": "Наименование",
-                                    "title": {
-                                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                    },
-                                    "dataPath": "Объект.Description",
-                                    "items": []
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 269,
+                            "name": "ГруппаНаименованиеИНомер",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
                                   },
-                                  {
-                                    "type": "LABEL_FIELD",
-                                    "id": 129,
-                                    "name": "Предмет",
-                                    "title": {
-                                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[11]/synonym"
-                                    },
-                                    "dataPath": "ПредметСтрокой",
-                                    "items": []
-                                  },
-                                  {
-                                    "type": "INPUT_FIELD",
-                                    "id": 18,
-                                    "name": "Содержание",
-                                    "title": {
-                                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[14]/synonym"
-                                    },
-                                    "dataPath": "ЗаданиеСодержание",
-                                    "items": []
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Наименование и номер"
                                   }
-                                ],
-                                []
-                              ]
-                            }
-                          ]
-                        },
-                        {
-                          "type": "PAGE",
-                          "id": 205,
-                          "name": "ИсторияВыполнения",
-                          "title": {
-                            "content": [
-                              {
-                                "default": {
-                                  "tag": 2
-                                },
-                                "int": 1,
-                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                  "langKey": "ru",
-                                  "value": "История выполнения"
                                 }
-                              }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 159,
+                                  "name": "Наименование",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                  },
+                                  "dataPath": "Объект.Description",
+                                  "items": []
+                                },
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 178,
+                                  "name": "Номер",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                  },
+                                  "dataPath": "Объект.Number",
+                                  "items": []
+                                }
+                              ],
+                              []
                             ]
                           },
-                          "dataPath": "",
-                          "items": [
-                            {
-                              "type": "INPUT_FIELD",
-                              "id": 126,
-                              "name": "РезультатВыполнения",
-                              "title": {
-                                "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                              },
-                              "dataPath": "ЗаданиеРезультатВыполнения",
-                              "items": []
-                            }
-                          ]
-                        }
-                      ],
-                      []
-                    ]
-                  },
-                  {
-                    "type": "USUAL_GROUP",
-                    "id": 131,
-                    "name": "ГруппаСостояние",
-                    "title": {
-                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[15]/synonym"
-                    },
-                    "dataPath": "",
-                    "items": []
-                  },
-                  {
-                    "type": "USUAL_GROUP",
-                    "id": 27,
-                    "name": "ГруппаРезультат",
-                    "title": {
-                      "content": [
-                        {
-                          "default": {
-                            "tag": 2
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 18,
+                            "name": "Содержание",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[14]/synonym"
+                            },
+                            "dataPath": "ЗаданиеСодержание",
+                            "items": []
                           },
-                          "int": 1,
-                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                            "langKey": "ru",
-                            "value": "Результат выполнения задания:"
+                          {
+                            "type": "LABEL_FIELD",
+                            "id": 132,
+                            "name": "Предмет",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[11]/synonym"
+                            },
+                            "dataPath": "ПредметСтрокой",
+                            "items": []
+                          },
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 273,
+                            "name": "ГруппаПараметрыЗадачи",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Параметры задачи"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "USUAL_GROUP",
+                                  "id": 265,
+                                  "name": "ГруппаИсполнитель",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[6]/synonym"
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "INPUT_FIELD",
+                                        "id": 180,
+                                        "name": "Важность",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                        },
+                                        "dataPath": "Объект.Важность",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "LABEL_FIELD",
+                                        "id": 175,
+                                        "name": "СрокИсполнения",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                        },
+                                        "dataPath": "Объект.СрокИсполнения",
+                                        "items": []
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                },
+                                {
+                                  "type": "USUAL_GROUP",
+                                  "id": 271,
+                                  "name": "ГруппаПраво",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Право"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "LABEL_FIELD",
+                                        "id": 170,
+                                        "name": "Исполнитель",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[12]/synonym"
+                                        },
+                                        "dataPath": "Исполнитель",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "LABEL_FIELD",
+                                        "id": 168,
+                                        "name": "Автор",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                        },
+                                        "dataPath": "Объект.Автор",
+                                        "items": []
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                }
+                              ],
+                              []
+                            ]
                           }
-                        }
+                        ],
+                        []
                       ]
                     },
-                    "dataPath": "",
-                    "items": [
-                      [
-                        {
-                          "type": "INPUT_FIELD",
-                          "id": 78,
-                          "name": "ОписаниеРезультата",
-                          "title": {
-                            "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                    {
+                      "type": "PAGE",
+                      "id": 263,
+                      "name": "СтраницаРезультатВыполнения",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Результат"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 78,
+                            "name": "ОписаниеРезультата",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                            },
+                            "dataPath": "Объект.РезультатВыполнения",
+                            "items": []
                           },
-                          "dataPath": "Объект.РезультатВыполнения",
-                          "items": []
-                        },
-                        {
-                          "type": "USUAL_GROUP",
-                          "id": 54,
-                          "name": "ГруппаВыполненоДата",
-                          "title": {
-                            "content": [
-                              {
-                                "default": {
-                                  "tag": 2
-                                },
-                                "int": 1,
-                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                  "langKey": "ru",
-                                  "value": "Выполнено дата"
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 275,
+                            "name": "ГруппаДатыИсполнения",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Даты исполнения"
+                                  }
                                 }
-                              }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 55,
+                                  "name": "ДатаИсполнения",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Дата проверки"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "Объект.ДатаИсполнения",
+                                  "items": []
+                                },
+                                {
+                                  "type": "LABEL_FIELD",
+                                  "id": 183,
+                                  "name": "СрокНачалаИсполнения",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                  },
+                                  "dataPath": "Объект.ДатаНачала",
+                                  "items": []
+                                }
+                              ],
+                              []
                             ]
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "PAGE",
+                      "id": 226,
+                      "name": "ИсторияВыполнения",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "История выполнения"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 126,
+                            "name": "РезультатВыполнения",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                            },
+                            "dataPath": "ЗаданиеРезультатВыполнения",
+                            "items": []
                           },
-                          "dataPath": "",
-                          "items": [
-                            [
-                              {
-                                "type": "USUAL_BUTTON",
-                                "id": 123,
-                                "name": "Выполнено",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[3]/synonym"
-                                },
-                                "dataPath": "",
-                                "items": []
-                              },
-                              {
-                                "type": "USUAL_BUTTON",
-                                "id": 137,
-                                "name": "Отклонено",
-                                "title": {
-                                  "content": [
-                                    {
-                                      "default": {
-                                        "tag": 2
-                                      },
-                                      "int": 1,
-                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                        "langKey": "ru",
-                                        "value": "Отменено"
-                                      }
-                                    }
-                                  ]
-                                },
-                                "dataPath": "",
-                                "items": []
-                              },
-                              {
-                                "type": "INPUT_FIELD",
-                                "id": 55,
-                                "name": "ДатаИсполнения",
-                                "title": {
-                                  "content": [
-                                    {
-                                      "default": {
-                                        "tag": 2
-                                      },
-                                      "int": 1,
-                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                        "langKey": "ru",
-                                        "value": "Дата"
-                                      }
-                                    }
-                                  ]
-                                },
-                                "dataPath": "Объект.ДатаИсполнения",
-                                "items": []
-                              },
-                              {
-                                "type": "INPUT_FIELD",
-                                "id": 146,
-                                "name": "ДатаИсполненияВремя",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                },
-                                "dataPath": "Объект.ДатаИсполнения",
-                                "items": []
-                              },
-                              {
-                                "type": "HYPERLINK",
-                                "id": 199,
-                                "name": "ИзменитьЗадание",
-                                "title": {
-                                  "content": [
-                                    {
-                                      "default": {
-                                        "tag": 2
-                                      },
-                                      "int": 1,
-                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                        "langKey": "ru",
-                                        "value": "Изменить задание"
-                                      }
-                                    }
-                                  ]
-                                },
-                                "dataPath": "",
-                                "items": []
-                              }
-                            ],
-                            []
-                          ]
-                        }
-                      ],
-                      []
-                    ]
-                  }
-                ],
-                []
-              ]
-            }
+                          {
+                            "type": "LABEL_FIELD",
+                            "id": 173,
+                            "name": "Дата",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                            },
+                            "dataPath": "Объект.Date",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
           ],
           "attributes": [
             [
@@ -2550,16 +2387,6 @@
                 }
               },
               {
-                "id": 7,
-                "name": "ЗаданиеВыполнено",
-                "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                },
-                "type": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
-                }
-              },
-              {
                 "id": 6,
                 "name": "ЗаданиеСодержание",
                 "title": {
@@ -2567,6 +2394,16 @@
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[13]/type"
+                }
+              },
+              {
+                "id": 7,
+                "name": "ЗаданиеВыполнено",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
                 }
               },
               {
@@ -2588,6 +2425,26 @@
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[13]/type"
+                }
+              },
+              {
+                "id": 9,
+                "name": "ЗаданиеПодтверждено",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              },
+              {
+                "id": 10,
+                "name": "ЗаданиеСсылка",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[4]/type"
                 }
               },
               {
@@ -2631,12 +2488,12 @@
         ]
       },
       {
-        "uuid": "3e2f2ae1-c809-43fc-8276-b0a16a92858c",
-        "name": "ДействиеПроверить",
+        "uuid": "f0620d5a-e1fe-419f-af37-e0f462f97e8d",
+        "name": "ДействиеВыполнить",
         "mdoReference": {
           "type": "FORM",
-          "mdoRef": "BusinessProcess.Задание.Form.ДействиеПроверить",
-          "mdoRefRu": "БизнесПроцесс.Задание.Форма.ДействиеПроверить"
+          "mdoRef": "BusinessProcess.Задание.Form.ДействиеВыполнить",
+          "mdoRefRu": "БизнесПроцесс.Задание.Форма.ДействиеВыполнить"
         },
         "objectBelonging": "OWN",
         "comment": "",
@@ -2649,7 +2506,7 @@
               "int": 1,
               "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                 "langKey": "ru",
-                "value": "Действие проверить"
+                "value": "Действие выполнить"
               }
             }
           ]
@@ -2658,7 +2515,7 @@
         "modules": [
           {
             "moduleType": "FormModule",
-            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/BusinessProcesses/Задание/Forms/Де_ствиеПроверить/Ext/Form/Module.bsl",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/BusinessProcesses/Задание/Forms/Де_ствиеВыполнить/Ext/Form/Module.bsl",
             "owner": {
               "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/mdoReference"
             },
@@ -2696,426 +2553,329 @@
             []
           ],
           "items": [
-            {
-              "type": "USUAL_GROUP",
-              "id": 234,
-              "name": "Документ",
-              "title": {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+            [
+              {
+                "type": "COMMAND_BAR",
+                "id": 232,
+                "name": "ГруппаКоманднаяПанель",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Командная панель"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": []
               },
-              "dataPath": "",
-              "items": [
-                [
-                  {
-                    "type": "USUAL_GROUP",
-                    "id": 134,
-                    "name": "ГруппаСостояние",
-                    "title": {
-                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[15]/synonym"
-                    },
-                    "dataPath": "",
-                    "items": []
-                  },
-                  {
-                    "type": "USUAL_GROUP",
-                    "id": 165,
-                    "name": "Шапка",
-                    "title": {
-                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                    },
-                    "dataPath": "",
-                    "items": [
-                      [
-                        {
-                          "type": "USUAL_GROUP",
-                          "id": 166,
-                          "name": "ГруппыШапки",
-                          "title": {
-                            "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                          },
-                          "dataPath": "",
-                          "items": [
-                            [
-                              {
-                                "type": "USUAL_GROUP",
-                                "id": 167,
-                                "name": "ГруппаАвторИсполнитель",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                },
-                                "dataPath": "",
-                                "items": [
-                                  [
-                                    {
-                                      "type": "INPUT_FIELD",
-                                      "id": 168,
-                                      "name": "Автор",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                      },
-                                      "dataPath": "Объект.Автор",
-                                      "items": []
-                                    },
-                                    {
-                                      "type": "INPUT_FIELD",
-                                      "id": 170,
-                                      "name": "Исполнитель",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[12]/synonym"
-                                      },
-                                      "dataPath": "Исполнитель",
-                                      "items": []
-                                    }
-                                  ],
-                                  []
-                                ]
-                              },
-                              {
-                                "type": "USUAL_GROUP",
-                                "id": 172,
-                                "name": "ГруппаДатаИСрок",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                                },
-                                "dataPath": "",
-                                "items": [
-                                  [
-                                    {
-                                      "type": "INPUT_FIELD",
-                                      "id": 173,
-                                      "name": "Дата",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                      },
-                                      "dataPath": "Объект.Date",
-                                      "items": []
-                                    },
-                                    {
-                                      "type": "INPUT_FIELD",
-                                      "id": 175,
-                                      "name": "СрокИсполнения",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                      },
-                                      "dataPath": "Объект.СрокИсполнения",
-                                      "items": []
-                                    }
-                                  ],
-                                  []
-                                ]
-                              },
-                              {
-                                "type": "USUAL_GROUP",
-                                "id": 177,
-                                "name": "ГруппаНомерИВажность",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
-                                },
-                                "dataPath": "",
-                                "items": [
-                                  [
-                                    {
-                                      "type": "INPUT_FIELD",
-                                      "id": 178,
-                                      "name": "Номер",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                      },
-                                      "dataPath": "Объект.Number",
-                                      "items": []
-                                    },
-                                    {
-                                      "type": "INPUT_FIELD",
-                                      "id": 180,
-                                      "name": "Важность",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                      },
-                                      "dataPath": "Объект.Важность",
-                                      "items": []
-                                    }
-                                  ],
-                                  []
-                                ]
-                              }
-                            ],
-                            []
-                          ]
-                        },
-                        {
-                          "type": "USUAL_GROUP",
-                          "id": 182,
-                          "name": "ГруппаПриоритет",
-                          "title": {
-                            "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                          },
-                          "dataPath": "",
-                          "items": [
-                            [
-                              {
-                                "type": "INPUT_FIELD",
-                                "id": 183,
-                                "name": "СрокНачалаИсполнения",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                },
-                                "dataPath": "Объект.ДатаНачала",
-                                "items": []
-                              },
-                              {
-                                "type": "INPUT_FIELD",
-                                "id": 185,
-                                "name": "СрокНачалаИсполненияВремя",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                },
-                                "dataPath": "Объект.ДатаНачала",
-                                "items": []
-                              }
-                            ],
-                            []
-                          ]
-                        }
-                      ],
-                      []
-                    ]
-                  },
-                  {
-                    "type": "PAGES",
-                    "id": 222,
-                    "name": "Страницы",
-                    "title": {
-                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                    },
-                    "dataPath": "",
-                    "items": [
-                      [
-                        {
-                          "type": "PAGE",
-                          "id": 224,
-                          "name": "Главное",
-                          "title": {
-                            "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                          },
-                          "dataPath": "",
-                          "items": [
-                            {
-                              "type": "USUAL_GROUP",
-                              "id": 94,
-                              "name": "ГруппаСодержание",
-                              "title": {
-                                "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[14]/synonym"
-                              },
-                              "dataPath": "",
-                              "items": [
-                                [
-                                  {
-                                    "type": "INPUT_FIELD",
-                                    "id": 159,
-                                    "name": "Наименование",
-                                    "title": {
-                                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                    },
-                                    "dataPath": "Объект.Description",
-                                    "items": []
+              {
+                "type": "USUAL_GROUP",
+                "id": 131,
+                "name": "ГруппаСостояние",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[15]/synonym"
+                },
+                "dataPath": "",
+                "items": []
+              },
+              {
+                "type": "PAGES",
+                "id": 201,
+                "name": "Страницы",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "PAGE",
+                      "id": 226,
+                      "name": "ГруппаОЗадаче",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 244,
+                            "name": "ГруппаНаименованиеИНомер",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 156,
+                                  "name": "Наименование",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
                                   },
-                                  {
-                                    "type": "LABEL_FIELD",
-                                    "id": 132,
-                                    "name": "Предмет",
-                                    "title": {
-                                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[11]/synonym"
-                                    },
-                                    "dataPath": "ПредметСтрокой",
-                                    "items": []
-                                  },
-                                  {
-                                    "type": "INPUT_FIELD",
-                                    "id": 18,
-                                    "name": "Содержание",
-                                    "title": {
-                                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[14]/synonym"
-                                    },
-                                    "dataPath": "ЗаданиеСодержание",
-                                    "items": []
-                                  }
-                                ],
-                                []
-                              ]
-                            }
-                          ]
-                        },
-                        {
-                          "type": "PAGE",
-                          "id": 226,
-                          "name": "ИсторияВыполнения",
-                          "title": {
-                            "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                          },
-                          "dataPath": "",
-                          "items": [
-                            {
-                              "type": "INPUT_FIELD",
-                              "id": 126,
-                              "name": "РезультатВыполнения",
-                              "title": {
-                                "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                              },
-                              "dataPath": "ЗаданиеРезультатВыполнения",
-                              "items": []
-                            }
-                          ]
-                        }
-                      ],
-                      []
-                    ]
-                  },
-                  {
-                    "type": "USUAL_GROUP",
-                    "id": 27,
-                    "name": "ГруппаРезультат",
-                    "title": {
-                      "content": [
-                        {
-                          "default": {
-                            "tag": 2
-                          },
-                          "int": 1,
-                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                            "langKey": "ru",
-                            "value": "Результат проверки задания:"
-                          }
-                        }
-                      ]
-                    },
-                    "dataPath": "",
-                    "items": [
-                      [
-                        {
-                          "type": "INPUT_FIELD",
-                          "id": 78,
-                          "name": "ОписаниеРезультата",
-                          "title": {
-                            "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                          },
-                          "dataPath": "Объект.РезультатВыполнения",
-                          "items": []
-                        },
-                        {
-                          "type": "USUAL_GROUP",
-                          "id": 54,
-                          "name": "ГруппаВыполненаДата",
-                          "title": {
-                            "content": [
-                              {
-                                "default": {
-                                  "tag": 2
+                                  "dataPath": "Объект.Description",
+                                  "items": []
                                 },
-                                "int": 1,
-                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                  "langKey": "ru",
-                                  "value": "Выполнена дата"
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 149,
+                                  "name": "Номер",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                  },
+                                  "dataPath": "Объект.Number",
+                                  "items": []
                                 }
-                              }
+                              ],
+                              []
                             ]
                           },
-                          "dataPath": "",
-                          "items": [
-                            [
-                              {
-                                "type": "USUAL_BUTTON",
-                                "id": 123,
-                                "name": "Выполнено",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[3]/synonym"
-                                },
-                                "dataPath": "",
-                                "items": []
-                              },
-                              {
-                                "type": "USUAL_BUTTON",
-                                "id": 147,
-                                "name": "Отменено",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                                },
-                                "dataPath": "",
-                                "items": []
-                              },
-                              {
-                                "type": "USUAL_BUTTON",
-                                "id": 124,
-                                "name": "Возвращено",
-                                "title": {
-                                  "content": [
-                                    {
-                                      "default": {
-                                        "tag": 2
-                                      },
-                                      "int": 1,
-                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                        "langKey": "ru",
-                                        "value": "Возвращено исполнителю"
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 18,
+                            "name": "Содержание",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[14]/synonym"
+                            },
+                            "dataPath": "ЗаданиеСодержание",
+                            "items": []
+                          },
+                          {
+                            "type": "LABEL_FIELD",
+                            "id": 129,
+                            "name": "Предмет",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[11]/synonym"
+                            },
+                            "dataPath": "ПредметСтрокой",
+                            "items": []
+                          },
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 248,
+                            "name": "ГруппаПараметрыЗадачи",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "USUAL_GROUP",
+                                  "id": 246,
+                                  "name": "ГруппаЛево",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Лево"
+                                        }
                                       }
-                                    }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "INPUT_FIELD",
+                                        "id": 16,
+                                        "name": "Важность",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                        },
+                                        "dataPath": "Объект.Важность",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "LABEL_FIELD",
+                                        "id": 163,
+                                        "name": "Исполнитель",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[6]/synonym"
+                                        },
+                                        "dataPath": "Исполнитель",
+                                        "items": []
+                                      }
+                                    ],
+                                    []
                                   ]
                                 },
-                                "dataPath": "",
-                                "items": []
-                              },
-                              {
-                                "type": "INPUT_FIELD",
-                                "id": 55,
-                                "name": "ДатаИсполнения",
-                                "title": {
-                                  "content": [
-                                    {
-                                      "default": {
-                                        "tag": 2
+                                {
+                                  "type": "USUAL_GROUP",
+                                  "id": 242,
+                                  "name": "ГруппаПраво",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "LABEL_FIELD",
+                                        "id": 12,
+                                        "name": "СрокИсполнения",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                        },
+                                        "dataPath": "Объект.СрокИсполнения",
+                                        "items": []
                                       },
-                                      "int": 1,
-                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                        "langKey": "ru",
-                                        "value": "Дата проверки"
+                                      {
+                                        "type": "LABEL_FIELD",
+                                        "id": 161,
+                                        "name": "Автор",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                        },
+                                        "dataPath": "Объект.Автор",
+                                        "items": []
                                       }
-                                    }
+                                    ],
+                                    []
                                   ]
+                                }
+                              ],
+                              []
+                            ]
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "PAGE",
+                      "id": 240,
+                      "name": "СтраницаРезультатВыполнения",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 78,
+                            "name": "ОписаниеРезультата",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[13]/synonym"
+                            },
+                            "dataPath": "Объект.РезультатВыполнения",
+                            "items": []
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 55,
+                            "name": "ДатаИсполнения",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Дата выполнения"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "Объект.ДатаИсполнения",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "PAGE",
+                      "id": 205,
+                      "name": "СтраницаИсторияВыполнения",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 126,
+                            "name": "РезультатВыполнения",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                            },
+                            "dataPath": "ЗаданиеРезультатВыполнения",
+                            "items": []
+                          },
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 252,
+                            "name": "ГруппаДатыВыполнения",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Даты выполнения"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 119,
+                                  "name": "СрокНачалаИсполнения",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                  },
+                                  "dataPath": "Объект.ДатаНачала",
+                                  "items": []
                                 },
-                                "dataPath": "Объект.ДатаИсполнения",
-                                "items": []
-                              },
-                              {
-                                "type": "INPUT_FIELD",
-                                "id": 161,
-                                "name": "ДатаИсполненияВремя",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                },
-                                "dataPath": "Объект.ДатаИсполнения",
-                                "items": []
-                              },
-                              {
-                                "type": "HYPERLINK",
-                                "id": 130,
-                                "name": "ИзменитьЗадание",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/title"
-                                },
-                                "dataPath": "",
-                                "items": []
-                              }
-                            ],
-                            []
-                          ]
-                        }
-                      ],
-                      []
-                    ]
-                  }
-                ],
-                []
-              ]
-            }
+                                {
+                                  "type": "LABEL_FIELD",
+                                  "id": 152,
+                                  "name": "Дата",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                  },
+                                  "dataPath": "Объект.Date",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          }
+                        ],
+                        []
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
           ],
           "attributes": [
             [
@@ -3160,16 +2920,6 @@
                 }
               },
               {
-                "id": 6,
-                "name": "ЗаданиеСодержание",
-                "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[14]/synonym"
-                },
-                "type": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[13]/type"
-                }
-              },
-              {
                 "id": 7,
                 "name": "ЗаданиеВыполнено",
                 "title": {
@@ -3177,6 +2927,16 @@
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              },
+              {
+                "id": 6,
+                "name": "ЗаданиеСодержание",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[14]/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[13]/type"
                 }
               },
               {
@@ -3190,33 +2950,13 @@
                 }
               },
               {
-                "id": 9,
-                "name": "ЗаданиеПодтверждено",
-                "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                },
-                "type": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
-                }
-              },
-              {
-                "id": 10,
-                "name": "ЗаданиеСсылка",
-                "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                },
-                "type": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[4]/type"
-                }
-              },
-              {
                 "id": 4,
                 "name": "Исполнитель",
                 "title": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[6]/synonym"
                 },
                 "type": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[8]/type"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[10]/type"
                 }
               }
             ],
@@ -3312,258 +3052,20 @@
             []
           ],
           "items": [
-            {
-              "type": "USUAL_GROUP",
-              "id": 151,
-              "name": "Документ",
-              "title": {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-              },
-              "dataPath": "",
-              "items": [
-                [
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 92,
+                "name": "ГруппаСостояние",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[15]/synonym"
+                },
+                "dataPath": "",
+                "items": [
                   {
                     "type": "LABEL_FIELD",
-                    "id": 99,
-                    "name": "ГлавнаяЗадача",
-                    "title": {
-                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[4]/synonym"
-                    },
-                    "dataPath": "ГлавнаяЗадачаСтрокой",
-                    "items": []
-                  },
-                  {
-                    "type": "USUAL_GROUP",
-                    "id": 92,
-                    "name": "ГруппаСостояние",
-                    "title": {
-                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[15]/synonym"
-                    },
-                    "dataPath": "",
-                    "items": [
-                      [
-                        {
-                          "type": "PICTURE_DECORATION",
-                          "id": 93,
-                          "name": "ДекорацияЗначок",
-                          "title": {
-                            "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                          },
-                          "dataPath": "",
-                          "items": []
-                        },
-                        {
-                          "type": "LABEL_FIELD",
-                          "id": 155,
-                          "name": "ИнфоНадписьЗаголовок",
-                          "title": {
-                            "content": [
-                              {
-                                "default": {
-                                  "tag": 2
-                                },
-                                "int": 1,
-                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                  "langKey": "ru",
-                                  "value": "Инфо надпись заголовок"
-                                }
-                              }
-                            ]
-                          },
-                          "dataPath": "ИнфоНадписьЗаголовок",
-                          "items": []
-                        }
-                      ],
-                      []
-                    ]
-                  },
-                  {
-                    "type": "USUAL_GROUP",
-                    "id": 145,
-                    "name": "Шапка",
-                    "title": {
-                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                    },
-                    "dataPath": "",
-                    "items": [
-                      [
-                        {
-                          "type": "USUAL_GROUP",
-                          "id": 27,
-                          "name": "ГруппаСрокВажность",
-                          "title": {
-                            "content": [
-                              {
-                                "default": {
-                                  "tag": 2
-                                },
-                                "int": 1,
-                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                  "langKey": "ru",
-                                  "value": "Срок важность"
-                                }
-                              }
-                            ]
-                          },
-                          "dataPath": "",
-                          "items": [
-                            [
-                              {
-                                "type": "INPUT_FIELD",
-                                "id": 19,
-                                "name": "ЗаголовокЗадания",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                },
-                                "dataPath": "Объект.Наименование",
-                                "items": []
-                              },
-                              {
-                                "type": "INPUT_FIELD",
-                                "id": 57,
-                                "name": "Важность",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                },
-                                "dataPath": "Объект.Важность",
-                                "items": []
-                              },
-                              {
-                                "type": "INPUT_FIELD",
-                                "id": 103,
-                                "name": "Номер",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                },
-                                "dataPath": "Объект.Number",
-                                "items": []
-                              }
-                            ],
-                            []
-                          ]
-                        },
-                        {
-                          "type": "USUAL_GROUP",
-                          "id": 67,
-                          "name": "ГруппаИсполнение",
-                          "title": {
-                            "content": [
-                              {
-                                "default": {
-                                  "tag": 2
-                                },
-                                "int": 1,
-                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                  "langKey": "ru",
-                                  "value": "Исполнение"
-                                }
-                              }
-                            ]
-                          },
-                          "dataPath": "",
-                          "items": [
-                            [
-                              {
-                                "type": "INPUT_FIELD",
-                                "id": 69,
-                                "name": "Исполнитель",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                },
-                                "dataPath": "Объект.Исполнитель",
-                                "items": []
-                              },
-                              {
-                                "type": "USUAL_GROUP",
-                                "id": 147,
-                                "name": "ГруппаСрокИсполнения",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[16]/synonym"
-                                },
-                                "dataPath": "",
-                                "items": [
-                                  [
-                                    {
-                                      "type": "INPUT_FIELD",
-                                      "id": 21,
-                                      "name": "СрокИсполнения",
-                                      "title": {
-                                        "content": [
-                                          {
-                                            "default": {
-                                              "tag": 2
-                                            },
-                                            "int": 1,
-                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                              "langKey": "ru",
-                                              "value": "Срок"
-                                            }
-                                          }
-                                        ]
-                                      },
-                                      "dataPath": "Объект.СрокИсполнения",
-                                      "items": []
-                                    },
-                                    {
-                                      "type": "INPUT_FIELD",
-                                      "id": 88,
-                                      "name": "СрокИсполненияВремя",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                      },
-                                      "dataPath": "Объект.СрокИсполнения",
-                                      "items": []
-                                    }
-                                  ],
-                                  []
-                                ]
-                              }
-                            ],
-                            []
-                          ]
-                        }
-                      ],
-                      []
-                    ]
-                  },
-                  {
-                    "type": "USUAL_GROUP",
-                    "id": 75,
-                    "name": "ГруппаСодержание",
-                    "title": {
-                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[14]/synonym"
-                    },
-                    "dataPath": "",
-                    "items": [
-                      [
-                        {
-                          "type": "LABEL_FIELD",
-                          "id": 86,
-                          "name": "Предмет",
-                          "title": {
-                            "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[11]/synonym"
-                          },
-                          "dataPath": "ПредметСтрокой",
-                          "items": []
-                        },
-                        {
-                          "type": "INPUT_FIELD",
-                          "id": 17,
-                          "name": "Содержание",
-                          "title": {
-                            "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[14]/synonym"
-                          },
-                          "dataPath": "Объект.Содержание",
-                          "items": []
-                        }
-                      ],
-                      []
-                    ]
-                  },
-                  {
-                    "type": "USUAL_GROUP",
-                    "id": 56,
-                    "name": "ГруппаПроверка",
+                    "id": 155,
+                    "name": "ИнфоНадписьЗаголовок",
                     "title": {
                       "content": [
                         {
@@ -3573,146 +3075,334 @@
                           "int": 1,
                           "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                             "langKey": "ru",
-                            "value": "Проверка"
+                            "value": "Инфо надпись заголовок"
                           }
                         }
                       ]
                     },
-                    "dataPath": "",
-                    "items": [
-                      [
-                        {
-                          "type": "CHECK_BOX_FIELD",
-                          "id": 54,
-                          "name": "НаПроверке",
-                          "title": {
-                            "content": [
-                              {
-                                "default": {
-                                  "tag": 2
-                                },
-                                "int": 1,
-                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                  "langKey": "ru",
-                                  "value": "Проверить выполнение:"
-                                }
-                              }
-                            ]
-                          },
-                          "dataPath": "Объект.НаПроверке",
-                          "items": []
-                        },
-                        {
-                          "type": "USUAL_GROUP",
-                          "id": 28,
-                          "name": "ГруппаПроверяющий",
-                          "title": {
-                            "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[12]/synonym"
-                          },
-                          "dataPath": "",
-                          "items": [
-                            [
-                              {
-                                "type": "INPUT_FIELD",
-                                "id": 14,
-                                "name": "Проверяющий",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                },
-                                "dataPath": "Объект.Проверяющий",
-                                "items": []
-                              },
-                              {
-                                "type": "USUAL_GROUP",
-                                "id": 149,
-                                "name": "ГруппаСрокПроверки",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[17]/synonym"
-                                },
-                                "dataPath": "",
-                                "items": [
-                                  [
-                                    {
-                                      "type": "INPUT_FIELD",
-                                      "id": 23,
-                                      "name": "СрокПроверки",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                      },
-                                      "dataPath": "Объект.СрокПроверки",
-                                      "items": []
-                                    },
-                                    {
-                                      "type": "INPUT_FIELD",
-                                      "id": 90,
-                                      "name": "СрокПроверкиВремя",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                      },
-                                      "dataPath": "Объект.СрокПроверки",
-                                      "items": []
-                                    }
-                                  ],
-                                  []
-                                ]
-                              }
-                            ],
-                            []
-                          ]
-                        }
-                      ],
-                      []
-                    ]
-                  },
-                  {
-                    "type": "USUAL_GROUP",
-                    "id": 81,
-                    "name": "ГруппаОбщиеСведения",
-                    "title": {
-                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/synonym"
-                    },
-                    "dataPath": "",
-                    "items": [
-                      [
-                        {
-                          "type": "INPUT_FIELD",
-                          "id": 79,
-                          "name": "Автор",
-                          "title": {
-                            "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                          },
-                          "dataPath": "Объект.Автор",
-                          "items": []
-                        },
-                        {
-                          "type": "INPUT_FIELD",
-                          "id": 97,
-                          "name": "Дата",
-                          "title": {
-                            "content": [
-                              {
-                                "default": {
-                                  "tag": 2
-                                },
-                                "int": 1,
-                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                  "langKey": "ru",
-                                  "value": "Начато"
-                                }
-                              }
-                            ]
-                          },
-                          "dataPath": "Объект.Date",
-                          "items": []
-                        }
-                      ],
-                      []
-                    ]
+                    "dataPath": "ИнфоНадписьЗаголовок",
+                    "items": []
                   }
-                ],
-                []
-              ]
-            }
+                ]
+              },
+              {
+                "type": "PAGES",
+                "id": 182,
+                "name": "Страницы",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "PAGE",
+                      "id": 184,
+                      "name": "СтраницаОписаниеЗадания",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Описание задания"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 194,
+                            "name": "ГруппаЗаголовок",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Группа"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 19,
+                                  "name": "ЗаголовокЗадания",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                  },
+                                  "dataPath": "Объект.Наименование",
+                                  "items": []
+                                },
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 103,
+                                  "name": "Номер",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                  },
+                                  "dataPath": "Объект.Number",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 17,
+                            "name": "Содержание",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[14]/synonym"
+                            },
+                            "dataPath": "Объект.Содержание",
+                            "items": []
+                          },
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 200,
+                            "name": "ГруппаОсновнаяИнформация",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Основная информация"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "USUAL_GROUP",
+                                  "id": 176,
+                                  "name": "ГруппаИсполнитель",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[6]/synonym"
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "INPUT_FIELD",
+                                        "id": 69,
+                                        "name": "Исполнитель",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                        },
+                                        "dataPath": "Объект.Исполнитель",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "INPUT_FIELD",
+                                        "id": 21,
+                                        "name": "СрокИсполнения",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Срок выполнения"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "Объект.СрокИсполнения",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "INPUT_FIELD",
+                                        "id": 57,
+                                        "name": "Важность",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                        },
+                                        "dataPath": "Объект.Важность",
+                                        "items": []
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                },
+                                {
+                                  "type": "CHECK_BOX_FIELD",
+                                  "id": 54,
+                                  "name": "НаПроверке",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Проверить выполнение:"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "Объект.НаПроверке",
+                                  "items": []
+                                },
+                                {
+                                  "type": "USUAL_GROUP",
+                                  "id": 198,
+                                  "name": "ГруппаПроверка",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Проверка"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "INPUT_FIELD",
+                                        "id": 14,
+                                        "name": "Проверяющий",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                        },
+                                        "dataPath": "Объект.Проверяющий",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "INPUT_FIELD",
+                                        "id": 23,
+                                        "name": "СрокПроверки",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                        },
+                                        "dataPath": "Объект.СрокПроверки",
+                                        "items": []
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                }
+                              ],
+                              []
+                            ]
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "PAGE",
+                      "id": 190,
+                      "name": "СтраницаДополнительно",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Дополнительно"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "LABEL_FIELD",
+                            "id": 86,
+                            "name": "Предмет",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[11]/synonym"
+                            },
+                            "dataPath": "ПредметСтрокой",
+                            "items": []
+                          },
+                          {
+                            "type": "LABEL_FIELD",
+                            "id": 99,
+                            "name": "ГлавнаяЗадача",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[4]/synonym"
+                            },
+                            "dataPath": "ГлавнаяЗадачаСтрокой",
+                            "items": []
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 79,
+                            "name": "Автор",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                            },
+                            "dataPath": "Объект.Автор",
+                            "items": []
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 97,
+                            "name": "Дата",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Начато"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "Объект.Date",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
           ],
           "attributes": [
             [
@@ -3777,7 +3467,7 @@
                 "id": 5,
                 "name": "ИнфоНадписьЗаголовок",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "types": [
@@ -3903,6 +3593,10 @@
           "handlers": [
             [
               {
+                "event": "OnLoadDataFromSettingsAtServer",
+                "name": "ПриЗагрузкеДанныхИзНастроекНаСервере"
+              },
+              {
                 "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[5]"
               },
               {
@@ -3971,73 +3665,6 @@
               },
               {
                 "type": "USUAL_GROUP",
-                "id": 50,
-                "name": "Флажки",
-                "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Флажки"
-                      }
-                    }
-                  ]
-                },
-                "dataPath": "",
-                "items": [
-                  [
-                    {
-                      "type": "CHECK_BOX_FIELD",
-                      "id": 22,
-                      "name": "ПоказыватьЗавершенныеЗадания",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Показывать завершенные задания"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "ПоказыватьЗавершенныеЗадания",
-                      "items": []
-                    },
-                    {
-                      "type": "CHECK_BOX_FIELD",
-                      "id": 48,
-                      "name": "ПоказыватьОстановленные",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Показывать остановленные"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "ПоказыватьОстановленные",
-                      "items": []
-                    }
-                  ],
-                  []
-                ]
-              },
-              {
-                "type": "USUAL_GROUP",
                 "id": 92,
                 "name": "ГруппаПользовательскихНастроек",
                 "title": {
@@ -4056,83 +3683,6 @@
                 },
                 "dataPath": "",
                 "items": []
-              },
-              {
-                "type": "COMMAND_BAR",
-                "id": 53,
-                "name": "КоманднаяПанель",
-                "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Командная панель"
-                      }
-                    }
-                  ]
-                },
-                "dataPath": "",
-                "items": [
-                  [
-                    {
-                      "type": "COMMAND_BAR_BUTTON",
-                      "id": 94,
-                      "name": "ФормаОбщаяКомандаКартаМаршрутаБизнесПроцесса",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                      },
-                      "dataPath": "Items.Список.CurrentData.Ref",
-                      "items": []
-                    },
-                    {
-                      "type": "COMMAND_BAR_BUTTON",
-                      "id": 51,
-                      "name": "ФормаОстановить",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Остановить"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "COMMAND_BAR_BUTTON",
-                      "id": 52,
-                      "name": "ФормаПродолжитьБизнесПроцесс",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Продолжить"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": []
-                    }
-                  ],
-                  []
-                ]
               },
               {
                 "type": "TABLE",
@@ -4177,6 +3727,36 @@
                     },
                     {
                       "type": "LABEL_FIELD",
+                      "id": 26,
+                      "name": "Наименование",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.Наименование",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 32,
+                      "name": "Предмет",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.Предмет",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 28,
+                      "name": "Содержание",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.Содержание",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
                       "id": 6,
                       "name": "Дата",
                       "title": {
@@ -4184,50 +3764,6 @@
                       },
                       "dataPath": "Список.Date",
                       "items": []
-                    },
-                    {
-                      "type": "COLUMN_GROUP",
-                      "id": 54,
-                      "name": "ГруппаСодержание",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[14]/synonym"
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "LABEL_FIELD",
-                            "id": 26,
-                            "name": "Наименование",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                            },
-                            "dataPath": "Список.Наименование",
-                            "items": []
-                          },
-                          {
-                            "type": "LABEL_FIELD",
-                            "id": 32,
-                            "name": "Предмет",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                            },
-                            "dataPath": "Список.Предмет",
-                            "items": []
-                          },
-                          {
-                            "type": "LABEL_FIELD",
-                            "id": 28,
-                            "name": "Содержание",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                            },
-                            "dataPath": "Список.Содержание",
-                            "items": []
-                          }
-                        ],
-                        []
-                      ]
                     },
                     {
                       "type": "LABEL_FIELD",
@@ -4300,38 +3836,24 @@
                       "items": []
                     },
                     {
-                      "type": "COLUMN_GROUP",
-                      "id": 57,
-                      "name": "ГруппаПроверка",
+                      "type": "CHECK_BOX_FIELD",
+                      "id": 55,
+                      "name": "НаПроверке",
                       "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[8]/synonym"
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
                       },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "CHECK_BOX_FIELD",
-                            "id": 55,
-                            "name": "НаПроверке",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                            },
-                            "dataPath": "Список.НаПроверке",
-                            "items": []
-                          },
-                          {
-                            "type": "LABEL_FIELD",
-                            "id": 40,
-                            "name": "Проверяющий",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                            },
-                            "dataPath": "Список.Проверяющий",
-                            "items": []
-                          }
-                        ],
-                        []
-                      ]
+                      "dataPath": "Список.НаПроверке",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 40,
+                      "name": "Проверяющий",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.Проверяющий",
+                      "items": []
                     },
                     {
                       "type": "LABEL_FIELD",
@@ -4406,7 +3928,7 @@
                 "id": 5,
                 "name": "ПоказыватьЗавершенныеЗадания",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
@@ -4416,7 +3938,7 @@
                 "id": 6,
                 "name": "ПоказыватьОстановленные",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"

--- a/src/test/resources/fixtures/ssl_3_2/BusinessProcesses.Задание.json
+++ b/src/test/resources/fixtures/ssl_3_2/BusinessProcesses.Задание.json
@@ -1,0 +1,4527 @@
+{"com.github._1c_syntax.bsl.mdo.BusinessProcess": {
+  "attributes": [
+    [
+      {
+        "uuid": "dad11c2e-08fc-4a6b-8829-8be6c64c15fc",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.StandardAttribute.Started",
+          "mdoRefRu": "БизнесПроцесс.Задание.СтандартныйРеквизит.Стартован"
+        },
+        "comment": "",
+        "synonym": {
+          "content": []
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "type": "BUSINESS_PROCESS",
+          "mdoRef": "BusinessProcess.Задание",
+          "mdoRefRu": "БизнесПроцесс.Задание"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "BOOLEAN"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 0
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "Стартован",
+          "nameEn": "Started"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "dad11c2e-08fc-4a6b-8829-8be6c64c15fc",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.StandardAttribute.HeadTask",
+          "mdoRefRu": "БизнесПроцесс.Задание.СтандартныйРеквизит.ВедущаяЗадача"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "ЗадачаСсылка.ЗадачаИсполнителя",
+                  "nameEn": "TaskRef.ЗадачаИсполнителя"
+                },
+                "variant": "METADATA",
+                "kind": "TASK"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "fullName": {
+          "nameRu": "ВедущаяЗадача",
+          "nameEn": "HeadTask"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "dad11c2e-08fc-4a6b-8829-8be6c64c15fc",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.StandardAttribute.Completed",
+          "mdoRefRu": "БизнесПроцесс.Задание.СтандартныйРеквизит.Завершен"
+        },
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Завершено"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+        },
+        "fullName": {
+          "nameRu": "Завершен",
+          "nameEn": "Completed"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "dad11c2e-08fc-4a6b-8829-8be6c64c15fc",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.StandardAttribute.Ref",
+          "mdoRefRu": "БизнесПроцесс.Задание.СтандартныйРеквизит.Ссылка"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "БизнесПроцессСсылка.Задание",
+                  "nameEn": "BusinessProcessRef.Задание"
+                },
+                "variant": "METADATA",
+                "kind": "BUSINESS_PROCESS"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "fullName": {
+          "nameRu": "Ссылка",
+          "nameEn": "Ref"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "dad11c2e-08fc-4a6b-8829-8be6c64c15fc",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.StandardAttribute.DeletionMark",
+          "mdoRefRu": "БизнесПроцесс.Задание.СтандартныйРеквизит.ПометкаУдаления"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+        },
+        "fullName": {
+          "nameRu": "ПометкаУдаления",
+          "nameEn": "DeletionMark"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "dad11c2e-08fc-4a6b-8829-8be6c64c15fc",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.StandardAttribute.Date",
+          "mdoRefRu": "БизнесПроцесс.Задание.СтандартныйРеквизит.Дата"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "DATE"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.DateQualifiers": {
+                "dateFractions": 2,
+                "description": {
+                  "value": {
+                    "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                    "nameRu": "КвалификаторыДаты (ДатаВремя)",
+                    "nameEn": "DateQualifiers (DateTime)"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "Дата",
+          "nameEn": "Date"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "dad11c2e-08fc-4a6b-8829-8be6c64c15fc",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.StandardAttribute.Number",
+          "mdoRefRu": "БизнесПроцесс.Задание.СтандартныйРеквизит.Номер"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                "length": 11,
+                "allowedLength": 0,
+                "description": {}
+              }
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "Номер",
+          "nameEn": "Number"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "a76b1fd1-ba00-40e6-8756-f17fee449818",
+        "name": "Автор",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.Attribute.Автор",
+          "mdoRefRu": "БизнесПроцесс.Задание.Реквизит.Автор"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Автор"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 2,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "СправочникСсылка.ВнешниеПользователи",
+                  "nameEn": "CatalogRef.ВнешниеПользователи"
+                },
+                "variant": "METADATA",
+                "kind": "CATALOG"
+              },
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "СправочникСсылка.Пользователи",
+                  "nameEn": "CatalogRef.Пользователи"
+                },
+                "variant": "METADATA",
+                "kind": "CATALOG"
+              }
+            }
+          ],
+          "composite": true,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "5c913626-48d1-4e0a-a423-64078ce59c7b",
+        "name": "Важность",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.Attribute.Важность",
+          "mdoRefRu": "БизнесПроцесс.Задание.Реквизит.Важность"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Важность задач точки действия Выполнить для исполнителя",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Важность"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "ПеречислениеСсылка.ВариантыВажностиЗадачи",
+                  "nameEn": "EnumRef.ВариантыВажностиЗадачи"
+                },
+                "variant": "METADATA",
+                "kind": "ENUM"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": true
+      },
+      {
+        "uuid": "0a4e6b7a-b380-4547-bc3c-5d6895a5d19a",
+        "name": "Выполнено",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.Attribute.Выполнено",
+          "mdoRefRu": "БизнесПроцесс.Задание.Реквизит.Выполнено"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Результат выполнения задания после завершения бизнес-процесса.",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Выполнено"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "7b0ec304-1904-413e-a9c6-ff62e87107dd",
+        "name": "ГлавнаяЗадача",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.Attribute.ГлавнаяЗадача",
+          "mdoRefRu": "БизнесПроцесс.Задание.Реквизит.ГлавнаяЗадача"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Главная задача"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[2]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "d4dd8c96-914d-496f-b735-ef85ec473605",
+        "name": "ДатаЗавершения",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.Attribute.ДатаЗавершения",
+          "mdoRefRu": "БизнесПроцесс.Задание.Реквизит.ДатаЗавершения"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Фактическая дата завершения бизнес-процесса",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Дата завершения"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[6]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "62517db4-59e6-4945-bcd6-b3f1845572bf",
+        "name": "Исполнитель",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.Attribute.Исполнитель",
+          "mdoRefRu": "БизнесПроцесс.Задание.Реквизит.Исполнитель"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Исполнитель"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 3,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/type/types/java.util.CollSer/com.github._1c_syntax.bsl.types.value.CustomValueType"
+              },
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/type/types/java.util.CollSer/com.github._1c_syntax.bsl.types.value.CustomValueType[2]"
+              },
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "СправочникСсылка.РолиИсполнителей",
+                  "nameEn": "CatalogRef.РолиИсполнителей"
+                },
+                "variant": "METADATA",
+                "kind": "CATALOG"
+              }
+            }
+          ],
+          "composite": true,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "a6a9dd40-24cd-4d40-a12d-44f94f8c05a7",
+        "name": "Наименование",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.Attribute.Наименование",
+          "mdoRefRu": "БизнесПроцесс.Задание.Реквизит.Наименование"
+        },
+        "objectBelonging": "OWN",
+        "comment": "АПК:58 - Описание задания",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Задание"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                "length": 250,
+                "allowedLength": 0,
+                "description": {}
+              }
+            }
+          ]
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "f0f72149-0e7f-441a-b70d-8f47d4977927",
+        "name": "НаПроверке",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.Attribute.НаПроверке",
+          "mdoRefRu": "БизнесПроцесс.Задание.Реквизит.НаПроверке"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Признак того, что указан проверяющий по задаче",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "На проверке"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "776efc3e-ac27-4550-bafd-6e91aa987af2",
+        "name": "НомерИтерации",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.Attribute.НомерИтерации",
+          "mdoRefRu": "БизнесПроцесс.Задание.Реквизит.НомерИтерации"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Количество циклов бизнес-процесса между исполнителем и проверяющим",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Номер итерации"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                "precision": 10,
+                "scale": 0,
+                "nonNegative": true,
+                "description": {}
+              }
+            }
+          ]
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "9f478c85-b72c-40ae-aa08-7ddf73b5b15c",
+        "name": "Подтверждено",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.Attribute.Подтверждено",
+          "mdoRefRu": "БизнесПроцесс.Задание.Реквизит.Подтверждено"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Внутреннее состояние бизнес-процесса",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Подтверждено"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "cc438366-85ea-48be-8b74-d05cddb1fc51",
+        "name": "Предмет",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.Attribute.Предмет",
+          "mdoRefRu": "БизнесПроцесс.Задание.Реквизит.Предмет"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Объект системы, \"по поводу\" которого был создан бизнес-процесс.",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Предмет"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "ОпределяемыйТип.ПредметЗадачи",
+                  "nameEn": "DefinedType.ПредметЗадачи"
+                },
+                "variant": "METADATA",
+                "kind": "DEFINED_TYPE"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "4688fd3b-4a92-4ed8-b111-0cf22a729b1c",
+        "name": "Проверяющий",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.Attribute.Проверяющий",
+          "mdoRefRu": "БизнесПроцесс.Задание.Реквизит.Проверяющий"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Проверяющий"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[6]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "92029d1f-0472-4aaa-8fd6-9fb3c3cf414e",
+        "name": "РезультатВыполнения",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.Attribute.РезультатВыполнения",
+          "mdoRefRu": "БизнесПроцесс.Задание.Реквизит.РезультатВыполнения"
+        },
+        "objectBelonging": "OWN",
+        "comment": "История переписки исполнителя и проверяющего",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Результат выполнения"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                "length": 0,
+                "allowedLength": 0,
+                "description": {
+                  "value": {
+                    "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                    "nameRu": "КвалификаторыСтроки (0, Переменная)",
+                    "nameEn": "StringQualifiers (0, Variable)"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": true,
+        "extendedEdit": true,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "3271b800-1825-422f-97bb-757baf403e90",
+        "name": "Содержание",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.Attribute.Содержание",
+          "mdoRefRu": "БизнесПроцесс.Задание.Реквизит.Содержание"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Содержание"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[13]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": true,
+        "extendedEdit": true,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "6fd6efc1-facc-4ece-a5b3-3dce6acca81d",
+        "name": "Состояние",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.Attribute.Состояние",
+          "mdoRefRu": "БизнесПроцесс.Задание.Реквизит.Состояние"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Состояние"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "ПеречислениеСсылка.СостоянияБизнесПроцессов",
+                  "nameEn": "EnumRef.СостоянияБизнесПроцессов"
+                },
+                "variant": "METADATA",
+                "kind": "ENUM"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": true
+      },
+      {
+        "uuid": "4ee82868-7a20-4c3a-91f9-42a6bf53ac37",
+        "name": "СрокИсполнения",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.Attribute.СрокИсполнения",
+          "mdoRefRu": "БизнесПроцесс.Задание.Реквизит.СрокИсполнения"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Срок исполнения"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[6]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "a040c756-4687-4bfd-a690-b122d3c490e5",
+        "name": "СрокПроверки",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.Attribute.СрокПроверки",
+          "mdoRefRu": "БизнесПроцесс.Задание.Реквизит.СрокПроверки"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Срок проверки"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[6]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "bd5940d5-13fd-4f59-bb6c-614f93f9c8e4",
+        "name": "АвторСтрокой",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.Attribute.АвторСтрокой",
+          "mdoRefRu": "БизнесПроцесс.Задание.Реквизит.АвторСтрокой"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Автор строкой"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                "length": 150,
+                "allowedLength": 0,
+                "description": {}
+              }
+            }
+          ]
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "961a9801-3956-4ea0-b0d3-908f09bf4929",
+        "name": "ВнешнееЗадание",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.Attribute.ВнешнееЗадание",
+          "mdoRefRu": "БизнесПроцесс.Задание.Реквизит.ВнешнееЗадание"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Внешнее задание"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "6fac5c14-e126-4342-9078-edf1d0efcbf2",
+        "name": "ЗадачаИсточник",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.Attribute.ЗадачаИсточник",
+          "mdoRefRu": "БизнесПроцесс.Задание.Реквизит.ЗадачаИсточник"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Задача источник"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[2]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "0a3325a1-21c4-4997-882f-4ac2edc175f0",
+        "name": "СодержаниеПредмета",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.Attribute.СодержаниеПредмета",
+          "mdoRefRu": "БизнесПроцесс.Задание.Реквизит.СодержаниеПредмета"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Содержание предмета"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.V8ValueType": "VALUE_STORAGE"
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "71102d3f-f020-4d6f-9582-9a7eefb4e797",
+        "name": "ОсновнойОбъектАдресации",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.Attribute.ОсновнойОбъектАдресации",
+          "mdoRefRu": "БизнесПроцесс.Задание.Реквизит.ОсновнойОбъектАдресации"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Основной объект адресации"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "Характеристика.ОбъектыАдресацииЗадач",
+                  "nameEn": "Characteristic.ОбъектыАдресацииЗадач"
+                },
+                "variant": "METADATA",
+                "kind": "CHART_OF_CHARACTERISTIC_TYPES"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "53ef6849-a3f3-4171-9167-f349f2d6a736",
+        "name": "ОсновнойОбъектАдресацииПроверяющий",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.Attribute.ОсновнойОбъектАдресацииПроверяющий",
+          "mdoRefRu": "БизнесПроцесс.Задание.Реквизит.ОсновнойОбъектАдресацииПроверяющий"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Основной объект адресации (проверяющий)"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[22]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "3f588bd3-d461-42b7-8ab1-386af6399d56",
+        "name": "ДополнительныйОбъектАдресации",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.Attribute.ДополнительныйОбъектАдресации",
+          "mdoRefRu": "БизнесПроцесс.Задание.Реквизит.ДополнительныйОбъектАдресации"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Дополнительный объект адресации"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[22]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "c04ff85e-b4af-4a9f-b0e9-c5c65e3d10a1",
+        "name": "ДополнительныйОбъектАдресацииПроверяющий",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.Attribute.ДополнительныйОбъектАдресацииПроверяющий",
+          "mdoRefRu": "БизнесПроцесс.Задание.Реквизит.ДополнительныйОбъектАдресацииПроверяющий"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Дополнительный объект адресации (проверяющий)"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[22]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "8c576405-29c1-46b1-ab2e-40e52c21cab0",
+        "name": "ГруппаИсполнителейЗадач",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.Attribute.ГруппаИсполнителейЗадач",
+          "mdoRefRu": "БизнесПроцесс.Задание.Реквизит.ГруппаИсполнителейЗадач"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Группа исполнителей задач"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 3,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/type/types/java.util.CollSer/com.github._1c_syntax.bsl.types.value.CustomValueType"
+              },
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "СправочникСсылка.ГруппыИсполнителейЗадач",
+                  "nameEn": "CatalogRef.ГруппыИсполнителейЗадач"
+                },
+                "variant": "METADATA",
+                "kind": "CATALOG"
+              },
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/type/types/java.util.CollSer/com.github._1c_syntax.bsl.types.value.CustomValueType[2]"
+              }
+            }
+          ],
+          "composite": true,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "b33a89da-8589-4902-83fa-6545e5fce23e",
+        "name": "ГруппаИсполнителейЗадачПроверяющий",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.Attribute.ГруппаИсполнителейЗадачПроверяющий",
+          "mdoRefRu": "БизнесПроцесс.Задание.Реквизит.ГруппаИсполнителейЗадачПроверяющий"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Группа исполнителей задач (проверяющий)"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[26]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      }
+    ],
+    []
+  ],
+  "commands": [],
+  "comment": "",
+  "description": "Задание",
+  "explanation": {
+    "content": [
+      {
+        "default": {
+          "tag": 2
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+          "langKey": "ru",
+          "value": "Задание для исполнителя"
+        }
+      }
+    ]
+  },
+  "forms": [
+    [
+      {
+        "uuid": "f0620d5a-e1fe-419f-af37-e0f462f97e8d",
+        "name": "ДействиеВыполнить",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "BusinessProcess.Задание.Form.ДействиеВыполнить",
+          "mdoRefRu": "БизнесПроцесс.Задание.Форма.ДействиеВыполнить"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Действие выполнить"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/BusinessProcesses/Задание/Forms/Де_ствиеВыполнить/Ext/Form/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+          },
+          "handlers": [
+            [
+              {
+                "event": "AfterWriteAtServer",
+                "name": "ПослеЗаписиНаСервере"
+              },
+              {
+                "event": "NotificationProcessing",
+                "name": "ОбработкаОповещения"
+              },
+              {
+                "event": "OnReadAtServer",
+                "name": "ПриЧтенииНаСервере"
+              },
+              {
+                "event": "OnOpen",
+                "name": "ПриОткрытии"
+              },
+              {
+                "event": "OnCreateAtServer",
+                "name": "ПриСозданииНаСервере"
+              },
+              {
+                "event": "BeforeWriteAtServer",
+                "name": "ПередЗаписьюНаСервере"
+              }
+            ],
+            []
+          ],
+          "items": [
+            {
+              "type": "USUAL_GROUP",
+              "id": 207,
+              "name": "Документ",
+              "title": {
+                "content": [
+                  {
+                    "default": {
+                      "tag": 2
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                      "langKey": "ru",
+                      "value": "Документ"
+                    }
+                  }
+                ]
+              },
+              "dataPath": "",
+              "items": [
+                [
+                  {
+                    "type": "USUAL_GROUP",
+                    "id": 154,
+                    "name": "Шапка",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Шапка"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 165,
+                          "name": "ГруппыШапки",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Группы шапки"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "USUAL_GROUP",
+                                "id": 160,
+                                "name": "ГруппаАвторИсполнитель",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Автор исполнитель"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 161,
+                                      "name": "Автор",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                      },
+                                      "dataPath": "Объект.Автор",
+                                      "items": []
+                                    },
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 163,
+                                      "name": "Исполнитель",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[6]/synonym"
+                                      },
+                                      "dataPath": "Исполнитель",
+                                      "items": []
+                                    }
+                                  ],
+                                  []
+                                ]
+                              },
+                              {
+                                "type": "USUAL_GROUP",
+                                "id": 109,
+                                "name": "ГруппаДатаИСрок",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Дата и срок"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 152,
+                                      "name": "Дата",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                      },
+                                      "dataPath": "Объект.Date",
+                                      "items": []
+                                    },
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 12,
+                                      "name": "СрокИсполнения",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                      },
+                                      "dataPath": "Объект.СрокИсполнения",
+                                      "items": []
+                                    }
+                                  ],
+                                  []
+                                ]
+                              },
+                              {
+                                "type": "USUAL_GROUP",
+                                "id": 28,
+                                "name": "ГруппаНомерИВажность",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Номер и важность"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 149,
+                                      "name": "Номер",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                      },
+                                      "dataPath": "Объект.Number",
+                                      "items": []
+                                    },
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 16,
+                                      "name": "Важность",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                      },
+                                      "dataPath": "Объект.Важность",
+                                      "items": []
+                                    }
+                                  ],
+                                  []
+                                ]
+                              }
+                            ],
+                            []
+                          ]
+                        },
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 155,
+                          "name": "ГруппаПриоритет",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Приоритет"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 119,
+                                "name": "СрокНачалаИсполнения",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                },
+                                "dataPath": "Объект.ДатаНачала",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 135,
+                                "name": "СрокНачалаИсполненияВремя",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                },
+                                "dataPath": "Объект.ДатаНачала",
+                                "items": []
+                              }
+                            ],
+                            []
+                          ]
+                        }
+                      ],
+                      []
+                    ]
+                  },
+                  {
+                    "type": "PAGES",
+                    "id": 201,
+                    "name": "Страницы",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Страницы"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "PAGE",
+                          "id": 203,
+                          "name": "Главное",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Главное"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            {
+                              "type": "USUAL_GROUP",
+                              "id": 94,
+                              "name": "ГруппаСодержание",
+                              "title": {
+                                "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[14]/synonym"
+                              },
+                              "dataPath": "",
+                              "items": [
+                                [
+                                  {
+                                    "type": "INPUT_FIELD",
+                                    "id": 156,
+                                    "name": "Наименование",
+                                    "title": {
+                                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                    },
+                                    "dataPath": "Объект.Description",
+                                    "items": []
+                                  },
+                                  {
+                                    "type": "LABEL_FIELD",
+                                    "id": 129,
+                                    "name": "Предмет",
+                                    "title": {
+                                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[11]/synonym"
+                                    },
+                                    "dataPath": "ПредметСтрокой",
+                                    "items": []
+                                  },
+                                  {
+                                    "type": "INPUT_FIELD",
+                                    "id": 18,
+                                    "name": "Содержание",
+                                    "title": {
+                                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[14]/synonym"
+                                    },
+                                    "dataPath": "ЗаданиеСодержание",
+                                    "items": []
+                                  }
+                                ],
+                                []
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "PAGE",
+                          "id": 205,
+                          "name": "ИсторияВыполнения",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "История выполнения"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            {
+                              "type": "INPUT_FIELD",
+                              "id": 126,
+                              "name": "РезультатВыполнения",
+                              "title": {
+                                "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                              },
+                              "dataPath": "ЗаданиеРезультатВыполнения",
+                              "items": []
+                            }
+                          ]
+                        }
+                      ],
+                      []
+                    ]
+                  },
+                  {
+                    "type": "USUAL_GROUP",
+                    "id": 131,
+                    "name": "ГруппаСостояние",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[15]/synonym"
+                    },
+                    "dataPath": "",
+                    "items": []
+                  },
+                  {
+                    "type": "USUAL_GROUP",
+                    "id": 27,
+                    "name": "ГруппаРезультат",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Результат выполнения задания:"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "INPUT_FIELD",
+                          "id": 78,
+                          "name": "ОписаниеРезультата",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                          },
+                          "dataPath": "Объект.РезультатВыполнения",
+                          "items": []
+                        },
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 54,
+                          "name": "ГруппаВыполненоДата",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Выполнено дата"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "USUAL_BUTTON",
+                                "id": 123,
+                                "name": "Выполнено",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[3]/synonym"
+                                },
+                                "dataPath": "",
+                                "items": []
+                              },
+                              {
+                                "type": "USUAL_BUTTON",
+                                "id": 137,
+                                "name": "Отклонено",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Отменено"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 55,
+                                "name": "ДатаИсполнения",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Дата"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "Объект.ДатаИсполнения",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 146,
+                                "name": "ДатаИсполненияВремя",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                },
+                                "dataPath": "Объект.ДатаИсполнения",
+                                "items": []
+                              },
+                              {
+                                "type": "HYPERLINK",
+                                "id": 199,
+                                "name": "ИзменитьЗадание",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Изменить задание"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": []
+                              }
+                            ],
+                            []
+                          ]
+                        }
+                      ],
+                      []
+                    ]
+                  }
+                ],
+                []
+              ]
+            }
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "Объект",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "ЗадачаОбъект.ЗадачаИсполнителя",
+                          "nameEn": "TaskObject.ЗадачаИсполнителя"
+                        },
+                        "variant": "METADATA",
+                        "kind": "TASK"
+                      }
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 2,
+                "name": "НачальныйПризнакВыполнения",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              },
+              {
+                "id": 3,
+                "name": "ПредметСтрокой",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[11]/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[13]/type"
+                }
+              },
+              {
+                "id": 5,
+                "name": "ТекущийПользователь",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/type/types/java.util.CollSer/com.github._1c_syntax.bsl.types.value.CustomValueType[2]"
+                      }
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 7,
+                "name": "ЗаданиеВыполнено",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              },
+              {
+                "id": 6,
+                "name": "ЗаданиеСодержание",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[14]/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[13]/type"
+                }
+              },
+              {
+                "id": 8,
+                "name": "ЗаданиеРезультатВыполнения",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "История сообщений"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[13]/type"
+                }
+              },
+              {
+                "id": 4,
+                "name": "Исполнитель",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[6]/synonym"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 2,
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/type/types/java.util.CollSer/com.github._1c_syntax.bsl.types.value.CustomValueType[2]"
+                      },
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[6]/type/types/java.util.CollSer/com.github._1c_syntax.bsl.types.value.CustomValueType[3]"
+                      }
+                    }
+                  ],
+                  "composite": true,
+                  "qualifiers": []
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "3e2f2ae1-c809-43fc-8276-b0a16a92858c",
+        "name": "ДействиеПроверить",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "BusinessProcess.Задание.Form.ДействиеПроверить",
+          "mdoRefRu": "БизнесПроцесс.Задание.Форма.ДействиеПроверить"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Действие проверить"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/BusinessProcesses/Задание/Forms/Де_ствиеПроверить/Ext/Form/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+          },
+          "handlers": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[2]"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[3]"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[4]"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[5]"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[6]"
+              }
+            ],
+            []
+          ],
+          "items": [
+            {
+              "type": "USUAL_GROUP",
+              "id": 234,
+              "name": "Документ",
+              "title": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+              },
+              "dataPath": "",
+              "items": [
+                [
+                  {
+                    "type": "USUAL_GROUP",
+                    "id": 134,
+                    "name": "ГруппаСостояние",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[15]/synonym"
+                    },
+                    "dataPath": "",
+                    "items": []
+                  },
+                  {
+                    "type": "USUAL_GROUP",
+                    "id": 165,
+                    "name": "Шапка",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 166,
+                          "name": "ГруппыШапки",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "USUAL_GROUP",
+                                "id": 167,
+                                "name": "ГруппаАвторИсполнитель",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 168,
+                                      "name": "Автор",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                      },
+                                      "dataPath": "Объект.Автор",
+                                      "items": []
+                                    },
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 170,
+                                      "name": "Исполнитель",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[12]/synonym"
+                                      },
+                                      "dataPath": "Исполнитель",
+                                      "items": []
+                                    }
+                                  ],
+                                  []
+                                ]
+                              },
+                              {
+                                "type": "USUAL_GROUP",
+                                "id": 172,
+                                "name": "ГруппаДатаИСрок",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 173,
+                                      "name": "Дата",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                      },
+                                      "dataPath": "Объект.Date",
+                                      "items": []
+                                    },
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 175,
+                                      "name": "СрокИсполнения",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                      },
+                                      "dataPath": "Объект.СрокИсполнения",
+                                      "items": []
+                                    }
+                                  ],
+                                  []
+                                ]
+                              },
+                              {
+                                "type": "USUAL_GROUP",
+                                "id": 177,
+                                "name": "ГруппаНомерИВажность",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 178,
+                                      "name": "Номер",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                      },
+                                      "dataPath": "Объект.Number",
+                                      "items": []
+                                    },
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 180,
+                                      "name": "Важность",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                      },
+                                      "dataPath": "Объект.Важность",
+                                      "items": []
+                                    }
+                                  ],
+                                  []
+                                ]
+                              }
+                            ],
+                            []
+                          ]
+                        },
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 182,
+                          "name": "ГруппаПриоритет",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 183,
+                                "name": "СрокНачалаИсполнения",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                },
+                                "dataPath": "Объект.ДатаНачала",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 185,
+                                "name": "СрокНачалаИсполненияВремя",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                },
+                                "dataPath": "Объект.ДатаНачала",
+                                "items": []
+                              }
+                            ],
+                            []
+                          ]
+                        }
+                      ],
+                      []
+                    ]
+                  },
+                  {
+                    "type": "PAGES",
+                    "id": 222,
+                    "name": "Страницы",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "PAGE",
+                          "id": 224,
+                          "name": "Главное",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                          },
+                          "dataPath": "",
+                          "items": [
+                            {
+                              "type": "USUAL_GROUP",
+                              "id": 94,
+                              "name": "ГруппаСодержание",
+                              "title": {
+                                "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[14]/synonym"
+                              },
+                              "dataPath": "",
+                              "items": [
+                                [
+                                  {
+                                    "type": "INPUT_FIELD",
+                                    "id": 159,
+                                    "name": "Наименование",
+                                    "title": {
+                                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                    },
+                                    "dataPath": "Объект.Description",
+                                    "items": []
+                                  },
+                                  {
+                                    "type": "LABEL_FIELD",
+                                    "id": 132,
+                                    "name": "Предмет",
+                                    "title": {
+                                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[11]/synonym"
+                                    },
+                                    "dataPath": "ПредметСтрокой",
+                                    "items": []
+                                  },
+                                  {
+                                    "type": "INPUT_FIELD",
+                                    "id": 18,
+                                    "name": "Содержание",
+                                    "title": {
+                                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[14]/synonym"
+                                    },
+                                    "dataPath": "ЗаданиеСодержание",
+                                    "items": []
+                                  }
+                                ],
+                                []
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "PAGE",
+                          "id": 226,
+                          "name": "ИсторияВыполнения",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                          },
+                          "dataPath": "",
+                          "items": [
+                            {
+                              "type": "INPUT_FIELD",
+                              "id": 126,
+                              "name": "РезультатВыполнения",
+                              "title": {
+                                "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                              },
+                              "dataPath": "ЗаданиеРезультатВыполнения",
+                              "items": []
+                            }
+                          ]
+                        }
+                      ],
+                      []
+                    ]
+                  },
+                  {
+                    "type": "USUAL_GROUP",
+                    "id": 27,
+                    "name": "ГруппаРезультат",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Результат проверки задания:"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "INPUT_FIELD",
+                          "id": 78,
+                          "name": "ОписаниеРезультата",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                          },
+                          "dataPath": "Объект.РезультатВыполнения",
+                          "items": []
+                        },
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 54,
+                          "name": "ГруппаВыполненаДата",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Выполнена дата"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "USUAL_BUTTON",
+                                "id": 123,
+                                "name": "Выполнено",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[3]/synonym"
+                                },
+                                "dataPath": "",
+                                "items": []
+                              },
+                              {
+                                "type": "USUAL_BUTTON",
+                                "id": 147,
+                                "name": "Отменено",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                },
+                                "dataPath": "",
+                                "items": []
+                              },
+                              {
+                                "type": "USUAL_BUTTON",
+                                "id": 124,
+                                "name": "Возвращено",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Возвращено исполнителю"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 55,
+                                "name": "ДатаИсполнения",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Дата проверки"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "Объект.ДатаИсполнения",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 161,
+                                "name": "ДатаИсполненияВремя",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                },
+                                "dataPath": "Объект.ДатаИсполнения",
+                                "items": []
+                              },
+                              {
+                                "type": "HYPERLINK",
+                                "id": 130,
+                                "name": "ИзменитьЗадание",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/title"
+                                },
+                                "dataPath": "",
+                                "items": []
+                              }
+                            ],
+                            []
+                          ]
+                        }
+                      ],
+                      []
+                    ]
+                  }
+                ],
+                []
+              ]
+            }
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "Объект",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 2,
+                "name": "НачальныйПризнакВыполнения",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              },
+              {
+                "id": 3,
+                "name": "ПредметСтрокой",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[11]/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[13]/type"
+                }
+              },
+              {
+                "id": 5,
+                "name": "ТекущийПользователь",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 6,
+                "name": "ЗаданиеСодержание",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[14]/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[13]/type"
+                }
+              },
+              {
+                "id": 7,
+                "name": "ЗаданиеВыполнено",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              },
+              {
+                "id": 8,
+                "name": "ЗаданиеРезультатВыполнения",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[7]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[13]/type"
+                }
+              },
+              {
+                "id": 9,
+                "name": "ЗаданиеПодтверждено",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              },
+              {
+                "id": 10,
+                "name": "ЗаданиеСсылка",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[4]/type"
+                }
+              },
+              {
+                "id": 4,
+                "name": "Исполнитель",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[6]/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[8]/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "b58942ca-1367-4e1d-b5b4-7d973d0fecd8",
+        "name": "ФормаБизнесПроцесса",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "BusinessProcess.Задание.Form.ФормаБизнесПроцесса",
+          "mdoRefRu": "БизнесПроцесс.Задание.Форма.ФормаБизнесПроцесса"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Форма бизнес-процесса"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/BusinessProcesses/Задание/Forms/ФормаБизнесПроцесса/Ext/Form/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+          },
+          "handlers": [
+            [
+              {
+                "event": "AfterWrite",
+                "name": "ПослеЗаписи"
+              },
+              {
+                "event": "ChoiceProcessing",
+                "name": "ОбработкаВыбора"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[2]"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[3]"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[4]"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[5]"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[6]"
+              },
+              {
+                "event": "OnWriteAtServer",
+                "name": "ПриЗаписиНаСервере"
+              }
+            ],
+            []
+          ],
+          "items": [
+            {
+              "type": "USUAL_GROUP",
+              "id": 151,
+              "name": "Документ",
+              "title": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+              },
+              "dataPath": "",
+              "items": [
+                [
+                  {
+                    "type": "LABEL_FIELD",
+                    "id": 99,
+                    "name": "ГлавнаяЗадача",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[4]/synonym"
+                    },
+                    "dataPath": "ГлавнаяЗадачаСтрокой",
+                    "items": []
+                  },
+                  {
+                    "type": "USUAL_GROUP",
+                    "id": 92,
+                    "name": "ГруппаСостояние",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[15]/synonym"
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "PICTURE_DECORATION",
+                          "id": 93,
+                          "name": "ДекорацияЗначок",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                          },
+                          "dataPath": "",
+                          "items": []
+                        },
+                        {
+                          "type": "LABEL_FIELD",
+                          "id": 155,
+                          "name": "ИнфоНадписьЗаголовок",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Инфо надпись заголовок"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "ИнфоНадписьЗаголовок",
+                          "items": []
+                        }
+                      ],
+                      []
+                    ]
+                  },
+                  {
+                    "type": "USUAL_GROUP",
+                    "id": 145,
+                    "name": "Шапка",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 27,
+                          "name": "ГруппаСрокВажность",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Срок важность"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 19,
+                                "name": "ЗаголовокЗадания",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                },
+                                "dataPath": "Объект.Наименование",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 57,
+                                "name": "Важность",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                },
+                                "dataPath": "Объект.Важность",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 103,
+                                "name": "Номер",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                },
+                                "dataPath": "Объект.Number",
+                                "items": []
+                              }
+                            ],
+                            []
+                          ]
+                        },
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 67,
+                          "name": "ГруппаИсполнение",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Исполнение"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 69,
+                                "name": "Исполнитель",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                },
+                                "dataPath": "Объект.Исполнитель",
+                                "items": []
+                              },
+                              {
+                                "type": "USUAL_GROUP",
+                                "id": 147,
+                                "name": "ГруппаСрокИсполнения",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[16]/synonym"
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 21,
+                                      "name": "СрокИсполнения",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Срок"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "Объект.СрокИсполнения",
+                                      "items": []
+                                    },
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 88,
+                                      "name": "СрокИсполненияВремя",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                      },
+                                      "dataPath": "Объект.СрокИсполнения",
+                                      "items": []
+                                    }
+                                  ],
+                                  []
+                                ]
+                              }
+                            ],
+                            []
+                          ]
+                        }
+                      ],
+                      []
+                    ]
+                  },
+                  {
+                    "type": "USUAL_GROUP",
+                    "id": 75,
+                    "name": "ГруппаСодержание",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[14]/synonym"
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "LABEL_FIELD",
+                          "id": 86,
+                          "name": "Предмет",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[11]/synonym"
+                          },
+                          "dataPath": "ПредметСтрокой",
+                          "items": []
+                        },
+                        {
+                          "type": "INPUT_FIELD",
+                          "id": 17,
+                          "name": "Содержание",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[14]/synonym"
+                          },
+                          "dataPath": "Объект.Содержание",
+                          "items": []
+                        }
+                      ],
+                      []
+                    ]
+                  },
+                  {
+                    "type": "USUAL_GROUP",
+                    "id": 56,
+                    "name": "ГруппаПроверка",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Проверка"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "CHECK_BOX_FIELD",
+                          "id": 54,
+                          "name": "НаПроверке",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Проверить выполнение:"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "Объект.НаПроверке",
+                          "items": []
+                        },
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 28,
+                          "name": "ГруппаПроверяющий",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[12]/synonym"
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 14,
+                                "name": "Проверяющий",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                },
+                                "dataPath": "Объект.Проверяющий",
+                                "items": []
+                              },
+                              {
+                                "type": "USUAL_GROUP",
+                                "id": 149,
+                                "name": "ГруппаСрокПроверки",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[17]/synonym"
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 23,
+                                      "name": "СрокПроверки",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                      },
+                                      "dataPath": "Объект.СрокПроверки",
+                                      "items": []
+                                    },
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 90,
+                                      "name": "СрокПроверкиВремя",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                      },
+                                      "dataPath": "Объект.СрокПроверки",
+                                      "items": []
+                                    }
+                                  ],
+                                  []
+                                ]
+                              }
+                            ],
+                            []
+                          ]
+                        }
+                      ],
+                      []
+                    ]
+                  },
+                  {
+                    "type": "USUAL_GROUP",
+                    "id": 81,
+                    "name": "ГруппаОбщиеСведения",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/synonym"
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "INPUT_FIELD",
+                          "id": 79,
+                          "name": "Автор",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                          },
+                          "dataPath": "Объект.Автор",
+                          "items": []
+                        },
+                        {
+                          "type": "INPUT_FIELD",
+                          "id": 97,
+                          "name": "Дата",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Начато"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "Объект.Date",
+                          "items": []
+                        }
+                      ],
+                      []
+                    ]
+                  }
+                ],
+                []
+              ]
+            }
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "Объект",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "БизнесПроцессОбъект.Задание",
+                          "nameEn": "BusinessProcessObject.Задание"
+                        },
+                        "variant": "METADATA",
+                        "kind": "BUSINESS_PROCESS"
+                      }
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 2,
+                "name": "НачальныйПризнакСтарта",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              },
+              {
+                "id": 3,
+                "name": "ПредметСтрокой",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[11]/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[13]/type"
+                }
+              },
+              {
+                "id": 4,
+                "name": "ГлавнаяЗадачаСтрокой",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[4]/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[13]/type"
+                }
+              },
+              {
+                "id": 5,
+                "name": "ИнфоНадписьЗаголовок",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "FORMATTED_STRING"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 6,
+                "name": "Отложен",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              },
+              {
+                "id": 7,
+                "name": "ДатаОтложенногоСтарта",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[6]/type"
+                }
+              },
+              {
+                "id": 8,
+                "name": "ИспользоватьДатуИВремяВСрокахЗадач",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              },
+              {
+                "id": 9,
+                "name": "ИспользоватьПодчиненныеБизнесПроцессы",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              },
+              {
+                "id": 10,
+                "name": "ИзменятьЗаданияЗаднимЧислом",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "1a7c7427-bead-4655-9dd6-df6e722663c5",
+        "name": "ФормаСписка",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "BusinessProcess.Задание.Form.ФормаСписка",
+          "mdoRefRu": "БизнесПроцесс.Задание.Форма.ФормаСписка"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Форма списка"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/BusinessProcesses/Задание/Forms/ФормаСписка/Ext/Form/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+          },
+          "handlers": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[5]"
+              },
+              {
+                "event": "BeforeLoadDataFromSettingsAtServer",
+                "name": "ПриЗагрузкеДанныхИзНастроекНаСервере"
+              }
+            ],
+            []
+          ],
+          "items": [
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 21,
+                "name": "ГруппаПоРеквизитам",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Отборы"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 14,
+                      "name": "ПоАвтору",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/synonym"
+                      },
+                      "dataPath": "ПоАвтору",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 17,
+                      "name": "ПоИсполнителю",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[6]/synonym"
+                      },
+                      "dataPath": "ПоИсполнителю",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 19,
+                      "name": "ПоПроверяющему",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[12]/synonym"
+                      },
+                      "dataPath": "ПоПроверяющему",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 50,
+                "name": "Флажки",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Флажки"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "CHECK_BOX_FIELD",
+                      "id": 22,
+                      "name": "ПоказыватьЗавершенныеЗадания",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Показывать завершенные задания"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "ПоказыватьЗавершенныеЗадания",
+                      "items": []
+                    },
+                    {
+                      "type": "CHECK_BOX_FIELD",
+                      "id": 48,
+                      "name": "ПоказыватьОстановленные",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Показывать остановленные"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "ПоказыватьОстановленные",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 92,
+                "name": "ГруппаПользовательскихНастроек",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Группа пользовательских настроек"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": []
+              },
+              {
+                "type": "COMMAND_BAR",
+                "id": 53,
+                "name": "КоманднаяПанель",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Командная панель"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "COMMAND_BAR_BUTTON",
+                      "id": 94,
+                      "name": "ФормаОбщаяКомандаКартаМаршрутаБизнесПроцесса",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Items.Список.CurrentData.Ref",
+                      "items": []
+                    },
+                    {
+                      "type": "COMMAND_BAR_BUTTON",
+                      "id": 51,
+                      "name": "ФормаОстановить",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Остановить"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "COMMAND_BAR_BUTTON",
+                      "id": 52,
+                      "name": "ФормаПродолжитьБизнесПроцесс",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Продолжить"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "TABLE",
+                "id": 1,
+                "name": "Список",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Список"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "Список",
+                "items": [
+                  [
+                    {
+                      "type": "PICTURE_FIELD",
+                      "id": 24,
+                      "name": "ВажностьКартинка",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[2]/synonym"
+                      },
+                      "dataPath": "Список.ВажностьКартинка",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 4,
+                      "name": "Номер",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.Number",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 6,
+                      "name": "Дата",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.Date",
+                      "items": []
+                    },
+                    {
+                      "type": "COLUMN_GROUP",
+                      "id": 54,
+                      "name": "ГруппаСодержание",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[14]/synonym"
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "LABEL_FIELD",
+                            "id": 26,
+                            "name": "Наименование",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                            },
+                            "dataPath": "Список.Наименование",
+                            "items": []
+                          },
+                          {
+                            "type": "LABEL_FIELD",
+                            "id": 32,
+                            "name": "Предмет",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                            },
+                            "dataPath": "Список.Предмет",
+                            "items": []
+                          },
+                          {
+                            "type": "LABEL_FIELD",
+                            "id": 28,
+                            "name": "Содержание",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                            },
+                            "dataPath": "Список.Содержание",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 42,
+                      "name": "СрокИсполнения",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.СрокИсполнения",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 44,
+                      "name": "СрокПроверки",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.СрокПроверки",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 38,
+                      "name": "ДатаЗавершения",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[3]/synonym"
+                      },
+                      "dataPath": "Список.ДатаЗавершения",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 10,
+                      "name": "ВедущаяЗадача",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.HeadTask",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 30,
+                      "name": "НомерИтерации",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.НомерИтерации",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 34,
+                      "name": "Автор",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.Автор",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 36,
+                      "name": "Исполнитель",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.Исполнитель",
+                      "items": []
+                    },
+                    {
+                      "type": "COLUMN_GROUP",
+                      "id": 57,
+                      "name": "ГруппаПроверка",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[8]/synonym"
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "CHECK_BOX_FIELD",
+                            "id": 55,
+                            "name": "НаПроверке",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                            },
+                            "dataPath": "Список.НаПроверке",
+                            "items": []
+                          },
+                          {
+                            "type": "LABEL_FIELD",
+                            "id": 40,
+                            "name": "Проверяющий",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                            },
+                            "dataPath": "Список.Проверяющий",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 89,
+                      "name": "Ссылка",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.Ref",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "Список",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "DYNAMIC_LIST"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 2,
+                "name": "ПоАвтору",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 3,
+                "name": "ПоИсполнителю",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[6]/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 4,
+                "name": "ПоПроверяющему",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[12]/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 5,
+                "name": "ПоказыватьЗавершенныеЗадания",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              },
+              {
+                "id": 6,
+                "name": "ПоказыватьОстановленные",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      }
+    ],
+    []
+  ],
+  "mdoReference": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+  },
+  "mdoType": "BUSINESS_PROCESS",
+  "moduleTypes": [
+    [
+      "ManagerModule",
+      [
+        "src/test/resources/ext/designer/ssl_3_2/src/cf/BusinessProcesses/Задание/Ext/ManagerModule.bsl"
+      ]
+    ],
+    [
+      "ObjectModule",
+      [
+        "src/test/resources/ext/designer/ssl_3_2/src/cf/BusinessProcesses/Задание/Ext/ObjectModule.bsl"
+      ]
+    ]
+  ],
+  "modules": [
+    {
+      "moduleType": "ManagerModule",
+      "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/BusinessProcesses/Задание/Ext/ManagerModule.bsl",
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "isProtected": false
+    },
+    {
+      "moduleType": "ObjectModule",
+      "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/BusinessProcesses/Задание/Ext/ObjectModule.bsl",
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "isProtected": false
+    }
+  ],
+  "name": "Задание",
+  "objectBelonging": "OWN",
+  "possibleRights": [
+    {
+      "default": {
+        "tag": 4
+      },
+      "int": 24,
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INSERT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "DELETE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "VIEW",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "EDIT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INPUT_BY_STRING",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_DELETE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_INSERT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_SET_DELETION_MARK",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_CLEAR_DELETION_MARK",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_DELETE_MARKED",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "START",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_START",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_ACTIVATE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "VIEW_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ_DATA_HISTORY_OF_MISSING_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_OF_MISSING_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_SETTINGS",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_VERSION_COMMENT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "EDIT_DATA_HISTORY_VERSION_COMMENT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "SWITCH_TO_DATA_HISTORY_VERSION"
+    }
+  ],
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[7]/synonym"
+  },
+  "tabularSections": [],
+  "task": {
+    "type": "TASK",
+    "mdoRef": "Task.ЗадачаИсполнителя",
+    "mdoRefRu": "Задача.ЗадачаИсполнителя"
+  },
+  "templates": [],
+  "uuid": "dad11c2e-08fc-4a6b-8829-8be6c64c15fc"
+}}

--- a/src/test/resources/fixtures/ssl_3_2/BusinessProcesses.Задание_edt.json
+++ b/src/test/resources/fixtures/ssl_3_2/BusinessProcesses.Задание_edt.json
@@ -1875,12 +1875,12 @@
   "forms": [
     [
       {
-        "uuid": "f0620d5a-e1fe-419f-af37-e0f462f97e8d",
-        "name": "ДействиеВыполнить",
+        "uuid": "3e2f2ae1-c809-43fc-8276-b0a16a92858c",
+        "name": "ДействиеПроверить",
         "mdoReference": {
           "type": "FORM",
-          "mdoRef": "BusinessProcess.Задание.Form.ДействиеВыполнить",
-          "mdoRefRu": "БизнесПроцесс.Задание.Форма.ДействиеВыполнить"
+          "mdoRef": "BusinessProcess.Задание.Form.ДействиеПроверить",
+          "mdoRefRu": "БизнесПроцесс.Задание.Форма.ДействиеПроверить"
         },
         "objectBelonging": "OWN",
         "comment": "",
@@ -1893,7 +1893,7 @@
               "int": 1,
               "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                 "langKey": "ru",
-                "value": "Действие выполнить"
+                "value": "Действие проверить"
               }
             }
           ]
@@ -1902,7 +1902,7 @@
         "modules": [
           {
             "moduleType": "FormModule",
-            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/BusinessProcesses/Задание/Forms/Де_ствиеВыполнить/Module.bsl",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/BusinessProcesses/Задание/Forms/Де_ствиеПроверить/Module.bsl",
             "owner": {
               "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/mdoReference"
             },
@@ -1934,537 +1934,374 @@
             []
           ],
           "items": [
-            {
-              "type": "USUAL_GROUP",
-              "id": 207,
-              "name": "Документ",
-              "title": {
-                "content": [
-                  {
-                    "default": {
-                      "tag": 2
-                    },
-                    "int": 1,
-                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                      "langKey": "ru",
-                      "value": "Документ"
-                    }
-                  }
-                ]
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 134,
+                "name": "ГруппаСостояние",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[15]/synonym"
+                },
+                "dataPath": "",
+                "items": []
               },
-              "dataPath": "",
-              "items": [
-                [
-                  {
-                    "type": "USUAL_GROUP",
-                    "id": 154,
-                    "name": "Шапка",
-                    "title": {
-                      "content": [
-                        {
-                          "default": {
-                            "tag": 2
-                          },
-                          "int": 1,
-                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                            "langKey": "ru",
-                            "value": "Шапка"
+              {
+                "type": "PAGES",
+                "id": 259,
+                "name": "Страницы",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Страницы"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "PAGE",
+                      "id": 267,
+                      "name": "СтраницаОписаниеЗадачи",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Описание задачи"
+                            }
                           }
-                        }
-                      ]
-                    },
-                    "dataPath": "",
-                    "items": [
-                      [
-                        {
-                          "type": "USUAL_GROUP",
-                          "id": 165,
-                          "name": "ГруппыШапки",
-                          "title": {
-                            "content": [
-                              {
-                                "default": {
-                                  "tag": 2
-                                },
-                                "int": 1,
-                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                  "langKey": "ru",
-                                  "value": "Группы шапки"
-                                }
-                              }
-                            ]
-                          },
-                          "dataPath": "",
-                          "items": [
-                            [
-                              {
-                                "type": "USUAL_GROUP",
-                                "id": 160,
-                                "name": "ГруппаАвторИсполнитель",
-                                "title": {
-                                  "content": [
-                                    {
-                                      "default": {
-                                        "tag": 2
-                                      },
-                                      "int": 1,
-                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                        "langKey": "ru",
-                                        "value": "Автор исполнитель"
-                                      }
-                                    }
-                                  ]
-                                },
-                                "dataPath": "",
-                                "items": [
-                                  [
-                                    {
-                                      "type": "INPUT_FIELD",
-                                      "id": 161,
-                                      "name": "Автор",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                      },
-                                      "dataPath": "Объект.Автор",
-                                      "items": []
-                                    },
-                                    {
-                                      "type": "INPUT_FIELD",
-                                      "id": 163,
-                                      "name": "Исполнитель",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[6]/synonym"
-                                      },
-                                      "dataPath": "Исполнитель",
-                                      "items": []
-                                    }
-                                  ],
-                                  []
-                                ]
-                              },
-                              {
-                                "type": "USUAL_GROUP",
-                                "id": 109,
-                                "name": "ГруппаДатаИСрок",
-                                "title": {
-                                  "content": [
-                                    {
-                                      "default": {
-                                        "tag": 2
-                                      },
-                                      "int": 1,
-                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                        "langKey": "ru",
-                                        "value": "Дата и срок"
-                                      }
-                                    }
-                                  ]
-                                },
-                                "dataPath": "",
-                                "items": [
-                                  [
-                                    {
-                                      "type": "INPUT_FIELD",
-                                      "id": 152,
-                                      "name": "Дата",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                      },
-                                      "dataPath": "Объект.Date",
-                                      "items": []
-                                    },
-                                    {
-                                      "type": "INPUT_FIELD",
-                                      "id": 12,
-                                      "name": "СрокИсполнения",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                      },
-                                      "dataPath": "Объект.СрокИсполнения",
-                                      "items": []
-                                    }
-                                  ],
-                                  []
-                                ]
-                              },
-                              {
-                                "type": "USUAL_GROUP",
-                                "id": 28,
-                                "name": "ГруппаНомерИВажность",
-                                "title": {
-                                  "content": [
-                                    {
-                                      "default": {
-                                        "tag": 2
-                                      },
-                                      "int": 1,
-                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                        "langKey": "ru",
-                                        "value": "Номер и важность"
-                                      }
-                                    }
-                                  ]
-                                },
-                                "dataPath": "",
-                                "items": [
-                                  [
-                                    {
-                                      "type": "INPUT_FIELD",
-                                      "id": 149,
-                                      "name": "Номер",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                      },
-                                      "dataPath": "Объект.Number",
-                                      "items": []
-                                    },
-                                    {
-                                      "type": "INPUT_FIELD",
-                                      "id": 16,
-                                      "name": "Важность",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                      },
-                                      "dataPath": "Объект.Важность",
-                                      "items": []
-                                    }
-                                  ],
-                                  []
-                                ]
-                              }
-                            ],
-                            []
-                          ]
-                        },
-                        {
-                          "type": "USUAL_GROUP",
-                          "id": 155,
-                          "name": "ГруппаПриоритет",
-                          "title": {
-                            "content": [
-                              {
-                                "default": {
-                                  "tag": 2
-                                },
-                                "int": 1,
-                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                  "langKey": "ru",
-                                  "value": "Приоритет"
-                                }
-                              }
-                            ]
-                          },
-                          "dataPath": "",
-                          "items": [
-                            [
-                              {
-                                "type": "INPUT_FIELD",
-                                "id": 119,
-                                "name": "СрокНачалаИсполнения",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                },
-                                "dataPath": "Объект.ДатаНачала",
-                                "items": []
-                              },
-                              {
-                                "type": "INPUT_FIELD",
-                                "id": 135,
-                                "name": "СрокНачалаИсполненияВремя",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                },
-                                "dataPath": "Объект.ДатаНачала",
-                                "items": []
-                              }
-                            ],
-                            []
-                          ]
-                        }
-                      ],
-                      []
-                    ]
-                  },
-                  {
-                    "type": "PAGES",
-                    "id": 201,
-                    "name": "Страницы",
-                    "title": {
-                      "content": [
-                        {
-                          "default": {
-                            "tag": 2
-                          },
-                          "int": 1,
-                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                            "langKey": "ru",
-                            "value": "Страницы"
-                          }
-                        }
-                      ]
-                    },
-                    "dataPath": "",
-                    "items": [
-                      [
-                        {
-                          "type": "PAGE",
-                          "id": 203,
-                          "name": "Главное",
-                          "title": {
-                            "content": [
-                              {
-                                "default": {
-                                  "tag": 2
-                                },
-                                "int": 1,
-                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                  "langKey": "ru",
-                                  "value": "Главное"
-                                }
-                              }
-                            ]
-                          },
-                          "dataPath": "",
-                          "items": [
-                            {
-                              "type": "USUAL_GROUP",
-                              "id": 94,
-                              "name": "ГруппаСодержание",
-                              "title": {
-                                "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[14]/synonym"
-                              },
-                              "dataPath": "",
-                              "items": [
-                                [
-                                  {
-                                    "type": "INPUT_FIELD",
-                                    "id": 156,
-                                    "name": "Наименование",
-                                    "title": {
-                                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                    },
-                                    "dataPath": "Объект.Description",
-                                    "items": []
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 269,
+                            "name": "ГруппаНаименованиеИНомер",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
                                   },
-                                  {
-                                    "type": "LABEL_FIELD",
-                                    "id": 129,
-                                    "name": "Предмет",
-                                    "title": {
-                                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[11]/synonym"
-                                    },
-                                    "dataPath": "ПредметСтрокой",
-                                    "items": []
-                                  },
-                                  {
-                                    "type": "INPUT_FIELD",
-                                    "id": 18,
-                                    "name": "Содержание",
-                                    "title": {
-                                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[14]/synonym"
-                                    },
-                                    "dataPath": "ЗаданиеСодержание",
-                                    "items": []
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Наименование и номер"
                                   }
-                                ],
-                                []
-                              ]
-                            }
-                          ]
-                        },
-                        {
-                          "type": "PAGE",
-                          "id": 205,
-                          "name": "ИсторияВыполнения",
-                          "title": {
-                            "content": [
-                              {
-                                "default": {
-                                  "tag": 2
-                                },
-                                "int": 1,
-                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                  "langKey": "ru",
-                                  "value": "История выполнения"
                                 }
-                              }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 159,
+                                  "name": "Наименование",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                  },
+                                  "dataPath": "Объект.Description",
+                                  "items": []
+                                },
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 178,
+                                  "name": "Номер",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                  },
+                                  "dataPath": "Объект.Number",
+                                  "items": []
+                                }
+                              ],
+                              []
                             ]
                           },
-                          "dataPath": "",
-                          "items": [
-                            {
-                              "type": "INPUT_FIELD",
-                              "id": 126,
-                              "name": "РезультатВыполнения",
-                              "title": {
-                                "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                              },
-                              "dataPath": "ЗаданиеРезультатВыполнения",
-                              "items": []
-                            }
-                          ]
-                        }
-                      ],
-                      []
-                    ]
-                  },
-                  {
-                    "type": "USUAL_GROUP",
-                    "id": 131,
-                    "name": "ГруппаСостояние",
-                    "title": {
-                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[15]/synonym"
-                    },
-                    "dataPath": "",
-                    "items": []
-                  },
-                  {
-                    "type": "USUAL_GROUP",
-                    "id": 27,
-                    "name": "ГруппаРезультат",
-                    "title": {
-                      "content": [
-                        {
-                          "default": {
-                            "tag": 2
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 18,
+                            "name": "Содержание",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[14]/synonym"
+                            },
+                            "dataPath": "ЗаданиеСодержание",
+                            "items": []
                           },
-                          "int": 1,
-                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                            "langKey": "ru",
-                            "value": "Результат выполнения задания:"
+                          {
+                            "type": "LABEL_FIELD",
+                            "id": 132,
+                            "name": "Предмет",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[11]/synonym"
+                            },
+                            "dataPath": "ПредметСтрокой",
+                            "items": []
+                          },
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 273,
+                            "name": "ГруппаПараметрыЗадачи",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Параметры задачи"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "USUAL_GROUP",
+                                  "id": 265,
+                                  "name": "ГруппаИсполнитель",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[6]/synonym"
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "INPUT_FIELD",
+                                        "id": 180,
+                                        "name": "Важность",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                        },
+                                        "dataPath": "Объект.Важность",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "LABEL_FIELD",
+                                        "id": 175,
+                                        "name": "СрокИсполнения",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                        },
+                                        "dataPath": "Объект.СрокИсполнения",
+                                        "items": []
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                },
+                                {
+                                  "type": "USUAL_GROUP",
+                                  "id": 271,
+                                  "name": "ГруппаПраво",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Право"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "LABEL_FIELD",
+                                        "id": 170,
+                                        "name": "Исполнитель",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[12]/synonym"
+                                        },
+                                        "dataPath": "Исполнитель",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "LABEL_FIELD",
+                                        "id": 168,
+                                        "name": "Автор",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                        },
+                                        "dataPath": "Объект.Автор",
+                                        "items": []
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                }
+                              ],
+                              []
+                            ]
                           }
-                        }
+                        ],
+                        []
                       ]
                     },
-                    "dataPath": "",
-                    "items": [
-                      [
-                        {
-                          "type": "INPUT_FIELD",
-                          "id": 78,
-                          "name": "ОписаниеРезультата",
-                          "title": {
-                            "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                    {
+                      "type": "PAGE",
+                      "id": 263,
+                      "name": "СтраницаРезультатВыполнения",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Результат"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 78,
+                            "name": "ОписаниеРезультата",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                            },
+                            "dataPath": "Объект.РезультатВыполнения",
+                            "items": []
                           },
-                          "dataPath": "Объект.РезультатВыполнения",
-                          "items": []
-                        },
-                        {
-                          "type": "USUAL_GROUP",
-                          "id": 54,
-                          "name": "ГруппаВыполненоДата",
-                          "title": {
-                            "content": [
-                              {
-                                "default": {
-                                  "tag": 2
-                                },
-                                "int": 1,
-                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                  "langKey": "ru",
-                                  "value": "Выполнено дата"
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 275,
+                            "name": "ГруппаДатыИсполнения",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Даты исполнения"
+                                  }
                                 }
-                              }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 55,
+                                  "name": "ДатаИсполнения",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Дата проверки"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "Объект.ДатаИсполнения",
+                                  "items": []
+                                },
+                                {
+                                  "type": "LABEL_FIELD",
+                                  "id": 183,
+                                  "name": "СрокНачалаИсполнения",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                  },
+                                  "dataPath": "Объект.ДатаНачала",
+                                  "items": []
+                                }
+                              ],
+                              []
                             ]
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "PAGE",
+                      "id": 226,
+                      "name": "ИсторияВыполнения",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "История выполнения"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 126,
+                            "name": "РезультатВыполнения",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                            },
+                            "dataPath": "ЗаданиеРезультатВыполнения",
+                            "items": []
                           },
-                          "dataPath": "",
-                          "items": [
-                            [
-                              {
-                                "type": "USUAL_BUTTON",
-                                "id": 123,
-                                "name": "Выполнено",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[3]/synonym"
-                                },
-                                "dataPath": "",
-                                "items": []
-                              },
-                              {
-                                "type": "USUAL_BUTTON",
-                                "id": 137,
-                                "name": "Отклонено",
-                                "title": {
-                                  "content": [
-                                    {
-                                      "default": {
-                                        "tag": 2
-                                      },
-                                      "int": 1,
-                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                        "langKey": "ru",
-                                        "value": "Отменено"
-                                      }
-                                    }
-                                  ]
-                                },
-                                "dataPath": "",
-                                "items": []
-                              },
-                              {
-                                "type": "INPUT_FIELD",
-                                "id": 55,
-                                "name": "ДатаИсполнения",
-                                "title": {
-                                  "content": [
-                                    {
-                                      "default": {
-                                        "tag": 2
-                                      },
-                                      "int": 1,
-                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                        "langKey": "ru",
-                                        "value": "Дата"
-                                      }
-                                    }
-                                  ]
-                                },
-                                "dataPath": "Объект.ДатаИсполнения",
-                                "items": []
-                              },
-                              {
-                                "type": "INPUT_FIELD",
-                                "id": 146,
-                                "name": "ДатаИсполненияВремя",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                },
-                                "dataPath": "Объект.ДатаИсполнения",
-                                "items": []
-                              },
-                              {
-                                "type": "HYPERLINK",
-                                "id": 199,
-                                "name": "ИзменитьЗадание",
-                                "title": {
-                                  "content": [
-                                    {
-                                      "default": {
-                                        "tag": 2
-                                      },
-                                      "int": 1,
-                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                        "langKey": "ru",
-                                        "value": "Изменить задание"
-                                      }
-                                    }
-                                  ]
-                                },
-                                "dataPath": "",
-                                "items": []
-                              }
-                            ],
-                            []
-                          ]
-                        }
-                      ],
-                      []
-                    ]
-                  }
-                ],
-                []
-              ]
-            }
+                          {
+                            "type": "LABEL_FIELD",
+                            "id": 173,
+                            "name": "Дата",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                            },
+                            "dataPath": "Объект.Date",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
           ],
           "attributes": [
             [
@@ -2538,16 +2375,6 @@
                 }
               },
               {
-                "id": 7,
-                "name": "ЗаданиеВыполнено",
-                "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                },
-                "type": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
-                }
-              },
-              {
                 "id": 6,
                 "name": "ЗаданиеСодержание",
                 "title": {
@@ -2555,6 +2382,16 @@
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[13]/type"
+                }
+              },
+              {
+                "id": 7,
+                "name": "ЗаданиеВыполнено",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
                 }
               },
               {
@@ -2576,6 +2413,26 @@
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[13]/type"
+                }
+              },
+              {
+                "id": 9,
+                "name": "ЗаданиеПодтверждено",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              },
+              {
+                "id": 10,
+                "name": "ЗаданиеСсылка",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[4]/type"
                 }
               },
               {
@@ -2619,12 +2476,12 @@
         ]
       },
       {
-        "uuid": "3e2f2ae1-c809-43fc-8276-b0a16a92858c",
-        "name": "ДействиеПроверить",
+        "uuid": "f0620d5a-e1fe-419f-af37-e0f462f97e8d",
+        "name": "ДействиеВыполнить",
         "mdoReference": {
           "type": "FORM",
-          "mdoRef": "BusinessProcess.Задание.Form.ДействиеПроверить",
-          "mdoRefRu": "БизнесПроцесс.Задание.Форма.ДействиеПроверить"
+          "mdoRef": "BusinessProcess.Задание.Form.ДействиеВыполнить",
+          "mdoRefRu": "БизнесПроцесс.Задание.Форма.ДействиеВыполнить"
         },
         "objectBelonging": "OWN",
         "comment": "",
@@ -2637,7 +2494,7 @@
               "int": 1,
               "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                 "langKey": "ru",
-                "value": "Действие проверить"
+                "value": "Действие выполнить"
               }
             }
           ]
@@ -2646,7 +2503,7 @@
         "modules": [
           {
             "moduleType": "FormModule",
-            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/BusinessProcesses/Задание/Forms/Де_ствиеПроверить/Module.bsl",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/BusinessProcesses/Задание/Forms/Де_ствиеВыполнить/Module.bsl",
             "owner": {
               "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/mdoReference"
             },
@@ -2675,426 +2532,329 @@
             []
           ],
           "items": [
-            {
-              "type": "USUAL_GROUP",
-              "id": 234,
-              "name": "Документ",
-              "title": {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+            [
+              {
+                "type": "COMMAND_BAR",
+                "id": 232,
+                "name": "ГруппаКоманднаяПанель",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Командная панель"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": []
               },
-              "dataPath": "",
-              "items": [
-                [
-                  {
-                    "type": "USUAL_GROUP",
-                    "id": 134,
-                    "name": "ГруппаСостояние",
-                    "title": {
-                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[15]/synonym"
-                    },
-                    "dataPath": "",
-                    "items": []
-                  },
-                  {
-                    "type": "USUAL_GROUP",
-                    "id": 165,
-                    "name": "Шапка",
-                    "title": {
-                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                    },
-                    "dataPath": "",
-                    "items": [
-                      [
-                        {
-                          "type": "USUAL_GROUP",
-                          "id": 166,
-                          "name": "ГруппыШапки",
-                          "title": {
-                            "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                          },
-                          "dataPath": "",
-                          "items": [
-                            [
-                              {
-                                "type": "USUAL_GROUP",
-                                "id": 167,
-                                "name": "ГруппаАвторИсполнитель",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                },
-                                "dataPath": "",
-                                "items": [
-                                  [
-                                    {
-                                      "type": "INPUT_FIELD",
-                                      "id": 168,
-                                      "name": "Автор",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                      },
-                                      "dataPath": "Объект.Автор",
-                                      "items": []
-                                    },
-                                    {
-                                      "type": "INPUT_FIELD",
-                                      "id": 170,
-                                      "name": "Исполнитель",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[12]/synonym"
-                                      },
-                                      "dataPath": "Исполнитель",
-                                      "items": []
-                                    }
-                                  ],
-                                  []
-                                ]
-                              },
-                              {
-                                "type": "USUAL_GROUP",
-                                "id": 172,
-                                "name": "ГруппаДатаИСрок",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                                },
-                                "dataPath": "",
-                                "items": [
-                                  [
-                                    {
-                                      "type": "INPUT_FIELD",
-                                      "id": 173,
-                                      "name": "Дата",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                      },
-                                      "dataPath": "Объект.Date",
-                                      "items": []
-                                    },
-                                    {
-                                      "type": "INPUT_FIELD",
-                                      "id": 175,
-                                      "name": "СрокИсполнения",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                      },
-                                      "dataPath": "Объект.СрокИсполнения",
-                                      "items": []
-                                    }
-                                  ],
-                                  []
-                                ]
-                              },
-                              {
-                                "type": "USUAL_GROUP",
-                                "id": 177,
-                                "name": "ГруппаНомерИВажность",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
-                                },
-                                "dataPath": "",
-                                "items": [
-                                  [
-                                    {
-                                      "type": "INPUT_FIELD",
-                                      "id": 178,
-                                      "name": "Номер",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                      },
-                                      "dataPath": "Объект.Number",
-                                      "items": []
-                                    },
-                                    {
-                                      "type": "INPUT_FIELD",
-                                      "id": 180,
-                                      "name": "Важность",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                      },
-                                      "dataPath": "Объект.Важность",
-                                      "items": []
-                                    }
-                                  ],
-                                  []
-                                ]
-                              }
-                            ],
-                            []
-                          ]
-                        },
-                        {
-                          "type": "USUAL_GROUP",
-                          "id": 182,
-                          "name": "ГруппаПриоритет",
-                          "title": {
-                            "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                          },
-                          "dataPath": "",
-                          "items": [
-                            [
-                              {
-                                "type": "INPUT_FIELD",
-                                "id": 183,
-                                "name": "СрокНачалаИсполнения",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                },
-                                "dataPath": "Объект.ДатаНачала",
-                                "items": []
-                              },
-                              {
-                                "type": "INPUT_FIELD",
-                                "id": 185,
-                                "name": "СрокНачалаИсполненияВремя",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                },
-                                "dataPath": "Объект.ДатаНачала",
-                                "items": []
-                              }
-                            ],
-                            []
-                          ]
-                        }
-                      ],
-                      []
-                    ]
-                  },
-                  {
-                    "type": "PAGES",
-                    "id": 222,
-                    "name": "Страницы",
-                    "title": {
-                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                    },
-                    "dataPath": "",
-                    "items": [
-                      [
-                        {
-                          "type": "PAGE",
-                          "id": 224,
-                          "name": "Главное",
-                          "title": {
-                            "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                          },
-                          "dataPath": "",
-                          "items": [
-                            {
-                              "type": "USUAL_GROUP",
-                              "id": 94,
-                              "name": "ГруппаСодержание",
-                              "title": {
-                                "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[14]/synonym"
-                              },
-                              "dataPath": "",
-                              "items": [
-                                [
-                                  {
-                                    "type": "INPUT_FIELD",
-                                    "id": 159,
-                                    "name": "Наименование",
-                                    "title": {
-                                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                    },
-                                    "dataPath": "Объект.Description",
-                                    "items": []
+              {
+                "type": "USUAL_GROUP",
+                "id": 131,
+                "name": "ГруппаСостояние",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[15]/synonym"
+                },
+                "dataPath": "",
+                "items": []
+              },
+              {
+                "type": "PAGES",
+                "id": 201,
+                "name": "Страницы",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "PAGE",
+                      "id": 226,
+                      "name": "ГруппаОЗадаче",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 244,
+                            "name": "ГруппаНаименованиеИНомер",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 156,
+                                  "name": "Наименование",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
                                   },
-                                  {
-                                    "type": "LABEL_FIELD",
-                                    "id": 132,
-                                    "name": "Предмет",
-                                    "title": {
-                                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[11]/synonym"
-                                    },
-                                    "dataPath": "ПредметСтрокой",
-                                    "items": []
-                                  },
-                                  {
-                                    "type": "INPUT_FIELD",
-                                    "id": 18,
-                                    "name": "Содержание",
-                                    "title": {
-                                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[14]/synonym"
-                                    },
-                                    "dataPath": "ЗаданиеСодержание",
-                                    "items": []
-                                  }
-                                ],
-                                []
-                              ]
-                            }
-                          ]
-                        },
-                        {
-                          "type": "PAGE",
-                          "id": 226,
-                          "name": "ИсторияВыполнения",
-                          "title": {
-                            "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                          },
-                          "dataPath": "",
-                          "items": [
-                            {
-                              "type": "INPUT_FIELD",
-                              "id": 126,
-                              "name": "РезультатВыполнения",
-                              "title": {
-                                "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                              },
-                              "dataPath": "ЗаданиеРезультатВыполнения",
-                              "items": []
-                            }
-                          ]
-                        }
-                      ],
-                      []
-                    ]
-                  },
-                  {
-                    "type": "USUAL_GROUP",
-                    "id": 27,
-                    "name": "ГруппаРезультат",
-                    "title": {
-                      "content": [
-                        {
-                          "default": {
-                            "tag": 2
-                          },
-                          "int": 1,
-                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                            "langKey": "ru",
-                            "value": "Результат проверки задания:"
-                          }
-                        }
-                      ]
-                    },
-                    "dataPath": "",
-                    "items": [
-                      [
-                        {
-                          "type": "INPUT_FIELD",
-                          "id": 78,
-                          "name": "ОписаниеРезультата",
-                          "title": {
-                            "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                          },
-                          "dataPath": "Объект.РезультатВыполнения",
-                          "items": []
-                        },
-                        {
-                          "type": "USUAL_GROUP",
-                          "id": 54,
-                          "name": "ГруппаВыполненаДата",
-                          "title": {
-                            "content": [
-                              {
-                                "default": {
-                                  "tag": 2
+                                  "dataPath": "Объект.Description",
+                                  "items": []
                                 },
-                                "int": 1,
-                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                  "langKey": "ru",
-                                  "value": "Выполнена дата"
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 149,
+                                  "name": "Номер",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                  },
+                                  "dataPath": "Объект.Number",
+                                  "items": []
                                 }
-                              }
+                              ],
+                              []
                             ]
                           },
-                          "dataPath": "",
-                          "items": [
-                            [
-                              {
-                                "type": "USUAL_BUTTON",
-                                "id": 123,
-                                "name": "Выполнено",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[3]/synonym"
-                                },
-                                "dataPath": "",
-                                "items": []
-                              },
-                              {
-                                "type": "USUAL_BUTTON",
-                                "id": 147,
-                                "name": "Отменено",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                                },
-                                "dataPath": "",
-                                "items": []
-                              },
-                              {
-                                "type": "USUAL_BUTTON",
-                                "id": 124,
-                                "name": "Возвращено",
-                                "title": {
-                                  "content": [
-                                    {
-                                      "default": {
-                                        "tag": 2
-                                      },
-                                      "int": 1,
-                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                        "langKey": "ru",
-                                        "value": "Возвращено исполнителю"
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 18,
+                            "name": "Содержание",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[14]/synonym"
+                            },
+                            "dataPath": "ЗаданиеСодержание",
+                            "items": []
+                          },
+                          {
+                            "type": "LABEL_FIELD",
+                            "id": 129,
+                            "name": "Предмет",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[11]/synonym"
+                            },
+                            "dataPath": "ПредметСтрокой",
+                            "items": []
+                          },
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 248,
+                            "name": "ГруппаПараметрыЗадачи",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "USUAL_GROUP",
+                                  "id": 246,
+                                  "name": "ГруппаЛево",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Лево"
+                                        }
                                       }
-                                    }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "INPUT_FIELD",
+                                        "id": 16,
+                                        "name": "Важность",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                        },
+                                        "dataPath": "Объект.Важность",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "LABEL_FIELD",
+                                        "id": 163,
+                                        "name": "Исполнитель",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[6]/synonym"
+                                        },
+                                        "dataPath": "Исполнитель",
+                                        "items": []
+                                      }
+                                    ],
+                                    []
                                   ]
                                 },
-                                "dataPath": "",
-                                "items": []
-                              },
-                              {
-                                "type": "INPUT_FIELD",
-                                "id": 55,
-                                "name": "ДатаИсполнения",
-                                "title": {
-                                  "content": [
-                                    {
-                                      "default": {
-                                        "tag": 2
+                                {
+                                  "type": "USUAL_GROUP",
+                                  "id": 242,
+                                  "name": "ГруппаПраво",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "LABEL_FIELD",
+                                        "id": 12,
+                                        "name": "СрокИсполнения",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                        },
+                                        "dataPath": "Объект.СрокИсполнения",
+                                        "items": []
                                       },
-                                      "int": 1,
-                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                        "langKey": "ru",
-                                        "value": "Дата проверки"
+                                      {
+                                        "type": "LABEL_FIELD",
+                                        "id": 161,
+                                        "name": "Автор",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                        },
+                                        "dataPath": "Объект.Автор",
+                                        "items": []
                                       }
-                                    }
+                                    ],
+                                    []
                                   ]
+                                }
+                              ],
+                              []
+                            ]
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "PAGE",
+                      "id": 240,
+                      "name": "СтраницаРезультатВыполнения",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 78,
+                            "name": "ОписаниеРезультата",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[13]/synonym"
+                            },
+                            "dataPath": "Объект.РезультатВыполнения",
+                            "items": []
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 55,
+                            "name": "ДатаИсполнения",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Дата выполнения"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "Объект.ДатаИсполнения",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "PAGE",
+                      "id": 205,
+                      "name": "СтраницаИсторияВыполнения",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 126,
+                            "name": "РезультатВыполнения",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                            },
+                            "dataPath": "ЗаданиеРезультатВыполнения",
+                            "items": []
+                          },
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 252,
+                            "name": "ГруппаДатыВыполнения",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Даты выполнения"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 119,
+                                  "name": "СрокНачалаИсполнения",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                  },
+                                  "dataPath": "Объект.ДатаНачала",
+                                  "items": []
                                 },
-                                "dataPath": "Объект.ДатаИсполнения",
-                                "items": []
-                              },
-                              {
-                                "type": "INPUT_FIELD",
-                                "id": 161,
-                                "name": "ДатаИсполненияВремя",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                },
-                                "dataPath": "Объект.ДатаИсполнения",
-                                "items": []
-                              },
-                              {
-                                "type": "HYPERLINK",
-                                "id": 130,
-                                "name": "ИзменитьЗадание",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/title"
-                                },
-                                "dataPath": "",
-                                "items": []
-                              }
-                            ],
-                            []
-                          ]
-                        }
-                      ],
-                      []
-                    ]
-                  }
-                ],
-                []
-              ]
-            }
+                                {
+                                  "type": "LABEL_FIELD",
+                                  "id": 152,
+                                  "name": "Дата",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                  },
+                                  "dataPath": "Объект.Date",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          }
+                        ],
+                        []
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
           ],
           "attributes": [
             [
@@ -3139,16 +2899,6 @@
                 }
               },
               {
-                "id": 6,
-                "name": "ЗаданиеСодержание",
-                "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[14]/synonym"
-                },
-                "type": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[13]/type"
-                }
-              },
-              {
                 "id": 7,
                 "name": "ЗаданиеВыполнено",
                 "title": {
@@ -3156,6 +2906,16 @@
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              },
+              {
+                "id": 6,
+                "name": "ЗаданиеСодержание",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[14]/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[13]/type"
                 }
               },
               {
@@ -3169,33 +2929,13 @@
                 }
               },
               {
-                "id": 9,
-                "name": "ЗаданиеПодтверждено",
-                "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                },
-                "type": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
-                }
-              },
-              {
-                "id": 10,
-                "name": "ЗаданиеСсылка",
-                "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                },
-                "type": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[4]/type"
-                }
-              },
-              {
                 "id": 4,
                 "name": "Исполнитель",
                 "title": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[6]/synonym"
                 },
                 "type": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[8]/type"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[10]/type"
                 }
               }
             ],
@@ -3274,258 +3014,20 @@
             []
           ],
           "items": [
-            {
-              "type": "USUAL_GROUP",
-              "id": 151,
-              "name": "Документ",
-              "title": {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-              },
-              "dataPath": "",
-              "items": [
-                [
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 92,
+                "name": "ГруппаСостояние",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[15]/synonym"
+                },
+                "dataPath": "",
+                "items": [
                   {
                     "type": "LABEL_FIELD",
-                    "id": 99,
-                    "name": "ГлавнаяЗадача",
-                    "title": {
-                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[4]/synonym"
-                    },
-                    "dataPath": "ГлавнаяЗадачаСтрокой",
-                    "items": []
-                  },
-                  {
-                    "type": "USUAL_GROUP",
-                    "id": 92,
-                    "name": "ГруппаСостояние",
-                    "title": {
-                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[15]/synonym"
-                    },
-                    "dataPath": "",
-                    "items": [
-                      [
-                        {
-                          "type": "DECORATION",
-                          "id": 93,
-                          "name": "ДекорацияЗначок",
-                          "title": {
-                            "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                          },
-                          "dataPath": "",
-                          "items": []
-                        },
-                        {
-                          "type": "LABEL_FIELD",
-                          "id": 155,
-                          "name": "ИнфоНадписьЗаголовок",
-                          "title": {
-                            "content": [
-                              {
-                                "default": {
-                                  "tag": 2
-                                },
-                                "int": 1,
-                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                  "langKey": "ru",
-                                  "value": "Инфо надпись заголовок"
-                                }
-                              }
-                            ]
-                          },
-                          "dataPath": "ИнфоНадписьЗаголовок",
-                          "items": []
-                        }
-                      ],
-                      []
-                    ]
-                  },
-                  {
-                    "type": "USUAL_GROUP",
-                    "id": 145,
-                    "name": "Шапка",
-                    "title": {
-                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                    },
-                    "dataPath": "",
-                    "items": [
-                      [
-                        {
-                          "type": "USUAL_GROUP",
-                          "id": 27,
-                          "name": "ГруппаСрокВажность",
-                          "title": {
-                            "content": [
-                              {
-                                "default": {
-                                  "tag": 2
-                                },
-                                "int": 1,
-                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                  "langKey": "ru",
-                                  "value": "Срок важность"
-                                }
-                              }
-                            ]
-                          },
-                          "dataPath": "",
-                          "items": [
-                            [
-                              {
-                                "type": "INPUT_FIELD",
-                                "id": 19,
-                                "name": "ЗаголовокЗадания",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                },
-                                "dataPath": "Объект.Наименование",
-                                "items": []
-                              },
-                              {
-                                "type": "INPUT_FIELD",
-                                "id": 57,
-                                "name": "Важность",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                },
-                                "dataPath": "Объект.Важность",
-                                "items": []
-                              },
-                              {
-                                "type": "INPUT_FIELD",
-                                "id": 103,
-                                "name": "Номер",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                },
-                                "dataPath": "Объект.Number",
-                                "items": []
-                              }
-                            ],
-                            []
-                          ]
-                        },
-                        {
-                          "type": "USUAL_GROUP",
-                          "id": 67,
-                          "name": "ГруппаИсполнение",
-                          "title": {
-                            "content": [
-                              {
-                                "default": {
-                                  "tag": 2
-                                },
-                                "int": 1,
-                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                  "langKey": "ru",
-                                  "value": "Исполнение"
-                                }
-                              }
-                            ]
-                          },
-                          "dataPath": "",
-                          "items": [
-                            [
-                              {
-                                "type": "INPUT_FIELD",
-                                "id": 69,
-                                "name": "Исполнитель",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                },
-                                "dataPath": "Объект.Исполнитель",
-                                "items": []
-                              },
-                              {
-                                "type": "USUAL_GROUP",
-                                "id": 147,
-                                "name": "ГруппаСрокИсполнения",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[16]/synonym"
-                                },
-                                "dataPath": "",
-                                "items": [
-                                  [
-                                    {
-                                      "type": "INPUT_FIELD",
-                                      "id": 21,
-                                      "name": "СрокИсполнения",
-                                      "title": {
-                                        "content": [
-                                          {
-                                            "default": {
-                                              "tag": 2
-                                            },
-                                            "int": 1,
-                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                              "langKey": "ru",
-                                              "value": "Срок"
-                                            }
-                                          }
-                                        ]
-                                      },
-                                      "dataPath": "Объект.СрокИсполнения",
-                                      "items": []
-                                    },
-                                    {
-                                      "type": "INPUT_FIELD",
-                                      "id": 88,
-                                      "name": "СрокИсполненияВремя",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                      },
-                                      "dataPath": "Объект.СрокИсполнения",
-                                      "items": []
-                                    }
-                                  ],
-                                  []
-                                ]
-                              }
-                            ],
-                            []
-                          ]
-                        }
-                      ],
-                      []
-                    ]
-                  },
-                  {
-                    "type": "USUAL_GROUP",
-                    "id": 75,
-                    "name": "ГруппаСодержание",
-                    "title": {
-                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[14]/synonym"
-                    },
-                    "dataPath": "",
-                    "items": [
-                      [
-                        {
-                          "type": "LABEL_FIELD",
-                          "id": 86,
-                          "name": "Предмет",
-                          "title": {
-                            "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[11]/synonym"
-                          },
-                          "dataPath": "ПредметСтрокой",
-                          "items": []
-                        },
-                        {
-                          "type": "INPUT_FIELD",
-                          "id": 17,
-                          "name": "Содержание",
-                          "title": {
-                            "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[14]/synonym"
-                          },
-                          "dataPath": "Объект.Содержание",
-                          "items": []
-                        }
-                      ],
-                      []
-                    ]
-                  },
-                  {
-                    "type": "USUAL_GROUP",
-                    "id": 56,
-                    "name": "ГруппаПроверка",
+                    "id": 155,
+                    "name": "ИнфоНадписьЗаголовок",
                     "title": {
                       "content": [
                         {
@@ -3535,146 +3037,334 @@
                           "int": 1,
                           "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                             "langKey": "ru",
-                            "value": "Проверка"
+                            "value": "Инфо надпись заголовок"
                           }
                         }
                       ]
                     },
-                    "dataPath": "",
-                    "items": [
-                      [
-                        {
-                          "type": "CHECK_BOX_FIELD",
-                          "id": 54,
-                          "name": "НаПроверке",
-                          "title": {
-                            "content": [
-                              {
-                                "default": {
-                                  "tag": 2
-                                },
-                                "int": 1,
-                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                  "langKey": "ru",
-                                  "value": "Проверить выполнение:"
-                                }
-                              }
-                            ]
-                          },
-                          "dataPath": "Объект.НаПроверке",
-                          "items": []
-                        },
-                        {
-                          "type": "USUAL_GROUP",
-                          "id": 28,
-                          "name": "ГруппаПроверяющий",
-                          "title": {
-                            "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[12]/synonym"
-                          },
-                          "dataPath": "",
-                          "items": [
-                            [
-                              {
-                                "type": "INPUT_FIELD",
-                                "id": 14,
-                                "name": "Проверяющий",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                },
-                                "dataPath": "Объект.Проверяющий",
-                                "items": []
-                              },
-                              {
-                                "type": "USUAL_GROUP",
-                                "id": 149,
-                                "name": "ГруппаСрокПроверки",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[17]/synonym"
-                                },
-                                "dataPath": "",
-                                "items": [
-                                  [
-                                    {
-                                      "type": "INPUT_FIELD",
-                                      "id": 23,
-                                      "name": "СрокПроверки",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                      },
-                                      "dataPath": "Объект.СрокПроверки",
-                                      "items": []
-                                    },
-                                    {
-                                      "type": "INPUT_FIELD",
-                                      "id": 90,
-                                      "name": "СрокПроверкиВремя",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                      },
-                                      "dataPath": "Объект.СрокПроверки",
-                                      "items": []
-                                    }
-                                  ],
-                                  []
-                                ]
-                              }
-                            ],
-                            []
-                          ]
-                        }
-                      ],
-                      []
-                    ]
-                  },
-                  {
-                    "type": "USUAL_GROUP",
-                    "id": 81,
-                    "name": "ГруппаОбщиеСведения",
-                    "title": {
-                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/synonym"
-                    },
-                    "dataPath": "",
-                    "items": [
-                      [
-                        {
-                          "type": "INPUT_FIELD",
-                          "id": 79,
-                          "name": "Автор",
-                          "title": {
-                            "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                          },
-                          "dataPath": "Объект.Автор",
-                          "items": []
-                        },
-                        {
-                          "type": "INPUT_FIELD",
-                          "id": 97,
-                          "name": "Дата",
-                          "title": {
-                            "content": [
-                              {
-                                "default": {
-                                  "tag": 2
-                                },
-                                "int": 1,
-                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                  "langKey": "ru",
-                                  "value": "Начато"
-                                }
-                              }
-                            ]
-                          },
-                          "dataPath": "Объект.Date",
-                          "items": []
-                        }
-                      ],
-                      []
-                    ]
+                    "dataPath": "ИнфоНадписьЗаголовок",
+                    "items": []
                   }
-                ],
-                []
-              ]
-            }
+                ]
+              },
+              {
+                "type": "PAGES",
+                "id": 182,
+                "name": "Страницы",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "PAGE",
+                      "id": 184,
+                      "name": "СтраницаОписаниеЗадания",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Описание задания"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 194,
+                            "name": "ГруппаЗаголовок",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Группа"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 19,
+                                  "name": "ЗаголовокЗадания",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                  },
+                                  "dataPath": "Объект.Наименование",
+                                  "items": []
+                                },
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 103,
+                                  "name": "Номер",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                  },
+                                  "dataPath": "Объект.Number",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 17,
+                            "name": "Содержание",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[14]/synonym"
+                            },
+                            "dataPath": "Объект.Содержание",
+                            "items": []
+                          },
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 200,
+                            "name": "ГруппаОсновнаяИнформация",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Основная информация"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "USUAL_GROUP",
+                                  "id": 176,
+                                  "name": "ГруппаИсполнитель",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[6]/synonym"
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "INPUT_FIELD",
+                                        "id": 69,
+                                        "name": "Исполнитель",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                        },
+                                        "dataPath": "Объект.Исполнитель",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "INPUT_FIELD",
+                                        "id": 21,
+                                        "name": "СрокИсполнения",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Срок выполнения"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "Объект.СрокИсполнения",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "INPUT_FIELD",
+                                        "id": 57,
+                                        "name": "Важность",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                        },
+                                        "dataPath": "Объект.Важность",
+                                        "items": []
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                },
+                                {
+                                  "type": "CHECK_BOX_FIELD",
+                                  "id": 54,
+                                  "name": "НаПроверке",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Проверить выполнение:"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "Объект.НаПроверке",
+                                  "items": []
+                                },
+                                {
+                                  "type": "USUAL_GROUP",
+                                  "id": 198,
+                                  "name": "ГруппаПроверка",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Проверка"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "INPUT_FIELD",
+                                        "id": 14,
+                                        "name": "Проверяющий",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                        },
+                                        "dataPath": "Объект.Проверяющий",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "INPUT_FIELD",
+                                        "id": 23,
+                                        "name": "СрокПроверки",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                        },
+                                        "dataPath": "Объект.СрокПроверки",
+                                        "items": []
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                }
+                              ],
+                              []
+                            ]
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "PAGE",
+                      "id": 190,
+                      "name": "СтраницаДополнительно",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Дополнительно"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "LABEL_FIELD",
+                            "id": 86,
+                            "name": "Предмет",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[11]/synonym"
+                            },
+                            "dataPath": "ПредметСтрокой",
+                            "items": []
+                          },
+                          {
+                            "type": "LABEL_FIELD",
+                            "id": 99,
+                            "name": "ГлавнаяЗадача",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[4]/synonym"
+                            },
+                            "dataPath": "ГлавнаяЗадачаСтрокой",
+                            "items": []
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 79,
+                            "name": "Автор",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                            },
+                            "dataPath": "Объект.Автор",
+                            "items": []
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 97,
+                            "name": "Дата",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Начато"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "Объект.Date",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
           ],
           "attributes": [
             [
@@ -3739,7 +3429,7 @@
                 "id": 5,
                 "name": "ИнфоНадписьЗаголовок",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "types": [
@@ -3865,6 +3555,10 @@
           "handlers": [
             [
               {
+                "event": "OnLoadDataFromSettingsAtServer",
+                "name": "ПриЗагрузкеДанныхИзНастроекНаСервере"
+              },
+              {
                 "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[3]"
               },
               {
@@ -3933,73 +3627,6 @@
               },
               {
                 "type": "USUAL_GROUP",
-                "id": 50,
-                "name": "Флажки",
-                "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Флажки"
-                      }
-                    }
-                  ]
-                },
-                "dataPath": "",
-                "items": [
-                  [
-                    {
-                      "type": "CHECK_BOX_FIELD",
-                      "id": 22,
-                      "name": "ПоказыватьЗавершенныеЗадания",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Показывать завершенные задания"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "ПоказыватьЗавершенныеЗадания",
-                      "items": []
-                    },
-                    {
-                      "type": "CHECK_BOX_FIELD",
-                      "id": 48,
-                      "name": "ПоказыватьОстановленные",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Показывать остановленные"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "ПоказыватьОстановленные",
-                      "items": []
-                    }
-                  ],
-                  []
-                ]
-              },
-              {
-                "type": "USUAL_GROUP",
                 "id": 92,
                 "name": "ГруппаПользовательскихНастроек",
                 "title": {
@@ -4018,83 +3645,6 @@
                 },
                 "dataPath": "",
                 "items": []
-              },
-              {
-                "type": "COMMAND_BAR",
-                "id": 53,
-                "name": "КоманднаяПанель",
-                "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Командная панель"
-                      }
-                    }
-                  ]
-                },
-                "dataPath": "",
-                "items": [
-                  [
-                    {
-                      "type": "BUTTON",
-                      "id": 94,
-                      "name": "ФормаОбщаяКомандаКартаМаршрутаБизнесПроцесса",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                      },
-                      "dataPath": "Items.Список.CurrentData.Ref",
-                      "items": []
-                    },
-                    {
-                      "type": "BUTTON",
-                      "id": 51,
-                      "name": "ФормаОстановить",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Остановить"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "BUTTON",
-                      "id": 52,
-                      "name": "ФормаПродолжитьБизнесПроцесс",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Продолжить"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": []
-                    }
-                  ],
-                  []
-                ]
               },
               {
                 "type": "TABLE",
@@ -4139,6 +3689,36 @@
                     },
                     {
                       "type": "LABEL_FIELD",
+                      "id": 26,
+                      "name": "Наименование",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.Наименование",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 32,
+                      "name": "Предмет",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.Предмет",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 28,
+                      "name": "Содержание",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.Содержание",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
                       "id": 6,
                       "name": "Дата",
                       "title": {
@@ -4146,50 +3726,6 @@
                       },
                       "dataPath": "Список.Date",
                       "items": []
-                    },
-                    {
-                      "type": "COLUMN_GROUP",
-                      "id": 54,
-                      "name": "ГруппаСодержание",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[14]/synonym"
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "LABEL_FIELD",
-                            "id": 26,
-                            "name": "Наименование",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                            },
-                            "dataPath": "Список.Наименование",
-                            "items": []
-                          },
-                          {
-                            "type": "LABEL_FIELD",
-                            "id": 32,
-                            "name": "Предмет",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                            },
-                            "dataPath": "Список.Предмет",
-                            "items": []
-                          },
-                          {
-                            "type": "LABEL_FIELD",
-                            "id": 28,
-                            "name": "Содержание",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                            },
-                            "dataPath": "Список.Содержание",
-                            "items": []
-                          }
-                        ],
-                        []
-                      ]
                     },
                     {
                       "type": "LABEL_FIELD",
@@ -4262,38 +3798,24 @@
                       "items": []
                     },
                     {
-                      "type": "COLUMN_GROUP",
-                      "id": 57,
-                      "name": "ГруппаПроверка",
+                      "type": "CHECK_BOX_FIELD",
+                      "id": 55,
+                      "name": "НаПроверке",
                       "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[8]/synonym"
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
                       },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "CHECK_BOX_FIELD",
-                            "id": 55,
-                            "name": "НаПроверке",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                            },
-                            "dataPath": "Список.НаПроверке",
-                            "items": []
-                          },
-                          {
-                            "type": "LABEL_FIELD",
-                            "id": 40,
-                            "name": "Проверяющий",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                            },
-                            "dataPath": "Список.Проверяющий",
-                            "items": []
-                          }
-                        ],
-                        []
-                      ]
+                      "dataPath": "Список.НаПроверке",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 40,
+                      "name": "Проверяющий",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.Проверяющий",
+                      "items": []
                     },
                     {
                       "type": "LABEL_FIELD",
@@ -4368,7 +3890,7 @@
                 "id": 5,
                 "name": "ПоказыватьЗавершенныеЗадания",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
@@ -4378,7 +3900,7 @@
                 "id": 6,
                 "name": "ПоказыватьОстановленные",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"

--- a/src/test/resources/fixtures/ssl_3_2/BusinessProcesses.Задание_edt.json
+++ b/src/test/resources/fixtures/ssl_3_2/BusinessProcesses.Задание_edt.json
@@ -1,0 +1,4489 @@
+{"com.github._1c_syntax.bsl.mdo.BusinessProcess": {
+  "attributes": [
+    [
+      {
+        "uuid": "dad11c2e-08fc-4a6b-8829-8be6c64c15fc",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.StandardAttribute.Started",
+          "mdoRefRu": "БизнесПроцесс.Задание.СтандартныйРеквизит.Стартован"
+        },
+        "comment": "",
+        "synonym": {
+          "content": []
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "type": "BUSINESS_PROCESS",
+          "mdoRef": "BusinessProcess.Задание",
+          "mdoRefRu": "БизнесПроцесс.Задание"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "BOOLEAN"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 0
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "Стартован",
+          "nameEn": "Started"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "dad11c2e-08fc-4a6b-8829-8be6c64c15fc",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.StandardAttribute.HeadTask",
+          "mdoRefRu": "БизнесПроцесс.Задание.СтандартныйРеквизит.ВедущаяЗадача"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "ЗадачаСсылка.ЗадачаИсполнителя",
+                  "nameEn": "TaskRef.ЗадачаИсполнителя"
+                },
+                "variant": "METADATA",
+                "kind": "TASK"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "fullName": {
+          "nameRu": "ВедущаяЗадача",
+          "nameEn": "HeadTask"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "dad11c2e-08fc-4a6b-8829-8be6c64c15fc",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.StandardAttribute.Completed",
+          "mdoRefRu": "БизнесПроцесс.Задание.СтандартныйРеквизит.Завершен"
+        },
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Завершено"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+        },
+        "fullName": {
+          "nameRu": "Завершен",
+          "nameEn": "Completed"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "dad11c2e-08fc-4a6b-8829-8be6c64c15fc",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.StandardAttribute.Ref",
+          "mdoRefRu": "БизнесПроцесс.Задание.СтандартныйРеквизит.Ссылка"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "БизнесПроцессСсылка.Задание",
+                  "nameEn": "BusinessProcessRef.Задание"
+                },
+                "variant": "METADATA",
+                "kind": "BUSINESS_PROCESS"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "fullName": {
+          "nameRu": "Ссылка",
+          "nameEn": "Ref"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "dad11c2e-08fc-4a6b-8829-8be6c64c15fc",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.StandardAttribute.DeletionMark",
+          "mdoRefRu": "БизнесПроцесс.Задание.СтандартныйРеквизит.ПометкаУдаления"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+        },
+        "fullName": {
+          "nameRu": "ПометкаУдаления",
+          "nameEn": "DeletionMark"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "dad11c2e-08fc-4a6b-8829-8be6c64c15fc",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.StandardAttribute.Date",
+          "mdoRefRu": "БизнесПроцесс.Задание.СтандартныйРеквизит.Дата"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "DATE"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.DateQualifiers": {
+                "dateFractions": 2,
+                "description": {
+                  "value": {
+                    "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                    "nameRu": "КвалификаторыДаты (ДатаВремя)",
+                    "nameEn": "DateQualifiers (DateTime)"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "Дата",
+          "nameEn": "Date"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "dad11c2e-08fc-4a6b-8829-8be6c64c15fc",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.StandardAttribute.Number",
+          "mdoRefRu": "БизнесПроцесс.Задание.СтандартныйРеквизит.Номер"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                "length": 11,
+                "allowedLength": 0,
+                "description": {}
+              }
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "Номер",
+          "nameEn": "Number"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "a76b1fd1-ba00-40e6-8756-f17fee449818",
+        "name": "Автор",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.Attribute.Автор",
+          "mdoRefRu": "БизнесПроцесс.Задание.Реквизит.Автор"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Автор"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 2,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "СправочникСсылка.ВнешниеПользователи",
+                  "nameEn": "CatalogRef.ВнешниеПользователи"
+                },
+                "variant": "METADATA",
+                "kind": "CATALOG"
+              },
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "СправочникСсылка.Пользователи",
+                  "nameEn": "CatalogRef.Пользователи"
+                },
+                "variant": "METADATA",
+                "kind": "CATALOG"
+              }
+            }
+          ],
+          "composite": true,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "5c913626-48d1-4e0a-a423-64078ce59c7b",
+        "name": "Важность",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.Attribute.Важность",
+          "mdoRefRu": "БизнесПроцесс.Задание.Реквизит.Важность"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Важность задач точки действия Выполнить для исполнителя",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Важность"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "ПеречислениеСсылка.ВариантыВажностиЗадачи",
+                  "nameEn": "EnumRef.ВариантыВажностиЗадачи"
+                },
+                "variant": "METADATA",
+                "kind": "ENUM"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": true
+      },
+      {
+        "uuid": "0a4e6b7a-b380-4547-bc3c-5d6895a5d19a",
+        "name": "Выполнено",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.Attribute.Выполнено",
+          "mdoRefRu": "БизнесПроцесс.Задание.Реквизит.Выполнено"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Результат выполнения задания после завершения бизнес-процесса.",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Выполнено"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "7b0ec304-1904-413e-a9c6-ff62e87107dd",
+        "name": "ГлавнаяЗадача",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.Attribute.ГлавнаяЗадача",
+          "mdoRefRu": "БизнесПроцесс.Задание.Реквизит.ГлавнаяЗадача"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Главная задача"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[2]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "d4dd8c96-914d-496f-b735-ef85ec473605",
+        "name": "ДатаЗавершения",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.Attribute.ДатаЗавершения",
+          "mdoRefRu": "БизнесПроцесс.Задание.Реквизит.ДатаЗавершения"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Фактическая дата завершения бизнес-процесса",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Дата завершения"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[6]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "62517db4-59e6-4945-bcd6-b3f1845572bf",
+        "name": "Исполнитель",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.Attribute.Исполнитель",
+          "mdoRefRu": "БизнесПроцесс.Задание.Реквизит.Исполнитель"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Исполнитель"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 3,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/type/types/java.util.CollSer/com.github._1c_syntax.bsl.types.value.CustomValueType"
+              },
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/type/types/java.util.CollSer/com.github._1c_syntax.bsl.types.value.CustomValueType[2]"
+              },
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "СправочникСсылка.РолиИсполнителей",
+                  "nameEn": "CatalogRef.РолиИсполнителей"
+                },
+                "variant": "METADATA",
+                "kind": "CATALOG"
+              }
+            }
+          ],
+          "composite": true,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "a6a9dd40-24cd-4d40-a12d-44f94f8c05a7",
+        "name": "Наименование",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.Attribute.Наименование",
+          "mdoRefRu": "БизнесПроцесс.Задание.Реквизит.Наименование"
+        },
+        "objectBelonging": "OWN",
+        "comment": "АПК:58 - Описание задания",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Задание"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                "length": 250,
+                "allowedLength": 0,
+                "description": {}
+              }
+            }
+          ]
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "f0f72149-0e7f-441a-b70d-8f47d4977927",
+        "name": "НаПроверке",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.Attribute.НаПроверке",
+          "mdoRefRu": "БизнесПроцесс.Задание.Реквизит.НаПроверке"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Признак того, что указан проверяющий по задаче",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "На проверке"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "776efc3e-ac27-4550-bafd-6e91aa987af2",
+        "name": "НомерИтерации",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.Attribute.НомерИтерации",
+          "mdoRefRu": "БизнесПроцесс.Задание.Реквизит.НомерИтерации"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Количество циклов бизнес-процесса между исполнителем и проверяющим",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Номер итерации"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                "precision": 10,
+                "scale": 0,
+                "nonNegative": true,
+                "description": {}
+              }
+            }
+          ]
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "9f478c85-b72c-40ae-aa08-7ddf73b5b15c",
+        "name": "Подтверждено",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.Attribute.Подтверждено",
+          "mdoRefRu": "БизнесПроцесс.Задание.Реквизит.Подтверждено"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Внутреннее состояние бизнес-процесса",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Подтверждено"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "cc438366-85ea-48be-8b74-d05cddb1fc51",
+        "name": "Предмет",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.Attribute.Предмет",
+          "mdoRefRu": "БизнесПроцесс.Задание.Реквизит.Предмет"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Объект системы, \"по поводу\" которого был создан бизнес-процесс.",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Предмет"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "ОпределяемыйТип.ПредметЗадачи",
+                  "nameEn": "DefinedType.ПредметЗадачи"
+                },
+                "variant": "METADATA",
+                "kind": "DEFINED_TYPE"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "4688fd3b-4a92-4ed8-b111-0cf22a729b1c",
+        "name": "Проверяющий",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.Attribute.Проверяющий",
+          "mdoRefRu": "БизнесПроцесс.Задание.Реквизит.Проверяющий"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Проверяющий"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[6]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "92029d1f-0472-4aaa-8fd6-9fb3c3cf414e",
+        "name": "РезультатВыполнения",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.Attribute.РезультатВыполнения",
+          "mdoRefRu": "БизнесПроцесс.Задание.Реквизит.РезультатВыполнения"
+        },
+        "objectBelonging": "OWN",
+        "comment": "История переписки исполнителя и проверяющего",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Результат выполнения"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                "length": 0,
+                "allowedLength": 0,
+                "description": {
+                  "value": {
+                    "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                    "nameRu": "КвалификаторыСтроки (0, Переменная)",
+                    "nameEn": "StringQualifiers (0, Variable)"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": true,
+        "extendedEdit": true,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "3271b800-1825-422f-97bb-757baf403e90",
+        "name": "Содержание",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.Attribute.Содержание",
+          "mdoRefRu": "БизнесПроцесс.Задание.Реквизит.Содержание"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Содержание"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[13]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": true,
+        "extendedEdit": true,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "6fd6efc1-facc-4ece-a5b3-3dce6acca81d",
+        "name": "Состояние",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.Attribute.Состояние",
+          "mdoRefRu": "БизнесПроцесс.Задание.Реквизит.Состояние"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Состояние"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "ПеречислениеСсылка.СостоянияБизнесПроцессов",
+                  "nameEn": "EnumRef.СостоянияБизнесПроцессов"
+                },
+                "variant": "METADATA",
+                "kind": "ENUM"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": true
+      },
+      {
+        "uuid": "4ee82868-7a20-4c3a-91f9-42a6bf53ac37",
+        "name": "СрокИсполнения",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.Attribute.СрокИсполнения",
+          "mdoRefRu": "БизнесПроцесс.Задание.Реквизит.СрокИсполнения"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Срок исполнения"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[6]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "a040c756-4687-4bfd-a690-b122d3c490e5",
+        "name": "СрокПроверки",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.Attribute.СрокПроверки",
+          "mdoRefRu": "БизнесПроцесс.Задание.Реквизит.СрокПроверки"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Срок проверки"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[6]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "bd5940d5-13fd-4f59-bb6c-614f93f9c8e4",
+        "name": "АвторСтрокой",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.Attribute.АвторСтрокой",
+          "mdoRefRu": "БизнесПроцесс.Задание.Реквизит.АвторСтрокой"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Автор строкой"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                "length": 150,
+                "allowedLength": 0,
+                "description": {}
+              }
+            }
+          ]
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "961a9801-3956-4ea0-b0d3-908f09bf4929",
+        "name": "ВнешнееЗадание",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.Attribute.ВнешнееЗадание",
+          "mdoRefRu": "БизнесПроцесс.Задание.Реквизит.ВнешнееЗадание"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Внешнее задание"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "6fac5c14-e126-4342-9078-edf1d0efcbf2",
+        "name": "ЗадачаИсточник",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.Attribute.ЗадачаИсточник",
+          "mdoRefRu": "БизнесПроцесс.Задание.Реквизит.ЗадачаИсточник"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Задача источник"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[2]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "0a3325a1-21c4-4997-882f-4ac2edc175f0",
+        "name": "СодержаниеПредмета",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.Attribute.СодержаниеПредмета",
+          "mdoRefRu": "БизнесПроцесс.Задание.Реквизит.СодержаниеПредмета"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Содержание предмета"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.V8ValueType": "VALUE_STORAGE"
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "71102d3f-f020-4d6f-9582-9a7eefb4e797",
+        "name": "ОсновнойОбъектАдресации",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.Attribute.ОсновнойОбъектАдресации",
+          "mdoRefRu": "БизнесПроцесс.Задание.Реквизит.ОсновнойОбъектАдресации"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Основной объект адресации"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "Характеристика.ОбъектыАдресацииЗадач",
+                  "nameEn": "Characteristic.ОбъектыАдресацииЗадач"
+                },
+                "variant": "METADATA",
+                "kind": "CHART_OF_CHARACTERISTIC_TYPES"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "53ef6849-a3f3-4171-9167-f349f2d6a736",
+        "name": "ОсновнойОбъектАдресацииПроверяющий",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.Attribute.ОсновнойОбъектАдресацииПроверяющий",
+          "mdoRefRu": "БизнесПроцесс.Задание.Реквизит.ОсновнойОбъектАдресацииПроверяющий"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Основной объект адресации (проверяющий)"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[22]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "3f588bd3-d461-42b7-8ab1-386af6399d56",
+        "name": "ДополнительныйОбъектАдресации",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.Attribute.ДополнительныйОбъектАдресации",
+          "mdoRefRu": "БизнесПроцесс.Задание.Реквизит.ДополнительныйОбъектАдресации"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Дополнительный объект адресации"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[22]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "c04ff85e-b4af-4a9f-b0e9-c5c65e3d10a1",
+        "name": "ДополнительныйОбъектАдресацииПроверяющий",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.Attribute.ДополнительныйОбъектАдресацииПроверяющий",
+          "mdoRefRu": "БизнесПроцесс.Задание.Реквизит.ДополнительныйОбъектАдресацииПроверяющий"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Дополнительный объект адресации (проверяющий)"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[22]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "8c576405-29c1-46b1-ab2e-40e52c21cab0",
+        "name": "ГруппаИсполнителейЗадач",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.Attribute.ГруппаИсполнителейЗадач",
+          "mdoRefRu": "БизнесПроцесс.Задание.Реквизит.ГруппаИсполнителейЗадач"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Группа исполнителей задач"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 3,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/type/types/java.util.CollSer/com.github._1c_syntax.bsl.types.value.CustomValueType"
+              },
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "СправочникСсылка.ГруппыИсполнителейЗадач",
+                  "nameEn": "CatalogRef.ГруппыИсполнителейЗадач"
+                },
+                "variant": "METADATA",
+                "kind": "CATALOG"
+              },
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/type/types/java.util.CollSer/com.github._1c_syntax.bsl.types.value.CustomValueType[2]"
+              }
+            }
+          ],
+          "composite": true,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "b33a89da-8589-4902-83fa-6545e5fce23e",
+        "name": "ГруппаИсполнителейЗадачПроверяющий",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "BusinessProcess.Задание.Attribute.ГруппаИсполнителейЗадачПроверяющий",
+          "mdoRefRu": "БизнесПроцесс.Задание.Реквизит.ГруппаИсполнителейЗадачПроверяющий"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Группа исполнителей задач (проверяющий)"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[26]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      }
+    ],
+    []
+  ],
+  "commands": [],
+  "comment": "",
+  "description": "Задание",
+  "explanation": {
+    "content": [
+      {
+        "default": {
+          "tag": 2
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+          "langKey": "ru",
+          "value": "Задание для исполнителя"
+        }
+      }
+    ]
+  },
+  "forms": [
+    [
+      {
+        "uuid": "f0620d5a-e1fe-419f-af37-e0f462f97e8d",
+        "name": "ДействиеВыполнить",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "BusinessProcess.Задание.Form.ДействиеВыполнить",
+          "mdoRefRu": "БизнесПроцесс.Задание.Форма.ДействиеВыполнить"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Действие выполнить"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/BusinessProcesses/Задание/Forms/Де_ствиеВыполнить/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+          },
+          "handlers": [
+            [
+              {
+                "event": "NotificationProcessing",
+                "name": "ОбработкаОповещения"
+              },
+              {
+                "event": "OnOpen",
+                "name": "ПриОткрытии"
+              },
+              {
+                "event": "OnCreateAtServer",
+                "name": "ПриСозданииНаСервере"
+              }
+            ],
+            []
+          ],
+          "items": [
+            {
+              "type": "USUAL_GROUP",
+              "id": 207,
+              "name": "Документ",
+              "title": {
+                "content": [
+                  {
+                    "default": {
+                      "tag": 2
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                      "langKey": "ru",
+                      "value": "Документ"
+                    }
+                  }
+                ]
+              },
+              "dataPath": "",
+              "items": [
+                [
+                  {
+                    "type": "USUAL_GROUP",
+                    "id": 154,
+                    "name": "Шапка",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Шапка"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 165,
+                          "name": "ГруппыШапки",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Группы шапки"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "USUAL_GROUP",
+                                "id": 160,
+                                "name": "ГруппаАвторИсполнитель",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Автор исполнитель"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 161,
+                                      "name": "Автор",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                      },
+                                      "dataPath": "Объект.Автор",
+                                      "items": []
+                                    },
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 163,
+                                      "name": "Исполнитель",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[6]/synonym"
+                                      },
+                                      "dataPath": "Исполнитель",
+                                      "items": []
+                                    }
+                                  ],
+                                  []
+                                ]
+                              },
+                              {
+                                "type": "USUAL_GROUP",
+                                "id": 109,
+                                "name": "ГруппаДатаИСрок",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Дата и срок"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 152,
+                                      "name": "Дата",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                      },
+                                      "dataPath": "Объект.Date",
+                                      "items": []
+                                    },
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 12,
+                                      "name": "СрокИсполнения",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                      },
+                                      "dataPath": "Объект.СрокИсполнения",
+                                      "items": []
+                                    }
+                                  ],
+                                  []
+                                ]
+                              },
+                              {
+                                "type": "USUAL_GROUP",
+                                "id": 28,
+                                "name": "ГруппаНомерИВажность",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Номер и важность"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 149,
+                                      "name": "Номер",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                      },
+                                      "dataPath": "Объект.Number",
+                                      "items": []
+                                    },
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 16,
+                                      "name": "Важность",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                      },
+                                      "dataPath": "Объект.Важность",
+                                      "items": []
+                                    }
+                                  ],
+                                  []
+                                ]
+                              }
+                            ],
+                            []
+                          ]
+                        },
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 155,
+                          "name": "ГруппаПриоритет",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Приоритет"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 119,
+                                "name": "СрокНачалаИсполнения",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                },
+                                "dataPath": "Объект.ДатаНачала",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 135,
+                                "name": "СрокНачалаИсполненияВремя",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                },
+                                "dataPath": "Объект.ДатаНачала",
+                                "items": []
+                              }
+                            ],
+                            []
+                          ]
+                        }
+                      ],
+                      []
+                    ]
+                  },
+                  {
+                    "type": "PAGES",
+                    "id": 201,
+                    "name": "Страницы",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Страницы"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "PAGE",
+                          "id": 203,
+                          "name": "Главное",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Главное"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            {
+                              "type": "USUAL_GROUP",
+                              "id": 94,
+                              "name": "ГруппаСодержание",
+                              "title": {
+                                "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[14]/synonym"
+                              },
+                              "dataPath": "",
+                              "items": [
+                                [
+                                  {
+                                    "type": "INPUT_FIELD",
+                                    "id": 156,
+                                    "name": "Наименование",
+                                    "title": {
+                                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                    },
+                                    "dataPath": "Объект.Description",
+                                    "items": []
+                                  },
+                                  {
+                                    "type": "LABEL_FIELD",
+                                    "id": 129,
+                                    "name": "Предмет",
+                                    "title": {
+                                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[11]/synonym"
+                                    },
+                                    "dataPath": "ПредметСтрокой",
+                                    "items": []
+                                  },
+                                  {
+                                    "type": "INPUT_FIELD",
+                                    "id": 18,
+                                    "name": "Содержание",
+                                    "title": {
+                                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[14]/synonym"
+                                    },
+                                    "dataPath": "ЗаданиеСодержание",
+                                    "items": []
+                                  }
+                                ],
+                                []
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "PAGE",
+                          "id": 205,
+                          "name": "ИсторияВыполнения",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "История выполнения"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            {
+                              "type": "INPUT_FIELD",
+                              "id": 126,
+                              "name": "РезультатВыполнения",
+                              "title": {
+                                "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                              },
+                              "dataPath": "ЗаданиеРезультатВыполнения",
+                              "items": []
+                            }
+                          ]
+                        }
+                      ],
+                      []
+                    ]
+                  },
+                  {
+                    "type": "USUAL_GROUP",
+                    "id": 131,
+                    "name": "ГруппаСостояние",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[15]/synonym"
+                    },
+                    "dataPath": "",
+                    "items": []
+                  },
+                  {
+                    "type": "USUAL_GROUP",
+                    "id": 27,
+                    "name": "ГруппаРезультат",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Результат выполнения задания:"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "INPUT_FIELD",
+                          "id": 78,
+                          "name": "ОписаниеРезультата",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                          },
+                          "dataPath": "Объект.РезультатВыполнения",
+                          "items": []
+                        },
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 54,
+                          "name": "ГруппаВыполненоДата",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Выполнено дата"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "USUAL_BUTTON",
+                                "id": 123,
+                                "name": "Выполнено",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[3]/synonym"
+                                },
+                                "dataPath": "",
+                                "items": []
+                              },
+                              {
+                                "type": "USUAL_BUTTON",
+                                "id": 137,
+                                "name": "Отклонено",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Отменено"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 55,
+                                "name": "ДатаИсполнения",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Дата"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "Объект.ДатаИсполнения",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 146,
+                                "name": "ДатаИсполненияВремя",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                },
+                                "dataPath": "Объект.ДатаИсполнения",
+                                "items": []
+                              },
+                              {
+                                "type": "HYPERLINK",
+                                "id": 199,
+                                "name": "ИзменитьЗадание",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Изменить задание"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": []
+                              }
+                            ],
+                            []
+                          ]
+                        }
+                      ],
+                      []
+                    ]
+                  }
+                ],
+                []
+              ]
+            }
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "Объект",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "ЗадачаОбъект.ЗадачаИсполнителя",
+                          "nameEn": "TaskObject.ЗадачаИсполнителя"
+                        },
+                        "variant": "METADATA",
+                        "kind": "TASK"
+                      }
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 2,
+                "name": "НачальныйПризнакВыполнения",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              },
+              {
+                "id": 3,
+                "name": "ПредметСтрокой",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[11]/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[13]/type"
+                }
+              },
+              {
+                "id": 5,
+                "name": "ТекущийПользователь",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/type/types/java.util.CollSer/com.github._1c_syntax.bsl.types.value.CustomValueType[2]"
+                      }
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 7,
+                "name": "ЗаданиеВыполнено",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              },
+              {
+                "id": 6,
+                "name": "ЗаданиеСодержание",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[14]/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[13]/type"
+                }
+              },
+              {
+                "id": 8,
+                "name": "ЗаданиеРезультатВыполнения",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "История сообщений"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[13]/type"
+                }
+              },
+              {
+                "id": 4,
+                "name": "Исполнитель",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[6]/synonym"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 2,
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/type/types/java.util.CollSer/com.github._1c_syntax.bsl.types.value.CustomValueType[2]"
+                      },
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[6]/type/types/java.util.CollSer/com.github._1c_syntax.bsl.types.value.CustomValueType[3]"
+                      }
+                    }
+                  ],
+                  "composite": true,
+                  "qualifiers": []
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "3e2f2ae1-c809-43fc-8276-b0a16a92858c",
+        "name": "ДействиеПроверить",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "BusinessProcess.Задание.Form.ДействиеПроверить",
+          "mdoRefRu": "БизнесПроцесс.Задание.Форма.ДействиеПроверить"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Действие проверить"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/BusinessProcesses/Задание/Forms/Де_ствиеПроверить/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+          },
+          "handlers": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[2]"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[3]"
+              }
+            ],
+            []
+          ],
+          "items": [
+            {
+              "type": "USUAL_GROUP",
+              "id": 234,
+              "name": "Документ",
+              "title": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+              },
+              "dataPath": "",
+              "items": [
+                [
+                  {
+                    "type": "USUAL_GROUP",
+                    "id": 134,
+                    "name": "ГруппаСостояние",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[15]/synonym"
+                    },
+                    "dataPath": "",
+                    "items": []
+                  },
+                  {
+                    "type": "USUAL_GROUP",
+                    "id": 165,
+                    "name": "Шапка",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 166,
+                          "name": "ГруппыШапки",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "USUAL_GROUP",
+                                "id": 167,
+                                "name": "ГруппаАвторИсполнитель",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 168,
+                                      "name": "Автор",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                      },
+                                      "dataPath": "Объект.Автор",
+                                      "items": []
+                                    },
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 170,
+                                      "name": "Исполнитель",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[12]/synonym"
+                                      },
+                                      "dataPath": "Исполнитель",
+                                      "items": []
+                                    }
+                                  ],
+                                  []
+                                ]
+                              },
+                              {
+                                "type": "USUAL_GROUP",
+                                "id": 172,
+                                "name": "ГруппаДатаИСрок",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 173,
+                                      "name": "Дата",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                      },
+                                      "dataPath": "Объект.Date",
+                                      "items": []
+                                    },
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 175,
+                                      "name": "СрокИсполнения",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                      },
+                                      "dataPath": "Объект.СрокИсполнения",
+                                      "items": []
+                                    }
+                                  ],
+                                  []
+                                ]
+                              },
+                              {
+                                "type": "USUAL_GROUP",
+                                "id": 177,
+                                "name": "ГруппаНомерИВажность",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 178,
+                                      "name": "Номер",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                      },
+                                      "dataPath": "Объект.Number",
+                                      "items": []
+                                    },
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 180,
+                                      "name": "Важность",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                      },
+                                      "dataPath": "Объект.Важность",
+                                      "items": []
+                                    }
+                                  ],
+                                  []
+                                ]
+                              }
+                            ],
+                            []
+                          ]
+                        },
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 182,
+                          "name": "ГруппаПриоритет",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 183,
+                                "name": "СрокНачалаИсполнения",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                },
+                                "dataPath": "Объект.ДатаНачала",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 185,
+                                "name": "СрокНачалаИсполненияВремя",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                },
+                                "dataPath": "Объект.ДатаНачала",
+                                "items": []
+                              }
+                            ],
+                            []
+                          ]
+                        }
+                      ],
+                      []
+                    ]
+                  },
+                  {
+                    "type": "PAGES",
+                    "id": 222,
+                    "name": "Страницы",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "PAGE",
+                          "id": 224,
+                          "name": "Главное",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                          },
+                          "dataPath": "",
+                          "items": [
+                            {
+                              "type": "USUAL_GROUP",
+                              "id": 94,
+                              "name": "ГруппаСодержание",
+                              "title": {
+                                "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[14]/synonym"
+                              },
+                              "dataPath": "",
+                              "items": [
+                                [
+                                  {
+                                    "type": "INPUT_FIELD",
+                                    "id": 159,
+                                    "name": "Наименование",
+                                    "title": {
+                                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                    },
+                                    "dataPath": "Объект.Description",
+                                    "items": []
+                                  },
+                                  {
+                                    "type": "LABEL_FIELD",
+                                    "id": 132,
+                                    "name": "Предмет",
+                                    "title": {
+                                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[11]/synonym"
+                                    },
+                                    "dataPath": "ПредметСтрокой",
+                                    "items": []
+                                  },
+                                  {
+                                    "type": "INPUT_FIELD",
+                                    "id": 18,
+                                    "name": "Содержание",
+                                    "title": {
+                                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[14]/synonym"
+                                    },
+                                    "dataPath": "ЗаданиеСодержание",
+                                    "items": []
+                                  }
+                                ],
+                                []
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "PAGE",
+                          "id": 226,
+                          "name": "ИсторияВыполнения",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                          },
+                          "dataPath": "",
+                          "items": [
+                            {
+                              "type": "INPUT_FIELD",
+                              "id": 126,
+                              "name": "РезультатВыполнения",
+                              "title": {
+                                "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                              },
+                              "dataPath": "ЗаданиеРезультатВыполнения",
+                              "items": []
+                            }
+                          ]
+                        }
+                      ],
+                      []
+                    ]
+                  },
+                  {
+                    "type": "USUAL_GROUP",
+                    "id": 27,
+                    "name": "ГруппаРезультат",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Результат проверки задания:"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "INPUT_FIELD",
+                          "id": 78,
+                          "name": "ОписаниеРезультата",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                          },
+                          "dataPath": "Объект.РезультатВыполнения",
+                          "items": []
+                        },
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 54,
+                          "name": "ГруппаВыполненаДата",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Выполнена дата"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "USUAL_BUTTON",
+                                "id": 123,
+                                "name": "Выполнено",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[3]/synonym"
+                                },
+                                "dataPath": "",
+                                "items": []
+                              },
+                              {
+                                "type": "USUAL_BUTTON",
+                                "id": 147,
+                                "name": "Отменено",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                },
+                                "dataPath": "",
+                                "items": []
+                              },
+                              {
+                                "type": "USUAL_BUTTON",
+                                "id": 124,
+                                "name": "Возвращено",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Возвращено исполнителю"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 55,
+                                "name": "ДатаИсполнения",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Дата проверки"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "Объект.ДатаИсполнения",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 161,
+                                "name": "ДатаИсполненияВремя",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                },
+                                "dataPath": "Объект.ДатаИсполнения",
+                                "items": []
+                              },
+                              {
+                                "type": "HYPERLINK",
+                                "id": 130,
+                                "name": "ИзменитьЗадание",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/title"
+                                },
+                                "dataPath": "",
+                                "items": []
+                              }
+                            ],
+                            []
+                          ]
+                        }
+                      ],
+                      []
+                    ]
+                  }
+                ],
+                []
+              ]
+            }
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "Объект",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 2,
+                "name": "НачальныйПризнакВыполнения",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              },
+              {
+                "id": 3,
+                "name": "ПредметСтрокой",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[11]/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[13]/type"
+                }
+              },
+              {
+                "id": 5,
+                "name": "ТекущийПользователь",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 6,
+                "name": "ЗаданиеСодержание",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[14]/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[13]/type"
+                }
+              },
+              {
+                "id": 7,
+                "name": "ЗаданиеВыполнено",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              },
+              {
+                "id": 8,
+                "name": "ЗаданиеРезультатВыполнения",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[7]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[13]/type"
+                }
+              },
+              {
+                "id": 9,
+                "name": "ЗаданиеПодтверждено",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              },
+              {
+                "id": 10,
+                "name": "ЗаданиеСсылка",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[4]/type"
+                }
+              },
+              {
+                "id": 4,
+                "name": "Исполнитель",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[6]/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[8]/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "b58942ca-1367-4e1d-b5b4-7d973d0fecd8",
+        "name": "ФормаБизнесПроцесса",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "BusinessProcess.Задание.Form.ФормаБизнесПроцесса",
+          "mdoRefRu": "БизнесПроцесс.Задание.Форма.ФормаБизнесПроцесса"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Форма бизнес-процесса"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/BusinessProcesses/Задание/Forms/ФормаБизнесПроцесса/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+          },
+          "handlers": [
+            [
+              {
+                "event": "ChoiceProcessing",
+                "name": "ОбработкаВыбора"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[2]"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[3]"
+              }
+            ],
+            []
+          ],
+          "items": [
+            {
+              "type": "USUAL_GROUP",
+              "id": 151,
+              "name": "Документ",
+              "title": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+              },
+              "dataPath": "",
+              "items": [
+                [
+                  {
+                    "type": "LABEL_FIELD",
+                    "id": 99,
+                    "name": "ГлавнаяЗадача",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[4]/synonym"
+                    },
+                    "dataPath": "ГлавнаяЗадачаСтрокой",
+                    "items": []
+                  },
+                  {
+                    "type": "USUAL_GROUP",
+                    "id": 92,
+                    "name": "ГруппаСостояние",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[15]/synonym"
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "DECORATION",
+                          "id": 93,
+                          "name": "ДекорацияЗначок",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                          },
+                          "dataPath": "",
+                          "items": []
+                        },
+                        {
+                          "type": "LABEL_FIELD",
+                          "id": 155,
+                          "name": "ИнфоНадписьЗаголовок",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Инфо надпись заголовок"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "ИнфоНадписьЗаголовок",
+                          "items": []
+                        }
+                      ],
+                      []
+                    ]
+                  },
+                  {
+                    "type": "USUAL_GROUP",
+                    "id": 145,
+                    "name": "Шапка",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 27,
+                          "name": "ГруппаСрокВажность",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Срок важность"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 19,
+                                "name": "ЗаголовокЗадания",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                },
+                                "dataPath": "Объект.Наименование",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 57,
+                                "name": "Важность",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                },
+                                "dataPath": "Объект.Важность",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 103,
+                                "name": "Номер",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                },
+                                "dataPath": "Объект.Number",
+                                "items": []
+                              }
+                            ],
+                            []
+                          ]
+                        },
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 67,
+                          "name": "ГруппаИсполнение",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Исполнение"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 69,
+                                "name": "Исполнитель",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                },
+                                "dataPath": "Объект.Исполнитель",
+                                "items": []
+                              },
+                              {
+                                "type": "USUAL_GROUP",
+                                "id": 147,
+                                "name": "ГруппаСрокИсполнения",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[16]/synonym"
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 21,
+                                      "name": "СрокИсполнения",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Срок"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "Объект.СрокИсполнения",
+                                      "items": []
+                                    },
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 88,
+                                      "name": "СрокИсполненияВремя",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                      },
+                                      "dataPath": "Объект.СрокИсполнения",
+                                      "items": []
+                                    }
+                                  ],
+                                  []
+                                ]
+                              }
+                            ],
+                            []
+                          ]
+                        }
+                      ],
+                      []
+                    ]
+                  },
+                  {
+                    "type": "USUAL_GROUP",
+                    "id": 75,
+                    "name": "ГруппаСодержание",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[14]/synonym"
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "LABEL_FIELD",
+                          "id": 86,
+                          "name": "Предмет",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[11]/synonym"
+                          },
+                          "dataPath": "ПредметСтрокой",
+                          "items": []
+                        },
+                        {
+                          "type": "INPUT_FIELD",
+                          "id": 17,
+                          "name": "Содержание",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[14]/synonym"
+                          },
+                          "dataPath": "Объект.Содержание",
+                          "items": []
+                        }
+                      ],
+                      []
+                    ]
+                  },
+                  {
+                    "type": "USUAL_GROUP",
+                    "id": 56,
+                    "name": "ГруппаПроверка",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Проверка"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "CHECK_BOX_FIELD",
+                          "id": 54,
+                          "name": "НаПроверке",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Проверить выполнение:"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "Объект.НаПроверке",
+                          "items": []
+                        },
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 28,
+                          "name": "ГруппаПроверяющий",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[12]/synonym"
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 14,
+                                "name": "Проверяющий",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                },
+                                "dataPath": "Объект.Проверяющий",
+                                "items": []
+                              },
+                              {
+                                "type": "USUAL_GROUP",
+                                "id": 149,
+                                "name": "ГруппаСрокПроверки",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[17]/synonym"
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 23,
+                                      "name": "СрокПроверки",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                      },
+                                      "dataPath": "Объект.СрокПроверки",
+                                      "items": []
+                                    },
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 90,
+                                      "name": "СрокПроверкиВремя",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                      },
+                                      "dataPath": "Объект.СрокПроверки",
+                                      "items": []
+                                    }
+                                  ],
+                                  []
+                                ]
+                              }
+                            ],
+                            []
+                          ]
+                        }
+                      ],
+                      []
+                    ]
+                  },
+                  {
+                    "type": "USUAL_GROUP",
+                    "id": 81,
+                    "name": "ГруппаОбщиеСведения",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/synonym"
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "INPUT_FIELD",
+                          "id": 79,
+                          "name": "Автор",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                          },
+                          "dataPath": "Объект.Автор",
+                          "items": []
+                        },
+                        {
+                          "type": "INPUT_FIELD",
+                          "id": 97,
+                          "name": "Дата",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Начато"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "Объект.Date",
+                          "items": []
+                        }
+                      ],
+                      []
+                    ]
+                  }
+                ],
+                []
+              ]
+            }
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "Объект",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "БизнесПроцессОбъект.Задание",
+                          "nameEn": "BusinessProcessObject.Задание"
+                        },
+                        "variant": "METADATA",
+                        "kind": "BUSINESS_PROCESS"
+                      }
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 2,
+                "name": "НачальныйПризнакСтарта",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              },
+              {
+                "id": 3,
+                "name": "ПредметСтрокой",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[11]/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[13]/type"
+                }
+              },
+              {
+                "id": 4,
+                "name": "ГлавнаяЗадачаСтрокой",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[4]/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[13]/type"
+                }
+              },
+              {
+                "id": 5,
+                "name": "ИнфоНадписьЗаголовок",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "FORMATTED_STRING"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 6,
+                "name": "Отложен",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              },
+              {
+                "id": 7,
+                "name": "ДатаОтложенногоСтарта",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[6]/type"
+                }
+              },
+              {
+                "id": 8,
+                "name": "ИспользоватьДатуИВремяВСрокахЗадач",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              },
+              {
+                "id": 9,
+                "name": "ИспользоватьПодчиненныеБизнесПроцессы",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              },
+              {
+                "id": 10,
+                "name": "ИзменятьЗаданияЗаднимЧислом",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "1a7c7427-bead-4655-9dd6-df6e722663c5",
+        "name": "ФормаСписка",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "BusinessProcess.Задание.Form.ФормаСписка",
+          "mdoRefRu": "БизнесПроцесс.Задание.Форма.ФормаСписка"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Форма списка"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/BusinessProcesses/Задание/Forms/ФормаСписка/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+          },
+          "handlers": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[3]"
+              },
+              {
+                "event": "BeforeLoadDataFromSettingsAtServer",
+                "name": "ПриЗагрузкеДанныхИзНастроекНаСервере"
+              }
+            ],
+            []
+          ],
+          "items": [
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 21,
+                "name": "ГруппаПоРеквизитам",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Отборы"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 14,
+                      "name": "ПоАвтору",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/synonym"
+                      },
+                      "dataPath": "ПоАвтору",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 17,
+                      "name": "ПоИсполнителю",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[6]/synonym"
+                      },
+                      "dataPath": "ПоИсполнителю",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 19,
+                      "name": "ПоПроверяющему",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[12]/synonym"
+                      },
+                      "dataPath": "ПоПроверяющему",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 50,
+                "name": "Флажки",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Флажки"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "CHECK_BOX_FIELD",
+                      "id": 22,
+                      "name": "ПоказыватьЗавершенныеЗадания",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Показывать завершенные задания"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "ПоказыватьЗавершенныеЗадания",
+                      "items": []
+                    },
+                    {
+                      "type": "CHECK_BOX_FIELD",
+                      "id": 48,
+                      "name": "ПоказыватьОстановленные",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Показывать остановленные"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "ПоказыватьОстановленные",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 92,
+                "name": "ГруппаПользовательскихНастроек",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Группа пользовательских настроек"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": []
+              },
+              {
+                "type": "COMMAND_BAR",
+                "id": 53,
+                "name": "КоманднаяПанель",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Командная панель"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "BUTTON",
+                      "id": 94,
+                      "name": "ФормаОбщаяКомандаКартаМаршрутаБизнесПроцесса",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Items.Список.CurrentData.Ref",
+                      "items": []
+                    },
+                    {
+                      "type": "BUTTON",
+                      "id": 51,
+                      "name": "ФормаОстановить",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Остановить"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "BUTTON",
+                      "id": 52,
+                      "name": "ФормаПродолжитьБизнесПроцесс",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Продолжить"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "TABLE",
+                "id": 1,
+                "name": "Список",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Список"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "Список",
+                "items": [
+                  [
+                    {
+                      "type": "PICTURE_FIELD",
+                      "id": 24,
+                      "name": "ВажностьКартинка",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[2]/synonym"
+                      },
+                      "dataPath": "Список.ВажностьКартинка",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 4,
+                      "name": "Номер",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.Number",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 6,
+                      "name": "Дата",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.Date",
+                      "items": []
+                    },
+                    {
+                      "type": "COLUMN_GROUP",
+                      "id": 54,
+                      "name": "ГруппаСодержание",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[14]/synonym"
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "LABEL_FIELD",
+                            "id": 26,
+                            "name": "Наименование",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                            },
+                            "dataPath": "Список.Наименование",
+                            "items": []
+                          },
+                          {
+                            "type": "LABEL_FIELD",
+                            "id": 32,
+                            "name": "Предмет",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                            },
+                            "dataPath": "Список.Предмет",
+                            "items": []
+                          },
+                          {
+                            "type": "LABEL_FIELD",
+                            "id": 28,
+                            "name": "Содержание",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                            },
+                            "dataPath": "Список.Содержание",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 42,
+                      "name": "СрокИсполнения",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.СрокИсполнения",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 44,
+                      "name": "СрокПроверки",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.СрокПроверки",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 38,
+                      "name": "ДатаЗавершения",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[3]/synonym"
+                      },
+                      "dataPath": "Список.ДатаЗавершения",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 10,
+                      "name": "ВедущаяЗадача",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.HeadTask",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 30,
+                      "name": "НомерИтерации",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.НомерИтерации",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 34,
+                      "name": "Автор",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.Автор",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 36,
+                      "name": "Исполнитель",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.Исполнитель",
+                      "items": []
+                    },
+                    {
+                      "type": "COLUMN_GROUP",
+                      "id": 57,
+                      "name": "ГруппаПроверка",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[8]/synonym"
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "CHECK_BOX_FIELD",
+                            "id": 55,
+                            "name": "НаПроверке",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                            },
+                            "dataPath": "Список.НаПроверке",
+                            "items": []
+                          },
+                          {
+                            "type": "LABEL_FIELD",
+                            "id": 40,
+                            "name": "Проверяющий",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                            },
+                            "dataPath": "Список.Проверяющий",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 89,
+                      "name": "Ссылка",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.Ref",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "Список",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "DYNAMIC_LIST"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 2,
+                "name": "ПоАвтору",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 3,
+                "name": "ПоИсполнителю",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[6]/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 4,
+                "name": "ПоПроверяющему",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[12]/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 5,
+                "name": "ПоказыватьЗавершенныеЗадания",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              },
+              {
+                "id": 6,
+                "name": "ПоказыватьОстановленные",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      }
+    ],
+    []
+  ],
+  "mdoReference": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+  },
+  "mdoType": "BUSINESS_PROCESS",
+  "moduleTypes": [
+    [
+      "ManagerModule",
+      [
+        "src/test/resources/ext/edt/ssl_3_2/configuration/src/BusinessProcesses/Задание/ManagerModule.bsl"
+      ]
+    ],
+    [
+      "ObjectModule",
+      [
+        "src/test/resources/ext/edt/ssl_3_2/configuration/src/BusinessProcesses/Задание/ObjectModule.bsl"
+      ]
+    ]
+  ],
+  "modules": [
+    {
+      "moduleType": "ManagerModule",
+      "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/BusinessProcesses/Задание/ManagerModule.bsl",
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "isProtected": false
+    },
+    {
+      "moduleType": "ObjectModule",
+      "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/BusinessProcesses/Задание/ObjectModule.bsl",
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "isProtected": false
+    }
+  ],
+  "name": "Задание",
+  "objectBelonging": "OWN",
+  "possibleRights": [
+    {
+      "default": {
+        "tag": 4
+      },
+      "int": 24,
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INSERT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "DELETE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "VIEW",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "EDIT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INPUT_BY_STRING",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_DELETE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_INSERT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_SET_DELETION_MARK",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_CLEAR_DELETION_MARK",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_DELETE_MARKED",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "START",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_START",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_ACTIVATE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "VIEW_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ_DATA_HISTORY_OF_MISSING_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_OF_MISSING_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_SETTINGS",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_VERSION_COMMENT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "EDIT_DATA_HISTORY_VERSION_COMMENT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "SWITCH_TO_DATA_HISTORY_VERSION"
+    }
+  ],
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.BusinessProcess/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[7]/synonym"
+  },
+  "tabularSections": [],
+  "task": {
+    "type": "TASK",
+    "mdoRef": "Task.ЗадачаИсполнителя",
+    "mdoRefRu": "Задача.ЗадачаИсполнителя"
+  },
+  "templates": [],
+  "uuid": "dad11c2e-08fc-4a6b-8829-8be6c64c15fc"
+}}

--- a/src/test/resources/fixtures/ssl_3_2/Catalogs.ВерсииФайлов.json
+++ b/src/test/resources/fixtures/ssl_3_2/Catalogs.ВерсииФайлов.json
@@ -1408,6 +1408,125 @@
         "multiLine": false,
         "extendedEdit": false,
         "fillFromFillingValue": false
+      },
+      {
+        "uuid": "d970abc7-4437-4fc4-87d1-bab2ddde8884",
+        "name": "ДатаПереносаВАрхив",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.Attribute.ДатаПереносаВАрхив",
+          "mdoRefRu": "Справочник.ВерсииФайлов.Реквизит.ДатаПереносаВАрхив"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Дата переноса в архив"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "DATE"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.DateQualifiers": {
+                "dateFractions": 1,
+                "description": {
+                  "value": {
+                    "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                    "nameRu": "КвалификаторыДаты (Дата)",
+                    "nameEn": "DateQualifiers (Date)"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "ee83328e-91d2-4022-b1d3-d7d137098ee9",
+        "name": "УсловноПеренесенВАрхив",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.Attribute.УсловноПеренесенВАрхив",
+          "mdoRefRu": "Справочник.ВерсииФайлов.Реквизит.УсловноПеренесенВАрхив"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Условно перенесен в архив"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[2]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
       }
     ],
     []
@@ -1501,181 +1620,6 @@
                 "items": []
               },
               {
-                "type": "COMMAND_BAR",
-                "id": 53,
-                "name": "КоманднаяПанель",
-                "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Командная панель"
-                      }
-                    }
-                  ]
-                },
-                "dataPath": "",
-                "items": [
-                  [
-                    {
-                      "type": "COMMAND_BAR_BUTTON",
-                      "id": 13,
-                      "name": "ФормаИзменить",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Открыть карточку"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "BUTTON_GROUP",
-                      "id": 68,
-                      "name": "ГруппаУдаление",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Удаление"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "COMMAND_BAR_BUTTON",
-                            "id": 70,
-                            "name": "УстановитьПометкуУдаления",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "COMMAND_BAR_BUTTON",
-                            "id": 72,
-                            "name": "ФормаУдалить",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Удалить"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": []
-                          }
-                        ],
-                        []
-                      ]
-                    },
-                    {
-                      "type": "BUTTON_GROUP",
-                      "id": 15,
-                      "name": "ФормаСтандартныеКоманды",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Форма стандартные команды"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "COMMAND_BAR_BUTTON",
-                      "id": 74,
-                      "name": "ПоказыватьПомеченныеФайлы",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Показывать помеченные файлы"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "COMMAND_BAR_BUTTON",
-                      "id": 14,
-                      "name": "ФормаСправка",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "SEARCH_STRING_ADDITION",
-                      "id": 78,
-                      "name": "СтрокаПоиска",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Поиск"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": []
-                    }
-                  ],
-                  []
-                ]
-              },
-              {
                 "type": "TABLE",
                 "id": 1,
                 "name": "Список",
@@ -1716,126 +1660,119 @@
                       },
                       "dataPath": "",
                       "items": [
-                        [
-                          {
-                            "type": "COLUMN_GROUP",
-                            "id": 66,
-                            "name": "ГруппаОсновное",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Основное"
-                                  }
+                        {
+                          "type": "COLUMN_GROUP",
+                          "id": 66,
+                          "name": "ГруппаОсновное",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Основное"
                                 }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": [
-                              [
-                                {
-                                  "type": "LABEL_FIELD",
-                                  "id": 8,
-                                  "name": "СписокПолноеНаименование",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Наименование"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "Список.Description",
-                                  "items": []
-                                },
-                                {
-                                  "type": "LABEL_FIELD",
-                                  "id": 30,
-                                  "name": "СписокРасширение",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                  },
-                                  "dataPath": "Список.Расширение",
-                                  "items": []
-                                },
-                                {
-                                  "type": "LABEL_FIELD",
-                                  "id": 16,
-                                  "name": "СписокВладелец",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                  },
-                                  "dataPath": "Список.Owner",
-                                  "items": []
-                                },
-                                {
-                                  "type": "LABEL_FIELD",
-                                  "id": 18,
-                                  "name": "СписокАвтор",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                  },
-                                  "dataPath": "Список.Автор",
-                                  "items": []
-                                },
-                                {
-                                  "type": "LABEL_FIELD",
-                                  "id": 22,
-                                  "name": "СписокДатаСоздания",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                  },
-                                  "dataPath": "Список.ДатаСоздания",
-                                  "items": []
-                                },
-                                {
-                                  "type": "LABEL_FIELD",
-                                  "id": 24,
-                                  "name": "СписокРазмер",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                  },
-                                  "dataPath": "Список.Размер",
-                                  "items": []
-                                },
-                                {
-                                  "type": "LABEL_FIELD",
-                                  "id": 26,
-                                  "name": "СписокНомерВерсии",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                  },
-                                  "dataPath": "Список.НомерВерсии",
-                                  "items": []
-                                }
-                              ],
-                              []
+                              }
                             ]
                           },
-                          {
-                            "type": "LABEL_FIELD",
-                            "id": 20,
-                            "name": "СписокКомментарий",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                            },
-                            "dataPath": "Список.Комментарий",
-                            "items": []
-                          }
-                        ],
-                        []
+                          "dataPath": "",
+                          "items": []
+                        }
                       ]
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 8,
+                      "name": "СписокПолноеНаименование",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Наименование"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "Список.Наименование",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 26,
+                      "name": "СписокНомерВерсии",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.НомерВерсии",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 16,
+                      "name": "СписокВладелец",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.Владелец",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 18,
+                      "name": "СписокАвтор",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.Автор",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 22,
+                      "name": "СписокДатаСоздания",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.ДатаСоздания",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 20,
+                      "name": "СписокКомментарий",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[6]/synonym"
+                      },
+                      "dataPath": "Список.Комментарий",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 30,
+                      "name": "СписокРасширение",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.Расширение",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 24,
+                      "name": "СписокРазмер",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.Размер",
+                      "items": []
                     },
                     {
                       "type": "LABEL_FIELD",
@@ -1959,296 +1896,45 @@
                 "items": []
               },
               {
-                "type": "COMMAND_BAR",
-                "id": 37,
-                "name": "КоманднаяПанель",
-                "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                },
-                "dataPath": "",
-                "items": [
-                  [
-                    {
-                      "type": "COMMAND_BAR_BUTTON",
-                      "id": 58,
-                      "name": "ФормаВыбрать",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "COMMAND_BAR_BUTTON",
-                      "id": 60,
-                      "name": "ФормаСоздать",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "COMMAND_BAR_BUTTON",
-                      "id": 62,
-                      "name": "ФормаСкопировать",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "COMMAND_BAR_BUTTON",
-                      "id": 64,
-                      "name": "ФормаИзменить",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "COMMAND_BAR_BUTTON",
-                      "id": 66,
-                      "name": "ФормаОбновить",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "BUTTON_GROUP",
-                      "id": 68,
-                      "name": "ГруппаУдаление",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "COMMAND_BAR_BUTTON",
-                            "id": 70,
-                            "name": "УстановитьПометкуУдаления",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "COMMAND_BAR_BUTTON",
-                            "id": 72,
-                            "name": "ФормаУдалить",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                            },
-                            "dataPath": "",
-                            "items": []
-                          }
-                        ],
-                        []
-                      ]
-                    },
-                    {
-                      "type": "COMMAND_BAR_BUTTON",
-                      "id": 74,
-                      "name": "ФормаПоискПоТекущемуЗначению",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "COMMAND_BAR_BUTTON",
-                      "id": 76,
-                      "name": "ФормаНайти",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "COMMAND_BAR_BUTTON",
-                      "id": 78,
-                      "name": "ФормаОтменитьПоиск",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "COMMAND_BAR_BUTTON",
-                      "id": 80,
-                      "name": "ФормаИсторияИзменений",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "COMMAND_BAR_BUTTON",
-                      "id": 82,
-                      "name": "ФормаНастройкаСписка",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "COMMAND_BAR_BUTTON",
-                      "id": 84,
-                      "name": "ФормаЗагрузитьНастройкиДинамическогоСписка",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "COMMAND_BAR_BUTTON",
-                      "id": 86,
-                      "name": "ФормаСохранитьНастройкиДинамическогоСписка",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "COMMAND_BAR_BUTTON",
-                      "id": 88,
-                      "name": "ФормаСтандартныеНастройкиДинамическогоСписка",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "COMMAND_BAR_BUTTON",
-                      "id": 90,
-                      "name": "ФормаВывестиСписок",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "COMMAND_BAR_BUTTON",
-                      "id": 92,
-                      "name": "ПоказыватьПомеченныеФайлы",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "SEARCH_STRING_ADDITION",
-                      "id": 94,
-                      "name": "СтрокаПоиска",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[6]/title"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    }
-                  ],
-                  []
-                ]
-              },
-              {
                 "type": "TABLE",
                 "id": 2,
                 "name": "Список",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                 },
                 "dataPath": "Список",
                 "items": [
                   [
                     {
                       "type": "COLUMN_GROUP",
-                      "id": 51,
-                      "name": "ГруппаВертикально",
+                      "id": 110,
+                      "name": "ГруппаФайлКомментарий",
                       "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Файл, комментарий"
+                            }
+                          }
+                        ]
                       },
                       "dataPath": "",
                       "items": [
                         [
                           {
-                            "type": "COLUMN_GROUP",
-                            "id": 53,
-                            "name": "ГруппаОсновное",
+                            "type": "LABEL_FIELD",
+                            "id": 39,
+                            "name": "СписокВладелец",
                             "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
                             },
-                            "dataPath": "",
-                            "items": [
-                              [
-                                {
-                                  "type": "LABEL_FIELD",
-                                  "id": 39,
-                                  "name": "СписокВладелец",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                  },
-                                  "dataPath": "Список.Владелец",
-                                  "items": []
-                                },
-                                {
-                                  "type": "INPUT_FIELD",
-                                  "id": 19,
-                                  "name": "СписокНомерВерсии",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                  },
-                                  "dataPath": "Список.НомерВерсии",
-                                  "items": []
-                                },
-                                {
-                                  "type": "INPUT_FIELD",
-                                  "id": 21,
-                                  "name": "СписокАвтор",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                  },
-                                  "dataPath": "Список.Автор",
-                                  "items": []
-                                },
-                                {
-                                  "type": "INPUT_FIELD",
-                                  "id": 23,
-                                  "name": "СписокДатаСоздания",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                  },
-                                  "dataPath": "Список.ДатаСоздания",
-                                  "items": []
-                                },
-                                {
-                                  "type": "INPUT_FIELD",
-                                  "id": 25,
-                                  "name": "СписокРазмер",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                  },
-                                  "dataPath": "Список.Размер",
-                                  "items": []
-                                }
-                              ],
-                              []
-                            ]
+                            "dataPath": "Список.Владелец",
+                            "items": []
                           },
                           {
                             "type": "LABEL_FIELD",
@@ -2265,6 +1951,46 @@
                       ]
                     },
                     {
+                      "type": "INPUT_FIELD",
+                      "id": 19,
+                      "name": "СписокНомерВерсии",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.НомерВерсии",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 21,
+                      "name": "СписокАвтор",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.Автор",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 23,
+                      "name": "СписокДатаСоздания",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.ДатаСоздания",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 25,
+                      "name": "СписокРазмер",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.Размер",
+                      "items": []
+                    },
+                    {
                       "type": "LABEL_FIELD",
                       "id": 32,
                       "name": "СписокСсылка",
@@ -2273,6 +1999,27 @@
                       },
                       "dataPath": "Список.Ссылка",
                       "items": []
+                    },
+                    {
+                      "type": "COLUMN_GROUP",
+                      "id": 51,
+                      "name": "ГруппаВертикально",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                      },
+                      "dataPath": "",
+                      "items": [
+                        {
+                          "type": "COLUMN_GROUP",
+                          "id": 53,
+                          "name": "ГруппаОсновное",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                          },
+                          "dataPath": "",
+                          "items": []
+                        }
+                      ]
                     }
                   ],
                   []
@@ -2364,98 +2111,91 @@
               "id": 2,
               "name": "Список",
               "title": {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
               },
               "dataPath": "Список",
               "items": [
                 [
                   {
-                    "type": "COLUMN_GROUP",
-                    "id": 114,
-                    "name": "ГруппаВертикально",
+                    "type": "PICTURE_FIELD",
+                    "id": 149,
+                    "name": "СписокНомерКартинкиЭтоАрхив",
                     "title": {
-                      "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                    },
-                    "dataPath": "",
-                    "items": [
-                      [
+                      "content": [
                         {
-                          "type": "COLUMN_GROUP",
-                          "id": 116,
-                          "name": "ГруппаОсновное",
-                          "title": {
-                            "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                          "default": {
+                            "tag": 2
                           },
-                          "dataPath": "",
-                          "items": [
-                            [
-                              {
-                                "type": "INPUT_FIELD",
-                                "id": 49,
-                                "name": "СписокАвтор",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                },
-                                "dataPath": "Список.Автор",
-                                "items": []
-                              },
-                              {
-                                "type": "INPUT_FIELD",
-                                "id": 47,
-                                "name": "СписокВладелец",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                },
-                                "dataPath": "Список.Владелец",
-                                "items": []
-                              },
-                              {
-                                "type": "INPUT_FIELD",
-                                "id": 57,
-                                "name": "СписокНомерВерсии",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                },
-                                "dataPath": "Список.НомерВерсии",
-                                "items": []
-                              },
-                              {
-                                "type": "INPUT_FIELD",
-                                "id": 53,
-                                "name": "СписокДатаСоздания",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                },
-                                "dataPath": "Список.ДатаСоздания",
-                                "items": []
-                              },
-                              {
-                                "type": "INPUT_FIELD",
-                                "id": 55,
-                                "name": "СписокРазмер",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                },
-                                "dataPath": "Список.Размер",
-                                "items": []
-                              }
-                            ],
-                            []
-                          ]
-                        },
-                        {
-                          "type": "INPUT_FIELD",
-                          "id": 51,
-                          "name": "СписокКомментарий",
-                          "title": {
-                            "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                          },
-                          "dataPath": "Список.Комментарий",
-                          "items": []
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "В архиве"
+                          }
                         }
-                      ],
-                      []
-                    ]
+                      ]
+                    },
+                    "dataPath": "Список.НомерКартинкиЭтоАрхив",
+                    "items": []
+                  },
+                  {
+                    "type": "INPUT_FIELD",
+                    "id": 49,
+                    "name": "СписокАвтор",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                    },
+                    "dataPath": "Список.Автор",
+                    "items": []
+                  },
+                  {
+                    "type": "INPUT_FIELD",
+                    "id": 47,
+                    "name": "СписокВладелец",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                    },
+                    "dataPath": "Список.Владелец",
+                    "items": []
+                  },
+                  {
+                    "type": "INPUT_FIELD",
+                    "id": 57,
+                    "name": "СписокНомерВерсии",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                    },
+                    "dataPath": "Список.НомерВерсии",
+                    "items": []
+                  },
+                  {
+                    "type": "INPUT_FIELD",
+                    "id": 53,
+                    "name": "СписокДатаСоздания",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                    },
+                    "dataPath": "Список.ДатаСоздания",
+                    "items": []
+                  },
+                  {
+                    "type": "INPUT_FIELD",
+                    "id": 55,
+                    "name": "СписокРазмер",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                    },
+                    "dataPath": "Список.Размер",
+                    "items": []
+                  },
+                  {
+                    "type": "INPUT_FIELD",
+                    "id": 51,
+                    "name": "СписокКомментарий",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[6]/synonym"
+                    },
+                    "dataPath": "Список.Комментарий",
+                    "items": []
                   },
                   {
                     "type": "INPUT_FIELD",
@@ -2478,7 +2218,7 @@
                 "id": 2,
                 "name": "Список",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
@@ -2638,583 +2378,7 @@
       }
     ]
   },
-  "tabularSections": [
-    {
-      "uuid": "ab1bcabf-ffb0-4914-8ad0-b94b5aaeab1d",
-      "name": "УдалитьЭлектронныеПодписи",
-      "mdoReference": {
-        "type": "TABULAR_SECTION",
-        "mdoRef": "Catalog.ВерсииФайлов.TabularSection.УдалитьЭлектронныеПодписи",
-        "mdoRefRu": "Справочник.ВерсииФайлов.ТабличнаяЧасть.УдалитьЭлектронныеПодписи"
-      },
-      "objectBelonging": "OWN",
-      "comment": "",
-      "synonym": {
-        "content": [
-          {
-            "default": {
-              "tag": 2
-            },
-            "int": 1,
-            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-              "langKey": "ru",
-              "value": "(не используется) Электронные подписи"
-            }
-          }
-        ]
-      },
-      "supportVariant": "NOT_EDITABLE",
-      "owner": {
-        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
-      },
-      "attributes": [
-        [
-          {
-            "uuid": "ab1bcabf-ffb0-4914-8ad0-b94b5aaeab1d",
-            "mdoReference": {
-              "type": "STANDARD_ATTRIBUTE",
-              "mdoRef": "Catalog.ВерсииФайлов.TabularSection.УдалитьЭлектронныеПодписи.StandardAttribute.LineNumber",
-              "mdoRefRu": "Справочник.ВерсииФайлов.ТабличнаяЧасть.УдалитьЭлектронныеПодписи.СтандартныйРеквизит.НомерСтроки"
-            },
-            "comment": "",
-            "synonym": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-            },
-            "supportVariant": "NOT_EDITABLE",
-            "owner": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
-            },
-            "passwordMode": false,
-            "kind": "STANDARD",
-            "type": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[7]/type"
-            },
-            "fullName": {
-              "nameRu": "НомерСтроки",
-              "nameEn": "LineNumber"
-            },
-            "format": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-            },
-            "editFormat": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-            },
-            "markNegatives": false,
-            "mask": "",
-            "multiLine": false,
-            "extendedEdit": false,
-            "fillFromFillingValue": false
-          },
-          {
-            "uuid": "c5478d09-c8d3-4cc6-878e-27656ecc8409",
-            "name": "ДатаПодписи",
-            "mdoReference": {
-              "type": "ATTRIBUTE",
-              "mdoRef": "Catalog.ВерсииФайлов.TabularSection.УдалитьЭлектронныеПодписи.Attribute.ДатаПодписи",
-              "mdoRefRu": "Справочник.ВерсииФайлов.ТабличнаяЧасть.УдалитьЭлектронныеПодписи.Реквизит.ДатаПодписи"
-            },
-            "objectBelonging": "OWN",
-            "comment": "",
-            "synonym": {
-              "content": [
-                {
-                  "default": {
-                    "tag": 2
-                  },
-                  "int": 1,
-                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                    "langKey": "ru",
-                    "value": "Дата подписи"
-                  }
-                }
-              ]
-            },
-            "supportVariant": "NOT_EDITABLE",
-            "owner": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
-            },
-            "passwordMode": false,
-            "kind": "CUSTOM",
-            "indexing": "DONT_INDEX",
-            "type": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[2]/type"
-            },
-            "format": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-            },
-            "editFormat": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-            },
-            "markNegatives": false,
-            "mask": "",
-            "multiLine": false,
-            "extendedEdit": false,
-            "fillFromFillingValue": false
-          },
-          {
-            "uuid": "01b97d2f-40b9-4f12-8bc5-ab75fd160b7c",
-            "name": "ИмяФайлаПодписи",
-            "mdoReference": {
-              "type": "ATTRIBUTE",
-              "mdoRef": "Catalog.ВерсииФайлов.TabularSection.УдалитьЭлектронныеПодписи.Attribute.ИмяФайлаПодписи",
-              "mdoRefRu": "Справочник.ВерсииФайлов.ТабличнаяЧасть.УдалитьЭлектронныеПодписи.Реквизит.ИмяФайлаПодписи"
-            },
-            "objectBelonging": "OWN",
-            "comment": "",
-            "synonym": {
-              "content": [
-                {
-                  "default": {
-                    "tag": 2
-                  },
-                  "int": 1,
-                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                    "langKey": "ru",
-                    "value": "Имя файла подписи"
-                  }
-                }
-              ]
-            },
-            "supportVariant": "NOT_EDITABLE",
-            "owner": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
-            },
-            "passwordMode": false,
-            "kind": "CUSTOM",
-            "indexing": "DONT_INDEX",
-            "type": {
-              "types": [
-                {
-                  "default": {
-                    "tag": 4
-                  },
-                  "int": 1,
-                  "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
-                }
-              ],
-              "composite": false,
-              "qualifiers": [
-                {
-                  "default": {
-                    "tag": 4
-                  },
-                  "int": 1,
-                  "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
-                    "length": 260,
-                    "allowedLength": 0,
-                    "description": {}
-                  }
-                }
-              ]
-            },
-            "format": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-            },
-            "editFormat": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-            },
-            "markNegatives": false,
-            "mask": "",
-            "multiLine": false,
-            "extendedEdit": false,
-            "fillFromFillingValue": false
-          },
-          {
-            "uuid": "75974146-5b1a-412c-b7d5-1575704bbdab",
-            "name": "Комментарий",
-            "mdoReference": {
-              "type": "ATTRIBUTE",
-              "mdoRef": "Catalog.ВерсииФайлов.TabularSection.УдалитьЭлектронныеПодписи.Attribute.Комментарий",
-              "mdoRefRu": "Справочник.ВерсииФайлов.ТабличнаяЧасть.УдалитьЭлектронныеПодписи.Реквизит.Комментарий"
-            },
-            "objectBelonging": "OWN",
-            "comment": "",
-            "synonym": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[6]/synonym"
-            },
-            "supportVariant": "NOT_EDITABLE",
-            "owner": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
-            },
-            "passwordMode": false,
-            "kind": "CUSTOM",
-            "indexing": "DONT_INDEX",
-            "type": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
-            },
-            "format": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-            },
-            "editFormat": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-            },
-            "markNegatives": false,
-            "mask": "",
-            "multiLine": false,
-            "extendedEdit": false,
-            "fillFromFillingValue": false
-          },
-          {
-            "uuid": "949f87cb-258c-4b6b-95ee-8a7491a4b64e",
-            "name": "КомуВыданСертификат",
-            "mdoReference": {
-              "type": "ATTRIBUTE",
-              "mdoRef": "Catalog.ВерсииФайлов.TabularSection.УдалитьЭлектронныеПодписи.Attribute.КомуВыданСертификат",
-              "mdoRefRu": "Справочник.ВерсииФайлов.ТабличнаяЧасть.УдалитьЭлектронныеПодписи.Реквизит.КомуВыданСертификат"
-            },
-            "objectBelonging": "OWN",
-            "comment": "",
-            "synonym": {
-              "content": [
-                {
-                  "default": {
-                    "tag": 2
-                  },
-                  "int": 1,
-                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                    "langKey": "ru",
-                    "value": "Кому выдан сертификат"
-                  }
-                }
-              ]
-            },
-            "supportVariant": "NOT_EDITABLE",
-            "owner": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
-            },
-            "passwordMode": false,
-            "kind": "CUSTOM",
-            "indexing": "DONT_INDEX",
-            "type": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
-            },
-            "format": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-            },
-            "editFormat": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-            },
-            "markNegatives": false,
-            "mask": "",
-            "multiLine": false,
-            "extendedEdit": false,
-            "fillFromFillingValue": false
-          },
-          {
-            "uuid": "8a348012-99dc-4dc9-8bec-0df3caf4cdc5",
-            "name": "Отпечаток",
-            "mdoReference": {
-              "type": "ATTRIBUTE",
-              "mdoRef": "Catalog.ВерсииФайлов.TabularSection.УдалитьЭлектронныеПодписи.Attribute.Отпечаток",
-              "mdoRefRu": "Справочник.ВерсииФайлов.ТабличнаяЧасть.УдалитьЭлектронныеПодписи.Реквизит.Отпечаток"
-            },
-            "objectBelonging": "OWN",
-            "comment": "",
-            "synonym": {
-              "content": [
-                {
-                  "default": {
-                    "tag": 2
-                  },
-                  "int": 1,
-                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                    "langKey": "ru",
-                    "value": "Отпечаток"
-                  }
-                }
-              ]
-            },
-            "supportVariant": "NOT_EDITABLE",
-            "owner": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
-            },
-            "passwordMode": false,
-            "kind": "CUSTOM",
-            "indexing": "DONT_INDEX",
-            "type": {
-              "types": [
-                {
-                  "default": {
-                    "tag": 4
-                  },
-                  "int": 1,
-                  "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
-                }
-              ],
-              "composite": false,
-              "qualifiers": [
-                {
-                  "default": {
-                    "tag": 4
-                  },
-                  "int": 1,
-                  "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
-                    "length": 28,
-                    "allowedLength": 0,
-                    "description": {}
-                  }
-                }
-              ]
-            },
-            "format": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-            },
-            "editFormat": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-            },
-            "markNegatives": false,
-            "mask": "",
-            "multiLine": false,
-            "extendedEdit": false,
-            "fillFromFillingValue": false
-          },
-          {
-            "uuid": "5c089988-5381-41ed-9f05-f85db46b8d94",
-            "name": "Подпись",
-            "mdoReference": {
-              "type": "ATTRIBUTE",
-              "mdoRef": "Catalog.ВерсииФайлов.TabularSection.УдалитьЭлектронныеПодписи.Attribute.Подпись",
-              "mdoRefRu": "Справочник.ВерсииФайлов.ТабличнаяЧасть.УдалитьЭлектронныеПодписи.Реквизит.Подпись"
-            },
-            "objectBelonging": "OWN",
-            "comment": "",
-            "synonym": {
-              "content": [
-                {
-                  "default": {
-                    "tag": 2
-                  },
-                  "int": 1,
-                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                    "langKey": "ru",
-                    "value": "Подпись"
-                  }
-                }
-              ]
-            },
-            "supportVariant": "NOT_EDITABLE",
-            "owner": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
-            },
-            "passwordMode": false,
-            "kind": "CUSTOM",
-            "indexing": "DONT_INDEX",
-            "type": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[13]/type"
-            },
-            "format": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-            },
-            "editFormat": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-            },
-            "markNegatives": false,
-            "mask": "",
-            "multiLine": false,
-            "extendedEdit": false,
-            "fillFromFillingValue": false
-          },
-          {
-            "uuid": "85a36352-1569-4ce4-aeba-477db524c36d",
-            "name": "УстановившийПодпись",
-            "mdoReference": {
-              "type": "ATTRIBUTE",
-              "mdoRef": "Catalog.ВерсииФайлов.TabularSection.УдалитьЭлектронныеПодписи.Attribute.УстановившийПодпись",
-              "mdoRefRu": "Справочник.ВерсииФайлов.ТабличнаяЧасть.УдалитьЭлектронныеПодписи.Реквизит.УстановившийПодпись"
-            },
-            "objectBelonging": "OWN",
-            "comment": "",
-            "synonym": {
-              "content": [
-                {
-                  "default": {
-                    "tag": 2
-                  },
-                  "int": 1,
-                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                    "langKey": "ru",
-                    "value": "Установивший подпись"
-                  }
-                }
-              ]
-            },
-            "supportVariant": "NOT_EDITABLE",
-            "owner": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
-            },
-            "passwordMode": false,
-            "kind": "CUSTOM",
-            "indexing": "DONT_INDEX",
-            "type": {
-              "types": [
-                {
-                  "default": {
-                    "tag": 4
-                  },
-                  "int": 1,
-                  "com.github._1c_syntax.bsl.types.value.CustomValueType": {
-                    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/type/types/java.util.CollSer/com.github._1c_syntax.bsl.types.value.CustomValueType[2]"
-                  }
-                }
-              ],
-              "composite": false,
-              "qualifiers": []
-            },
-            "format": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-            },
-            "editFormat": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-            },
-            "markNegatives": false,
-            "mask": "",
-            "multiLine": false,
-            "extendedEdit": false,
-            "fillFromFillingValue": false
-          },
-          {
-            "uuid": "ebfb6f80-88f5-4046-8ae7-e11a7b0c1beb",
-            "name": "Сертификат",
-            "mdoReference": {
-              "type": "ATTRIBUTE",
-              "mdoRef": "Catalog.ВерсииФайлов.TabularSection.УдалитьЭлектронныеПодписи.Attribute.Сертификат",
-              "mdoRefRu": "Справочник.ВерсииФайлов.ТабличнаяЧасть.УдалитьЭлектронныеПодписи.Реквизит.Сертификат"
-            },
-            "objectBelonging": "OWN",
-            "comment": "",
-            "synonym": {
-              "content": [
-                {
-                  "default": {
-                    "tag": 2
-                  },
-                  "int": 1,
-                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                    "langKey": "ru",
-                    "value": "Сертификат"
-                  }
-                }
-              ]
-            },
-            "supportVariant": "NOT_EDITABLE",
-            "owner": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
-            },
-            "passwordMode": false,
-            "kind": "CUSTOM",
-            "indexing": "DONT_INDEX",
-            "type": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[13]/type"
-            },
-            "format": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-            },
-            "editFormat": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-            },
-            "markNegatives": false,
-            "mask": "",
-            "multiLine": false,
-            "extendedEdit": false,
-            "fillFromFillingValue": false
-          },
-          {
-            "uuid": "d99991b8-3a81-4e18-b0ad-05fc3e3a199b",
-            "name": "ДатаПроверкиПодписи",
-            "mdoReference": {
-              "type": "ATTRIBUTE",
-              "mdoRef": "Catalog.ВерсииФайлов.TabularSection.УдалитьЭлектронныеПодписи.Attribute.ДатаПроверкиПодписи",
-              "mdoRefRu": "Справочник.ВерсииФайлов.ТабличнаяЧасть.УдалитьЭлектронныеПодписи.Реквизит.ДатаПроверкиПодписи"
-            },
-            "objectBelonging": "OWN",
-            "comment": "",
-            "synonym": {
-              "content": [
-                {
-                  "default": {
-                    "tag": 2
-                  },
-                  "int": 1,
-                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                    "langKey": "ru",
-                    "value": "Дата проверки подписи"
-                  }
-                }
-              ]
-            },
-            "supportVariant": "NOT_EDITABLE",
-            "owner": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
-            },
-            "passwordMode": false,
-            "kind": "CUSTOM",
-            "indexing": "DONT_INDEX",
-            "type": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[2]/type"
-            },
-            "format": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-            },
-            "editFormat": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-            },
-            "markNegatives": false,
-            "mask": "",
-            "multiLine": false,
-            "extendedEdit": false,
-            "fillFromFillingValue": false
-          },
-          {
-            "uuid": "dd383422-dddb-4a81-9326-015fd345b5c1",
-            "name": "ПодписьВерна",
-            "mdoReference": {
-              "type": "ATTRIBUTE",
-              "mdoRef": "Catalog.ВерсииФайлов.TabularSection.УдалитьЭлектронныеПодписи.Attribute.ПодписьВерна",
-              "mdoRefRu": "Справочник.ВерсииФайлов.ТабличнаяЧасть.УдалитьЭлектронныеПодписи.Реквизит.ПодписьВерна"
-            },
-            "objectBelonging": "OWN",
-            "comment": "",
-            "synonym": {
-              "content": [
-                {
-                  "default": {
-                    "tag": 2
-                  },
-                  "int": 1,
-                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                    "langKey": "ru",
-                    "value": "Подпись верна"
-                  }
-                }
-              ]
-            },
-            "supportVariant": "NOT_EDITABLE",
-            "owner": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
-            },
-            "passwordMode": false,
-            "kind": "CUSTOM",
-            "indexing": "DONT_INDEX",
-            "type": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[2]/type"
-            },
-            "format": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-            },
-            "editFormat": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-            },
-            "markNegatives": false,
-            "mask": "",
-            "multiLine": false,
-            "extendedEdit": false,
-            "fillFromFillingValue": false
-          }
-        ],
-        []
-      ]
-    }
-  ],
+  "tabularSections": [],
   "templates": [],
   "uuid": "eb3dfdc7-58b8-4b1f-b079-368c262364c9"
 }}

--- a/src/test/resources/fixtures/ssl_3_2/Catalogs.ВерсииФайлов.json
+++ b/src/test/resources/fixtures/ssl_3_2/Catalogs.ВерсииФайлов.json
@@ -1,0 +1,3220 @@
+{"com.github._1c_syntax.bsl.mdo.Catalog": {
+  "attributes": [
+    [
+      {
+        "uuid": "eb3dfdc7-58b8-4b1f-b079-368c262364c9",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.StandardAttribute.PredefinedDataName",
+          "mdoRefRu": "Справочник.ВерсииФайлов.СтандартныйРеквизит.ИмяПредопределенныхДанных"
+        },
+        "comment": "",
+        "synonym": {
+          "content": []
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ВерсииФайлов",
+          "mdoRefRu": "Справочник.ВерсииФайлов"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                "length": 0,
+                "allowedLength": 0,
+                "description": {
+                  "value": {
+                    "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                    "nameRu": "КвалификаторыСтроки (0, Переменная)",
+                    "nameEn": "StringQualifiers (0, Variable)"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "ИмяПредопределенныхДанных",
+          "nameEn": "PredefinedDataName"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "eb3dfdc7-58b8-4b1f-b079-368c262364c9",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.StandardAttribute.Predefined",
+          "mdoRefRu": "Справочник.ВерсииФайлов.СтандартныйРеквизит.Предопределенный"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "BOOLEAN"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 0
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "Предопределенный",
+          "nameEn": "Predefined"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "eb3dfdc7-58b8-4b1f-b079-368c262364c9",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.StandardAttribute.Ref",
+          "mdoRefRu": "Справочник.ВерсииФайлов.СтандартныйРеквизит.Ссылка"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "СправочникСсылка.ВерсииФайлов",
+                  "nameEn": "CatalogRef.ВерсииФайлов"
+                },
+                "variant": "METADATA",
+                "kind": "CATALOG"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "fullName": {
+          "nameRu": "Ссылка",
+          "nameEn": "Ref"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "eb3dfdc7-58b8-4b1f-b079-368c262364c9",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.StandardAttribute.DeletionMark",
+          "mdoRefRu": "Справочник.ВерсииФайлов.СтандартныйРеквизит.ПометкаУдаления"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[2]/type"
+        },
+        "fullName": {
+          "nameRu": "ПометкаУдаления",
+          "nameEn": "DeletionMark"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "eb3dfdc7-58b8-4b1f-b079-368c262364c9",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.StandardAttribute.IsFolder",
+          "mdoRefRu": "Справочник.ВерсииФайлов.СтандартныйРеквизит.ЭтоГруппа"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[2]/type"
+        },
+        "fullName": {
+          "nameRu": "ЭтоГруппа",
+          "nameEn": "IsFolder"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "eb3dfdc7-58b8-4b1f-b079-368c262364c9",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.StandardAttribute.Owner",
+          "mdoRefRu": "Справочник.ВерсииФайлов.СтандартныйРеквизит.Владелец"
+        },
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Файл"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "СправочникСсылка.Файлы",
+                  "nameEn": "CatalogRef.Файлы"
+                },
+                "variant": "METADATA",
+                "kind": "CATALOG"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "fullName": {
+          "nameRu": "Владелец",
+          "nameEn": "Owner"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": true
+      },
+      {
+        "uuid": "eb3dfdc7-58b8-4b1f-b079-368c262364c9",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.StandardAttribute.Parent",
+          "mdoRefRu": "Справочник.ВерсииФайлов.СтандартныйРеквизит.Родитель"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[3]/type"
+        },
+        "fullName": {
+          "nameRu": "Родитель",
+          "nameEn": "Parent"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": true
+      },
+      {
+        "uuid": "eb3dfdc7-58b8-4b1f-b079-368c262364c9",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.StandardAttribute.Description",
+          "mdoRefRu": "Справочник.ВерсииФайлов.СтандартныйРеквизит.Наименование"
+        },
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Краткое наименование"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                "length": 150,
+                "allowedLength": 0,
+                "description": {}
+              }
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "Наименование",
+          "nameEn": "Description"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "eb3dfdc7-58b8-4b1f-b079-368c262364c9",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.StandardAttribute.Code",
+          "mdoRefRu": "Справочник.ВерсииФайлов.СтандартныйРеквизит.Код"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                "length": 11,
+                "allowedLength": 0,
+                "description": {}
+              }
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "Код",
+          "nameEn": "Code"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "5030a318-f8f7-4ec7-80d6-6eee0772562f",
+        "name": "Автор",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.Attribute.Автор",
+          "mdoRefRu": "Справочник.ВерсииФайлов.Реквизит.Автор"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Автор"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 3,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "СправочникСсылка.ВнешниеПользователи",
+                  "nameEn": "CatalogRef.ВнешниеПользователи"
+                },
+                "variant": "METADATA",
+                "kind": "CATALOG"
+              },
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "СправочникСсылка.Пользователи",
+                  "nameEn": "CatalogRef.Пользователи"
+                },
+                "variant": "METADATA",
+                "kind": "CATALOG"
+              },
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "СправочникСсылка.УчетныеЗаписиСинхронизацииФайлов",
+                  "nameEn": "CatalogRef.УчетныеЗаписиСинхронизацииФайлов"
+                },
+                "variant": "METADATA",
+                "kind": "CATALOG"
+              }
+            }
+          ],
+          "composite": true,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "242e911d-e49c-4b8a-8543-cc2e079220fd",
+        "name": "ДатаМодификацииУниверсальная",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.Attribute.ДатаМодификацииУниверсальная",
+          "mdoRefRu": "Справочник.ВерсииФайлов.Реквизит.ДатаМодификацииУниверсальная"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Дата изменения (универсальное время)"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "DATE"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.DateQualifiers": {
+                "dateFractions": 2,
+                "description": {
+                  "value": {
+                    "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                    "nameRu": "КвалификаторыДаты (ДатаВремя)",
+                    "nameEn": "DateQualifiers (DateTime)"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "9ea39d31-3775-4fb8-a3f3-202e54354d49",
+        "name": "ДатаМодификацииФайла",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.Attribute.ДатаМодификацииФайла",
+          "mdoRefRu": "Справочник.ВерсииФайлов.Реквизит.ДатаМодификацииФайла"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Дата изменения (местное время)"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[2]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "73044e20-148c-46e9-b5b5-973c91de0d61",
+        "name": "ДатаСоздания",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.Attribute.ДатаСоздания",
+          "mdoRefRu": "Справочник.ВерсииФайлов.Реквизит.ДатаСоздания"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Дата создания"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[2]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "24cff6c8-6c20-4383-b97c-6afa52738960",
+        "name": "ИндексКартинки",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.Attribute.ИндексКартинки",
+          "mdoRefRu": "Справочник.ВерсииФайлов.Реквизит.ИндексКартинки"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Индекс значка"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                "precision": 10,
+                "scale": 0,
+                "nonNegative": false,
+                "description": {
+                  "value": {
+                    "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                    "nameRu": "КвалификаторыЧисла (10.0)",
+                    "nameEn": "NumberQualifiers (10.0)"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "462e2694-750d-49ef-93ac-17a7779be68d",
+        "name": "Комментарий",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.Attribute.Комментарий",
+          "mdoRefRu": "Справочник.ВерсииФайлов.Реквизит.Комментарий"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Комментарий"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": true,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "c24ff02e-5afc-45df-81cf-64ea2b261c2d",
+        "name": "НомерВерсии",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.Attribute.НомерВерсии",
+          "mdoRefRu": "Справочник.ВерсииФайлов.Реквизит.НомерВерсии"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Номер"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                "precision": 5,
+                "scale": 0,
+                "nonNegative": false,
+                "description": {}
+              }
+            }
+          ]
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "5d9d88ea-b2e4-425c-bb4d-a005e867d56c",
+        "name": "ПутьКФайлу",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.Attribute.ПутьКФайлу",
+          "mdoRefRu": "Справочник.ВерсииФайлов.Реквизит.ПутьКФайлу"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Путь к файлу"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "b76d342c-0f9d-4eb0-b49e-a9f472a4dd0d",
+        "name": "Размер",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.Attribute.Размер",
+          "mdoRefRu": "Справочник.ВерсииФайлов.Реквизит.Размер"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Размер (байт)"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[5]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "85639a53-b367-49ce-84f2-4e21d81c489b",
+        "name": "Расширение",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.Attribute.Расширение",
+          "mdoRefRu": "Справочник.ВерсииФайлов.Реквизит.Расширение"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Расширение"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                "length": 10,
+                "allowedLength": 0,
+                "description": {
+                  "value": {
+                    "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                    "nameRu": "КвалификаторыСтроки (10, Переменная)",
+                    "nameEn": "StringQualifiers (10, Variable)"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "24b59586-178e-4efc-90ae-529553f3bb6c",
+        "name": "РодительскаяВерсия",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.Attribute.РодительскаяВерсия",
+          "mdoRefRu": "Справочник.ВерсииФайлов.Реквизит.РодительскаяВерсия"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Родительская версия"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[3]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "20e75dd5-222a-4100-aa43-3684991e3f21",
+        "name": "СтатусИзвлеченияТекста",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.Attribute.СтатусИзвлеченияТекста",
+          "mdoRefRu": "Справочник.ВерсииФайлов.Реквизит.СтатусИзвлеченияТекста"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Статус извлечения текста"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "ПеречислениеСсылка.СтатусыИзвлеченияТекстаФайлов",
+                  "nameEn": "EnumRef.СтатусыИзвлеченияТекстаФайлов"
+                },
+                "variant": "METADATA",
+                "kind": "ENUM"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "3c611832-4bc2-4229-a27d-d5dc82f3a498",
+        "name": "ТекстХранилище",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.Attribute.ТекстХранилище",
+          "mdoRefRu": "Справочник.ВерсииФайлов.Реквизит.ТекстХранилище"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Текст"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.V8ValueType": "VALUE_STORAGE"
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "50e9eb52-02e3-44ff-9c9e-e76dbe38da63",
+        "name": "ТипХраненияФайла",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.Attribute.ТипХраненияФайла",
+          "mdoRefRu": "Справочник.ВерсииФайлов.Реквизит.ТипХраненияФайла"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Тип хранения версии файла"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "ПеречислениеСсылка.ТипыХраненияФайлов",
+                  "nameEn": "EnumRef.ТипыХраненияФайлов"
+                },
+                "variant": "METADATA",
+                "kind": "ENUM"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "5dadc422-1fbd-4918-9db3-09ec72c3404e",
+        "name": "Том",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.Attribute.Том",
+          "mdoRefRu": "Справочник.ВерсииФайлов.Реквизит.Том"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Том"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "СправочникСсылка.ТомаХраненияФайлов",
+                  "nameEn": "CatalogRef.ТомаХраненияФайлов"
+                },
+                "variant": "METADATA",
+                "kind": "CATALOG"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "ffdaf8a0-7a8f-4756-bdfc-a0c6ae6c3869",
+        "name": "ФайлХранилище",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.Attribute.ФайлХранилище",
+          "mdoRefRu": "Справочник.ВерсииФайлов.Реквизит.ФайлХранилище"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Временное хранилище версии файла"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[13]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      }
+    ],
+    []
+  ],
+  "checkUnique": true,
+  "codeSeries": "WITHIN_OWNER_SUBORDINATION",
+  "commands": [],
+  "comment": "",
+  "description": "Версии файлов",
+  "explanation": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+  },
+  "forms": [
+    [
+      {
+        "uuid": "b2e656c1-f4ff-4d95-b066-4ee11ce4dea8",
+        "name": "ФормаСписка",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "Catalog.ВерсииФайлов.Form.ФормаСписка",
+          "mdoRefRu": "Справочник.ВерсииФайлов.Форма.ФормаСписка"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Форма списка"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/Catalogs/ВерсииФа_лов/Forms/ФормаСписка/Ext/Form/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+          },
+          "handlers": [
+            [
+              {
+                "event": "NotificationProcessing",
+                "name": "ОбработкаОповещения"
+              },
+              {
+                "event": "OnCreateAtServer",
+                "name": "ПриСозданииНаСервере"
+              }
+            ],
+            []
+          ],
+          "items": [
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 51,
+                "name": "ГруппаПользовательскихНастроек",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Группа пользовательских настроек"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": []
+              },
+              {
+                "type": "COMMAND_BAR",
+                "id": 53,
+                "name": "КоманднаяПанель",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Командная панель"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "COMMAND_BAR_BUTTON",
+                      "id": 13,
+                      "name": "ФормаИзменить",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Открыть карточку"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "BUTTON_GROUP",
+                      "id": 68,
+                      "name": "ГруппаУдаление",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Удаление"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "COMMAND_BAR_BUTTON",
+                            "id": 70,
+                            "name": "УстановитьПометкуУдаления",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "COMMAND_BAR_BUTTON",
+                            "id": 72,
+                            "name": "ФормаУдалить",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Удалить"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "BUTTON_GROUP",
+                      "id": 15,
+                      "name": "ФормаСтандартныеКоманды",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Форма стандартные команды"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "COMMAND_BAR_BUTTON",
+                      "id": 74,
+                      "name": "ПоказыватьПомеченныеФайлы",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Показывать помеченные файлы"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "COMMAND_BAR_BUTTON",
+                      "id": 14,
+                      "name": "ФормаСправка",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "SEARCH_STRING_ADDITION",
+                      "id": 78,
+                      "name": "СтрокаПоиска",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Поиск"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "TABLE",
+                "id": 1,
+                "name": "Список",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Список"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "Список",
+                "items": [
+                  [
+                    {
+                      "type": "COLUMN_GROUP",
+                      "id": 64,
+                      "name": "ГруппаВертикально",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Вертикально"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "COLUMN_GROUP",
+                            "id": 66,
+                            "name": "ГруппаОсновное",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Основное"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "LABEL_FIELD",
+                                  "id": 8,
+                                  "name": "СписокПолноеНаименование",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Наименование"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "Список.Description",
+                                  "items": []
+                                },
+                                {
+                                  "type": "LABEL_FIELD",
+                                  "id": 30,
+                                  "name": "СписокРасширение",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                  },
+                                  "dataPath": "Список.Расширение",
+                                  "items": []
+                                },
+                                {
+                                  "type": "LABEL_FIELD",
+                                  "id": 16,
+                                  "name": "СписокВладелец",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                  },
+                                  "dataPath": "Список.Owner",
+                                  "items": []
+                                },
+                                {
+                                  "type": "LABEL_FIELD",
+                                  "id": 18,
+                                  "name": "СписокАвтор",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                  },
+                                  "dataPath": "Список.Автор",
+                                  "items": []
+                                },
+                                {
+                                  "type": "LABEL_FIELD",
+                                  "id": 22,
+                                  "name": "СписокДатаСоздания",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                  },
+                                  "dataPath": "Список.ДатаСоздания",
+                                  "items": []
+                                },
+                                {
+                                  "type": "LABEL_FIELD",
+                                  "id": 24,
+                                  "name": "СписокРазмер",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                  },
+                                  "dataPath": "Список.Размер",
+                                  "items": []
+                                },
+                                {
+                                  "type": "LABEL_FIELD",
+                                  "id": 26,
+                                  "name": "СписокНомерВерсии",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                  },
+                                  "dataPath": "Список.НомерВерсии",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          },
+                          {
+                            "type": "LABEL_FIELD",
+                            "id": 20,
+                            "name": "СписокКомментарий",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                            },
+                            "dataPath": "Список.Комментарий",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 48,
+                      "name": "СписокСсылка",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.Ссылка",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            {
+              "id": 1,
+              "name": "Список",
+              "title": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "type": {
+                "types": [
+                  {
+                    "default": {
+                      "tag": 4
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.value.V8ValueType": "DYNAMIC_LIST"
+                  }
+                ],
+                "composite": false,
+                "qualifiers": []
+              }
+            }
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "2d86d1fc-5367-47b8-804e-7f9c5fc8f3b1",
+        "name": "ФормаВыбора",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "Catalog.ВерсииФайлов.Form.ФормаВыбора",
+          "mdoRefRu": "Справочник.ВерсииФайлов.Форма.ФормаВыбора"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Форма выбора"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/Catalogs/ВерсииФа_лов/Forms/ФормаВыбора/Ext/Form/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "content": [
+              {
+                "default": {
+                  "tag": 2
+                },
+                "int": 1,
+                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                  "langKey": "ru",
+                  "value": "Выбор версии файла"
+                }
+              }
+            ]
+          },
+          "handlers": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[2]"
+            }
+          ],
+          "items": [
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 35,
+                "name": "ГруппаПользовательскихНастроек",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "dataPath": "",
+                "items": []
+              },
+              {
+                "type": "COMMAND_BAR",
+                "id": 37,
+                "name": "КоманднаяПанель",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "COMMAND_BAR_BUTTON",
+                      "id": 58,
+                      "name": "ФормаВыбрать",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "COMMAND_BAR_BUTTON",
+                      "id": 60,
+                      "name": "ФормаСоздать",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "COMMAND_BAR_BUTTON",
+                      "id": 62,
+                      "name": "ФормаСкопировать",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "COMMAND_BAR_BUTTON",
+                      "id": 64,
+                      "name": "ФормаИзменить",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "COMMAND_BAR_BUTTON",
+                      "id": 66,
+                      "name": "ФормаОбновить",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "BUTTON_GROUP",
+                      "id": 68,
+                      "name": "ГруппаУдаление",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "COMMAND_BAR_BUTTON",
+                            "id": 70,
+                            "name": "УстановитьПометкуУдаления",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "COMMAND_BAR_BUTTON",
+                            "id": 72,
+                            "name": "ФормаУдалить",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "COMMAND_BAR_BUTTON",
+                      "id": 74,
+                      "name": "ФормаПоискПоТекущемуЗначению",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "COMMAND_BAR_BUTTON",
+                      "id": 76,
+                      "name": "ФормаНайти",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "COMMAND_BAR_BUTTON",
+                      "id": 78,
+                      "name": "ФормаОтменитьПоиск",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "COMMAND_BAR_BUTTON",
+                      "id": 80,
+                      "name": "ФормаИсторияИзменений",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "COMMAND_BAR_BUTTON",
+                      "id": 82,
+                      "name": "ФормаНастройкаСписка",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "COMMAND_BAR_BUTTON",
+                      "id": 84,
+                      "name": "ФормаЗагрузитьНастройкиДинамическогоСписка",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "COMMAND_BAR_BUTTON",
+                      "id": 86,
+                      "name": "ФормаСохранитьНастройкиДинамическогоСписка",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "COMMAND_BAR_BUTTON",
+                      "id": 88,
+                      "name": "ФормаСтандартныеНастройкиДинамическогоСписка",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "COMMAND_BAR_BUTTON",
+                      "id": 90,
+                      "name": "ФормаВывестиСписок",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "COMMAND_BAR_BUTTON",
+                      "id": 92,
+                      "name": "ПоказыватьПомеченныеФайлы",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "SEARCH_STRING_ADDITION",
+                      "id": 94,
+                      "name": "СтрокаПоиска",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[6]/title"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "TABLE",
+                "id": 2,
+                "name": "Список",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                },
+                "dataPath": "Список",
+                "items": [
+                  [
+                    {
+                      "type": "COLUMN_GROUP",
+                      "id": 51,
+                      "name": "ГруппаВертикально",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "COLUMN_GROUP",
+                            "id": 53,
+                            "name": "ГруппаОсновное",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "LABEL_FIELD",
+                                  "id": 39,
+                                  "name": "СписокВладелец",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                  },
+                                  "dataPath": "Список.Владелец",
+                                  "items": []
+                                },
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 19,
+                                  "name": "СписокНомерВерсии",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                  },
+                                  "dataPath": "Список.НомерВерсии",
+                                  "items": []
+                                },
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 21,
+                                  "name": "СписокАвтор",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                  },
+                                  "dataPath": "Список.Автор",
+                                  "items": []
+                                },
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 23,
+                                  "name": "СписокДатаСоздания",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                  },
+                                  "dataPath": "Список.ДатаСоздания",
+                                  "items": []
+                                },
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 25,
+                                  "name": "СписокРазмер",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                  },
+                                  "dataPath": "Список.Размер",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          },
+                          {
+                            "type": "LABEL_FIELD",
+                            "id": 55,
+                            "name": "Комментарий",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                            },
+                            "dataPath": "Список.Комментарий",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 32,
+                      "name": "СписокСсылка",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.Ссылка",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            {
+              "id": 1,
+              "name": "Список",
+              "title": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "type": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+              }
+            }
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "aa299fc6-051f-487c-ada4-451e08c4763c",
+        "name": "ВерсииФайла",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "Catalog.ВерсииФайлов.Form.ВерсииФайла",
+          "mdoRefRu": "Справочник.ВерсииФайлов.Форма.ВерсииФайла"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Версии файла"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/Catalogs/ВерсииФа_лов/Forms/ВерсииФа_ла/Ext/Form/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+          },
+          "handlers": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[2]"
+              }
+            ],
+            []
+          ],
+          "items": [
+            {
+              "type": "TABLE",
+              "id": 2,
+              "name": "Список",
+              "title": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+              },
+              "dataPath": "Список",
+              "items": [
+                [
+                  {
+                    "type": "COLUMN_GROUP",
+                    "id": 114,
+                    "name": "ГруппаВертикально",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "COLUMN_GROUP",
+                          "id": 116,
+                          "name": "ГруппаОсновное",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 49,
+                                "name": "СписокАвтор",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                },
+                                "dataPath": "Список.Автор",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 47,
+                                "name": "СписокВладелец",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                },
+                                "dataPath": "Список.Владелец",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 57,
+                                "name": "СписокНомерВерсии",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                },
+                                "dataPath": "Список.НомерВерсии",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 53,
+                                "name": "СписокДатаСоздания",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                },
+                                "dataPath": "Список.ДатаСоздания",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 55,
+                                "name": "СписокРазмер",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                },
+                                "dataPath": "Список.Размер",
+                                "items": []
+                              }
+                            ],
+                            []
+                          ]
+                        },
+                        {
+                          "type": "INPUT_FIELD",
+                          "id": 51,
+                          "name": "СписокКомментарий",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                          },
+                          "dataPath": "Список.Комментарий",
+                          "items": []
+                        }
+                      ],
+                      []
+                    ]
+                  },
+                  {
+                    "type": "INPUT_FIELD",
+                    "id": 59,
+                    "name": "СписокСсылка",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                    },
+                    "dataPath": "Список.Ссылка",
+                    "items": []
+                  }
+                ],
+                []
+              ]
+            }
+          ],
+          "attributes": [
+            [
+              {
+                "id": 2,
+                "name": "Список",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 3,
+                "name": "УникальныйИдентификаторКарточкиФайла",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "UUID"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 1,
+                "name": "ВладелецВерсии",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.MDOValueType": "CATALOG_REF"
+                    }
+                  ],
+                  "composite": true,
+                  "qualifiers": []
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      }
+    ],
+    []
+  ],
+  "mdoReference": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+  },
+  "mdoType": "CATALOG",
+  "moduleTypes": [
+    [
+      "ManagerModule",
+      [
+        "src/test/resources/ext/designer/ssl_3_2/src/cf/Catalogs/ВерсииФа_лов/Ext/ManagerModule.bsl"
+      ]
+    ],
+    [
+      "ObjectModule",
+      [
+        "src/test/resources/ext/designer/ssl_3_2/src/cf/Catalogs/ВерсииФа_лов/Ext/ObjectModule.bsl"
+      ]
+    ]
+  ],
+  "modules": [
+    {
+      "moduleType": "ManagerModule",
+      "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/Catalogs/ВерсииФа_лов/Ext/ManagerModule.bsl",
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "isProtected": false
+    },
+    {
+      "moduleType": "ObjectModule",
+      "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/Catalogs/ВерсииФа_лов/Ext/ObjectModule.bsl",
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "isProtected": false
+    }
+  ],
+  "name": "ВерсииФайлов",
+  "objectBelonging": "OWN",
+  "owners": [
+    {
+      "type": "CATALOG",
+      "mdoRef": "Catalog.Файлы",
+      "mdoRefRu": "Справочник.Файлы"
+    }
+  ],
+  "possibleRights": [
+    {
+      "default": {
+        "tag": 4
+      },
+      "int": 25,
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INSERT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "DELETE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "VIEW",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "EDIT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INPUT_BY_STRING",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_DELETE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_INSERT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_SET_DELETION_MARK",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_CLEAR_DELETION_MARK",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_DELETE_MARKED",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_DELETE_PREDEFINED_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_SET_DELETION_MARK_PREDEFINED_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_CLEAR_DELETION_MARK_PREDEFINED_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_DELETE_MARKED_PREDEFINED_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "VIEW_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ_DATA_HISTORY_OF_MISSING_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_OF_MISSING_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_SETTINGS",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_VERSION_COMMENT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "EDIT_DATA_HISTORY_VERSION_COMMENT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "SWITCH_TO_DATA_HISTORY_VERSION"
+    }
+  ],
+  "predefinedValues": [],
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "content": [
+      {
+        "default": {
+          "tag": 2
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+          "langKey": "ru",
+          "value": "Версии файлов"
+        }
+      }
+    ]
+  },
+  "tabularSections": [
+    {
+      "uuid": "ab1bcabf-ffb0-4914-8ad0-b94b5aaeab1d",
+      "name": "УдалитьЭлектронныеПодписи",
+      "mdoReference": {
+        "type": "TABULAR_SECTION",
+        "mdoRef": "Catalog.ВерсииФайлов.TabularSection.УдалитьЭлектронныеПодписи",
+        "mdoRefRu": "Справочник.ВерсииФайлов.ТабличнаяЧасть.УдалитьЭлектронныеПодписи"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": [
+          {
+            "default": {
+              "tag": 2
+            },
+            "int": 1,
+            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+              "langKey": "ru",
+              "value": "(не используется) Электронные подписи"
+            }
+          }
+        ]
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+      },
+      "attributes": [
+        [
+          {
+            "uuid": "ab1bcabf-ffb0-4914-8ad0-b94b5aaeab1d",
+            "mdoReference": {
+              "type": "STANDARD_ATTRIBUTE",
+              "mdoRef": "Catalog.ВерсииФайлов.TabularSection.УдалитьЭлектронныеПодписи.StandardAttribute.LineNumber",
+              "mdoRefRu": "Справочник.ВерсииФайлов.ТабличнаяЧасть.УдалитьЭлектронныеПодписи.СтандартныйРеквизит.НомерСтроки"
+            },
+            "comment": "",
+            "synonym": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+            },
+            "passwordMode": false,
+            "kind": "STANDARD",
+            "type": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[7]/type"
+            },
+            "fullName": {
+              "nameRu": "НомерСтроки",
+              "nameEn": "LineNumber"
+            },
+            "format": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "editFormat": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "markNegatives": false,
+            "mask": "",
+            "multiLine": false,
+            "extendedEdit": false,
+            "fillFromFillingValue": false
+          },
+          {
+            "uuid": "c5478d09-c8d3-4cc6-878e-27656ecc8409",
+            "name": "ДатаПодписи",
+            "mdoReference": {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Catalog.ВерсииФайлов.TabularSection.УдалитьЭлектронныеПодписи.Attribute.ДатаПодписи",
+              "mdoRefRu": "Справочник.ВерсииФайлов.ТабличнаяЧасть.УдалитьЭлектронныеПодписи.Реквизит.ДатаПодписи"
+            },
+            "objectBelonging": "OWN",
+            "comment": "",
+            "synonym": {
+              "content": [
+                {
+                  "default": {
+                    "tag": 2
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                    "langKey": "ru",
+                    "value": "Дата подписи"
+                  }
+                }
+              ]
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+            },
+            "passwordMode": false,
+            "kind": "CUSTOM",
+            "indexing": "DONT_INDEX",
+            "type": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[2]/type"
+            },
+            "format": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "editFormat": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "markNegatives": false,
+            "mask": "",
+            "multiLine": false,
+            "extendedEdit": false,
+            "fillFromFillingValue": false
+          },
+          {
+            "uuid": "01b97d2f-40b9-4f12-8bc5-ab75fd160b7c",
+            "name": "ИмяФайлаПодписи",
+            "mdoReference": {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Catalog.ВерсииФайлов.TabularSection.УдалитьЭлектронныеПодписи.Attribute.ИмяФайлаПодписи",
+              "mdoRefRu": "Справочник.ВерсииФайлов.ТабличнаяЧасть.УдалитьЭлектронныеПодписи.Реквизит.ИмяФайлаПодписи"
+            },
+            "objectBelonging": "OWN",
+            "comment": "",
+            "synonym": {
+              "content": [
+                {
+                  "default": {
+                    "tag": 2
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                    "langKey": "ru",
+                    "value": "Имя файла подписи"
+                  }
+                }
+              ]
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+            },
+            "passwordMode": false,
+            "kind": "CUSTOM",
+            "indexing": "DONT_INDEX",
+            "type": {
+              "types": [
+                {
+                  "default": {
+                    "tag": 4
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+                }
+              ],
+              "composite": false,
+              "qualifiers": [
+                {
+                  "default": {
+                    "tag": 4
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                    "length": 260,
+                    "allowedLength": 0,
+                    "description": {}
+                  }
+                }
+              ]
+            },
+            "format": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "editFormat": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "markNegatives": false,
+            "mask": "",
+            "multiLine": false,
+            "extendedEdit": false,
+            "fillFromFillingValue": false
+          },
+          {
+            "uuid": "75974146-5b1a-412c-b7d5-1575704bbdab",
+            "name": "Комментарий",
+            "mdoReference": {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Catalog.ВерсииФайлов.TabularSection.УдалитьЭлектронныеПодписи.Attribute.Комментарий",
+              "mdoRefRu": "Справочник.ВерсииФайлов.ТабличнаяЧасть.УдалитьЭлектронныеПодписи.Реквизит.Комментарий"
+            },
+            "objectBelonging": "OWN",
+            "comment": "",
+            "synonym": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[6]/synonym"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+            },
+            "passwordMode": false,
+            "kind": "CUSTOM",
+            "indexing": "DONT_INDEX",
+            "type": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+            },
+            "format": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "editFormat": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "markNegatives": false,
+            "mask": "",
+            "multiLine": false,
+            "extendedEdit": false,
+            "fillFromFillingValue": false
+          },
+          {
+            "uuid": "949f87cb-258c-4b6b-95ee-8a7491a4b64e",
+            "name": "КомуВыданСертификат",
+            "mdoReference": {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Catalog.ВерсииФайлов.TabularSection.УдалитьЭлектронныеПодписи.Attribute.КомуВыданСертификат",
+              "mdoRefRu": "Справочник.ВерсииФайлов.ТабличнаяЧасть.УдалитьЭлектронныеПодписи.Реквизит.КомуВыданСертификат"
+            },
+            "objectBelonging": "OWN",
+            "comment": "",
+            "synonym": {
+              "content": [
+                {
+                  "default": {
+                    "tag": 2
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                    "langKey": "ru",
+                    "value": "Кому выдан сертификат"
+                  }
+                }
+              ]
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+            },
+            "passwordMode": false,
+            "kind": "CUSTOM",
+            "indexing": "DONT_INDEX",
+            "type": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+            },
+            "format": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "editFormat": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "markNegatives": false,
+            "mask": "",
+            "multiLine": false,
+            "extendedEdit": false,
+            "fillFromFillingValue": false
+          },
+          {
+            "uuid": "8a348012-99dc-4dc9-8bec-0df3caf4cdc5",
+            "name": "Отпечаток",
+            "mdoReference": {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Catalog.ВерсииФайлов.TabularSection.УдалитьЭлектронныеПодписи.Attribute.Отпечаток",
+              "mdoRefRu": "Справочник.ВерсииФайлов.ТабличнаяЧасть.УдалитьЭлектронныеПодписи.Реквизит.Отпечаток"
+            },
+            "objectBelonging": "OWN",
+            "comment": "",
+            "synonym": {
+              "content": [
+                {
+                  "default": {
+                    "tag": 2
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                    "langKey": "ru",
+                    "value": "Отпечаток"
+                  }
+                }
+              ]
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+            },
+            "passwordMode": false,
+            "kind": "CUSTOM",
+            "indexing": "DONT_INDEX",
+            "type": {
+              "types": [
+                {
+                  "default": {
+                    "tag": 4
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+                }
+              ],
+              "composite": false,
+              "qualifiers": [
+                {
+                  "default": {
+                    "tag": 4
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                    "length": 28,
+                    "allowedLength": 0,
+                    "description": {}
+                  }
+                }
+              ]
+            },
+            "format": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "editFormat": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "markNegatives": false,
+            "mask": "",
+            "multiLine": false,
+            "extendedEdit": false,
+            "fillFromFillingValue": false
+          },
+          {
+            "uuid": "5c089988-5381-41ed-9f05-f85db46b8d94",
+            "name": "Подпись",
+            "mdoReference": {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Catalog.ВерсииФайлов.TabularSection.УдалитьЭлектронныеПодписи.Attribute.Подпись",
+              "mdoRefRu": "Справочник.ВерсииФайлов.ТабличнаяЧасть.УдалитьЭлектронныеПодписи.Реквизит.Подпись"
+            },
+            "objectBelonging": "OWN",
+            "comment": "",
+            "synonym": {
+              "content": [
+                {
+                  "default": {
+                    "tag": 2
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                    "langKey": "ru",
+                    "value": "Подпись"
+                  }
+                }
+              ]
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+            },
+            "passwordMode": false,
+            "kind": "CUSTOM",
+            "indexing": "DONT_INDEX",
+            "type": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[13]/type"
+            },
+            "format": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "editFormat": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "markNegatives": false,
+            "mask": "",
+            "multiLine": false,
+            "extendedEdit": false,
+            "fillFromFillingValue": false
+          },
+          {
+            "uuid": "85a36352-1569-4ce4-aeba-477db524c36d",
+            "name": "УстановившийПодпись",
+            "mdoReference": {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Catalog.ВерсииФайлов.TabularSection.УдалитьЭлектронныеПодписи.Attribute.УстановившийПодпись",
+              "mdoRefRu": "Справочник.ВерсииФайлов.ТабличнаяЧасть.УдалитьЭлектронныеПодписи.Реквизит.УстановившийПодпись"
+            },
+            "objectBelonging": "OWN",
+            "comment": "",
+            "synonym": {
+              "content": [
+                {
+                  "default": {
+                    "tag": 2
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                    "langKey": "ru",
+                    "value": "Установивший подпись"
+                  }
+                }
+              ]
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+            },
+            "passwordMode": false,
+            "kind": "CUSTOM",
+            "indexing": "DONT_INDEX",
+            "type": {
+              "types": [
+                {
+                  "default": {
+                    "tag": 4
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/type/types/java.util.CollSer/com.github._1c_syntax.bsl.types.value.CustomValueType[2]"
+                  }
+                }
+              ],
+              "composite": false,
+              "qualifiers": []
+            },
+            "format": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "editFormat": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "markNegatives": false,
+            "mask": "",
+            "multiLine": false,
+            "extendedEdit": false,
+            "fillFromFillingValue": false
+          },
+          {
+            "uuid": "ebfb6f80-88f5-4046-8ae7-e11a7b0c1beb",
+            "name": "Сертификат",
+            "mdoReference": {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Catalog.ВерсииФайлов.TabularSection.УдалитьЭлектронныеПодписи.Attribute.Сертификат",
+              "mdoRefRu": "Справочник.ВерсииФайлов.ТабличнаяЧасть.УдалитьЭлектронныеПодписи.Реквизит.Сертификат"
+            },
+            "objectBelonging": "OWN",
+            "comment": "",
+            "synonym": {
+              "content": [
+                {
+                  "default": {
+                    "tag": 2
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                    "langKey": "ru",
+                    "value": "Сертификат"
+                  }
+                }
+              ]
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+            },
+            "passwordMode": false,
+            "kind": "CUSTOM",
+            "indexing": "DONT_INDEX",
+            "type": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[13]/type"
+            },
+            "format": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "editFormat": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "markNegatives": false,
+            "mask": "",
+            "multiLine": false,
+            "extendedEdit": false,
+            "fillFromFillingValue": false
+          },
+          {
+            "uuid": "d99991b8-3a81-4e18-b0ad-05fc3e3a199b",
+            "name": "ДатаПроверкиПодписи",
+            "mdoReference": {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Catalog.ВерсииФайлов.TabularSection.УдалитьЭлектронныеПодписи.Attribute.ДатаПроверкиПодписи",
+              "mdoRefRu": "Справочник.ВерсииФайлов.ТабличнаяЧасть.УдалитьЭлектронныеПодписи.Реквизит.ДатаПроверкиПодписи"
+            },
+            "objectBelonging": "OWN",
+            "comment": "",
+            "synonym": {
+              "content": [
+                {
+                  "default": {
+                    "tag": 2
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                    "langKey": "ru",
+                    "value": "Дата проверки подписи"
+                  }
+                }
+              ]
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+            },
+            "passwordMode": false,
+            "kind": "CUSTOM",
+            "indexing": "DONT_INDEX",
+            "type": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[2]/type"
+            },
+            "format": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "editFormat": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "markNegatives": false,
+            "mask": "",
+            "multiLine": false,
+            "extendedEdit": false,
+            "fillFromFillingValue": false
+          },
+          {
+            "uuid": "dd383422-dddb-4a81-9326-015fd345b5c1",
+            "name": "ПодписьВерна",
+            "mdoReference": {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Catalog.ВерсииФайлов.TabularSection.УдалитьЭлектронныеПодписи.Attribute.ПодписьВерна",
+              "mdoRefRu": "Справочник.ВерсииФайлов.ТабличнаяЧасть.УдалитьЭлектронныеПодписи.Реквизит.ПодписьВерна"
+            },
+            "objectBelonging": "OWN",
+            "comment": "",
+            "synonym": {
+              "content": [
+                {
+                  "default": {
+                    "tag": 2
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                    "langKey": "ru",
+                    "value": "Подпись верна"
+                  }
+                }
+              ]
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+            },
+            "passwordMode": false,
+            "kind": "CUSTOM",
+            "indexing": "DONT_INDEX",
+            "type": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[2]/type"
+            },
+            "format": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "editFormat": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "markNegatives": false,
+            "mask": "",
+            "multiLine": false,
+            "extendedEdit": false,
+            "fillFromFillingValue": false
+          }
+        ],
+        []
+      ]
+    }
+  ],
+  "templates": [],
+  "uuid": "eb3dfdc7-58b8-4b1f-b079-368c262364c9"
+}}

--- a/src/test/resources/fixtures/ssl_3_2/Catalogs.ВерсииФайлов_edt.json
+++ b/src/test/resources/fixtures/ssl_3_2/Catalogs.ВерсииФайлов_edt.json
@@ -1,0 +1,3220 @@
+{"com.github._1c_syntax.bsl.mdo.Catalog": {
+  "attributes": [
+    [
+      {
+        "uuid": "eb3dfdc7-58b8-4b1f-b079-368c262364c9",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.StandardAttribute.PredefinedDataName",
+          "mdoRefRu": "Справочник.ВерсииФайлов.СтандартныйРеквизит.ИмяПредопределенныхДанных"
+        },
+        "comment": "",
+        "synonym": {
+          "content": []
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ВерсииФайлов",
+          "mdoRefRu": "Справочник.ВерсииФайлов"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                "length": 0,
+                "allowedLength": 0,
+                "description": {
+                  "value": {
+                    "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                    "nameRu": "КвалификаторыСтроки (0, Переменная)",
+                    "nameEn": "StringQualifiers (0, Variable)"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "ИмяПредопределенныхДанных",
+          "nameEn": "PredefinedDataName"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "eb3dfdc7-58b8-4b1f-b079-368c262364c9",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.StandardAttribute.Predefined",
+          "mdoRefRu": "Справочник.ВерсииФайлов.СтандартныйРеквизит.Предопределенный"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "BOOLEAN"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 0
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "Предопределенный",
+          "nameEn": "Predefined"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "eb3dfdc7-58b8-4b1f-b079-368c262364c9",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.StandardAttribute.Ref",
+          "mdoRefRu": "Справочник.ВерсииФайлов.СтандартныйРеквизит.Ссылка"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "СправочникСсылка.ВерсииФайлов",
+                  "nameEn": "CatalogRef.ВерсииФайлов"
+                },
+                "variant": "METADATA",
+                "kind": "CATALOG"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "fullName": {
+          "nameRu": "Ссылка",
+          "nameEn": "Ref"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "eb3dfdc7-58b8-4b1f-b079-368c262364c9",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.StandardAttribute.DeletionMark",
+          "mdoRefRu": "Справочник.ВерсииФайлов.СтандартныйРеквизит.ПометкаУдаления"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[2]/type"
+        },
+        "fullName": {
+          "nameRu": "ПометкаУдаления",
+          "nameEn": "DeletionMark"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "eb3dfdc7-58b8-4b1f-b079-368c262364c9",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.StandardAttribute.IsFolder",
+          "mdoRefRu": "Справочник.ВерсииФайлов.СтандартныйРеквизит.ЭтоГруппа"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[2]/type"
+        },
+        "fullName": {
+          "nameRu": "ЭтоГруппа",
+          "nameEn": "IsFolder"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "eb3dfdc7-58b8-4b1f-b079-368c262364c9",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.StandardAttribute.Owner",
+          "mdoRefRu": "Справочник.ВерсииФайлов.СтандартныйРеквизит.Владелец"
+        },
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Файл"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "СправочникСсылка.Файлы",
+                  "nameEn": "CatalogRef.Файлы"
+                },
+                "variant": "METADATA",
+                "kind": "CATALOG"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "fullName": {
+          "nameRu": "Владелец",
+          "nameEn": "Owner"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": true
+      },
+      {
+        "uuid": "eb3dfdc7-58b8-4b1f-b079-368c262364c9",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.StandardAttribute.Parent",
+          "mdoRefRu": "Справочник.ВерсииФайлов.СтандартныйРеквизит.Родитель"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[3]/type"
+        },
+        "fullName": {
+          "nameRu": "Родитель",
+          "nameEn": "Parent"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": true
+      },
+      {
+        "uuid": "eb3dfdc7-58b8-4b1f-b079-368c262364c9",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.StandardAttribute.Description",
+          "mdoRefRu": "Справочник.ВерсииФайлов.СтандартныйРеквизит.Наименование"
+        },
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Краткое наименование"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                "length": 150,
+                "allowedLength": 0,
+                "description": {}
+              }
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "Наименование",
+          "nameEn": "Description"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "eb3dfdc7-58b8-4b1f-b079-368c262364c9",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.StandardAttribute.Code",
+          "mdoRefRu": "Справочник.ВерсииФайлов.СтандартныйРеквизит.Код"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                "length": 11,
+                "allowedLength": 0,
+                "description": {}
+              }
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "Код",
+          "nameEn": "Code"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "5030a318-f8f7-4ec7-80d6-6eee0772562f",
+        "name": "Автор",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.Attribute.Автор",
+          "mdoRefRu": "Справочник.ВерсииФайлов.Реквизит.Автор"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Автор"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 3,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "СправочникСсылка.ВнешниеПользователи",
+                  "nameEn": "CatalogRef.ВнешниеПользователи"
+                },
+                "variant": "METADATA",
+                "kind": "CATALOG"
+              },
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "СправочникСсылка.Пользователи",
+                  "nameEn": "CatalogRef.Пользователи"
+                },
+                "variant": "METADATA",
+                "kind": "CATALOG"
+              },
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "СправочникСсылка.УчетныеЗаписиСинхронизацииФайлов",
+                  "nameEn": "CatalogRef.УчетныеЗаписиСинхронизацииФайлов"
+                },
+                "variant": "METADATA",
+                "kind": "CATALOG"
+              }
+            }
+          ],
+          "composite": true,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "242e911d-e49c-4b8a-8543-cc2e079220fd",
+        "name": "ДатаМодификацииУниверсальная",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.Attribute.ДатаМодификацииУниверсальная",
+          "mdoRefRu": "Справочник.ВерсииФайлов.Реквизит.ДатаМодификацииУниверсальная"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Дата изменения (универсальное время)"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "DATE"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.DateQualifiers": {
+                "dateFractions": 2,
+                "description": {
+                  "value": {
+                    "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                    "nameRu": "КвалификаторыДаты (ДатаВремя)",
+                    "nameEn": "DateQualifiers (DateTime)"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "9ea39d31-3775-4fb8-a3f3-202e54354d49",
+        "name": "ДатаМодификацииФайла",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.Attribute.ДатаМодификацииФайла",
+          "mdoRefRu": "Справочник.ВерсииФайлов.Реквизит.ДатаМодификацииФайла"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Дата изменения (местное время)"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[2]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "73044e20-148c-46e9-b5b5-973c91de0d61",
+        "name": "ДатаСоздания",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.Attribute.ДатаСоздания",
+          "mdoRefRu": "Справочник.ВерсииФайлов.Реквизит.ДатаСоздания"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Дата создания"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[2]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "24cff6c8-6c20-4383-b97c-6afa52738960",
+        "name": "ИндексКартинки",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.Attribute.ИндексКартинки",
+          "mdoRefRu": "Справочник.ВерсииФайлов.Реквизит.ИндексКартинки"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Индекс значка"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                "precision": 10,
+                "scale": 0,
+                "nonNegative": false,
+                "description": {
+                  "value": {
+                    "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                    "nameRu": "КвалификаторыЧисла (10.0)",
+                    "nameEn": "NumberQualifiers (10.0)"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "462e2694-750d-49ef-93ac-17a7779be68d",
+        "name": "Комментарий",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.Attribute.Комментарий",
+          "mdoRefRu": "Справочник.ВерсииФайлов.Реквизит.Комментарий"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Комментарий"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": true,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "c24ff02e-5afc-45df-81cf-64ea2b261c2d",
+        "name": "НомерВерсии",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.Attribute.НомерВерсии",
+          "mdoRefRu": "Справочник.ВерсииФайлов.Реквизит.НомерВерсии"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Номер"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                "precision": 5,
+                "scale": 0,
+                "nonNegative": false,
+                "description": {}
+              }
+            }
+          ]
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "5d9d88ea-b2e4-425c-bb4d-a005e867d56c",
+        "name": "ПутьКФайлу",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.Attribute.ПутьКФайлу",
+          "mdoRefRu": "Справочник.ВерсииФайлов.Реквизит.ПутьКФайлу"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Путь к файлу"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "b76d342c-0f9d-4eb0-b49e-a9f472a4dd0d",
+        "name": "Размер",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.Attribute.Размер",
+          "mdoRefRu": "Справочник.ВерсииФайлов.Реквизит.Размер"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Размер (байт)"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[5]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "85639a53-b367-49ce-84f2-4e21d81c489b",
+        "name": "Расширение",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.Attribute.Расширение",
+          "mdoRefRu": "Справочник.ВерсииФайлов.Реквизит.Расширение"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Расширение"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                "length": 10,
+                "allowedLength": 0,
+                "description": {
+                  "value": {
+                    "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                    "nameRu": "КвалификаторыСтроки (10, Переменная)",
+                    "nameEn": "StringQualifiers (10, Variable)"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "24b59586-178e-4efc-90ae-529553f3bb6c",
+        "name": "РодительскаяВерсия",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.Attribute.РодительскаяВерсия",
+          "mdoRefRu": "Справочник.ВерсииФайлов.Реквизит.РодительскаяВерсия"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Родительская версия"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[3]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "20e75dd5-222a-4100-aa43-3684991e3f21",
+        "name": "СтатусИзвлеченияТекста",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.Attribute.СтатусИзвлеченияТекста",
+          "mdoRefRu": "Справочник.ВерсииФайлов.Реквизит.СтатусИзвлеченияТекста"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Статус извлечения текста"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "ПеречислениеСсылка.СтатусыИзвлеченияТекстаФайлов",
+                  "nameEn": "EnumRef.СтатусыИзвлеченияТекстаФайлов"
+                },
+                "variant": "METADATA",
+                "kind": "ENUM"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "3c611832-4bc2-4229-a27d-d5dc82f3a498",
+        "name": "ТекстХранилище",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.Attribute.ТекстХранилище",
+          "mdoRefRu": "Справочник.ВерсииФайлов.Реквизит.ТекстХранилище"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Текст"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.V8ValueType": "VALUE_STORAGE"
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "50e9eb52-02e3-44ff-9c9e-e76dbe38da63",
+        "name": "ТипХраненияФайла",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.Attribute.ТипХраненияФайла",
+          "mdoRefRu": "Справочник.ВерсииФайлов.Реквизит.ТипХраненияФайла"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Тип хранения версии файла"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "ПеречислениеСсылка.ТипыХраненияФайлов",
+                  "nameEn": "EnumRef.ТипыХраненияФайлов"
+                },
+                "variant": "METADATA",
+                "kind": "ENUM"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "5dadc422-1fbd-4918-9db3-09ec72c3404e",
+        "name": "Том",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.Attribute.Том",
+          "mdoRefRu": "Справочник.ВерсииФайлов.Реквизит.Том"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Том"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "СправочникСсылка.ТомаХраненияФайлов",
+                  "nameEn": "CatalogRef.ТомаХраненияФайлов"
+                },
+                "variant": "METADATA",
+                "kind": "CATALOG"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "ffdaf8a0-7a8f-4756-bdfc-a0c6ae6c3869",
+        "name": "ФайлХранилище",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.Attribute.ФайлХранилище",
+          "mdoRefRu": "Справочник.ВерсииФайлов.Реквизит.ФайлХранилище"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Временное хранилище версии файла"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[13]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      }
+    ],
+    []
+  ],
+  "checkUnique": true,
+  "codeSeries": "WITHIN_OWNER_SUBORDINATION",
+  "commands": [],
+  "comment": "",
+  "description": "Версии файлов",
+  "explanation": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+  },
+  "forms": [
+    [
+      {
+        "uuid": "b2e656c1-f4ff-4d95-b066-4ee11ce4dea8",
+        "name": "ФормаСписка",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "Catalog.ВерсииФайлов.Form.ФормаСписка",
+          "mdoRefRu": "Справочник.ВерсииФайлов.Форма.ФормаСписка"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Форма списка"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/Catalogs/ВерсииФа_лов/Forms/ФормаСписка/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+          },
+          "handlers": [
+            [
+              {
+                "event": "NotificationProcessing",
+                "name": "ОбработкаОповещения"
+              },
+              {
+                "event": "OnCreateAtServer",
+                "name": "ПриСозданииНаСервере"
+              }
+            ],
+            []
+          ],
+          "items": [
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 51,
+                "name": "ГруппаПользовательскихНастроек",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Группа пользовательских настроек"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": []
+              },
+              {
+                "type": "COMMAND_BAR",
+                "id": 53,
+                "name": "КоманднаяПанель",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Командная панель"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "BUTTON",
+                      "id": 13,
+                      "name": "ФормаИзменить",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Открыть карточку"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "FORM_GROUP",
+                      "id": 68,
+                      "name": "ГруппаУдаление",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Удаление"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "BUTTON",
+                            "id": 70,
+                            "name": "УстановитьПометкуУдаления",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "BUTTON",
+                            "id": 72,
+                            "name": "ФормаУдалить",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Удалить"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "FORM_GROUP",
+                      "id": 15,
+                      "name": "ФормаСтандартныеКоманды",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Форма стандартные команды"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "BUTTON",
+                      "id": 74,
+                      "name": "ПоказыватьПомеченныеФайлы",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Показывать помеченные файлы"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "BUTTON",
+                      "id": 14,
+                      "name": "ФормаСправка",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "ADDITION",
+                      "id": 78,
+                      "name": "СтрокаПоиска",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Поиск"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "TABLE",
+                "id": 1,
+                "name": "Список",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Список"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "Список",
+                "items": [
+                  [
+                    {
+                      "type": "COLUMN_GROUP",
+                      "id": 64,
+                      "name": "ГруппаВертикально",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Вертикально"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "COLUMN_GROUP",
+                            "id": 66,
+                            "name": "ГруппаОсновное",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Основное"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "LABEL_FIELD",
+                                  "id": 8,
+                                  "name": "СписокПолноеНаименование",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Наименование"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "Список.Description",
+                                  "items": []
+                                },
+                                {
+                                  "type": "LABEL_FIELD",
+                                  "id": 30,
+                                  "name": "СписокРасширение",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                  },
+                                  "dataPath": "Список.Расширение",
+                                  "items": []
+                                },
+                                {
+                                  "type": "LABEL_FIELD",
+                                  "id": 16,
+                                  "name": "СписокВладелец",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                  },
+                                  "dataPath": "Список.Owner",
+                                  "items": []
+                                },
+                                {
+                                  "type": "LABEL_FIELD",
+                                  "id": 18,
+                                  "name": "СписокАвтор",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                  },
+                                  "dataPath": "Список.Автор",
+                                  "items": []
+                                },
+                                {
+                                  "type": "LABEL_FIELD",
+                                  "id": 22,
+                                  "name": "СписокДатаСоздания",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                  },
+                                  "dataPath": "Список.ДатаСоздания",
+                                  "items": []
+                                },
+                                {
+                                  "type": "LABEL_FIELD",
+                                  "id": 24,
+                                  "name": "СписокРазмер",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                  },
+                                  "dataPath": "Список.Размер",
+                                  "items": []
+                                },
+                                {
+                                  "type": "LABEL_FIELD",
+                                  "id": 26,
+                                  "name": "СписокНомерВерсии",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                  },
+                                  "dataPath": "Список.НомерВерсии",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          },
+                          {
+                            "type": "LABEL_FIELD",
+                            "id": 20,
+                            "name": "СписокКомментарий",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                            },
+                            "dataPath": "Список.Комментарий",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 48,
+                      "name": "СписокСсылка",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.Ссылка",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            {
+              "id": 1,
+              "name": "Список",
+              "title": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "type": {
+                "types": [
+                  {
+                    "default": {
+                      "tag": 4
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.value.V8ValueType": "DYNAMIC_LIST"
+                  }
+                ],
+                "composite": false,
+                "qualifiers": []
+              }
+            }
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "2d86d1fc-5367-47b8-804e-7f9c5fc8f3b1",
+        "name": "ФормаВыбора",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "Catalog.ВерсииФайлов.Form.ФормаВыбора",
+          "mdoRefRu": "Справочник.ВерсииФайлов.Форма.ФормаВыбора"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Форма выбора"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/Catalogs/ВерсииФа_лов/Forms/ФормаВыбора/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "content": [
+              {
+                "default": {
+                  "tag": 2
+                },
+                "int": 1,
+                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                  "langKey": "ru",
+                  "value": "Выбор версии файла"
+                }
+              }
+            ]
+          },
+          "handlers": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[2]"
+            }
+          ],
+          "items": [
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 35,
+                "name": "ГруппаПользовательскихНастроек",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "dataPath": "",
+                "items": []
+              },
+              {
+                "type": "COMMAND_BAR",
+                "id": 37,
+                "name": "КоманднаяПанель",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "BUTTON",
+                      "id": 58,
+                      "name": "ФормаВыбрать",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "BUTTON",
+                      "id": 60,
+                      "name": "ФормаСоздать",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "BUTTON",
+                      "id": 62,
+                      "name": "ФормаСкопировать",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "BUTTON",
+                      "id": 64,
+                      "name": "ФормаИзменить",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "BUTTON",
+                      "id": 66,
+                      "name": "ФормаОбновить",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "FORM_GROUP",
+                      "id": 68,
+                      "name": "ГруппаУдаление",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "BUTTON",
+                            "id": 70,
+                            "name": "УстановитьПометкуУдаления",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "BUTTON",
+                            "id": 72,
+                            "name": "ФормаУдалить",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "BUTTON",
+                      "id": 74,
+                      "name": "ФормаПоискПоТекущемуЗначению",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "BUTTON",
+                      "id": 76,
+                      "name": "ФормаНайти",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "BUTTON",
+                      "id": 78,
+                      "name": "ФормаОтменитьПоиск",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "BUTTON",
+                      "id": 80,
+                      "name": "ФормаИсторияИзменений",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "BUTTON",
+                      "id": 82,
+                      "name": "ФормаНастройкаСписка",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "BUTTON",
+                      "id": 84,
+                      "name": "ФормаЗагрузитьНастройкиДинамическогоСписка",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "BUTTON",
+                      "id": 86,
+                      "name": "ФормаСохранитьНастройкиДинамическогоСписка",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "BUTTON",
+                      "id": 88,
+                      "name": "ФормаСтандартныеНастройкиДинамическогоСписка",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "BUTTON",
+                      "id": 90,
+                      "name": "ФормаВывестиСписок",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "BUTTON",
+                      "id": 92,
+                      "name": "ПоказыватьПомеченныеФайлы",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "ADDITION",
+                      "id": 94,
+                      "name": "СтрокаПоиска",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[6]/title"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "TABLE",
+                "id": 2,
+                "name": "Список",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                },
+                "dataPath": "Список",
+                "items": [
+                  [
+                    {
+                      "type": "COLUMN_GROUP",
+                      "id": 51,
+                      "name": "ГруппаВертикально",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "COLUMN_GROUP",
+                            "id": 53,
+                            "name": "ГруппаОсновное",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "LABEL_FIELD",
+                                  "id": 39,
+                                  "name": "СписокВладелец",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                  },
+                                  "dataPath": "Список.Владелец",
+                                  "items": []
+                                },
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 19,
+                                  "name": "СписокНомерВерсии",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                  },
+                                  "dataPath": "Список.НомерВерсии",
+                                  "items": []
+                                },
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 21,
+                                  "name": "СписокАвтор",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                  },
+                                  "dataPath": "Список.Автор",
+                                  "items": []
+                                },
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 23,
+                                  "name": "СписокДатаСоздания",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                  },
+                                  "dataPath": "Список.ДатаСоздания",
+                                  "items": []
+                                },
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 25,
+                                  "name": "СписокРазмер",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                  },
+                                  "dataPath": "Список.Размер",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          },
+                          {
+                            "type": "LABEL_FIELD",
+                            "id": 55,
+                            "name": "Комментарий",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                            },
+                            "dataPath": "Список.Комментарий",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 32,
+                      "name": "СписокСсылка",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.Ссылка",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            {
+              "id": 1,
+              "name": "Список",
+              "title": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "type": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+              }
+            }
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "aa299fc6-051f-487c-ada4-451e08c4763c",
+        "name": "ВерсииФайла",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "Catalog.ВерсииФайлов.Form.ВерсииФайла",
+          "mdoRefRu": "Справочник.ВерсииФайлов.Форма.ВерсииФайла"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Версии файла"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/Catalogs/ВерсииФа_лов/Forms/ВерсииФа_ла/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+          },
+          "handlers": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[2]"
+              }
+            ],
+            []
+          ],
+          "items": [
+            {
+              "type": "TABLE",
+              "id": 2,
+              "name": "Список",
+              "title": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+              },
+              "dataPath": "Список",
+              "items": [
+                [
+                  {
+                    "type": "COLUMN_GROUP",
+                    "id": 114,
+                    "name": "ГруппаВертикально",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "COLUMN_GROUP",
+                          "id": 116,
+                          "name": "ГруппаОсновное",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 49,
+                                "name": "СписокАвтор",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                },
+                                "dataPath": "Список.Автор",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 47,
+                                "name": "СписокВладелец",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                },
+                                "dataPath": "Список.Владелец",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 57,
+                                "name": "СписокНомерВерсии",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                },
+                                "dataPath": "Список.НомерВерсии",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 53,
+                                "name": "СписокДатаСоздания",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                },
+                                "dataPath": "Список.ДатаСоздания",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 55,
+                                "name": "СписокРазмер",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                },
+                                "dataPath": "Список.Размер",
+                                "items": []
+                              }
+                            ],
+                            []
+                          ]
+                        },
+                        {
+                          "type": "INPUT_FIELD",
+                          "id": 51,
+                          "name": "СписокКомментарий",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                          },
+                          "dataPath": "Список.Комментарий",
+                          "items": []
+                        }
+                      ],
+                      []
+                    ]
+                  },
+                  {
+                    "type": "INPUT_FIELD",
+                    "id": 59,
+                    "name": "СписокСсылка",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                    },
+                    "dataPath": "Список.Ссылка",
+                    "items": []
+                  }
+                ],
+                []
+              ]
+            }
+          ],
+          "attributes": [
+            [
+              {
+                "id": 2,
+                "name": "Список",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 3,
+                "name": "УникальныйИдентификаторКарточкиФайла",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "UUID"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 1,
+                "name": "ВладелецВерсии",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.MDOValueType": "CATALOG_REF"
+                    }
+                  ],
+                  "composite": true,
+                  "qualifiers": []
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      }
+    ],
+    []
+  ],
+  "mdoReference": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+  },
+  "mdoType": "CATALOG",
+  "moduleTypes": [
+    [
+      "ManagerModule",
+      [
+        "src/test/resources/ext/edt/ssl_3_2/configuration/src/Catalogs/ВерсииФа_лов/ManagerModule.bsl"
+      ]
+    ],
+    [
+      "ObjectModule",
+      [
+        "src/test/resources/ext/edt/ssl_3_2/configuration/src/Catalogs/ВерсииФа_лов/ObjectModule.bsl"
+      ]
+    ]
+  ],
+  "modules": [
+    {
+      "moduleType": "ManagerModule",
+      "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/Catalogs/ВерсииФа_лов/ManagerModule.bsl",
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "isProtected": false
+    },
+    {
+      "moduleType": "ObjectModule",
+      "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/Catalogs/ВерсииФа_лов/ObjectModule.bsl",
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "isProtected": false
+    }
+  ],
+  "name": "ВерсииФайлов",
+  "objectBelonging": "OWN",
+  "owners": [
+    {
+      "type": "CATALOG",
+      "mdoRef": "Catalog.Файлы",
+      "mdoRefRu": "Справочник.Файлы"
+    }
+  ],
+  "possibleRights": [
+    {
+      "default": {
+        "tag": 4
+      },
+      "int": 25,
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INSERT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "DELETE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "VIEW",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "EDIT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INPUT_BY_STRING",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_DELETE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_INSERT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_SET_DELETION_MARK",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_CLEAR_DELETION_MARK",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_DELETE_MARKED",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_DELETE_PREDEFINED_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_SET_DELETION_MARK_PREDEFINED_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_CLEAR_DELETION_MARK_PREDEFINED_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_DELETE_MARKED_PREDEFINED_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "VIEW_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ_DATA_HISTORY_OF_MISSING_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_OF_MISSING_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_SETTINGS",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_VERSION_COMMENT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "EDIT_DATA_HISTORY_VERSION_COMMENT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "SWITCH_TO_DATA_HISTORY_VERSION"
+    }
+  ],
+  "predefinedValues": [],
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "content": [
+      {
+        "default": {
+          "tag": 2
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+          "langKey": "ru",
+          "value": "Версии файлов"
+        }
+      }
+    ]
+  },
+  "tabularSections": [
+    {
+      "uuid": "ab1bcabf-ffb0-4914-8ad0-b94b5aaeab1d",
+      "name": "УдалитьЭлектронныеПодписи",
+      "mdoReference": {
+        "type": "TABULAR_SECTION",
+        "mdoRef": "Catalog.ВерсииФайлов.TabularSection.УдалитьЭлектронныеПодписи",
+        "mdoRefRu": "Справочник.ВерсииФайлов.ТабличнаяЧасть.УдалитьЭлектронныеПодписи"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": [
+          {
+            "default": {
+              "tag": 2
+            },
+            "int": 1,
+            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+              "langKey": "ru",
+              "value": "(не используется) Электронные подписи"
+            }
+          }
+        ]
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+      },
+      "attributes": [
+        [
+          {
+            "uuid": "ab1bcabf-ffb0-4914-8ad0-b94b5aaeab1d",
+            "mdoReference": {
+              "type": "STANDARD_ATTRIBUTE",
+              "mdoRef": "Catalog.ВерсииФайлов.TabularSection.УдалитьЭлектронныеПодписи.StandardAttribute.LineNumber",
+              "mdoRefRu": "Справочник.ВерсииФайлов.ТабличнаяЧасть.УдалитьЭлектронныеПодписи.СтандартныйРеквизит.НомерСтроки"
+            },
+            "comment": "",
+            "synonym": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+            },
+            "passwordMode": false,
+            "kind": "STANDARD",
+            "type": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[7]/type"
+            },
+            "fullName": {
+              "nameRu": "НомерСтроки",
+              "nameEn": "LineNumber"
+            },
+            "format": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "editFormat": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "markNegatives": false,
+            "mask": "",
+            "multiLine": false,
+            "extendedEdit": false,
+            "fillFromFillingValue": false
+          },
+          {
+            "uuid": "c5478d09-c8d3-4cc6-878e-27656ecc8409",
+            "name": "ДатаПодписи",
+            "mdoReference": {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Catalog.ВерсииФайлов.TabularSection.УдалитьЭлектронныеПодписи.Attribute.ДатаПодписи",
+              "mdoRefRu": "Справочник.ВерсииФайлов.ТабличнаяЧасть.УдалитьЭлектронныеПодписи.Реквизит.ДатаПодписи"
+            },
+            "objectBelonging": "OWN",
+            "comment": "",
+            "synonym": {
+              "content": [
+                {
+                  "default": {
+                    "tag": 2
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                    "langKey": "ru",
+                    "value": "Дата подписи"
+                  }
+                }
+              ]
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+            },
+            "passwordMode": false,
+            "kind": "CUSTOM",
+            "indexing": "DONT_INDEX",
+            "type": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[2]/type"
+            },
+            "format": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "editFormat": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "markNegatives": false,
+            "mask": "",
+            "multiLine": false,
+            "extendedEdit": false,
+            "fillFromFillingValue": false
+          },
+          {
+            "uuid": "01b97d2f-40b9-4f12-8bc5-ab75fd160b7c",
+            "name": "ИмяФайлаПодписи",
+            "mdoReference": {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Catalog.ВерсииФайлов.TabularSection.УдалитьЭлектронныеПодписи.Attribute.ИмяФайлаПодписи",
+              "mdoRefRu": "Справочник.ВерсииФайлов.ТабличнаяЧасть.УдалитьЭлектронныеПодписи.Реквизит.ИмяФайлаПодписи"
+            },
+            "objectBelonging": "OWN",
+            "comment": "",
+            "synonym": {
+              "content": [
+                {
+                  "default": {
+                    "tag": 2
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                    "langKey": "ru",
+                    "value": "Имя файла подписи"
+                  }
+                }
+              ]
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+            },
+            "passwordMode": false,
+            "kind": "CUSTOM",
+            "indexing": "DONT_INDEX",
+            "type": {
+              "types": [
+                {
+                  "default": {
+                    "tag": 4
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+                }
+              ],
+              "composite": false,
+              "qualifiers": [
+                {
+                  "default": {
+                    "tag": 4
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                    "length": 260,
+                    "allowedLength": 0,
+                    "description": {}
+                  }
+                }
+              ]
+            },
+            "format": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "editFormat": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "markNegatives": false,
+            "mask": "",
+            "multiLine": false,
+            "extendedEdit": false,
+            "fillFromFillingValue": false
+          },
+          {
+            "uuid": "75974146-5b1a-412c-b7d5-1575704bbdab",
+            "name": "Комментарий",
+            "mdoReference": {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Catalog.ВерсииФайлов.TabularSection.УдалитьЭлектронныеПодписи.Attribute.Комментарий",
+              "mdoRefRu": "Справочник.ВерсииФайлов.ТабличнаяЧасть.УдалитьЭлектронныеПодписи.Реквизит.Комментарий"
+            },
+            "objectBelonging": "OWN",
+            "comment": "",
+            "synonym": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[6]/synonym"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+            },
+            "passwordMode": false,
+            "kind": "CUSTOM",
+            "indexing": "DONT_INDEX",
+            "type": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+            },
+            "format": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "editFormat": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "markNegatives": false,
+            "mask": "",
+            "multiLine": false,
+            "extendedEdit": false,
+            "fillFromFillingValue": false
+          },
+          {
+            "uuid": "949f87cb-258c-4b6b-95ee-8a7491a4b64e",
+            "name": "КомуВыданСертификат",
+            "mdoReference": {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Catalog.ВерсииФайлов.TabularSection.УдалитьЭлектронныеПодписи.Attribute.КомуВыданСертификат",
+              "mdoRefRu": "Справочник.ВерсииФайлов.ТабличнаяЧасть.УдалитьЭлектронныеПодписи.Реквизит.КомуВыданСертификат"
+            },
+            "objectBelonging": "OWN",
+            "comment": "",
+            "synonym": {
+              "content": [
+                {
+                  "default": {
+                    "tag": 2
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                    "langKey": "ru",
+                    "value": "Кому выдан сертификат"
+                  }
+                }
+              ]
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+            },
+            "passwordMode": false,
+            "kind": "CUSTOM",
+            "indexing": "DONT_INDEX",
+            "type": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+            },
+            "format": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "editFormat": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "markNegatives": false,
+            "mask": "",
+            "multiLine": false,
+            "extendedEdit": false,
+            "fillFromFillingValue": false
+          },
+          {
+            "uuid": "8a348012-99dc-4dc9-8bec-0df3caf4cdc5",
+            "name": "Отпечаток",
+            "mdoReference": {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Catalog.ВерсииФайлов.TabularSection.УдалитьЭлектронныеПодписи.Attribute.Отпечаток",
+              "mdoRefRu": "Справочник.ВерсииФайлов.ТабличнаяЧасть.УдалитьЭлектронныеПодписи.Реквизит.Отпечаток"
+            },
+            "objectBelonging": "OWN",
+            "comment": "",
+            "synonym": {
+              "content": [
+                {
+                  "default": {
+                    "tag": 2
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                    "langKey": "ru",
+                    "value": "Отпечаток"
+                  }
+                }
+              ]
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+            },
+            "passwordMode": false,
+            "kind": "CUSTOM",
+            "indexing": "DONT_INDEX",
+            "type": {
+              "types": [
+                {
+                  "default": {
+                    "tag": 4
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+                }
+              ],
+              "composite": false,
+              "qualifiers": [
+                {
+                  "default": {
+                    "tag": 4
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                    "length": 28,
+                    "allowedLength": 0,
+                    "description": {}
+                  }
+                }
+              ]
+            },
+            "format": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "editFormat": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "markNegatives": false,
+            "mask": "",
+            "multiLine": false,
+            "extendedEdit": false,
+            "fillFromFillingValue": false
+          },
+          {
+            "uuid": "5c089988-5381-41ed-9f05-f85db46b8d94",
+            "name": "Подпись",
+            "mdoReference": {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Catalog.ВерсииФайлов.TabularSection.УдалитьЭлектронныеПодписи.Attribute.Подпись",
+              "mdoRefRu": "Справочник.ВерсииФайлов.ТабличнаяЧасть.УдалитьЭлектронныеПодписи.Реквизит.Подпись"
+            },
+            "objectBelonging": "OWN",
+            "comment": "",
+            "synonym": {
+              "content": [
+                {
+                  "default": {
+                    "tag": 2
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                    "langKey": "ru",
+                    "value": "Подпись"
+                  }
+                }
+              ]
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+            },
+            "passwordMode": false,
+            "kind": "CUSTOM",
+            "indexing": "DONT_INDEX",
+            "type": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[13]/type"
+            },
+            "format": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "editFormat": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "markNegatives": false,
+            "mask": "",
+            "multiLine": false,
+            "extendedEdit": false,
+            "fillFromFillingValue": false
+          },
+          {
+            "uuid": "85a36352-1569-4ce4-aeba-477db524c36d",
+            "name": "УстановившийПодпись",
+            "mdoReference": {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Catalog.ВерсииФайлов.TabularSection.УдалитьЭлектронныеПодписи.Attribute.УстановившийПодпись",
+              "mdoRefRu": "Справочник.ВерсииФайлов.ТабличнаяЧасть.УдалитьЭлектронныеПодписи.Реквизит.УстановившийПодпись"
+            },
+            "objectBelonging": "OWN",
+            "comment": "",
+            "synonym": {
+              "content": [
+                {
+                  "default": {
+                    "tag": 2
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                    "langKey": "ru",
+                    "value": "Установивший подпись"
+                  }
+                }
+              ]
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+            },
+            "passwordMode": false,
+            "kind": "CUSTOM",
+            "indexing": "DONT_INDEX",
+            "type": {
+              "types": [
+                {
+                  "default": {
+                    "tag": 4
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/type/types/java.util.CollSer/com.github._1c_syntax.bsl.types.value.CustomValueType[2]"
+                  }
+                }
+              ],
+              "composite": false,
+              "qualifiers": []
+            },
+            "format": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "editFormat": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "markNegatives": false,
+            "mask": "",
+            "multiLine": false,
+            "extendedEdit": false,
+            "fillFromFillingValue": false
+          },
+          {
+            "uuid": "ebfb6f80-88f5-4046-8ae7-e11a7b0c1beb",
+            "name": "Сертификат",
+            "mdoReference": {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Catalog.ВерсииФайлов.TabularSection.УдалитьЭлектронныеПодписи.Attribute.Сертификат",
+              "mdoRefRu": "Справочник.ВерсииФайлов.ТабличнаяЧасть.УдалитьЭлектронныеПодписи.Реквизит.Сертификат"
+            },
+            "objectBelonging": "OWN",
+            "comment": "",
+            "synonym": {
+              "content": [
+                {
+                  "default": {
+                    "tag": 2
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                    "langKey": "ru",
+                    "value": "Сертификат"
+                  }
+                }
+              ]
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+            },
+            "passwordMode": false,
+            "kind": "CUSTOM",
+            "indexing": "DONT_INDEX",
+            "type": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[13]/type"
+            },
+            "format": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "editFormat": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "markNegatives": false,
+            "mask": "",
+            "multiLine": false,
+            "extendedEdit": false,
+            "fillFromFillingValue": false
+          },
+          {
+            "uuid": "d99991b8-3a81-4e18-b0ad-05fc3e3a199b",
+            "name": "ДатаПроверкиПодписи",
+            "mdoReference": {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Catalog.ВерсииФайлов.TabularSection.УдалитьЭлектронныеПодписи.Attribute.ДатаПроверкиПодписи",
+              "mdoRefRu": "Справочник.ВерсииФайлов.ТабличнаяЧасть.УдалитьЭлектронныеПодписи.Реквизит.ДатаПроверкиПодписи"
+            },
+            "objectBelonging": "OWN",
+            "comment": "",
+            "synonym": {
+              "content": [
+                {
+                  "default": {
+                    "tag": 2
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                    "langKey": "ru",
+                    "value": "Дата проверки подписи"
+                  }
+                }
+              ]
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+            },
+            "passwordMode": false,
+            "kind": "CUSTOM",
+            "indexing": "DONT_INDEX",
+            "type": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[2]/type"
+            },
+            "format": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "editFormat": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "markNegatives": false,
+            "mask": "",
+            "multiLine": false,
+            "extendedEdit": false,
+            "fillFromFillingValue": false
+          },
+          {
+            "uuid": "dd383422-dddb-4a81-9326-015fd345b5c1",
+            "name": "ПодписьВерна",
+            "mdoReference": {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Catalog.ВерсииФайлов.TabularSection.УдалитьЭлектронныеПодписи.Attribute.ПодписьВерна",
+              "mdoRefRu": "Справочник.ВерсииФайлов.ТабличнаяЧасть.УдалитьЭлектронныеПодписи.Реквизит.ПодписьВерна"
+            },
+            "objectBelonging": "OWN",
+            "comment": "",
+            "synonym": {
+              "content": [
+                {
+                  "default": {
+                    "tag": 2
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                    "langKey": "ru",
+                    "value": "Подпись верна"
+                  }
+                }
+              ]
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+            },
+            "passwordMode": false,
+            "kind": "CUSTOM",
+            "indexing": "DONT_INDEX",
+            "type": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[2]/type"
+            },
+            "format": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "editFormat": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "markNegatives": false,
+            "mask": "",
+            "multiLine": false,
+            "extendedEdit": false,
+            "fillFromFillingValue": false
+          }
+        ],
+        []
+      ]
+    }
+  ],
+  "templates": [],
+  "uuid": "eb3dfdc7-58b8-4b1f-b079-368c262364c9"
+}}

--- a/src/test/resources/fixtures/ssl_3_2/Catalogs.ВерсииФайлов_edt.json
+++ b/src/test/resources/fixtures/ssl_3_2/Catalogs.ВерсииФайлов_edt.json
@@ -1408,6 +1408,125 @@
         "multiLine": false,
         "extendedEdit": false,
         "fillFromFillingValue": false
+      },
+      {
+        "uuid": "d970abc7-4437-4fc4-87d1-bab2ddde8884",
+        "name": "ДатаПереносаВАрхив",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.Attribute.ДатаПереносаВАрхив",
+          "mdoRefRu": "Справочник.ВерсииФайлов.Реквизит.ДатаПереносаВАрхив"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Дата переноса в архив"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "DATE"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.DateQualifiers": {
+                "dateFractions": 1,
+                "description": {
+                  "value": {
+                    "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                    "nameRu": "КвалификаторыДаты (Дата)",
+                    "nameEn": "DateQualifiers (Date)"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "ee83328e-91d2-4022-b1d3-d7d137098ee9",
+        "name": "УсловноПеренесенВАрхив",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.ВерсииФайлов.Attribute.УсловноПеренесенВАрхив",
+          "mdoRefRu": "Справочник.ВерсииФайлов.Реквизит.УсловноПеренесенВАрхив"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Условно перенесен в архив"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[2]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
       }
     ],
     []
@@ -1501,181 +1620,6 @@
                 "items": []
               },
               {
-                "type": "COMMAND_BAR",
-                "id": 53,
-                "name": "КоманднаяПанель",
-                "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Командная панель"
-                      }
-                    }
-                  ]
-                },
-                "dataPath": "",
-                "items": [
-                  [
-                    {
-                      "type": "BUTTON",
-                      "id": 13,
-                      "name": "ФормаИзменить",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Открыть карточку"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "FORM_GROUP",
-                      "id": 68,
-                      "name": "ГруппаУдаление",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Удаление"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "BUTTON",
-                            "id": 70,
-                            "name": "УстановитьПометкуУдаления",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "BUTTON",
-                            "id": 72,
-                            "name": "ФормаУдалить",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Удалить"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": []
-                          }
-                        ],
-                        []
-                      ]
-                    },
-                    {
-                      "type": "FORM_GROUP",
-                      "id": 15,
-                      "name": "ФормаСтандартныеКоманды",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Форма стандартные команды"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "BUTTON",
-                      "id": 74,
-                      "name": "ПоказыватьПомеченныеФайлы",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Показывать помеченные файлы"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "BUTTON",
-                      "id": 14,
-                      "name": "ФормаСправка",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "ADDITION",
-                      "id": 78,
-                      "name": "СтрокаПоиска",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Поиск"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": []
-                    }
-                  ],
-                  []
-                ]
-              },
-              {
                 "type": "TABLE",
                 "id": 1,
                 "name": "Список",
@@ -1716,126 +1660,119 @@
                       },
                       "dataPath": "",
                       "items": [
-                        [
-                          {
-                            "type": "COLUMN_GROUP",
-                            "id": 66,
-                            "name": "ГруппаОсновное",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Основное"
-                                  }
+                        {
+                          "type": "COLUMN_GROUP",
+                          "id": 66,
+                          "name": "ГруппаОсновное",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Основное"
                                 }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": [
-                              [
-                                {
-                                  "type": "LABEL_FIELD",
-                                  "id": 8,
-                                  "name": "СписокПолноеНаименование",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Наименование"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "Список.Description",
-                                  "items": []
-                                },
-                                {
-                                  "type": "LABEL_FIELD",
-                                  "id": 30,
-                                  "name": "СписокРасширение",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                  },
-                                  "dataPath": "Список.Расширение",
-                                  "items": []
-                                },
-                                {
-                                  "type": "LABEL_FIELD",
-                                  "id": 16,
-                                  "name": "СписокВладелец",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                  },
-                                  "dataPath": "Список.Owner",
-                                  "items": []
-                                },
-                                {
-                                  "type": "LABEL_FIELD",
-                                  "id": 18,
-                                  "name": "СписокАвтор",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                  },
-                                  "dataPath": "Список.Автор",
-                                  "items": []
-                                },
-                                {
-                                  "type": "LABEL_FIELD",
-                                  "id": 22,
-                                  "name": "СписокДатаСоздания",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                  },
-                                  "dataPath": "Список.ДатаСоздания",
-                                  "items": []
-                                },
-                                {
-                                  "type": "LABEL_FIELD",
-                                  "id": 24,
-                                  "name": "СписокРазмер",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                  },
-                                  "dataPath": "Список.Размер",
-                                  "items": []
-                                },
-                                {
-                                  "type": "LABEL_FIELD",
-                                  "id": 26,
-                                  "name": "СписокНомерВерсии",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                  },
-                                  "dataPath": "Список.НомерВерсии",
-                                  "items": []
-                                }
-                              ],
-                              []
+                              }
                             ]
                           },
-                          {
-                            "type": "LABEL_FIELD",
-                            "id": 20,
-                            "name": "СписокКомментарий",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                            },
-                            "dataPath": "Список.Комментарий",
-                            "items": []
-                          }
-                        ],
-                        []
+                          "dataPath": "",
+                          "items": []
+                        }
                       ]
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 8,
+                      "name": "СписокПолноеНаименование",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Наименование"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "Список.Наименование",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 26,
+                      "name": "СписокНомерВерсии",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.НомерВерсии",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 16,
+                      "name": "СписокВладелец",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.Владелец",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 18,
+                      "name": "СписокАвтор",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.Автор",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 22,
+                      "name": "СписокДатаСоздания",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.ДатаСоздания",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 20,
+                      "name": "СписокКомментарий",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[6]/synonym"
+                      },
+                      "dataPath": "Список.Комментарий",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 30,
+                      "name": "СписокРасширение",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.Расширение",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 24,
+                      "name": "СписокРазмер",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.Размер",
+                      "items": []
                     },
                     {
                       "type": "LABEL_FIELD",
@@ -1959,296 +1896,45 @@
                 "items": []
               },
               {
-                "type": "COMMAND_BAR",
-                "id": 37,
-                "name": "КоманднаяПанель",
-                "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                },
-                "dataPath": "",
-                "items": [
-                  [
-                    {
-                      "type": "BUTTON",
-                      "id": 58,
-                      "name": "ФормаВыбрать",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "BUTTON",
-                      "id": 60,
-                      "name": "ФормаСоздать",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "BUTTON",
-                      "id": 62,
-                      "name": "ФормаСкопировать",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "BUTTON",
-                      "id": 64,
-                      "name": "ФормаИзменить",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "BUTTON",
-                      "id": 66,
-                      "name": "ФормаОбновить",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "FORM_GROUP",
-                      "id": 68,
-                      "name": "ГруппаУдаление",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "BUTTON",
-                            "id": 70,
-                            "name": "УстановитьПометкуУдаления",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "BUTTON",
-                            "id": 72,
-                            "name": "ФормаУдалить",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                            },
-                            "dataPath": "",
-                            "items": []
-                          }
-                        ],
-                        []
-                      ]
-                    },
-                    {
-                      "type": "BUTTON",
-                      "id": 74,
-                      "name": "ФормаПоискПоТекущемуЗначению",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "BUTTON",
-                      "id": 76,
-                      "name": "ФормаНайти",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "BUTTON",
-                      "id": 78,
-                      "name": "ФормаОтменитьПоиск",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "BUTTON",
-                      "id": 80,
-                      "name": "ФормаИсторияИзменений",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "BUTTON",
-                      "id": 82,
-                      "name": "ФормаНастройкаСписка",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "BUTTON",
-                      "id": 84,
-                      "name": "ФормаЗагрузитьНастройкиДинамическогоСписка",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "BUTTON",
-                      "id": 86,
-                      "name": "ФормаСохранитьНастройкиДинамическогоСписка",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "BUTTON",
-                      "id": 88,
-                      "name": "ФормаСтандартныеНастройкиДинамическогоСписка",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "BUTTON",
-                      "id": 90,
-                      "name": "ФормаВывестиСписок",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "BUTTON",
-                      "id": 92,
-                      "name": "ПоказыватьПомеченныеФайлы",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "ADDITION",
-                      "id": 94,
-                      "name": "СтрокаПоиска",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[6]/title"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    }
-                  ],
-                  []
-                ]
-              },
-              {
                 "type": "TABLE",
                 "id": 2,
                 "name": "Список",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                 },
                 "dataPath": "Список",
                 "items": [
                   [
                     {
                       "type": "COLUMN_GROUP",
-                      "id": 51,
-                      "name": "ГруппаВертикально",
+                      "id": 110,
+                      "name": "ГруппаФайлКомментарий",
                       "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Файл, комментарий"
+                            }
+                          }
+                        ]
                       },
                       "dataPath": "",
                       "items": [
                         [
                           {
-                            "type": "COLUMN_GROUP",
-                            "id": 53,
-                            "name": "ГруппаОсновное",
+                            "type": "LABEL_FIELD",
+                            "id": 39,
+                            "name": "СписокВладелец",
                             "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
                             },
-                            "dataPath": "",
-                            "items": [
-                              [
-                                {
-                                  "type": "LABEL_FIELD",
-                                  "id": 39,
-                                  "name": "СписокВладелец",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                  },
-                                  "dataPath": "Список.Владелец",
-                                  "items": []
-                                },
-                                {
-                                  "type": "INPUT_FIELD",
-                                  "id": 19,
-                                  "name": "СписокНомерВерсии",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                  },
-                                  "dataPath": "Список.НомерВерсии",
-                                  "items": []
-                                },
-                                {
-                                  "type": "INPUT_FIELD",
-                                  "id": 21,
-                                  "name": "СписокАвтор",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                  },
-                                  "dataPath": "Список.Автор",
-                                  "items": []
-                                },
-                                {
-                                  "type": "INPUT_FIELD",
-                                  "id": 23,
-                                  "name": "СписокДатаСоздания",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                  },
-                                  "dataPath": "Список.ДатаСоздания",
-                                  "items": []
-                                },
-                                {
-                                  "type": "INPUT_FIELD",
-                                  "id": 25,
-                                  "name": "СписокРазмер",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                  },
-                                  "dataPath": "Список.Размер",
-                                  "items": []
-                                }
-                              ],
-                              []
-                            ]
+                            "dataPath": "Список.Владелец",
+                            "items": []
                           },
                           {
                             "type": "LABEL_FIELD",
@@ -2265,6 +1951,46 @@
                       ]
                     },
                     {
+                      "type": "INPUT_FIELD",
+                      "id": 19,
+                      "name": "СписокНомерВерсии",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.НомерВерсии",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 21,
+                      "name": "СписокАвтор",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.Автор",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 23,
+                      "name": "СписокДатаСоздания",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.ДатаСоздания",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 25,
+                      "name": "СписокРазмер",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.Размер",
+                      "items": []
+                    },
+                    {
                       "type": "LABEL_FIELD",
                       "id": 32,
                       "name": "СписокСсылка",
@@ -2273,6 +1999,27 @@
                       },
                       "dataPath": "Список.Ссылка",
                       "items": []
+                    },
+                    {
+                      "type": "COLUMN_GROUP",
+                      "id": 51,
+                      "name": "ГруппаВертикально",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                      },
+                      "dataPath": "",
+                      "items": [
+                        {
+                          "type": "COLUMN_GROUP",
+                          "id": 53,
+                          "name": "ГруппаОсновное",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                          },
+                          "dataPath": "",
+                          "items": []
+                        }
+                      ]
                     }
                   ],
                   []
@@ -2364,98 +2111,91 @@
               "id": 2,
               "name": "Список",
               "title": {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
               },
               "dataPath": "Список",
               "items": [
                 [
                   {
-                    "type": "COLUMN_GROUP",
-                    "id": 114,
-                    "name": "ГруппаВертикально",
+                    "type": "PICTURE_FIELD",
+                    "id": 149,
+                    "name": "СписокНомерКартинкиЭтоАрхив",
                     "title": {
-                      "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                    },
-                    "dataPath": "",
-                    "items": [
-                      [
+                      "content": [
                         {
-                          "type": "COLUMN_GROUP",
-                          "id": 116,
-                          "name": "ГруппаОсновное",
-                          "title": {
-                            "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                          "default": {
+                            "tag": 2
                           },
-                          "dataPath": "",
-                          "items": [
-                            [
-                              {
-                                "type": "INPUT_FIELD",
-                                "id": 49,
-                                "name": "СписокАвтор",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                },
-                                "dataPath": "Список.Автор",
-                                "items": []
-                              },
-                              {
-                                "type": "INPUT_FIELD",
-                                "id": 47,
-                                "name": "СписокВладелец",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                },
-                                "dataPath": "Список.Владелец",
-                                "items": []
-                              },
-                              {
-                                "type": "INPUT_FIELD",
-                                "id": 57,
-                                "name": "СписокНомерВерсии",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                },
-                                "dataPath": "Список.НомерВерсии",
-                                "items": []
-                              },
-                              {
-                                "type": "INPUT_FIELD",
-                                "id": 53,
-                                "name": "СписокДатаСоздания",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                },
-                                "dataPath": "Список.ДатаСоздания",
-                                "items": []
-                              },
-                              {
-                                "type": "INPUT_FIELD",
-                                "id": 55,
-                                "name": "СписокРазмер",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                },
-                                "dataPath": "Список.Размер",
-                                "items": []
-                              }
-                            ],
-                            []
-                          ]
-                        },
-                        {
-                          "type": "INPUT_FIELD",
-                          "id": 51,
-                          "name": "СписокКомментарий",
-                          "title": {
-                            "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                          },
-                          "dataPath": "Список.Комментарий",
-                          "items": []
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "В архиве"
+                          }
                         }
-                      ],
-                      []
-                    ]
+                      ]
+                    },
+                    "dataPath": "Список.НомерКартинкиЭтоАрхив",
+                    "items": []
+                  },
+                  {
+                    "type": "INPUT_FIELD",
+                    "id": 49,
+                    "name": "СписокАвтор",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                    },
+                    "dataPath": "Список.Автор",
+                    "items": []
+                  },
+                  {
+                    "type": "INPUT_FIELD",
+                    "id": 47,
+                    "name": "СписокВладелец",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                    },
+                    "dataPath": "Список.Владелец",
+                    "items": []
+                  },
+                  {
+                    "type": "INPUT_FIELD",
+                    "id": 57,
+                    "name": "СписокНомерВерсии",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                    },
+                    "dataPath": "Список.НомерВерсии",
+                    "items": []
+                  },
+                  {
+                    "type": "INPUT_FIELD",
+                    "id": 53,
+                    "name": "СписокДатаСоздания",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                    },
+                    "dataPath": "Список.ДатаСоздания",
+                    "items": []
+                  },
+                  {
+                    "type": "INPUT_FIELD",
+                    "id": 55,
+                    "name": "СписокРазмер",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                    },
+                    "dataPath": "Список.Размер",
+                    "items": []
+                  },
+                  {
+                    "type": "INPUT_FIELD",
+                    "id": 51,
+                    "name": "СписокКомментарий",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[6]/synonym"
+                    },
+                    "dataPath": "Список.Комментарий",
+                    "items": []
                   },
                   {
                     "type": "INPUT_FIELD",
@@ -2478,7 +2218,7 @@
                 "id": 2,
                 "name": "Список",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
@@ -2638,583 +2378,7 @@
       }
     ]
   },
-  "tabularSections": [
-    {
-      "uuid": "ab1bcabf-ffb0-4914-8ad0-b94b5aaeab1d",
-      "name": "УдалитьЭлектронныеПодписи",
-      "mdoReference": {
-        "type": "TABULAR_SECTION",
-        "mdoRef": "Catalog.ВерсииФайлов.TabularSection.УдалитьЭлектронныеПодписи",
-        "mdoRefRu": "Справочник.ВерсииФайлов.ТабличнаяЧасть.УдалитьЭлектронныеПодписи"
-      },
-      "objectBelonging": "OWN",
-      "comment": "",
-      "synonym": {
-        "content": [
-          {
-            "default": {
-              "tag": 2
-            },
-            "int": 1,
-            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-              "langKey": "ru",
-              "value": "(не используется) Электронные подписи"
-            }
-          }
-        ]
-      },
-      "supportVariant": "NOT_EDITABLE",
-      "owner": {
-        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
-      },
-      "attributes": [
-        [
-          {
-            "uuid": "ab1bcabf-ffb0-4914-8ad0-b94b5aaeab1d",
-            "mdoReference": {
-              "type": "STANDARD_ATTRIBUTE",
-              "mdoRef": "Catalog.ВерсииФайлов.TabularSection.УдалитьЭлектронныеПодписи.StandardAttribute.LineNumber",
-              "mdoRefRu": "Справочник.ВерсииФайлов.ТабличнаяЧасть.УдалитьЭлектронныеПодписи.СтандартныйРеквизит.НомерСтроки"
-            },
-            "comment": "",
-            "synonym": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-            },
-            "supportVariant": "NOT_EDITABLE",
-            "owner": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
-            },
-            "passwordMode": false,
-            "kind": "STANDARD",
-            "type": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[7]/type"
-            },
-            "fullName": {
-              "nameRu": "НомерСтроки",
-              "nameEn": "LineNumber"
-            },
-            "format": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-            },
-            "editFormat": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-            },
-            "markNegatives": false,
-            "mask": "",
-            "multiLine": false,
-            "extendedEdit": false,
-            "fillFromFillingValue": false
-          },
-          {
-            "uuid": "c5478d09-c8d3-4cc6-878e-27656ecc8409",
-            "name": "ДатаПодписи",
-            "mdoReference": {
-              "type": "ATTRIBUTE",
-              "mdoRef": "Catalog.ВерсииФайлов.TabularSection.УдалитьЭлектронныеПодписи.Attribute.ДатаПодписи",
-              "mdoRefRu": "Справочник.ВерсииФайлов.ТабличнаяЧасть.УдалитьЭлектронныеПодписи.Реквизит.ДатаПодписи"
-            },
-            "objectBelonging": "OWN",
-            "comment": "",
-            "synonym": {
-              "content": [
-                {
-                  "default": {
-                    "tag": 2
-                  },
-                  "int": 1,
-                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                    "langKey": "ru",
-                    "value": "Дата подписи"
-                  }
-                }
-              ]
-            },
-            "supportVariant": "NOT_EDITABLE",
-            "owner": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
-            },
-            "passwordMode": false,
-            "kind": "CUSTOM",
-            "indexing": "DONT_INDEX",
-            "type": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[2]/type"
-            },
-            "format": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-            },
-            "editFormat": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-            },
-            "markNegatives": false,
-            "mask": "",
-            "multiLine": false,
-            "extendedEdit": false,
-            "fillFromFillingValue": false
-          },
-          {
-            "uuid": "01b97d2f-40b9-4f12-8bc5-ab75fd160b7c",
-            "name": "ИмяФайлаПодписи",
-            "mdoReference": {
-              "type": "ATTRIBUTE",
-              "mdoRef": "Catalog.ВерсииФайлов.TabularSection.УдалитьЭлектронныеПодписи.Attribute.ИмяФайлаПодписи",
-              "mdoRefRu": "Справочник.ВерсииФайлов.ТабличнаяЧасть.УдалитьЭлектронныеПодписи.Реквизит.ИмяФайлаПодписи"
-            },
-            "objectBelonging": "OWN",
-            "comment": "",
-            "synonym": {
-              "content": [
-                {
-                  "default": {
-                    "tag": 2
-                  },
-                  "int": 1,
-                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                    "langKey": "ru",
-                    "value": "Имя файла подписи"
-                  }
-                }
-              ]
-            },
-            "supportVariant": "NOT_EDITABLE",
-            "owner": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
-            },
-            "passwordMode": false,
-            "kind": "CUSTOM",
-            "indexing": "DONT_INDEX",
-            "type": {
-              "types": [
-                {
-                  "default": {
-                    "tag": 4
-                  },
-                  "int": 1,
-                  "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
-                }
-              ],
-              "composite": false,
-              "qualifiers": [
-                {
-                  "default": {
-                    "tag": 4
-                  },
-                  "int": 1,
-                  "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
-                    "length": 260,
-                    "allowedLength": 0,
-                    "description": {}
-                  }
-                }
-              ]
-            },
-            "format": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-            },
-            "editFormat": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-            },
-            "markNegatives": false,
-            "mask": "",
-            "multiLine": false,
-            "extendedEdit": false,
-            "fillFromFillingValue": false
-          },
-          {
-            "uuid": "75974146-5b1a-412c-b7d5-1575704bbdab",
-            "name": "Комментарий",
-            "mdoReference": {
-              "type": "ATTRIBUTE",
-              "mdoRef": "Catalog.ВерсииФайлов.TabularSection.УдалитьЭлектронныеПодписи.Attribute.Комментарий",
-              "mdoRefRu": "Справочник.ВерсииФайлов.ТабличнаяЧасть.УдалитьЭлектронныеПодписи.Реквизит.Комментарий"
-            },
-            "objectBelonging": "OWN",
-            "comment": "",
-            "synonym": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[6]/synonym"
-            },
-            "supportVariant": "NOT_EDITABLE",
-            "owner": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
-            },
-            "passwordMode": false,
-            "kind": "CUSTOM",
-            "indexing": "DONT_INDEX",
-            "type": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
-            },
-            "format": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-            },
-            "editFormat": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-            },
-            "markNegatives": false,
-            "mask": "",
-            "multiLine": false,
-            "extendedEdit": false,
-            "fillFromFillingValue": false
-          },
-          {
-            "uuid": "949f87cb-258c-4b6b-95ee-8a7491a4b64e",
-            "name": "КомуВыданСертификат",
-            "mdoReference": {
-              "type": "ATTRIBUTE",
-              "mdoRef": "Catalog.ВерсииФайлов.TabularSection.УдалитьЭлектронныеПодписи.Attribute.КомуВыданСертификат",
-              "mdoRefRu": "Справочник.ВерсииФайлов.ТабличнаяЧасть.УдалитьЭлектронныеПодписи.Реквизит.КомуВыданСертификат"
-            },
-            "objectBelonging": "OWN",
-            "comment": "",
-            "synonym": {
-              "content": [
-                {
-                  "default": {
-                    "tag": 2
-                  },
-                  "int": 1,
-                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                    "langKey": "ru",
-                    "value": "Кому выдан сертификат"
-                  }
-                }
-              ]
-            },
-            "supportVariant": "NOT_EDITABLE",
-            "owner": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
-            },
-            "passwordMode": false,
-            "kind": "CUSTOM",
-            "indexing": "DONT_INDEX",
-            "type": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
-            },
-            "format": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-            },
-            "editFormat": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-            },
-            "markNegatives": false,
-            "mask": "",
-            "multiLine": false,
-            "extendedEdit": false,
-            "fillFromFillingValue": false
-          },
-          {
-            "uuid": "8a348012-99dc-4dc9-8bec-0df3caf4cdc5",
-            "name": "Отпечаток",
-            "mdoReference": {
-              "type": "ATTRIBUTE",
-              "mdoRef": "Catalog.ВерсииФайлов.TabularSection.УдалитьЭлектронныеПодписи.Attribute.Отпечаток",
-              "mdoRefRu": "Справочник.ВерсииФайлов.ТабличнаяЧасть.УдалитьЭлектронныеПодписи.Реквизит.Отпечаток"
-            },
-            "objectBelonging": "OWN",
-            "comment": "",
-            "synonym": {
-              "content": [
-                {
-                  "default": {
-                    "tag": 2
-                  },
-                  "int": 1,
-                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                    "langKey": "ru",
-                    "value": "Отпечаток"
-                  }
-                }
-              ]
-            },
-            "supportVariant": "NOT_EDITABLE",
-            "owner": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
-            },
-            "passwordMode": false,
-            "kind": "CUSTOM",
-            "indexing": "DONT_INDEX",
-            "type": {
-              "types": [
-                {
-                  "default": {
-                    "tag": 4
-                  },
-                  "int": 1,
-                  "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
-                }
-              ],
-              "composite": false,
-              "qualifiers": [
-                {
-                  "default": {
-                    "tag": 4
-                  },
-                  "int": 1,
-                  "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
-                    "length": 28,
-                    "allowedLength": 0,
-                    "description": {}
-                  }
-                }
-              ]
-            },
-            "format": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-            },
-            "editFormat": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-            },
-            "markNegatives": false,
-            "mask": "",
-            "multiLine": false,
-            "extendedEdit": false,
-            "fillFromFillingValue": false
-          },
-          {
-            "uuid": "5c089988-5381-41ed-9f05-f85db46b8d94",
-            "name": "Подпись",
-            "mdoReference": {
-              "type": "ATTRIBUTE",
-              "mdoRef": "Catalog.ВерсииФайлов.TabularSection.УдалитьЭлектронныеПодписи.Attribute.Подпись",
-              "mdoRefRu": "Справочник.ВерсииФайлов.ТабличнаяЧасть.УдалитьЭлектронныеПодписи.Реквизит.Подпись"
-            },
-            "objectBelonging": "OWN",
-            "comment": "",
-            "synonym": {
-              "content": [
-                {
-                  "default": {
-                    "tag": 2
-                  },
-                  "int": 1,
-                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                    "langKey": "ru",
-                    "value": "Подпись"
-                  }
-                }
-              ]
-            },
-            "supportVariant": "NOT_EDITABLE",
-            "owner": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
-            },
-            "passwordMode": false,
-            "kind": "CUSTOM",
-            "indexing": "DONT_INDEX",
-            "type": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[13]/type"
-            },
-            "format": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-            },
-            "editFormat": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-            },
-            "markNegatives": false,
-            "mask": "",
-            "multiLine": false,
-            "extendedEdit": false,
-            "fillFromFillingValue": false
-          },
-          {
-            "uuid": "85a36352-1569-4ce4-aeba-477db524c36d",
-            "name": "УстановившийПодпись",
-            "mdoReference": {
-              "type": "ATTRIBUTE",
-              "mdoRef": "Catalog.ВерсииФайлов.TabularSection.УдалитьЭлектронныеПодписи.Attribute.УстановившийПодпись",
-              "mdoRefRu": "Справочник.ВерсииФайлов.ТабличнаяЧасть.УдалитьЭлектронныеПодписи.Реквизит.УстановившийПодпись"
-            },
-            "objectBelonging": "OWN",
-            "comment": "",
-            "synonym": {
-              "content": [
-                {
-                  "default": {
-                    "tag": 2
-                  },
-                  "int": 1,
-                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                    "langKey": "ru",
-                    "value": "Установивший подпись"
-                  }
-                }
-              ]
-            },
-            "supportVariant": "NOT_EDITABLE",
-            "owner": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
-            },
-            "passwordMode": false,
-            "kind": "CUSTOM",
-            "indexing": "DONT_INDEX",
-            "type": {
-              "types": [
-                {
-                  "default": {
-                    "tag": 4
-                  },
-                  "int": 1,
-                  "com.github._1c_syntax.bsl.types.value.CustomValueType": {
-                    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/type/types/java.util.CollSer/com.github._1c_syntax.bsl.types.value.CustomValueType[2]"
-                  }
-                }
-              ],
-              "composite": false,
-              "qualifiers": []
-            },
-            "format": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-            },
-            "editFormat": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-            },
-            "markNegatives": false,
-            "mask": "",
-            "multiLine": false,
-            "extendedEdit": false,
-            "fillFromFillingValue": false
-          },
-          {
-            "uuid": "ebfb6f80-88f5-4046-8ae7-e11a7b0c1beb",
-            "name": "Сертификат",
-            "mdoReference": {
-              "type": "ATTRIBUTE",
-              "mdoRef": "Catalog.ВерсииФайлов.TabularSection.УдалитьЭлектронныеПодписи.Attribute.Сертификат",
-              "mdoRefRu": "Справочник.ВерсииФайлов.ТабличнаяЧасть.УдалитьЭлектронныеПодписи.Реквизит.Сертификат"
-            },
-            "objectBelonging": "OWN",
-            "comment": "",
-            "synonym": {
-              "content": [
-                {
-                  "default": {
-                    "tag": 2
-                  },
-                  "int": 1,
-                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                    "langKey": "ru",
-                    "value": "Сертификат"
-                  }
-                }
-              ]
-            },
-            "supportVariant": "NOT_EDITABLE",
-            "owner": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
-            },
-            "passwordMode": false,
-            "kind": "CUSTOM",
-            "indexing": "DONT_INDEX",
-            "type": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[13]/type"
-            },
-            "format": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-            },
-            "editFormat": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-            },
-            "markNegatives": false,
-            "mask": "",
-            "multiLine": false,
-            "extendedEdit": false,
-            "fillFromFillingValue": false
-          },
-          {
-            "uuid": "d99991b8-3a81-4e18-b0ad-05fc3e3a199b",
-            "name": "ДатаПроверкиПодписи",
-            "mdoReference": {
-              "type": "ATTRIBUTE",
-              "mdoRef": "Catalog.ВерсииФайлов.TabularSection.УдалитьЭлектронныеПодписи.Attribute.ДатаПроверкиПодписи",
-              "mdoRefRu": "Справочник.ВерсииФайлов.ТабличнаяЧасть.УдалитьЭлектронныеПодписи.Реквизит.ДатаПроверкиПодписи"
-            },
-            "objectBelonging": "OWN",
-            "comment": "",
-            "synonym": {
-              "content": [
-                {
-                  "default": {
-                    "tag": 2
-                  },
-                  "int": 1,
-                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                    "langKey": "ru",
-                    "value": "Дата проверки подписи"
-                  }
-                }
-              ]
-            },
-            "supportVariant": "NOT_EDITABLE",
-            "owner": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
-            },
-            "passwordMode": false,
-            "kind": "CUSTOM",
-            "indexing": "DONT_INDEX",
-            "type": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[2]/type"
-            },
-            "format": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-            },
-            "editFormat": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-            },
-            "markNegatives": false,
-            "mask": "",
-            "multiLine": false,
-            "extendedEdit": false,
-            "fillFromFillingValue": false
-          },
-          {
-            "uuid": "dd383422-dddb-4a81-9326-015fd345b5c1",
-            "name": "ПодписьВерна",
-            "mdoReference": {
-              "type": "ATTRIBUTE",
-              "mdoRef": "Catalog.ВерсииФайлов.TabularSection.УдалитьЭлектронныеПодписи.Attribute.ПодписьВерна",
-              "mdoRefRu": "Справочник.ВерсииФайлов.ТабличнаяЧасть.УдалитьЭлектронныеПодписи.Реквизит.ПодписьВерна"
-            },
-            "objectBelonging": "OWN",
-            "comment": "",
-            "synonym": {
-              "content": [
-                {
-                  "default": {
-                    "tag": 2
-                  },
-                  "int": 1,
-                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                    "langKey": "ru",
-                    "value": "Подпись верна"
-                  }
-                }
-              ]
-            },
-            "supportVariant": "NOT_EDITABLE",
-            "owner": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
-            },
-            "passwordMode": false,
-            "kind": "CUSTOM",
-            "indexing": "DONT_INDEX",
-            "type": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[2]/type"
-            },
-            "format": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-            },
-            "editFormat": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-            },
-            "markNegatives": false,
-            "mask": "",
-            "multiLine": false,
-            "extendedEdit": false,
-            "fillFromFillingValue": false
-          }
-        ],
-        []
-      ]
-    }
-  ],
+  "tabularSections": [],
   "templates": [],
   "uuid": "eb3dfdc7-58b8-4b1f-b079-368c262364c9"
 }}

--- a/src/test/resources/fixtures/ssl_3_2/Catalogs.Заметки.json
+++ b/src/test/resources/fixtures/ssl_3_2/Catalogs.Заметки.json
@@ -1,0 +1,2219 @@
+{"com.github._1c_syntax.bsl.mdo.Catalog": {
+  "attributes": [
+    [
+      {
+        "uuid": "3805ee39-a48a-499a-9ef8-9c2a5985404f",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Catalog.Заметки.StandardAttribute.PredefinedDataName",
+          "mdoRefRu": "Справочник.Заметки.СтандартныйРеквизит.ИмяПредопределенныхДанных"
+        },
+        "comment": "",
+        "synonym": {
+          "content": []
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.Заметки",
+          "mdoRefRu": "Справочник.Заметки"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                "length": 0,
+                "allowedLength": 0,
+                "description": {
+                  "value": {
+                    "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                    "nameRu": "КвалификаторыСтроки (0, Переменная)",
+                    "nameEn": "StringQualifiers (0, Variable)"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "ИмяПредопределенныхДанных",
+          "nameEn": "PredefinedDataName"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "3805ee39-a48a-499a-9ef8-9c2a5985404f",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Catalog.Заметки.StandardAttribute.Predefined",
+          "mdoRefRu": "Справочник.Заметки.СтандартныйРеквизит.Предопределенный"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "BOOLEAN"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 0
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "Предопределенный",
+          "nameEn": "Predefined"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "3805ee39-a48a-499a-9ef8-9c2a5985404f",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Catalog.Заметки.StandardAttribute.Ref",
+          "mdoRefRu": "Справочник.Заметки.СтандартныйРеквизит.Ссылка"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "СправочникСсылка.Заметки",
+                  "nameEn": "CatalogRef.Заметки"
+                },
+                "variant": "METADATA",
+                "kind": "CATALOG"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "fullName": {
+          "nameRu": "Ссылка",
+          "nameEn": "Ref"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "3805ee39-a48a-499a-9ef8-9c2a5985404f",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Catalog.Заметки.StandardAttribute.DeletionMark",
+          "mdoRefRu": "Справочник.Заметки.СтандартныйРеквизит.ПометкаУдаления"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[2]/type"
+        },
+        "fullName": {
+          "nameRu": "ПометкаУдаления",
+          "nameEn": "DeletionMark"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "3805ee39-a48a-499a-9ef8-9c2a5985404f",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Catalog.Заметки.StandardAttribute.IsFolder",
+          "mdoRefRu": "Справочник.Заметки.СтандартныйРеквизит.ЭтоГруппа"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[2]/type"
+        },
+        "fullName": {
+          "nameRu": "ЭтоГруппа",
+          "nameEn": "IsFolder"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "3805ee39-a48a-499a-9ef8-9c2a5985404f",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Catalog.Заметки.StandardAttribute.Owner",
+          "mdoRefRu": "Справочник.Заметки.СтандартныйРеквизит.Владелец"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [],
+          "composite": false,
+          "qualifiers": []
+        },
+        "fullName": {
+          "nameRu": "Владелец",
+          "nameEn": "Owner"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": true
+      },
+      {
+        "uuid": "3805ee39-a48a-499a-9ef8-9c2a5985404f",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Catalog.Заметки.StandardAttribute.Parent",
+          "mdoRefRu": "Справочник.Заметки.СтандартныйРеквизит.Родитель"
+        },
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Группа заметок"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[3]/type"
+        },
+        "fullName": {
+          "nameRu": "Родитель",
+          "nameEn": "Parent"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": true
+      },
+      {
+        "uuid": "3805ee39-a48a-499a-9ef8-9c2a5985404f",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Catalog.Заметки.StandardAttribute.Description",
+          "mdoRefRu": "Справочник.Заметки.СтандартныйРеквизит.Наименование"
+        },
+        "comment": "Реквизит заполняется автоматически",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Тема"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                "length": 100,
+                "allowedLength": 0,
+                "description": {}
+              }
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "Наименование",
+          "nameEn": "Description"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "3805ee39-a48a-499a-9ef8-9c2a5985404f",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Catalog.Заметки.StandardAttribute.Code",
+          "mdoRefRu": "Справочник.Заметки.СтандартныйРеквизит.Код"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+        },
+        "fullName": {
+          "nameRu": "Код",
+          "nameEn": "Code"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "07ccfe87-e1ab-4da7-92cb-a612e0972b0b",
+        "name": "Автор",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.Заметки.Attribute.Автор",
+          "mdoRefRu": "Справочник.Заметки.Реквизит.Автор"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Автор"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "СправочникСсылка.Пользователи",
+                  "nameEn": "CatalogRef.Пользователи"
+                },
+                "variant": "METADATA",
+                "kind": "CATALOG"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "08c2f92c-eb05-49e7-bfc9-4a89607b9864",
+        "name": "Предмет",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.Заметки.Attribute.Предмет",
+          "mdoRefRu": "Справочник.Заметки.Реквизит.Предмет"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Предмет"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "ОпределяемыйТип.ПредметЗаметок",
+                  "nameEn": "DefinedType.ПредметЗаметок"
+                },
+                "variant": "METADATA",
+                "kind": "DEFINED_TYPE"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": true
+      },
+      {
+        "uuid": "6d751379-89a7-49b5-93e5-578329c63d9c",
+        "name": "Содержание",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.Заметки.Attribute.Содержание",
+          "mdoRefRu": "Справочник.Заметки.Реквизит.Содержание"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Содержание"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.V8ValueType": "VALUE_STORAGE"
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "c3f156ef-947e-4ebb-883f-4f099a116063",
+        "name": "ТекстСодержания",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.Заметки.Attribute.ТекстСодержания",
+          "mdoRefRu": "Справочник.Заметки.Реквизит.ТекстСодержания"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Реквизит для полнотекстового поиска",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[3]/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "5e3ab0a3-c0a6-4f41-85d3-2eede4abb555",
+        "name": "ДляРабочегоСтола",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.Заметки.Attribute.ДляРабочегоСтола",
+          "mdoRefRu": "Справочник.Заметки.Реквизит.ДляРабочегоСтола"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Для рабочего стола"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[2]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "a065ffc3-f50b-4a78-9b84-bfc4e5515a4b",
+        "name": "Пометка",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.Заметки.Attribute.Пометка",
+          "mdoRefRu": "Справочник.Заметки.Реквизит.Пометка"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Пометка"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX_WITH_ADDITIONAL_ORDER",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "ПеречислениеСсылка.ЦветаЗаметок",
+                  "nameEn": "EnumRef.ЦветаЗаметок"
+                },
+                "variant": "METADATA",
+                "kind": "ENUM"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": true
+      },
+      {
+        "uuid": "4cba5a06-1484-4dd1-8e35-2d702c7d96d0",
+        "name": "ДатаИзменения",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.Заметки.Attribute.ДатаИзменения",
+          "mdoRefRu": "Справочник.Заметки.Реквизит.ДатаИзменения"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Дата изменения"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "DATE"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.DateQualifiers": {
+                "dateFractions": 2,
+                "description": {
+                  "value": {
+                    "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                    "nameRu": "КвалификаторыДаты (ДатаВремя)",
+                    "nameEn": "DateQualifiers (DateTime)"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "e98e9e56-2995-430c-bd3b-f1070aec15a5",
+        "name": "ПредставлениеПредмета",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.Заметки.Attribute.ПредставлениеПредмета",
+          "mdoRefRu": "Справочник.Заметки.Реквизит.ПредставлениеПредмета"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[2]/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[8]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      }
+    ],
+    []
+  ],
+  "checkUnique": false,
+  "codeSeries": "WHOLE_CATALOG",
+  "commands": [
+    {
+      "uuid": "fa0e0792-bffb-47ce-866f-9e8dbdab17a4",
+      "name": "ВсеЗаметки",
+      "mdoReference": {
+        "type": "COMMAND",
+        "mdoRef": "Catalog.Заметки.Command.ВсеЗаметки",
+        "mdoRefRu": "Справочник.Заметки.Команда.ВсеЗаметки"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": [
+          {
+            "default": {
+              "tag": 2
+            },
+            "int": 1,
+            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+              "langKey": "ru",
+              "value": "Все заметки"
+            }
+          }
+        ]
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "modules": [
+        {
+          "moduleType": "CommandModule",
+          "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/Catalogs/Заметки/Commands/ВсеЗаметки/Ext/CommandModule.bsl",
+          "owner": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/commands/com.github._1c_syntax.bsl.mdo.children.ObjectCommand/mdoReference"
+          },
+          "supportVariant": "NOT_EDITABLE",
+          "isProtected": false
+        }
+      ],
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+      }
+    }
+  ],
+  "comment": "",
+  "description": "Заметки",
+  "explanation": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+  },
+  "forms": [
+    [
+      {
+        "uuid": "d35c51b0-4cb7-4f9c-8aac-6a25a1b49adf",
+        "name": "ФормаЭлемента",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "Catalog.Заметки.Form.ФормаЭлемента",
+          "mdoRefRu": "Справочник.Заметки.Форма.ФормаЭлемента"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Форма элемента"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/Catalogs/Заметки/Forms/ФормаЭлемента/Ext/Form/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+          },
+          "handlers": [
+            [
+              {
+                "event": "AfterWrite",
+                "name": "ПослеЗаписи"
+              },
+              {
+                "event": "AfterWriteAtServer",
+                "name": "ПослеЗаписиНаСервере"
+              },
+              {
+                "event": "OnReadAtServer",
+                "name": "ПриЧтенииНаСервере"
+              },
+              {
+                "event": "OnOpen",
+                "name": "ПриОткрытии"
+              },
+              {
+                "event": "OnCreateAtServer",
+                "name": "ПриСозданииНаСервере"
+              },
+              {
+                "event": "BeforeWriteAtServer",
+                "name": "ПередЗаписьюНаСервере"
+              }
+            ],
+            []
+          ],
+          "items": [
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 14,
+                "name": "СодержаниеЗаметки",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Содержание заметки"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  {
+                    "type": "USUAL_GROUP",
+                    "id": 102,
+                    "name": "ГруппаПредмет",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[2]/synonym"
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "LABEL_DECORATION",
+                          "id": 65,
+                          "name": "НадписьПредмет",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Предмет:"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": []
+                        },
+                        {
+                          "type": "LABEL_DECORATION",
+                          "id": 63,
+                          "name": "Предмет",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[2]/synonym"
+                          },
+                          "dataPath": "",
+                          "items": []
+                        }
+                      ],
+                      []
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "FORMATTED_DOCUMENT_FIELD",
+                "id": 9,
+                "name": "Содержание",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[3]/synonym"
+                },
+                "dataPath": "ФорматированныйТекст",
+                "items": []
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 90,
+                "name": "ПараметрыОтображения",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Параметры отображения"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "CHECK_BOX_FIELD",
+                      "id": 80,
+                      "name": "ОтображатьНаРабочемСтоле",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Отображать на рабочем столе"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "Объект.ДляРабочегоСтола",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 82,
+                      "name": "Пометка",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Цвет"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "Объект.Пометка",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 105,
+                      "name": "ГруппаЗаметок",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Объект.Parent",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 91,
+                "name": "ИнформацияОбАвторе",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Информация об авторе"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "LABEL_DECORATION",
+                      "id": 92,
+                      "name": "НадписьАвтор",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Автор:"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_DECORATION",
+                      "id": 94,
+                      "name": "Автор",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/synonym"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "LABEL_DECORATION",
+                "id": 103,
+                "name": "ДатаЗаметки",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Записана: 25 ноября 2011 г."
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": []
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "Объект",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "СправочникОбъект.Заметки",
+                          "nameEn": "CatalogObject.Заметки"
+                        },
+                        "variant": "METADATA",
+                        "kind": "CATALOG"
+                      }
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 4,
+                "name": "ФорматированныйТекст",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Форматированный текст"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "FORMATTED_DOCUMENT"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "8a7546f4-bfc9-4732-bf60-43a41e2c8753",
+        "name": "ВсеЗаметки",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "Catalog.Заметки.Form.ВсеЗаметки",
+          "mdoRefRu": "Справочник.Заметки.Форма.ВсеЗаметки"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/commands/com.github._1c_syntax.bsl.mdo.children.ObjectCommand/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/Catalogs/Заметки/Forms/ВсеЗаметки/Ext/Form/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/commands/com.github._1c_syntax.bsl.mdo.children.ObjectCommand/synonym"
+          },
+          "handlers": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[4]"
+              },
+              {
+                "event": "OnLoadDataFromSettingsAtServer",
+                "name": "ПриЗагрузкеДанныхИзНастроекНаСервере"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[5]"
+              }
+            ],
+            []
+          ],
+          "items": [
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 30,
+                "name": "Фильтры",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Фильтры"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 28,
+                      "name": "ФильтрПоЦвету",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                      },
+                      "dataPath": "ВыбранныйЦвет",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 26,
+                      "name": "ФильтрПоПредмету",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[2]/synonym"
+                      },
+                      "dataPath": "ВыбранныйПредмет",
+                      "items": []
+                    },
+                    {
+                      "type": "CHECK_BOX_FIELD",
+                      "id": 31,
+                      "name": "ПоказыватьУдаленные",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Показывать удаленные"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "ПоказыватьУдаленные",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 43,
+                "name": "ГруппаПользовательскихНастроек",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Группа пользовательских настроек"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": []
+              },
+              {
+                "type": "COMMAND_BAR",
+                "id": 33,
+                "name": "КоманднаяПанель",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Командная панель"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  {
+                    "type": "POPUP",
+                    "id": 57,
+                    "name": "ПодменюОрганайзер",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Органайзер"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "",
+                    "items": []
+                  }
+                ]
+              },
+              {
+                "type": "TABLE",
+                "id": 1,
+                "name": "Список",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Список"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "Список",
+                "items": [
+                  [
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 20,
+                      "name": "Тема",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[8]/synonym"
+                      },
+                      "dataPath": "Список.Description",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 22,
+                      "name": "Предмет",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.ПредставлениеПредмета",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 24,
+                      "name": "ДатаИзменения",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.ДатаИзменения",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 54,
+                      "name": "Ссылка",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.Ref",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "Список",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "DYNAMIC_LIST"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 2,
+                "name": "ВыбранныйПредмет",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Выбранный предмет"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[8]/type"
+                }
+              },
+              {
+                "id": 3,
+                "name": "ВыбранныйЦвет",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Выбранный цвет"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[6]/type"
+                }
+              },
+              {
+                "id": 4,
+                "name": "ПоказыватьУдаленные",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[2]/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "16244165-d5a4-4012-8bb5-7f5fee1111af",
+        "name": "ЗаметкиПоПредмету",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "Catalog.Заметки.Form.ЗаметкиПоПредмету",
+          "mdoRefRu": "Справочник.Заметки.Форма.ЗаметкиПоПредмету"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Заметки"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/Catalogs/Заметки/Forms/ЗаметкиПоПредмету/Ext/Form/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "content": [
+              {
+                "default": {
+                  "tag": 2
+                },
+                "int": 1,
+                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                  "langKey": "ru",
+                  "value": "Мои заметки"
+                }
+              }
+            ]
+          },
+          "handlers": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[2]"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[5]"
+              }
+            ],
+            []
+          ],
+          "items": [
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 43,
+                "name": "ГруппаПользовательскихНастроек",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "dataPath": "",
+                "items": []
+              },
+              {
+                "type": "COMMAND_BAR",
+                "id": 41,
+                "name": "КоманднаяПанель",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                },
+                "dataPath": "",
+                "items": [
+                  {
+                    "type": "POPUP",
+                    "id": 60,
+                    "name": "ПодменюОрганайзер",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                    },
+                    "dataPath": "",
+                    "items": []
+                  }
+                ]
+              },
+              {
+                "type": "TABLE",
+                "id": 1,
+                "name": "Список",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                },
+                "dataPath": "Список",
+                "items": [
+                  [
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 45,
+                      "name": "Наименование",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.Description",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 25,
+                      "name": "Автор",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.Автор",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 57,
+                      "name": "Ссылка",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.Ref",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 30,
+                "name": "Фильтры",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "CHECK_BOX_FIELD",
+                      "id": 23,
+                      "name": "ПоказыватьЗаметкиДругихПользователей",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Показывать заметки других пользователей"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "ПоказыватьЗаметкиДругихПользователей",
+                      "items": []
+                    },
+                    {
+                      "type": "CHECK_BOX_FIELD",
+                      "id": 28,
+                      "name": "ПоказыватьУдаленные",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                      },
+                      "dataPath": "ПоказыватьУдаленные",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "Список",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 2,
+                "name": "Предмет",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[6]/type"
+                }
+              },
+              {
+                "id": 3,
+                "name": "ПоказыватьЗаметкиДругихПользователей",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[2]/type"
+                }
+              },
+              {
+                "id": 4,
+                "name": "ПоказыватьУдаленные",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[2]/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "290b72ad-004f-46ab-be5e-47557543b965",
+        "name": "МоиЗаметки",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "Catalog.Заметки.Form.МоиЗаметки",
+          "mdoRefRu": "Справочник.Заметки.Форма.МоиЗаметки"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Для рабочего стола",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/title"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/Catalogs/Заметки/Forms/МоиЗаметки/Ext/Form/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/title"
+          },
+          "handlers": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[5]"
+            }
+          ],
+          "items": [
+            {
+              "type": "TABLE",
+              "id": 1,
+              "name": "Список",
+              "title": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+              },
+              "dataPath": "Список",
+              "items": [
+                [
+                  {
+                    "type": "COLUMN_GROUP",
+                    "id": 8,
+                    "name": "Содержание",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[3]/synonym"
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "LABEL_FIELD",
+                          "id": 4,
+                          "name": "ПредставлениеЗаметки",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                          },
+                          "dataPath": "Список.Description",
+                          "items": []
+                        },
+                        {
+                          "type": "LABEL_FIELD",
+                          "id": 9,
+                          "name": "ПредставлениеПредмета",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                          },
+                          "dataPath": "Список.ПредставлениеПредмета",
+                          "items": []
+                        }
+                      ],
+                      []
+                    ]
+                  },
+                  {
+                    "type": "LABEL_FIELD",
+                    "id": 35,
+                    "name": "Ссылка",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                    },
+                    "dataPath": "Список.Ref",
+                    "items": []
+                  }
+                ],
+                []
+              ]
+            }
+          ],
+          "attributes": [
+            {
+              "id": 1,
+              "name": "Список",
+              "title": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "type": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+              }
+            }
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "e1b2ccf9-5a8f-4008-86f3-d2c7cf5581d1",
+        "name": "ФормаГруппы",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "Catalog.Заметки.Form.ФормаГруппы",
+          "mdoRefRu": "Справочник.Заметки.Форма.ФормаГруппы"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Форма группы"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/Catalogs/Заметки/Forms/ФормаГруппы/Ext/Form/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[5]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+          },
+          "handlers": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[2]"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[3]"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[5]"
+              }
+            ],
+            []
+          ],
+          "items": [
+            [
+              {
+                "type": "INPUT_FIELD",
+                "id": 1,
+                "name": "Код",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "dataPath": "",
+                "items": []
+              },
+              {
+                "type": "INPUT_FIELD",
+                "id": 3,
+                "name": "Наименование",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "dataPath": "Объект.Description",
+                "items": []
+              },
+              {
+                "type": "INPUT_FIELD",
+                "id": 5,
+                "name": "Родитель",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "dataPath": "Объект.Parent",
+                "items": []
+              },
+              {
+                "type": "INPUT_FIELD",
+                "id": 7,
+                "name": "Автор",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "dataPath": "Объект.Автор",
+                "items": []
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            {
+              "id": 1,
+              "name": "Объект",
+              "title": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "type": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+              }
+            }
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      }
+    ],
+    []
+  ],
+  "mdoReference": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+  },
+  "mdoType": "CATALOG",
+  "moduleTypes": [
+    [
+      "ManagerModule",
+      [
+        "src/test/resources/ext/designer/ssl_3_2/src/cf/Catalogs/Заметки/Ext/ManagerModule.bsl"
+      ]
+    ],
+    [
+      "ObjectModule",
+      [
+        "src/test/resources/ext/designer/ssl_3_2/src/cf/Catalogs/Заметки/Ext/ObjectModule.bsl"
+      ]
+    ]
+  ],
+  "modules": [
+    {
+      "moduleType": "ManagerModule",
+      "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/Catalogs/Заметки/Ext/ManagerModule.bsl",
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "isProtected": false
+    },
+    {
+      "moduleType": "ObjectModule",
+      "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/Catalogs/Заметки/Ext/ObjectModule.bsl",
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "isProtected": false
+    }
+  ],
+  "name": "Заметки",
+  "objectBelonging": "OWN",
+  "owners": [],
+  "possibleRights": [
+    {
+      "default": {
+        "tag": 4
+      },
+      "int": 25,
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INSERT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "DELETE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "VIEW",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "EDIT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INPUT_BY_STRING",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_DELETE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_INSERT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_SET_DELETION_MARK",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_CLEAR_DELETION_MARK",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_DELETE_MARKED",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_DELETE_PREDEFINED_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_SET_DELETION_MARK_PREDEFINED_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_CLEAR_DELETION_MARK_PREDEFINED_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_DELETE_MARKED_PREDEFINED_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "VIEW_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ_DATA_HISTORY_OF_MISSING_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_OF_MISSING_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_SETTINGS",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_VERSION_COMMENT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "EDIT_DATA_HISTORY_VERSION_COMMENT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "SWITCH_TO_DATA_HISTORY_VERSION"
+    }
+  ],
+  "predefinedValues": [],
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/synonym"
+  },
+  "tabularSections": [],
+  "templates": [],
+  "uuid": "3805ee39-a48a-499a-9ef8-9c2a5985404f"
+}}

--- a/src/test/resources/fixtures/ssl_3_2/Catalogs.Заметки.json
+++ b/src/test/resources/fixtures/ssl_3_2/Catalogs.Заметки.json
@@ -997,6 +997,27 @@
           "items": [
             [
               {
+                "type": "COMMAND_BAR",
+                "id": 79,
+                "name": "КоманднаяПанельРедактирования",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Командная панель редактирования"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": []
+              },
+              {
                 "type": "USUAL_GROUP",
                 "id": 14,
                 "name": "СодержаниеЗаметки",
@@ -1379,7 +1400,7 @@
                       "id": 28,
                       "name": "ФильтрПоЦвету",
                       "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                       },
                       "dataPath": "ВыбранныйЦвет",
                       "items": []
@@ -1420,9 +1441,9 @@
                 ]
               },
               {
-                "type": "USUAL_GROUP",
-                "id": 43,
-                "name": "ГруппаПользовательскихНастроек",
+                "type": "COMMAND_BAR",
+                "id": 71,
+                "name": "КоманднаяПанельТакси",
                 "title": {
                   "content": [
                     {
@@ -1432,56 +1453,13 @@
                       "int": 1,
                       "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                         "langKey": "ru",
-                        "value": "Группа пользовательских настроек"
+                        "value": "Командная панель такси"
                       }
                     }
                   ]
                 },
                 "dataPath": "",
                 "items": []
-              },
-              {
-                "type": "COMMAND_BAR",
-                "id": 33,
-                "name": "КоманднаяПанель",
-                "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Командная панель"
-                      }
-                    }
-                  ]
-                },
-                "dataPath": "",
-                "items": [
-                  {
-                    "type": "POPUP",
-                    "id": 57,
-                    "name": "ПодменюОрганайзер",
-                    "title": {
-                      "content": [
-                        {
-                          "default": {
-                            "tag": 2
-                          },
-                          "int": 1,
-                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                            "langKey": "ru",
-                            "value": "Органайзер"
-                          }
-                        }
-                      ]
-                    },
-                    "dataPath": "",
-                    "items": []
-                  }
-                ]
               },
               {
                 "type": "TABLE",
@@ -1707,42 +1685,11 @@
           "items": [
             [
               {
-                "type": "USUAL_GROUP",
-                "id": 43,
-                "name": "ГруппаПользовательскихНастроек",
-                "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                },
-                "dataPath": "",
-                "items": []
-              },
-              {
-                "type": "COMMAND_BAR",
-                "id": 41,
-                "name": "КоманднаяПанель",
-                "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
-                },
-                "dataPath": "",
-                "items": [
-                  {
-                    "type": "POPUP",
-                    "id": 60,
-                    "name": "ПодменюОрганайзер",
-                    "title": {
-                      "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                    },
-                    "dataPath": "",
-                    "items": []
-                  }
-                ]
-              },
-              {
                 "type": "TABLE",
                 "id": 1,
                 "name": "Список",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
                 },
                 "dataPath": "Список",
                 "items": [
@@ -1855,7 +1802,7 @@
                 "id": 3,
                 "name": "ПоказыватьЗаметкиДругихПользователей",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[2]/type"
@@ -1928,7 +1875,7 @@
               "id": 1,
               "name": "Список",
               "title": {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
               },
               "dataPath": "Список",
               "items": [

--- a/src/test/resources/fixtures/ssl_3_2/Catalogs.Заметки_edt.json
+++ b/src/test/resources/fixtures/ssl_3_2/Catalogs.Заметки_edt.json
@@ -981,6 +981,27 @@
           "items": [
             [
               {
+                "type": "COMMAND_BAR",
+                "id": 79,
+                "name": "КоманднаяПанельРедактирования",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Командная панель редактирования"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": []
+              },
+              {
                 "type": "USUAL_GROUP",
                 "id": 14,
                 "name": "СодержаниеЗаметки",
@@ -1363,7 +1384,7 @@
                       "id": 28,
                       "name": "ФильтрПоЦвету",
                       "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                       },
                       "dataPath": "ВыбранныйЦвет",
                       "items": []
@@ -1404,9 +1425,9 @@
                 ]
               },
               {
-                "type": "USUAL_GROUP",
-                "id": 43,
-                "name": "ГруппаПользовательскихНастроек",
+                "type": "COMMAND_BAR",
+                "id": 71,
+                "name": "КоманднаяПанельТакси",
                 "title": {
                   "content": [
                     {
@@ -1416,56 +1437,13 @@
                       "int": 1,
                       "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                         "langKey": "ru",
-                        "value": "Группа пользовательских настроек"
+                        "value": "Командная панель такси"
                       }
                     }
                   ]
                 },
                 "dataPath": "",
                 "items": []
-              },
-              {
-                "type": "COMMAND_BAR",
-                "id": 33,
-                "name": "КоманднаяПанель",
-                "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Командная панель"
-                      }
-                    }
-                  ]
-                },
-                "dataPath": "",
-                "items": [
-                  {
-                    "type": "POPUP",
-                    "id": 57,
-                    "name": "ПодменюОрганайзер",
-                    "title": {
-                      "content": [
-                        {
-                          "default": {
-                            "tag": 2
-                          },
-                          "int": 1,
-                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                            "langKey": "ru",
-                            "value": "Органайзер"
-                          }
-                        }
-                      ]
-                    },
-                    "dataPath": "",
-                    "items": []
-                  }
-                ]
               },
               {
                 "type": "TABLE",
@@ -1691,42 +1669,11 @@
           "items": [
             [
               {
-                "type": "USUAL_GROUP",
-                "id": 43,
-                "name": "ГруппаПользовательскихНастроек",
-                "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                },
-                "dataPath": "",
-                "items": []
-              },
-              {
-                "type": "COMMAND_BAR",
-                "id": 41,
-                "name": "КоманднаяПанель",
-                "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
-                },
-                "dataPath": "",
-                "items": [
-                  {
-                    "type": "POPUP",
-                    "id": 60,
-                    "name": "ПодменюОрганайзер",
-                    "title": {
-                      "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                    },
-                    "dataPath": "",
-                    "items": []
-                  }
-                ]
-              },
-              {
                 "type": "TABLE",
                 "id": 1,
                 "name": "Список",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
                 },
                 "dataPath": "Список",
                 "items": [
@@ -1839,7 +1786,7 @@
                 "id": 3,
                 "name": "ПоказыватьЗаметкиДругихПользователей",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[2]/type"
@@ -1912,7 +1859,7 @@
               "id": 1,
               "name": "Список",
               "title": {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
               },
               "dataPath": "Список",
               "items": [

--- a/src/test/resources/fixtures/ssl_3_2/Catalogs.Заметки_edt.json
+++ b/src/test/resources/fixtures/ssl_3_2/Catalogs.Заметки_edt.json
@@ -1,0 +1,2194 @@
+{"com.github._1c_syntax.bsl.mdo.Catalog": {
+  "attributes": [
+    [
+      {
+        "uuid": "3805ee39-a48a-499a-9ef8-9c2a5985404f",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Catalog.Заметки.StandardAttribute.PredefinedDataName",
+          "mdoRefRu": "Справочник.Заметки.СтандартныйРеквизит.ИмяПредопределенныхДанных"
+        },
+        "comment": "",
+        "synonym": {
+          "content": []
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.Заметки",
+          "mdoRefRu": "Справочник.Заметки"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                "length": 0,
+                "allowedLength": 0,
+                "description": {
+                  "value": {
+                    "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                    "nameRu": "КвалификаторыСтроки (0, Переменная)",
+                    "nameEn": "StringQualifiers (0, Variable)"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "ИмяПредопределенныхДанных",
+          "nameEn": "PredefinedDataName"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "3805ee39-a48a-499a-9ef8-9c2a5985404f",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Catalog.Заметки.StandardAttribute.Predefined",
+          "mdoRefRu": "Справочник.Заметки.СтандартныйРеквизит.Предопределенный"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "BOOLEAN"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 0
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "Предопределенный",
+          "nameEn": "Predefined"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "3805ee39-a48a-499a-9ef8-9c2a5985404f",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Catalog.Заметки.StandardAttribute.Ref",
+          "mdoRefRu": "Справочник.Заметки.СтандартныйРеквизит.Ссылка"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "СправочникСсылка.Заметки",
+                  "nameEn": "CatalogRef.Заметки"
+                },
+                "variant": "METADATA",
+                "kind": "CATALOG"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "fullName": {
+          "nameRu": "Ссылка",
+          "nameEn": "Ref"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "3805ee39-a48a-499a-9ef8-9c2a5985404f",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Catalog.Заметки.StandardAttribute.DeletionMark",
+          "mdoRefRu": "Справочник.Заметки.СтандартныйРеквизит.ПометкаУдаления"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[2]/type"
+        },
+        "fullName": {
+          "nameRu": "ПометкаУдаления",
+          "nameEn": "DeletionMark"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "3805ee39-a48a-499a-9ef8-9c2a5985404f",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Catalog.Заметки.StandardAttribute.IsFolder",
+          "mdoRefRu": "Справочник.Заметки.СтандартныйРеквизит.ЭтоГруппа"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[2]/type"
+        },
+        "fullName": {
+          "nameRu": "ЭтоГруппа",
+          "nameEn": "IsFolder"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "3805ee39-a48a-499a-9ef8-9c2a5985404f",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Catalog.Заметки.StandardAttribute.Owner",
+          "mdoRefRu": "Справочник.Заметки.СтандартныйРеквизит.Владелец"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [],
+          "composite": false,
+          "qualifiers": []
+        },
+        "fullName": {
+          "nameRu": "Владелец",
+          "nameEn": "Owner"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": true
+      },
+      {
+        "uuid": "3805ee39-a48a-499a-9ef8-9c2a5985404f",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Catalog.Заметки.StandardAttribute.Parent",
+          "mdoRefRu": "Справочник.Заметки.СтандартныйРеквизит.Родитель"
+        },
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Группа заметок"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[3]/type"
+        },
+        "fullName": {
+          "nameRu": "Родитель",
+          "nameEn": "Parent"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": true
+      },
+      {
+        "uuid": "3805ee39-a48a-499a-9ef8-9c2a5985404f",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Catalog.Заметки.StandardAttribute.Description",
+          "mdoRefRu": "Справочник.Заметки.СтандартныйРеквизит.Наименование"
+        },
+        "comment": "Реквизит заполняется автоматически",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Тема"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                "length": 100,
+                "allowedLength": 0,
+                "description": {}
+              }
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "Наименование",
+          "nameEn": "Description"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "3805ee39-a48a-499a-9ef8-9c2a5985404f",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Catalog.Заметки.StandardAttribute.Code",
+          "mdoRefRu": "Справочник.Заметки.СтандартныйРеквизит.Код"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+        },
+        "fullName": {
+          "nameRu": "Код",
+          "nameEn": "Code"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "07ccfe87-e1ab-4da7-92cb-a612e0972b0b",
+        "name": "Автор",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.Заметки.Attribute.Автор",
+          "mdoRefRu": "Справочник.Заметки.Реквизит.Автор"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Автор"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "СправочникСсылка.Пользователи",
+                  "nameEn": "CatalogRef.Пользователи"
+                },
+                "variant": "METADATA",
+                "kind": "CATALOG"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "08c2f92c-eb05-49e7-bfc9-4a89607b9864",
+        "name": "Предмет",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.Заметки.Attribute.Предмет",
+          "mdoRefRu": "Справочник.Заметки.Реквизит.Предмет"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Предмет"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "ОпределяемыйТип.ПредметЗаметок",
+                  "nameEn": "DefinedType.ПредметЗаметок"
+                },
+                "variant": "METADATA",
+                "kind": "DEFINED_TYPE"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": true
+      },
+      {
+        "uuid": "6d751379-89a7-49b5-93e5-578329c63d9c",
+        "name": "Содержание",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.Заметки.Attribute.Содержание",
+          "mdoRefRu": "Справочник.Заметки.Реквизит.Содержание"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Содержание"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.V8ValueType": "VALUE_STORAGE"
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "c3f156ef-947e-4ebb-883f-4f099a116063",
+        "name": "ТекстСодержания",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.Заметки.Attribute.ТекстСодержания",
+          "mdoRefRu": "Справочник.Заметки.Реквизит.ТекстСодержания"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Реквизит для полнотекстового поиска",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[3]/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "5e3ab0a3-c0a6-4f41-85d3-2eede4abb555",
+        "name": "ДляРабочегоСтола",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.Заметки.Attribute.ДляРабочегоСтола",
+          "mdoRefRu": "Справочник.Заметки.Реквизит.ДляРабочегоСтола"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Для рабочего стола"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[2]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "a065ffc3-f50b-4a78-9b84-bfc4e5515a4b",
+        "name": "Пометка",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.Заметки.Attribute.Пометка",
+          "mdoRefRu": "Справочник.Заметки.Реквизит.Пометка"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Пометка"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX_WITH_ADDITIONAL_ORDER",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "ПеречислениеСсылка.ЦветаЗаметок",
+                  "nameEn": "EnumRef.ЦветаЗаметок"
+                },
+                "variant": "METADATA",
+                "kind": "ENUM"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": true
+      },
+      {
+        "uuid": "4cba5a06-1484-4dd1-8e35-2d702c7d96d0",
+        "name": "ДатаИзменения",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.Заметки.Attribute.ДатаИзменения",
+          "mdoRefRu": "Справочник.Заметки.Реквизит.ДатаИзменения"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Дата изменения"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "DATE"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.DateQualifiers": {
+                "dateFractions": 2,
+                "description": {
+                  "value": {
+                    "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                    "nameRu": "КвалификаторыДаты (ДатаВремя)",
+                    "nameEn": "DateQualifiers (DateTime)"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "e98e9e56-2995-430c-bd3b-f1070aec15a5",
+        "name": "ПредставлениеПредмета",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Catalog.Заметки.Attribute.ПредставлениеПредмета",
+          "mdoRefRu": "Справочник.Заметки.Реквизит.ПредставлениеПредмета"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[2]/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[8]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      }
+    ],
+    []
+  ],
+  "checkUnique": false,
+  "codeSeries": "WHOLE_CATALOG",
+  "commands": [
+    {
+      "uuid": "fa0e0792-bffb-47ce-866f-9e8dbdab17a4",
+      "name": "ВсеЗаметки",
+      "mdoReference": {
+        "type": "COMMAND",
+        "mdoRef": "Catalog.Заметки.Command.ВсеЗаметки",
+        "mdoRefRu": "Справочник.Заметки.Команда.ВсеЗаметки"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": [
+          {
+            "default": {
+              "tag": 2
+            },
+            "int": 1,
+            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+              "langKey": "ru",
+              "value": "Все заметки"
+            }
+          }
+        ]
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "modules": [
+        {
+          "moduleType": "CommandModule",
+          "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/Catalogs/Заметки/Commands/ВсеЗаметки/CommandModule.bsl",
+          "owner": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/commands/com.github._1c_syntax.bsl.mdo.children.ObjectCommand/mdoReference"
+          },
+          "supportVariant": "NOT_EDITABLE",
+          "isProtected": false
+        }
+      ],
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+      }
+    }
+  ],
+  "comment": "",
+  "description": "Заметки",
+  "explanation": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+  },
+  "forms": [
+    [
+      {
+        "uuid": "d35c51b0-4cb7-4f9c-8aac-6a25a1b49adf",
+        "name": "ФормаЭлемента",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "Catalog.Заметки.Form.ФормаЭлемента",
+          "mdoRefRu": "Справочник.Заметки.Форма.ФормаЭлемента"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Форма элемента"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/Catalogs/Заметки/Forms/ФормаЭлемента/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+          },
+          "handlers": [
+            [
+              {
+                "event": "OnOpen",
+                "name": "ПриОткрытии"
+              },
+              {
+                "event": "OnCreateAtServer",
+                "name": "ПриСозданииНаСервере"
+              }
+            ],
+            []
+          ],
+          "items": [
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 14,
+                "name": "СодержаниеЗаметки",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Содержание заметки"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  {
+                    "type": "USUAL_GROUP",
+                    "id": 102,
+                    "name": "ГруппаПредмет",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[2]/synonym"
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "LABEL",
+                          "id": 65,
+                          "name": "НадписьПредмет",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Предмет:"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": []
+                        },
+                        {
+                          "type": "LABEL",
+                          "id": 63,
+                          "name": "Предмет",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[2]/synonym"
+                          },
+                          "dataPath": "",
+                          "items": []
+                        }
+                      ],
+                      []
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "FORMATTED_DOCUMENT_FIELD",
+                "id": 9,
+                "name": "Содержание",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[3]/synonym"
+                },
+                "dataPath": "ФорматированныйТекст",
+                "items": []
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 90,
+                "name": "ПараметрыОтображения",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Параметры отображения"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "CHECK_BOX_FIELD",
+                      "id": 80,
+                      "name": "ОтображатьНаРабочемСтоле",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Отображать на рабочем столе"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "Объект.ДляРабочегоСтола",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 82,
+                      "name": "Пометка",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Цвет"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "Объект.Пометка",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 105,
+                      "name": "ГруппаЗаметок",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Объект.Parent",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 91,
+                "name": "ИнформацияОбАвторе",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Информация об авторе"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "LABEL",
+                      "id": 92,
+                      "name": "НадписьАвтор",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Автор:"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL",
+                      "id": 94,
+                      "name": "Автор",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/synonym"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "LABEL",
+                "id": 103,
+                "name": "ДатаЗаметки",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Записана: 25 ноября 2011 г."
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": []
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "Объект",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "СправочникОбъект.Заметки",
+                          "nameEn": "CatalogObject.Заметки"
+                        },
+                        "variant": "METADATA",
+                        "kind": "CATALOG"
+                      }
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 4,
+                "name": "ФорматированныйТекст",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Форматированный текст"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "FORMATTED_DOCUMENT"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "8a7546f4-bfc9-4732-bf60-43a41e2c8753",
+        "name": "ВсеЗаметки",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "Catalog.Заметки.Form.ВсеЗаметки",
+          "mdoRefRu": "Справочник.Заметки.Форма.ВсеЗаметки"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/commands/com.github._1c_syntax.bsl.mdo.children.ObjectCommand/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/Catalogs/Заметки/Forms/ВсеЗаметки/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/commands/com.github._1c_syntax.bsl.mdo.children.ObjectCommand/synonym"
+          },
+          "handlers": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler"
+              },
+              {
+                "event": "OnLoadDataFromSettingsAtServer",
+                "name": "ПриЗагрузкеДанныхИзНастроекНаСервере"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[2]"
+              }
+            ],
+            []
+          ],
+          "items": [
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 30,
+                "name": "Фильтры",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Фильтры"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 28,
+                      "name": "ФильтрПоЦвету",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                      },
+                      "dataPath": "ВыбранныйЦвет",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 26,
+                      "name": "ФильтрПоПредмету",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[2]/synonym"
+                      },
+                      "dataPath": "ВыбранныйПредмет",
+                      "items": []
+                    },
+                    {
+                      "type": "CHECK_BOX_FIELD",
+                      "id": 31,
+                      "name": "ПоказыватьУдаленные",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Показывать удаленные"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "ПоказыватьУдаленные",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 43,
+                "name": "ГруппаПользовательскихНастроек",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Группа пользовательских настроек"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": []
+              },
+              {
+                "type": "COMMAND_BAR",
+                "id": 33,
+                "name": "КоманднаяПанель",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Командная панель"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  {
+                    "type": "POPUP",
+                    "id": 57,
+                    "name": "ПодменюОрганайзер",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Органайзер"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "",
+                    "items": []
+                  }
+                ]
+              },
+              {
+                "type": "TABLE",
+                "id": 1,
+                "name": "Список",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Список"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "Список",
+                "items": [
+                  [
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 20,
+                      "name": "Тема",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[8]/synonym"
+                      },
+                      "dataPath": "Список.Description",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 22,
+                      "name": "Предмет",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.ПредставлениеПредмета",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 24,
+                      "name": "ДатаИзменения",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.ДатаИзменения",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 54,
+                      "name": "Ссылка",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.Ref",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "Список",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "DYNAMIC_LIST"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 2,
+                "name": "ВыбранныйПредмет",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Выбранный предмет"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[8]/type"
+                }
+              },
+              {
+                "id": 3,
+                "name": "ВыбранныйЦвет",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Выбранный цвет"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[6]/type"
+                }
+              },
+              {
+                "id": 4,
+                "name": "ПоказыватьУдаленные",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[2]/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "16244165-d5a4-4012-8bb5-7f5fee1111af",
+        "name": "ЗаметкиПоПредмету",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "Catalog.Заметки.Form.ЗаметкиПоПредмету",
+          "mdoRefRu": "Справочник.Заметки.Форма.ЗаметкиПоПредмету"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Заметки"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/Catalogs/Заметки/Forms/ЗаметкиПоПредмету/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "content": [
+              {
+                "default": {
+                  "tag": 2
+                },
+                "int": 1,
+                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                  "langKey": "ru",
+                  "value": "Мои заметки"
+                }
+              }
+            ]
+          },
+          "handlers": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[2]"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[2]"
+              }
+            ],
+            []
+          ],
+          "items": [
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 43,
+                "name": "ГруппаПользовательскихНастроек",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "dataPath": "",
+                "items": []
+              },
+              {
+                "type": "COMMAND_BAR",
+                "id": 41,
+                "name": "КоманднаяПанель",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                },
+                "dataPath": "",
+                "items": [
+                  {
+                    "type": "POPUP",
+                    "id": 60,
+                    "name": "ПодменюОрганайзер",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                    },
+                    "dataPath": "",
+                    "items": []
+                  }
+                ]
+              },
+              {
+                "type": "TABLE",
+                "id": 1,
+                "name": "Список",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                },
+                "dataPath": "Список",
+                "items": [
+                  [
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 45,
+                      "name": "Наименование",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.Description",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 25,
+                      "name": "Автор",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.Автор",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 57,
+                      "name": "Ссылка",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.Ref",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 30,
+                "name": "Фильтры",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "CHECK_BOX_FIELD",
+                      "id": 23,
+                      "name": "ПоказыватьЗаметкиДругихПользователей",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Показывать заметки других пользователей"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "ПоказыватьЗаметкиДругихПользователей",
+                      "items": []
+                    },
+                    {
+                      "type": "CHECK_BOX_FIELD",
+                      "id": 28,
+                      "name": "ПоказыватьУдаленные",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                      },
+                      "dataPath": "ПоказыватьУдаленные",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "Список",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 2,
+                "name": "Предмет",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[6]/type"
+                }
+              },
+              {
+                "id": 3,
+                "name": "ПоказыватьЗаметкиДругихПользователей",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[2]/type"
+                }
+              },
+              {
+                "id": 4,
+                "name": "ПоказыватьУдаленные",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[2]/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "290b72ad-004f-46ab-be5e-47557543b965",
+        "name": "МоиЗаметки",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "Catalog.Заметки.Form.МоиЗаметки",
+          "mdoRefRu": "Справочник.Заметки.Форма.МоиЗаметки"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Для рабочего стола",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/title"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/Catalogs/Заметки/Forms/МоиЗаметки/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/title"
+          },
+          "handlers": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[2]"
+            }
+          ],
+          "items": [
+            {
+              "type": "TABLE",
+              "id": 1,
+              "name": "Список",
+              "title": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+              },
+              "dataPath": "Список",
+              "items": [
+                [
+                  {
+                    "type": "COLUMN_GROUP",
+                    "id": 8,
+                    "name": "Содержание",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[3]/synonym"
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "LABEL_FIELD",
+                          "id": 4,
+                          "name": "ПредставлениеЗаметки",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                          },
+                          "dataPath": "Список.Description",
+                          "items": []
+                        },
+                        {
+                          "type": "LABEL_FIELD",
+                          "id": 9,
+                          "name": "ПредставлениеПредмета",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                          },
+                          "dataPath": "Список.ПредставлениеПредмета",
+                          "items": []
+                        }
+                      ],
+                      []
+                    ]
+                  },
+                  {
+                    "type": "LABEL_FIELD",
+                    "id": 35,
+                    "name": "Ссылка",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                    },
+                    "dataPath": "Список.Ref",
+                    "items": []
+                  }
+                ],
+                []
+              ]
+            }
+          ],
+          "attributes": [
+            {
+              "id": 1,
+              "name": "Список",
+              "title": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "type": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+              }
+            }
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "e1b2ccf9-5a8f-4008-86f3-d2c7cf5581d1",
+        "name": "ФормаГруппы",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "Catalog.Заметки.Form.ФормаГруппы",
+          "mdoRefRu": "Справочник.Заметки.Форма.ФормаГруппы"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Форма группы"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/Catalogs/Заметки/Forms/ФормаГруппы/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[5]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+          },
+          "handlers": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[2]"
+            }
+          ],
+          "items": [
+            [
+              {
+                "type": "INPUT_FIELD",
+                "id": 1,
+                "name": "Код",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "dataPath": "",
+                "items": []
+              },
+              {
+                "type": "INPUT_FIELD",
+                "id": 3,
+                "name": "Наименование",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "dataPath": "Объект.Description",
+                "items": []
+              },
+              {
+                "type": "INPUT_FIELD",
+                "id": 5,
+                "name": "Родитель",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "dataPath": "Объект.Parent",
+                "items": []
+              },
+              {
+                "type": "INPUT_FIELD",
+                "id": 7,
+                "name": "Автор",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "dataPath": "Объект.Автор",
+                "items": []
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            {
+              "id": 1,
+              "name": "Объект",
+              "title": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "type": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+              }
+            }
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      }
+    ],
+    []
+  ],
+  "mdoReference": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+  },
+  "mdoType": "CATALOG",
+  "moduleTypes": [
+    [
+      "ManagerModule",
+      [
+        "src/test/resources/ext/edt/ssl_3_2/configuration/src/Catalogs/Заметки/ManagerModule.bsl"
+      ]
+    ],
+    [
+      "ObjectModule",
+      [
+        "src/test/resources/ext/edt/ssl_3_2/configuration/src/Catalogs/Заметки/ObjectModule.bsl"
+      ]
+    ]
+  ],
+  "modules": [
+    {
+      "moduleType": "ManagerModule",
+      "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/Catalogs/Заметки/ManagerModule.bsl",
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "isProtected": false
+    },
+    {
+      "moduleType": "ObjectModule",
+      "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/Catalogs/Заметки/ObjectModule.bsl",
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "isProtected": false
+    }
+  ],
+  "name": "Заметки",
+  "objectBelonging": "OWN",
+  "owners": [],
+  "possibleRights": [
+    {
+      "default": {
+        "tag": 4
+      },
+      "int": 25,
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INSERT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "DELETE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "VIEW",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "EDIT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INPUT_BY_STRING",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_DELETE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_INSERT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_SET_DELETION_MARK",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_CLEAR_DELETION_MARK",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_DELETE_MARKED",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_DELETE_PREDEFINED_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_SET_DELETION_MARK_PREDEFINED_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_CLEAR_DELETION_MARK_PREDEFINED_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_DELETE_MARKED_PREDEFINED_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "VIEW_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ_DATA_HISTORY_OF_MISSING_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_OF_MISSING_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_SETTINGS",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_VERSION_COMMENT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "EDIT_DATA_HISTORY_VERSION_COMMENT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "SWITCH_TO_DATA_HISTORY_VERSION"
+    }
+  ],
+  "predefinedValues": [],
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.Catalog/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/synonym"
+  },
+  "tabularSections": [],
+  "templates": [],
+  "uuid": "3805ee39-a48a-499a-9ef8-9c2a5985404f"
+}}

--- a/src/test/resources/fixtures/ssl_3_2/ChartsOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.json
+++ b/src/test/resources/fixtures/ssl_3_2/ChartsOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.json
@@ -2018,536 +2018,52 @@
             []
           ],
           "items": [
-            [
-              {
-                "type": "PAGES",
-                "id": 200,
-                "name": "СтраницыПомощникКарточка",
-                "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Страницы помощник карточка"
-                      }
+            {
+              "type": "PAGES",
+              "id": 200,
+              "name": "СтраницыПомощникКарточка",
+              "title": {
+                "content": [
+                  {
+                    "default": {
+                      "tag": 2
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                      "langKey": "ru",
+                      "value": "Страницы помощник карточка"
                     }
-                  ]
-                },
-                "dataPath": "",
-                "items": [
-                  [
-                    {
-                      "type": "PAGE",
-                      "id": 202,
-                      "name": "ВыборРеквизита",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Выбор реквизита"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "USUAL_GROUP",
-                            "id": 336,
-                            "name": "ГруппаЗаголовок",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Заголовок"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": [
-                              [
-                                {
-                                  "type": "LABEL_DECORATION",
-                                  "id": 338,
-                                  "name": "ДекорацияЗаголовок",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Выберите %1 для включения в набор \"%2\":"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": []
-                                },
-                                {
-                                  "type": "COMMAND_BAR",
-                                  "id": 408,
-                                  "name": "ПанельЕще",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Панель еще"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": [
-                                    {
-                                      "type": "POPUP",
-                                      "id": 410,
-                                      "name": "ПодменюЕще",
-                                      "title": {
-                                        "content": [
-                                          {
-                                            "default": {
-                                              "tag": 2
-                                            },
-                                            "int": 1,
-                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                              "langKey": "ru",
-                                              "value": "Еще"
-                                            }
-                                          }
-                                        ]
-                                      },
-                                      "dataPath": "",
-                                      "items": [
-                                        {
-                                          "type": "COMMAND_BAR_BUTTON",
-                                          "id": 412,
-                                          "name": "НеиспользуемыеРеквизиты",
-                                          "title": {
-                                            "content": [
-                                              {
-                                                "default": {
-                                                  "tag": 2
-                                                },
-                                                "int": 1,
-                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                  "langKey": "ru",
-                                                  "value": "Неиспользуемые реквизиты"
-                                                }
-                                              }
-                                            ]
-                                          },
-                                          "dataPath": "",
-                                          "items": []
-                                        }
-                                      ]
-                                    }
-                                  ]
-                                }
-                              ],
-                              []
-                            ]
+                  }
+                ]
+              },
+              "dataPath": "",
+              "items": [
+                [
+                  {
+                    "type": "PAGE",
+                    "id": 202,
+                    "name": "ВыборРеквизита",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
                           },
-                          {
-                            "type": "USUAL_GROUP",
-                            "id": 341,
-                            "name": "ГруппаСодержимое",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Содержимое"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": [
-                              [
-                                {
-                                  "type": "USUAL_GROUP",
-                                  "id": 343,
-                                  "name": "ГруппаНаборыСвойств",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Наборы свойств"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": [
-                                    {
-                                      "type": "PAGES",
-                                      "id": 414,
-                                      "name": "СтраницыНаборыСвойств",
-                                      "title": {
-                                        "content": [
-                                          {
-                                            "default": {
-                                              "tag": 2
-                                            },
-                                            "int": 1,
-                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                              "langKey": "ru",
-                                              "value": "Страницы наборы свойств"
-                                            }
-                                          }
-                                        ]
-                                      },
-                                      "dataPath": "",
-                                      "items": [
-                                        [
-                                          {
-                                            "type": "PAGE",
-                                            "id": 416,
-                                            "name": "СтраницаВсеНаборы",
-                                            "title": {
-                                              "content": [
-                                                {
-                                                  "default": {
-                                                    "tag": 2
-                                                  },
-                                                  "int": 1,
-                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                    "langKey": "ru",
-                                                    "value": "Страница все наборы"
-                                                  }
-                                                }
-                                              ]
-                                            },
-                                            "dataPath": "",
-                                            "items": [
-                                              {
-                                                "type": "TABLE",
-                                                "id": 345,
-                                                "name": "НаборыСвойств",
-                                                "title": {
-                                                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                                },
-                                                "dataPath": "НаборыСвойств",
-                                                "items": [
-                                                  [
-                                                    {
-                                                      "type": "LABEL_FIELD",
-                                                      "id": 396,
-                                                      "name": "Представление",
-                                                      "title": {
-                                                        "content": [
-                                                          {
-                                                            "default": {
-                                                              "tag": 2
-                                                            },
-                                                            "int": 1,
-                                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                              "langKey": "ru",
-                                                              "value": "Представление набора"
-                                                            }
-                                                          }
-                                                        ]
-                                                      },
-                                                      "dataPath": "НаборыСвойств.Представление",
-                                                      "items": []
-                                                    },
-                                                    {
-                                                      "type": "LABEL_FIELD",
-                                                      "id": 399,
-                                                      "name": "Ссылка",
-                                                      "title": {
-                                                        "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                                      },
-                                                      "dataPath": "НаборыСвойств.Ссылка",
-                                                      "items": []
-                                                    }
-                                                  ],
-                                                  []
-                                                ]
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "type": "PAGE",
-                                            "id": 418,
-                                            "name": "СтраницаОбщиеНаборы",
-                                            "title": {
-                                              "content": [
-                                                {
-                                                  "default": {
-                                                    "tag": 2
-                                                  },
-                                                  "int": 1,
-                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                    "langKey": "ru",
-                                                    "value": "Страница общие наборы"
-                                                  }
-                                                }
-                                              ]
-                                            },
-                                            "dataPath": "",
-                                            "items": [
-                                              {
-                                                "type": "TABLE",
-                                                "id": 420,
-                                                "name": "ОбщиеНаборыСвойств",
-                                                "title": {
-                                                  "content": [
-                                                    {
-                                                      "default": {
-                                                        "tag": 2
-                                                      },
-                                                      "int": 1,
-                                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                        "langKey": "ru",
-                                                        "value": "Общие наборы свойств"
-                                                      }
-                                                    }
-                                                  ]
-                                                },
-                                                "dataPath": "ОбщиеНаборыСвойств",
-                                                "items": [
-                                                  {
-                                                    "type": "LABEL_FIELD",
-                                                    "id": 436,
-                                                    "name": "ОбщиеНаборыСвойствПредставление",
-                                                    "title": {
-                                                      "content": [
-                                                        {
-                                                          "default": {
-                                                            "tag": 2
-                                                          },
-                                                          "int": 1,
-                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                            "langKey": "ru",
-                                                            "value": "Представление"
-                                                          }
-                                                        }
-                                                      ]
-                                                    },
-                                                    "dataPath": "ОбщиеНаборыСвойств.Представление",
-                                                    "items": []
-                                                  }
-                                                ]
-                                              }
-                                            ]
-                                          }
-                                        ],
-                                        []
-                                      ]
-                                    }
-                                  ]
-                                },
-                                {
-                                  "type": "USUAL_GROUP",
-                                  "id": 364,
-                                  "name": "РасшифровкаРеквизита",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Дополнительные реквизиты"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": [
-                                    [
-                                      {
-                                        "type": "TABLE",
-                                        "id": 366,
-                                        "name": "Свойства",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Свойства"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "Свойства",
-                                        "items": [
-                                          {
-                                            "type": "INPUT_FIELD",
-                                            "id": 379,
-                                            "name": "СвойстваЗаголовок",
-                                            "title": {
-                                              "content": [
-                                                {
-                                                  "default": {
-                                                    "tag": 2
-                                                  },
-                                                  "int": 1,
-                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                    "langKey": "ru",
-                                                    "value": "Реквизит"
-                                                  }
-                                                }
-                                              ]
-                                            },
-                                            "dataPath": "Свойства.Заголовок",
-                                            "items": []
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "USUAL_GROUP",
-                                        "id": 469,
-                                        "name": "ГруппаДополнительнаяИнформация",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Дополнительная информация"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "",
-                                        "items": [
-                                          [
-                                            {
-                                              "type": "INPUT_FIELD",
-                                              "id": 384,
-                                              "name": "СписокДополнительныхРеквизитовТипЗначения",
-                                              "title": {
-                                                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                              },
-                                              "dataPath": "Items.Свойства.CurrentData.ТипЗначения",
-                                              "items": []
-                                            },
-                                            {
-                                              "type": "INPUT_FIELD",
-                                              "id": 387,
-                                              "name": "СписокДополнительныхРеквизитовПодсказка",
-                                              "title": {
-                                                "content": [
-                                                  {
-                                                    "default": {
-                                                      "tag": 2
-                                                    },
-                                                    "int": 1,
-                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                      "langKey": "ru",
-                                                      "value": "Всплывающая подсказка"
-                                                    }
-                                                  }
-                                                ]
-                                              },
-                                              "dataPath": "Items.Свойства.CurrentData.Подсказка",
-                                              "items": []
-                                            },
-                                            {
-                                              "type": "INPUT_FIELD",
-                                              "id": 390,
-                                              "name": "СписокДополнительныхРеквизитовЗаголовокФормыЗначения",
-                                              "title": {
-                                                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                              },
-                                              "dataPath": "Items.Свойства.CurrentData.ЗаголовокФормыЗначения",
-                                              "items": []
-                                            },
-                                            {
-                                              "type": "INPUT_FIELD",
-                                              "id": 393,
-                                              "name": "СписокДополнительныхРеквизитовЗаголовокФормыВыбораЗначения",
-                                              "title": {
-                                                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                              },
-                                              "dataPath": "Items.Свойства.CurrentData.ЗаголовокФормыВыбораЗначения",
-                                              "items": []
-                                            }
-                                          ],
-                                          []
-                                        ]
-                                      }
-                                    ],
-                                    []
-                                  ]
-                                }
-                              ],
-                              []
-                            ]
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Выбор реквизита"
                           }
-                        ],
-                        []
+                        }
                       ]
                     },
-                    {
-                      "type": "PAGE",
-                      "id": 204,
-                      "name": "ВыборДействия",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Выбор действия"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
+                    "dataPath": "",
+                    "items": [
+                      [
                         {
-                          "type": "RADIO_BUTTON_FIELD",
-                          "id": 237,
-                          "name": "РежимДобавленияРеквизита",
+                          "type": "USUAL_GROUP",
+                          "id": 336,
+                          "name": "ГруппаЗаголовок",
                           "title": {
                             "content": [
                               {
@@ -2557,356 +2073,471 @@
                                 "int": 1,
                                 "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                                   "langKey": "ru",
-                                  "value": "Выберите вариант добавления дополнительного %1 \"%2\" в набор \"%3\""
+                                  "value": "Заголовок"
                                 }
                               }
                             ]
                           },
-                          "dataPath": "РежимДобавленияРеквизита",
-                          "items": []
+                          "dataPath": "",
+                          "items": [
+                            {
+                              "type": "LABEL_DECORATION",
+                              "id": 338,
+                              "name": "ДекорацияЗаголовок",
+                              "title": {
+                                "content": [
+                                  {
+                                    "default": {
+                                      "tag": 2
+                                    },
+                                    "int": 1,
+                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                      "langKey": "ru",
+                                      "value": "Выберите %1 для включения в набор \"%2\":"
+                                    }
+                                  }
+                                ]
+                              },
+                              "dataPath": "",
+                              "items": []
+                            }
+                          ]
+                        },
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 634,
+                          "name": "ГруппаОсновное",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Основное"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "USUAL_GROUP",
+                                "id": 636,
+                                "name": "ЛеваяКолонкаВыбор",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Левая колонка выбор"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  {
+                                    "type": "PAGES",
+                                    "id": 414,
+                                    "name": "СтраницыНаборыСвойств",
+                                    "title": {
+                                      "content": [
+                                        {
+                                          "default": {
+                                            "tag": 2
+                                          },
+                                          "int": 1,
+                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                            "langKey": "ru",
+                                            "value": "Страницы наборы свойств"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    "dataPath": "",
+                                    "items": [
+                                      [
+                                        {
+                                          "type": "PAGE",
+                                          "id": 416,
+                                          "name": "СтраницаВсеНаборы",
+                                          "title": {
+                                            "content": [
+                                              {
+                                                "default": {
+                                                  "tag": 2
+                                                },
+                                                "int": 1,
+                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                  "langKey": "ru",
+                                                  "value": "Страница все наборы"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "dataPath": "",
+                                          "items": [
+                                            {
+                                              "type": "TABLE",
+                                              "id": 345,
+                                              "name": "НаборыСвойств",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Наборы свойств"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "НаборыСвойств",
+                                              "items": [
+                                                [
+                                                  {
+                                                    "type": "LABEL_FIELD",
+                                                    "id": 396,
+                                                    "name": "Представление",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "Представление набора"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "НаборыСвойств.Представление",
+                                                    "items": []
+                                                  },
+                                                  {
+                                                    "type": "LABEL_FIELD",
+                                                    "id": 399,
+                                                    "name": "Ссылка",
+                                                    "title": {
+                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                                    },
+                                                    "dataPath": "НаборыСвойств.Ссылка",
+                                                    "items": []
+                                                  }
+                                                ],
+                                                []
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "type": "PAGE",
+                                          "id": 418,
+                                          "name": "СтраницаОбщиеНаборы",
+                                          "title": {
+                                            "content": [
+                                              {
+                                                "default": {
+                                                  "tag": 2
+                                                },
+                                                "int": 1,
+                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                  "langKey": "ru",
+                                                  "value": "Страница общие наборы"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "dataPath": "",
+                                          "items": [
+                                            {
+                                              "type": "TABLE",
+                                              "id": 420,
+                                              "name": "ОбщиеНаборыСвойств",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                              },
+                                              "dataPath": "ОбщиеНаборыСвойств",
+                                              "items": [
+                                                {
+                                                  "type": "LABEL_FIELD",
+                                                  "id": 436,
+                                                  "name": "ОбщиеНаборыСвойствПредставление",
+                                                  "title": {
+                                                    "content": [
+                                                      {
+                                                        "default": {
+                                                          "tag": 2
+                                                        },
+                                                        "int": 1,
+                                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                          "langKey": "ru",
+                                                          "value": "Представление"
+                                                        }
+                                                      }
+                                                    ]
+                                                  },
+                                                  "dataPath": "ОбщиеНаборыСвойств.Представление",
+                                                  "items": []
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ],
+                                      []
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "USUAL_GROUP",
+                                "id": 638,
+                                "name": "ПраваяКолонкаВыбор",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Правая колонка выбор"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "TABLE",
+                                      "id": 366,
+                                      "name": "Свойства",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Свойства"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "Свойства",
+                                      "items": [
+                                        {
+                                          "type": "INPUT_FIELD",
+                                          "id": 379,
+                                          "name": "СвойстваЗаголовок",
+                                          "title": {
+                                            "content": [
+                                              {
+                                                "default": {
+                                                  "tag": 2
+                                                },
+                                                "int": 1,
+                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                  "langKey": "ru",
+                                                  "value": "Реквизит"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "dataPath": "Свойства.Заголовок",
+                                          "items": []
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "USUAL_GROUP",
+                                      "id": 469,
+                                      "name": "ГруппаДополнительнаяИнформация",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Дополнительная информация"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        [
+                                          {
+                                            "type": "INPUT_FIELD",
+                                            "id": 384,
+                                            "name": "СписокДополнительныхРеквизитовТипЗначения",
+                                            "title": {
+                                              "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                            },
+                                            "dataPath": "Items.Свойства.CurrentData.ТипЗначения",
+                                            "items": []
+                                          },
+                                          {
+                                            "type": "INPUT_FIELD",
+                                            "id": 387,
+                                            "name": "СписокДополнительныхРеквизитовПодсказка",
+                                            "title": {
+                                              "content": [
+                                                {
+                                                  "default": {
+                                                    "tag": 2
+                                                  },
+                                                  "int": 1,
+                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                    "langKey": "ru",
+                                                    "value": "Всплывающая подсказка"
+                                                  }
+                                                }
+                                              ]
+                                            },
+                                            "dataPath": "Items.Свойства.CurrentData.Подсказка",
+                                            "items": []
+                                          },
+                                          {
+                                            "type": "INPUT_FIELD",
+                                            "id": 390,
+                                            "name": "СписокДополнительныхРеквизитовЗаголовокФормыЗначения",
+                                            "title": {
+                                              "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                            },
+                                            "dataPath": "Items.Свойства.CurrentData.ЗаголовокФормыЗначения",
+                                            "items": []
+                                          },
+                                          {
+                                            "type": "INPUT_FIELD",
+                                            "id": 393,
+                                            "name": "СписокДополнительныхРеквизитовЗаголовокФормыВыбораЗначения",
+                                            "title": {
+                                              "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                            },
+                                            "dataPath": "Items.Свойства.CurrentData.ЗаголовокФормыВыбораЗначения",
+                                            "items": []
+                                          }
+                                        ],
+                                        []
+                                      ]
+                                    }
+                                  ],
+                                  []
+                                ]
+                              }
+                            ],
+                            []
+                          ]
+                        }
+                      ],
+                      []
+                    ]
+                  },
+                  {
+                    "type": "PAGE",
+                    "id": 204,
+                    "name": "ВыборДействия",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Выбор действия"
+                          }
                         }
                       ]
                     },
-                    {
-                      "type": "PAGE",
-                      "id": 206,
-                      "name": "КарточкаРеквизита",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Карточка реквизита"
+                    "dataPath": "",
+                    "items": [
+                      {
+                        "type": "RADIO_BUTTON_FIELD",
+                        "id": 237,
+                        "name": "РежимДобавленияРеквизита",
+                        "title": {
+                          "content": [
+                            {
+                              "default": {
+                                "tag": 2
+                              },
+                              "int": 1,
+                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                "langKey": "ru",
+                                "value": "Выберите вариант добавления дополнительного %1 \"%2\" в набор \"%3\""
+                              }
                             }
+                          ]
+                        },
+                        "dataPath": "РежимДобавленияРеквизита",
+                        "items": []
+                      }
+                    ]
+                  },
+                  {
+                    "type": "PAGE",
+                    "id": 206,
+                    "name": "КарточкаРеквизита",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Карточка реквизита"
                           }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "USUAL_GROUP",
-                            "id": 79,
-                            "name": "ГруппаНаименованиеРеквизита",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Наименование реквизита"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": [
-                              [
-                                {
-                                  "type": "INPUT_FIELD",
-                                  "id": 1,
-                                  "name": "Заголовок",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[7]/synonym"
-                                  },
-                                  "dataPath": "Объект.Заголовок",
-                                  "items": []
-                                },
-                                {
-                                  "type": "RADIO_BUTTON_FIELD",
-                                  "id": 20,
-                                  "name": "ВидСвойства",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[27]/synonym"
-                                  },
-                                  "dataPath": "ВидСвойства",
-                                  "items": []
-                                }
-                              ],
-                              []
-                            ]
-                          },
-                          {
-                            "type": "USUAL_GROUP",
-                            "id": 43,
-                            "name": "ТипЗначенияРеквизита",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Тип значения реквизита"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": [
-                              [
-                                {
-                                  "type": "USUAL_GROUP",
-                                  "id": 471,
-                                  "name": "ГруппаТипЗначения",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Тип значения"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": [
-                                    [
-                                      {
-                                        "type": "INPUT_FIELD",
-                                        "id": 5,
-                                        "name": "ТипЗначения",
-                                        "title": {
-                                          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                        },
-                                        "dataPath": "Объект.ValueType",
-                                        "items": []
-                                      },
-                                      {
-                                        "type": "HYPERLINK",
-                                        "id": 37,
-                                        "name": "РедактироватьФорматЗначения",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Формат"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "",
-                                        "items": []
-                                      }
-                                    ],
-                                    []
-                                  ]
-                                },
-                                {
-                                  "type": "USUAL_GROUP",
-                                  "id": 476,
-                                  "name": "ГруппаПояснениеТипаЗначения",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Пояснение типа значения"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": [
-                                    [
-                                      {
-                                        "type": "PICTURE_DECORATION",
-                                        "id": 478,
-                                        "name": "КартинкаПояснение",
-                                        "title": {
-                                          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                        },
-                                        "dataPath": "",
-                                        "items": []
-                                      },
-                                      {
-                                        "type": "LABEL_DECORATION",
-                                        "id": 473,
-                                        "name": "ПояснениеОДлинеСтроки",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Максимальная длина строки составляет 1024 символа"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "",
-                                        "items": []
-                                      }
-                                    ],
-                                    []
-                                  ]
-                                }
-                              ],
-                              []
-                            ]
-                          },
-                          {
-                            "type": "USUAL_GROUP",
-                            "id": 38,
-                            "name": "ГруппаМногострочность",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Многострочность"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": [
-                              [
-                                {
-                                  "type": "USUAL_GROUP",
-                                  "id": 448,
-                                  "name": "ГруппаОднострочноеПолеВводаНастройки",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Однострочное поле ввода настройки"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": [
-                                    [
-                                      {
-                                        "type": "RADIO_BUTTON_FIELD",
-                                        "id": 442,
-                                        "name": "ОднострочныйВид",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Представление реквизита"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "ПредставлениеРеквизита",
-                                        "items": []
-                                      },
-                                      {
-                                        "type": "CHECK_BOX_FIELD",
-                                        "id": 445,
-                                        "name": "ВыводитьВВидеГиперссылки",
-                                        "title": {
-                                          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                        },
-                                        "dataPath": "Объект.ВыводитьВВидеГиперссылки",
-                                        "items": []
-                                      }
-                                    ],
-                                    []
-                                  ]
-                                },
-                                {
-                                  "type": "USUAL_GROUP",
-                                  "id": 46,
-                                  "name": "ГруппаМногострочноеПолеВводаНастройки",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Многострочное поле ввода настройки"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": [
-                                    [
-                                      {
-                                        "type": "RADIO_BUTTON_FIELD",
-                                        "id": 450,
-                                        "name": "МногострочныйВид",
-                                        "title": {
-                                          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                        },
-                                        "dataPath": "ПредставлениеРеквизита",
-                                        "items": []
-                                      },
-                                      {
-                                        "type": "INPUT_FIELD",
-                                        "id": 41,
-                                        "name": "МногострочноеПолеВводаЧисло",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "  строк"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "МногострочноеПолеВводаЧисло",
-                                        "items": []
-                                      }
-                                    ],
-                                    []
-                                  ]
-                                }
-                              ],
-                              []
-                            ]
-                          },
+                        }
+                      ]
+                    },
+                    "dataPath": "",
+                    "items": [
+                      {
+                        "type": "USUAL_GROUP",
+                        "id": 650,
+                        "name": "ГруппаОсновноеКарточка",
+                        "title": {
+                          "content": [
+                            {
+                              "default": {
+                                "tag": 2
+                              },
+                              "int": 1,
+                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                "langKey": "ru",
+                                "value": "Основное карточка"
+                              }
+                            }
+                          ]
+                        },
+                        "dataPath": "",
+                        "items": [
                           {
                             "type": "PAGES",
                             "id": 167,
@@ -2930,25 +2561,179 @@
                               [
                                 {
                                   "type": "PAGE",
-                                  "id": 169,
-                                  "name": "ГлавнаяСтраница",
+                                  "id": 656,
+                                  "name": "СтраницаОсновное",
                                   "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Главное"
-                                        }
-                                      }
-                                    ]
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                                   },
                                   "dataPath": "",
                                   "items": [
                                     [
+                                      {
+                                        "type": "USUAL_GROUP",
+                                        "id": 79,
+                                        "name": "ГруппаНаименованиеРеквизита",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Наименование реквизита"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": [
+                                          [
+                                            {
+                                              "type": "RADIO_BUTTON_FIELD",
+                                              "id": 20,
+                                              "name": "ВидСвойства",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Вид свойств"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "ВидСвойства",
+                                              "items": []
+                                            },
+                                            {
+                                              "type": "INPUT_FIELD",
+                                              "id": 1,
+                                              "name": "Заголовок",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[7]/synonym"
+                                              },
+                                              "dataPath": "Объект.Заголовок",
+                                              "items": []
+                                            }
+                                          ],
+                                          []
+                                        ]
+                                      },
+                                      {
+                                        "type": "USUAL_GROUP",
+                                        "id": 860,
+                                        "name": "ГруппаТипЗначения",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Тип значения"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": [
+                                          {
+                                            "type": "INPUT_FIELD",
+                                            "id": 5,
+                                            "name": "ТипЗначения",
+                                            "title": {
+                                              "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                            },
+                                            "dataPath": "Объект.ValueType",
+                                            "items": []
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "USUAL_GROUP",
+                                        "id": 38,
+                                        "name": "ГруппаМногострочность",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Многострочность"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": [
+                                          [
+                                            {
+                                              "type": "RADIO_BUTTON_FIELD",
+                                              "id": 576,
+                                              "name": "ПолеПереключатель",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Вид поля"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "ПредставлениеРеквизита",
+                                              "items": []
+                                            },
+                                            {
+                                              "type": "INPUT_FIELD",
+                                              "id": 41,
+                                              "name": "МногострочноеПолеВводаЧисло",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Высота поля"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "МногострочноеПолеВводаЧисло",
+                                              "items": []
+                                            },
+                                            {
+                                              "type": "CHECK_BOX_FIELD",
+                                              "id": 445,
+                                              "name": "ВыводитьВВидеГиперссылки",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                              },
+                                              "dataPath": "Объект.ВыводитьВВидеГиперссылки",
+                                              "items": []
+                                            }
+                                          ],
+                                          []
+                                        ]
+                                      },
                                       {
                                         "type": "USUAL_GROUP",
                                         "id": 498,
@@ -2969,287 +2754,27 @@
                                         },
                                         "dataPath": "",
                                         "items": [
-                                          [
-                                            {
-                                              "type": "LABEL_DECORATION",
-                                              "id": 500,
-                                              "name": "ДекорацияЦветСвойства",
-                                              "title": {
-                                                "content": [
-                                                  {
-                                                    "default": {
-                                                      "tag": 2
-                                                    },
-                                                    "int": 1,
-                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                      "langKey": "ru",
-                                                      "value": "Цвет:"
-                                                    }
-                                                  }
-                                                ]
-                                              },
-                                              "dataPath": "",
-                                              "items": []
-                                            },
-                                            {
-                                              "type": "COMMAND_BAR",
-                                              "id": 503,
-                                              "name": "КоманднаяПанельЦветаСвойств",
-                                              "title": {
-                                                "content": [
-                                                  {
-                                                    "default": {
-                                                      "tag": 2
-                                                    },
-                                                    "int": 1,
-                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                      "langKey": "ru",
-                                                      "value": "Командная панель цвета свойств"
-                                                    }
-                                                  }
-                                                ]
-                                              },
-                                              "dataPath": "",
-                                              "items": [
+                                          {
+                                            "type": "INPUT_FIELD",
+                                            "id": 703,
+                                            "name": "ЦветМетки",
+                                            "title": {
+                                              "content": [
                                                 {
-                                                  "type": "BUTTON_GROUP",
-                                                  "id": 505,
-                                                  "name": "ГруппаЦвета",
-                                                  "title": {
-                                                    "content": [
-                                                      {
-                                                        "default": {
-                                                          "tag": 2
-                                                        },
-                                                        "int": 1,
-                                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                          "langKey": "ru",
-                                                          "value": "Цвета"
-                                                        }
-                                                      }
-                                                    ]
+                                                  "default": {
+                                                    "tag": 2
                                                   },
-                                                  "dataPath": "",
-                                                  "items": [
-                                                    [
-                                                      {
-                                                        "type": "COMMAND_BAR_BUTTON",
-                                                        "id": 507,
-                                                        "name": "СвойствоСерое",
-                                                        "title": {
-                                                          "content": [
-                                                            {
-                                                              "default": {
-                                                                "tag": 2
-                                                              },
-                                                              "int": 1,
-                                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                                "langKey": "ru",
-                                                                "value": "Свойство серое"
-                                                              }
-                                                            }
-                                                          ]
-                                                        },
-                                                        "dataPath": "",
-                                                        "items": []
-                                                      },
-                                                      {
-                                                        "type": "COMMAND_BAR_BUTTON",
-                                                        "id": 517,
-                                                        "name": "СвойствоЗеленое",
-                                                        "title": {
-                                                          "content": [
-                                                            {
-                                                              "default": {
-                                                                "tag": 2
-                                                              },
-                                                              "int": 1,
-                                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                                "langKey": "ru",
-                                                                "value": "Свойство зеленое"
-                                                              }
-                                                            }
-                                                          ]
-                                                        },
-                                                        "dataPath": "",
-                                                        "items": []
-                                                      },
-                                                      {
-                                                        "type": "COMMAND_BAR_BUTTON",
-                                                        "id": 515,
-                                                        "name": "СвойствоЖелтое",
-                                                        "title": {
-                                                          "content": [
-                                                            {
-                                                              "default": {
-                                                                "tag": 2
-                                                              },
-                                                              "int": 1,
-                                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                                "langKey": "ru",
-                                                                "value": "Свойство желтое"
-                                                              }
-                                                            }
-                                                          ]
-                                                        },
-                                                        "dataPath": "",
-                                                        "items": []
-                                                      },
-                                                      {
-                                                        "type": "COMMAND_BAR_BUTTON",
-                                                        "id": 513,
-                                                        "name": "СвойствоОранжевое",
-                                                        "title": {
-                                                          "content": [
-                                                            {
-                                                              "default": {
-                                                                "tag": 2
-                                                              },
-                                                              "int": 1,
-                                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                                "langKey": "ru",
-                                                                "value": "Свойство оранжевое"
-                                                              }
-                                                            }
-                                                          ]
-                                                        },
-                                                        "dataPath": "",
-                                                        "items": []
-                                                      },
-                                                      {
-                                                        "type": "COMMAND_BAR_BUTTON",
-                                                        "id": 511,
-                                                        "name": "СвойствоКрасное",
-                                                        "title": {
-                                                          "content": [
-                                                            {
-                                                              "default": {
-                                                                "tag": 2
-                                                              },
-                                                              "int": 1,
-                                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                                "langKey": "ru",
-                                                                "value": "Свойство красное"
-                                                              }
-                                                            }
-                                                          ]
-                                                        },
-                                                        "dataPath": "",
-                                                        "items": []
-                                                      },
-                                                      {
-                                                        "type": "COMMAND_BAR_BUTTON",
-                                                        "id": 523,
-                                                        "name": "СвойствоФиолетовое",
-                                                        "title": {
-                                                          "content": [
-                                                            {
-                                                              "default": {
-                                                                "tag": 2
-                                                              },
-                                                              "int": 1,
-                                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                                "langKey": "ru",
-                                                                "value": "Свойство фиолетовое"
-                                                              }
-                                                            }
-                                                          ]
-                                                        },
-                                                        "dataPath": "",
-                                                        "items": []
-                                                      },
-                                                      {
-                                                        "type": "COMMAND_BAR_BUTTON",
-                                                        "id": 519,
-                                                        "name": "СвойствоСинее",
-                                                        "title": {
-                                                          "content": [
-                                                            {
-                                                              "default": {
-                                                                "tag": 2
-                                                              },
-                                                              "int": 1,
-                                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                                "langKey": "ru",
-                                                                "value": "Свойство синее"
-                                                              }
-                                                            }
-                                                          ]
-                                                        },
-                                                        "dataPath": "",
-                                                        "items": []
-                                                      },
-                                                      {
-                                                        "type": "COMMAND_BAR_BUTTON",
-                                                        "id": 509,
-                                                        "name": "СвойствоЛаймовое",
-                                                        "title": {
-                                                          "content": [
-                                                            {
-                                                              "default": {
-                                                                "tag": 2
-                                                              },
-                                                              "int": 1,
-                                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                                "langKey": "ru",
-                                                                "value": "Свойство лаймовое"
-                                                              }
-                                                            }
-                                                          ]
-                                                        },
-                                                        "dataPath": "",
-                                                        "items": []
-                                                      },
-                                                      {
-                                                        "type": "COMMAND_BAR_BUTTON",
-                                                        "id": 525,
-                                                        "name": "СвойствоРозовое",
-                                                        "title": {
-                                                          "content": [
-                                                            {
-                                                              "default": {
-                                                                "tag": 2
-                                                              },
-                                                              "int": 1,
-                                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                                "langKey": "ru",
-                                                                "value": "Свойство розовое"
-                                                              }
-                                                            }
-                                                          ]
-                                                        },
-                                                        "dataPath": "",
-                                                        "items": []
-                                                      },
-                                                      {
-                                                        "type": "COMMAND_BAR_BUTTON",
-                                                        "id": 521,
-                                                        "name": "СвойствоГолубое",
-                                                        "title": {
-                                                          "content": [
-                                                            {
-                                                              "default": {
-                                                                "tag": 2
-                                                              },
-                                                              "int": 1,
-                                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                                "langKey": "ru",
-                                                                "value": "Свойство голубое"
-                                                              }
-                                                            }
-                                                          ]
-                                                        },
-                                                        "dataPath": "",
-                                                        "items": []
-                                                      }
-                                                    ],
-                                                    []
-                                                  ]
+                                                  "int": 1,
+                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                    "langKey": "ru",
+                                                    "value": "Цвет"
+                                                  }
                                                 }
                                               ]
-                                            }
-                                          ],
-                                          []
+                                            },
+                                            "dataPath": "Объект.ЦветСвойства",
+                                            "items": []
+                                          }
                                         ]
                                       },
                                       {
@@ -3273,6 +2798,51 @@
                                         "dataPath": "",
                                         "items": [
                                           [
+                                            {
+                                              "type": "USUAL_GROUP",
+                                              "id": 467,
+                                              "name": "ГруппаЗаполнятьОбязательно",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[16]/synonym"
+                                              },
+                                              "dataPath": "",
+                                              "items": [
+                                                [
+                                                  {
+                                                    "type": "CHECK_BOX_FIELD",
+                                                    "id": 184,
+                                                    "name": "ЗаполнятьОбязательно",
+                                                    "title": {
+                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[16]/synonym"
+                                                    },
+                                                    "dataPath": "Объект.ЗаполнятьОбязательно",
+                                                    "items": []
+                                                  },
+                                                  {
+                                                    "type": "LABEL_DECORATION",
+                                                    "id": 670,
+                                                    "name": "ЗадатьУсловиеЗаполнения",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "всегда"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": []
+                                                  }
+                                                ],
+                                                []
+                                              ]
+                                            },
                                             {
                                               "type": "USUAL_GROUP",
                                               "id": 463,
@@ -3306,21 +2876,10 @@
                                                   },
                                                   {
                                                     "type": "LABEL_DECORATION",
-                                                    "id": 333,
+                                                    "id": 664,
                                                     "name": "ЗадатьУсловиеВидимости",
                                                     "title": {
-                                                      "content": [
-                                                        {
-                                                          "default": {
-                                                            "tag": 2
-                                                          },
-                                                          "int": 1,
-                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                            "langKey": "ru",
-                                                            "value": "всегда"
-                                                          }
-                                                        }
-                                                      ]
+                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                                                     },
                                                     "dataPath": "",
                                                     "items": []
@@ -3362,10 +2921,10 @@
                                                   },
                                                   {
                                                     "type": "LABEL_DECORATION",
-                                                    "id": 194,
+                                                    "id": 667,
                                                     "name": "ЗадатьУсловиеДоступности",
                                                     "title": {
-                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                                                     },
                                                     "dataPath": "",
                                                     "items": []
@@ -3373,186 +2932,6 @@
                                                 ],
                                                 []
                                               ]
-                                            },
-                                            {
-                                              "type": "USUAL_GROUP",
-                                              "id": 467,
-                                              "name": "ГруппаЗаполнятьОбязательно",
-                                              "title": {
-                                                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[16]/synonym"
-                                              },
-                                              "dataPath": "",
-                                              "items": [
-                                                [
-                                                  {
-                                                    "type": "CHECK_BOX_FIELD",
-                                                    "id": 184,
-                                                    "name": "ЗаполнятьОбязательно",
-                                                    "title": {
-                                                      "content": [
-                                                        {
-                                                          "default": {
-                                                            "tag": 2
-                                                          },
-                                                          "int": 1,
-                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                            "langKey": "ru",
-                                                            "value": "Заполнять обязательно:"
-                                                          }
-                                                        }
-                                                      ]
-                                                    },
-                                                    "dataPath": "Объект.ЗаполнятьОбязательно",
-                                                    "items": []
-                                                  },
-                                                  {
-                                                    "type": "LABEL_DECORATION",
-                                                    "id": 197,
-                                                    "name": "ЗадатьУсловиеЗаполнения",
-                                                    "title": {
-                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                                                    },
-                                                    "dataPath": "",
-                                                    "items": []
-                                                  }
-                                                ],
-                                                []
-                                              ]
-                                            }
-                                          ],
-                                          []
-                                        ]
-                                      },
-                                      {
-                                        "type": "USUAL_GROUP",
-                                        "id": 107,
-                                        "name": "ОстальныеРеквизиты",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Остальные реквизиты"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "",
-                                        "items": [
-                                          [
-                                            {
-                                              "type": "USUAL_GROUP",
-                                              "id": 481,
-                                              "name": "ГруппаИдентификаторДляФормул",
-                                              "title": {
-                                                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[17]/synonym"
-                                              },
-                                              "dataPath": "",
-                                              "items": [
-                                                [
-                                                  {
-                                                    "type": "INPUT_FIELD",
-                                                    "id": 483,
-                                                    "name": "ИдентификаторДляФормул",
-                                                    "title": {
-                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                                    },
-                                                    "dataPath": "Объект.ИдентификаторДляФормул",
-                                                    "items": []
-                                                  },
-                                                  {
-                                                    "type": "USUAL_BUTTON",
-                                                    "id": 486,
-                                                    "name": "ЗаполнитьИдентификаторДляФормул",
-                                                    "title": {
-                                                      "content": [
-                                                        {
-                                                          "default": {
-                                                            "tag": 2
-                                                          },
-                                                          "int": 1,
-                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                            "langKey": "ru",
-                                                            "value": "Заполнить идентификатор для формул"
-                                                          }
-                                                        }
-                                                      ]
-                                                    },
-                                                    "dataPath": "",
-                                                    "items": []
-                                                  }
-                                                ],
-                                                []
-                                              ]
-                                            },
-                                            {
-                                              "type": "INPUT_FIELD",
-                                              "id": 30,
-                                              "name": "Подсказка",
-                                              "title": {
-                                                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                                              },
-                                              "dataPath": "Объект.Подсказка",
-                                              "items": []
-                                            },
-                                            {
-                                              "type": "USUAL_GROUP",
-                                              "id": 32,
-                                              "name": "ГруппаЗаголовкиФормЗначений",
-                                              "title": {
-                                                "content": [
-                                                  {
-                                                    "default": {
-                                                      "tag": 2
-                                                    },
-                                                    "int": 1,
-                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                      "langKey": "ru",
-                                                      "value": "Заголовки форм значений"
-                                                    }
-                                                  }
-                                                ]
-                                              },
-                                              "dataPath": "",
-                                              "items": [
-                                                [
-                                                  {
-                                                    "type": "INPUT_FIELD",
-                                                    "id": 33,
-                                                    "name": "ЗаголовокФормыЗначения",
-                                                    "title": {
-                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                                    },
-                                                    "dataPath": "Объект.ЗаголовокФормыЗначения",
-                                                    "items": []
-                                                  },
-                                                  {
-                                                    "type": "INPUT_FIELD",
-                                                    "id": 35,
-                                                    "name": "ЗаголовокФормыВыбораЗначения",
-                                                    "title": {
-                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                                    },
-                                                    "dataPath": "Объект.ЗаголовокФормыВыбораЗначения",
-                                                    "items": []
-                                                  }
-                                                ],
-                                                []
-                                              ]
-                                            },
-                                            {
-                                              "type": "INPUT_FIELD",
-                                              "id": 28,
-                                              "name": "Комментарий",
-                                              "title": {
-                                                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                              },
-                                              "dataPath": "Объект.Комментарий",
-                                              "items": []
                                             }
                                           ],
                                           []
@@ -3696,7 +3075,7 @@
                                                   "id": 57,
                                                   "name": "Значения",
                                                   "title": {
-                                                    "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                                    "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                                                   },
                                                   "dataPath": "Значения",
                                                   "items": [
@@ -3770,7 +3149,7 @@
                                                         "int": 1,
                                                         "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                                                           "langKey": "ru",
-                                                          "value": "Значения дополнительного реквизита"
+                                                          "value": "Значения дополнительных реквизитов"
                                                         }
                                                       }
                                                     ]
@@ -3876,7 +3255,7 @@
                                               "id": 105,
                                               "name": "УточнениеСпискаЗначенийИзменить",
                                               "title": {
-                                                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[6]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                                               },
                                               "dataPath": "",
                                               "items": []
@@ -3888,188 +3267,129 @@
                                     ],
                                     []
                                   ]
+                                },
+                                {
+                                  "type": "PAGE",
+                                  "id": 592,
+                                  "name": "СтраницаПрочее",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Прочее"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "INPUT_FIELD",
+                                        "id": 30,
+                                        "name": "Подсказка",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                        },
+                                        "dataPath": "Объект.Подсказка",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "USUAL_GROUP",
+                                        "id": 32,
+                                        "name": "ГруппаЗаголовкиФормЗначений",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Заголовки форм значений"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": [
+                                          [
+                                            {
+                                              "type": "INPUT_FIELD",
+                                              "id": 33,
+                                              "name": "ЗаголовокФормыЗначения",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                              },
+                                              "dataPath": "Объект.ЗаголовокФормыЗначения",
+                                              "items": []
+                                            },
+                                            {
+                                              "type": "INPUT_FIELD",
+                                              "id": 35,
+                                              "name": "ЗаголовокФормыВыбораЗначения",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                              },
+                                              "dataPath": "Объект.ЗаголовокФормыВыбораЗначения",
+                                              "items": []
+                                            }
+                                          ],
+                                          []
+                                        ]
+                                      },
+                                      {
+                                        "type": "INPUT_FIELD",
+                                        "id": 28,
+                                        "name": "Комментарий",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                        },
+                                        "dataPath": "Объект.Комментарий",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "INPUT_FIELD",
+                                        "id": 483,
+                                        "name": "ИдентификаторДляФормул",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                        },
+                                        "dataPath": "Объект.ИдентификаторДляФормул",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "INPUT_FIELD",
+                                        "id": 457,
+                                        "name": "Имя",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                        },
+                                        "dataPath": "Объект.Имя",
+                                        "items": []
+                                      }
+                                    ],
+                                    []
+                                  ]
                                 }
                               ],
                               []
                             ]
-                          },
-                          {
-                            "type": "USUAL_GROUP",
-                            "id": 455,
-                            "name": "ГруппаДляРазработчиков",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Для разработчиков"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": [
-                              {
-                                "type": "INPUT_FIELD",
-                                "id": 457,
-                                "name": "Имя",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                },
-                                "dataPath": "Объект.Имя",
-                                "items": []
-                              }
-                            ]
                           }
-                        ],
-                        []
-                      ]
-                    }
-                  ],
-                  []
-                ]
-              },
-              {
-                "type": "USUAL_GROUP",
-                "id": 227,
-                "name": "КоманднаяПанельПомощника",
-                "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Командная панель помощника"
+                        ]
                       }
-                    }
-                  ]
-                },
-                "dataPath": "",
-                "items": [
-                  [
-                    {
-                      "type": "COMMAND_BAR",
-                      "id": 229,
-                      "name": "КоманднаяПанельЛево",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Командная панель лево"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
-                        {
-                          "type": "COMMAND_BAR_BUTTON",
-                          "id": 233,
-                          "name": "КомандаНазад",
-                          "title": {
-                            "content": [
-                              {
-                                "default": {
-                                  "tag": 2
-                                },
-                                "int": 1,
-                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                  "langKey": "ru",
-                                  "value": "< Назад"
-                                }
-                              }
-                            ]
-                          },
-                          "dataPath": "",
-                          "items": []
-                        }
-                      ]
-                    },
-                    {
-                      "type": "COMMAND_BAR",
-                      "id": 231,
-                      "name": "КоманднаяПанельПраво",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Командная панель право"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "COMMAND_BAR_BUTTON",
-                            "id": 235,
-                            "name": "КомандаДалее",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Далее >"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "COMMAND_BAR_BUTTON",
-                            "id": 242,
-                            "name": "Закрыть",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Закрыть"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": []
-                          }
-                        ],
-                        []
-                      ]
-                    }
-                  ],
-                  []
-                ]
-              }
-            ],
-            []
+                    ]
+                  }
+                ],
+                []
+              ]
+            }
           ],
           "attributes": [
             [
@@ -4165,7 +3485,7 @@
                 "id": 9,
                 "name": "Значения",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                 },
                 "type": {
                   "types": [
@@ -4248,18 +3568,7 @@
                 "id": 16,
                 "name": "ЗначенияДополнительныхРеквизитов",
                 "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Значения дополнительных реквизитов"
-                      }
-                    }
-                  ]
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "types": [
@@ -4319,7 +3628,7 @@
                 "id": 21,
                 "name": "НаборыСвойств",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[6]/type"
@@ -4329,7 +3638,7 @@
                 "id": 22,
                 "name": "Свойства",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "types": [
@@ -4349,7 +3658,18 @@
                 "id": 23,
                 "name": "ОбщиеНаборыСвойств",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Общие наборы свойств"
+                      }
+                    }
+                  ]
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[6]/type"
@@ -4359,7 +3679,18 @@
                 "id": 24,
                 "name": "ПредставлениеРеквизита",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Представление реквизита"
+                      }
+                    }
+                  ]
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
@@ -4481,27 +3812,6 @@
                 "items": []
               },
               {
-                "type": "COMMAND_BAR",
-                "id": 14,
-                "name": "КоманднаяПанель",
-                "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Командная панель"
-                      }
-                    }
-                  ]
-                },
-                "dataPath": "",
-                "items": []
-              },
-              {
                 "type": "TABLE",
                 "id": 1,
                 "name": "Список",
@@ -4537,7 +3847,7 @@
                       "id": 6,
                       "name": "ТипЗначения",
                       "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                       },
                       "dataPath": "Список.ValueType",
                       "items": []
@@ -5088,8 +4398,8 @@
                               },
                               {
                                 "type": "LABEL_DECORATION",
-                                "id": 50,
-                                "name": "РеквизитПредупреждениеКомментарий",
+                                "id": 98,
+                                "name": "ДекорацияПредупреждение",
                                 "title": {
                                   "content": [
                                     {
@@ -5133,27 +4443,6 @@
                           "items": []
                         },
                         {
-                          "type": "LABEL_DECORATION",
-                          "id": 14,
-                          "name": "ОтдельныеЗначенияРеквизитаКомментарий",
-                          "title": {
-                            "content": [
-                              {
-                                "default": {
-                                  "tag": 2
-                                },
-                                "int": 1,
-                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                  "langKey": "ru",
-                                  "value": "Данный реквизит входит только в один набор %1, и у него свой собственный список значений."
-                                }
-                              }
-                            ]
-                          },
-                          "dataPath": "",
-                          "items": []
-                        },
-                        {
                           "type": "PAGES",
                           "id": 30,
                           "name": "ВидыРеквизита",
@@ -5194,51 +4483,27 @@
                                 },
                                 "dataPath": "",
                                 "items": [
-                                  [
-                                    {
-                                      "type": "RADIO_BUTTON_FIELD",
-                                      "id": 6,
-                                      "name": "ОбщиеЗначенияРеквизитов",
-                                      "title": {
-                                        "content": [
-                                          {
-                                            "default": {
-                                              "tag": 2
-                                            },
-                                            "int": 1,
-                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                              "langKey": "ru",
-                                              "value": "Отдельное свойство с общим списком значений"
-                                            }
+                                  {
+                                    "type": "RADIO_BUTTON_FIELD",
+                                    "id": 6,
+                                    "name": "ОбщиеЗначенияРеквизитов",
+                                    "title": {
+                                      "content": [
+                                        {
+                                          "default": {
+                                            "tag": 2
+                                          },
+                                          "int": 1,
+                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                            "langKey": "ru",
+                                            "value": "Отдельное свойство с общим списком значений"
                                           }
-                                        ]
-                                      },
-                                      "dataPath": "ОтдельноеСвойствоСОбщимСпискомЗначений",
-                                      "items": []
+                                        }
+                                      ]
                                     },
-                                    {
-                                      "type": "LABEL_DECORATION",
-                                      "id": 12,
-                                      "name": "ОбщиеЗначенияРеквизитовКомментарий",
-                                      "title": {
-                                        "content": [
-                                          {
-                                            "default": {
-                                              "tag": 2
-                                            },
-                                            "int": 1,
-                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                              "langKey": "ru",
-                                              "value": "У данного реквизита общий список значений с другими реквизитами, добавленными по образцу. С помощью этого варианта удобно выполнять централизованную настройку списка значений сразу для нескольких однотипных реквизитов (например, \"Цвет одежды\", \"Цвет обуви\" и пр.)."
-                                            }
-                                          }
-                                        ]
-                                      },
-                                      "dataPath": "",
-                                      "items": []
-                                    }
-                                  ],
-                                  []
+                                    "dataPath": "ОтдельноеСвойствоСОбщимСпискомЗначений",
+                                    "items": []
+                                  }
                                 ]
                               },
                               {
@@ -5261,51 +4526,27 @@
                                 },
                                 "dataPath": "",
                                 "items": [
-                                  [
-                                    {
-                                      "type": "RADIO_BUTTON_FIELD",
-                                      "id": 4,
-                                      "name": "ОбщийРеквизит",
-                                      "title": {
-                                        "content": [
-                                          {
-                                            "default": {
-                                              "tag": 2
-                                            },
-                                            "int": 1,
-                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                              "langKey": "ru",
-                                              "value": "Общее свойство"
-                                            }
+                                  {
+                                    "type": "RADIO_BUTTON_FIELD",
+                                    "id": 4,
+                                    "name": "ОбщийРеквизит",
+                                    "title": {
+                                      "content": [
+                                        {
+                                          "default": {
+                                            "tag": 2
+                                          },
+                                          "int": 1,
+                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                            "langKey": "ru",
+                                            "value": "Общее свойство"
                                           }
-                                        ]
-                                      },
-                                      "dataPath": "ОбщееСвойство",
-                                      "items": []
+                                        }
+                                      ]
                                     },
-                                    {
-                                      "type": "LABEL_DECORATION",
-                                      "id": 10,
-                                      "name": "ОбщийРеквизитКомментарий",
-                                      "title": {
-                                        "content": [
-                                          {
-                                            "default": {
-                                              "tag": 2
-                                            },
-                                            "int": 1,
-                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                              "langKey": "ru",
-                                              "value": "Данный реквизит входит сразу в несколько наборов. Этот вариант подходит для тех случаев, когда общим\nдолжен быть не только список значений, но и сам реквизит. В списках и отчетах по элементам различных\nсправочников и документов, общие реквизиты группируются и выводятся как один реквизит, в одной колонке или поле.\nНапример, с помощью общего реквизита \"Цвет\" можно быстро отобрать всю желтую одежду и обувь."
-                                            }
-                                          }
-                                        ]
-                                      },
-                                      "dataPath": "",
-                                      "items": []
-                                    }
-                                  ],
-                                  []
+                                    "dataPath": "ОбщееСвойство",
+                                    "items": []
+                                  }
                                 ]
                               }
                             ],
@@ -5357,51 +4598,27 @@
                           },
                           "dataPath": "",
                           "items": [
-                            [
-                              {
-                                "type": "PICTURE_DECORATION",
-                                "id": 56,
-                                "name": "СведениеПредупреждениеКартинка",
-                                "title": {
-                                  "content": [
-                                    {
-                                      "default": {
-                                        "tag": 2
-                                      },
-                                      "int": 1,
-                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                        "langKey": "ru",
-                                        "value": "Сведение предупреждение картинка"
-                                      }
+                            {
+                              "type": "PICTURE_DECORATION",
+                              "id": 56,
+                              "name": "СведениеПредупреждениеКартинка",
+                              "title": {
+                                "content": [
+                                  {
+                                    "default": {
+                                      "tag": 2
+                                    },
+                                    "int": 1,
+                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                      "langKey": "ru",
+                                      "value": "Сведение предупреждение картинка"
                                     }
-                                  ]
-                                },
-                                "dataPath": "",
-                                "items": []
+                                  }
+                                ]
                               },
-                              {
-                                "type": "LABEL_DECORATION",
-                                "id": 58,
-                                "name": "СведениеПредупреждениеКомментарий",
-                                "title": {
-                                  "content": [
-                                    {
-                                      "default": {
-                                        "tag": 2
-                                      },
-                                      "int": 1,
-                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                        "langKey": "ru",
-                                        "value": "Перенастройка дополнительного сведения необратима и может занять длительное время, в зависимости от числа документов, в которых заполнено это сведение.\nВместо этого можно добавить новое сведение со своим списком значений, и выполнить вручную постепенный переход от использования этого сведения к новому (очистить значения этого сведения и заполнить значения нового)."
-                                      }
-                                    }
-                                  ]
-                                },
-                                "dataPath": "",
-                                "items": []
-                              }
-                            ],
-                            []
+                              "dataPath": "",
+                              "items": []
+                            }
                           ]
                         },
                         {
@@ -5412,27 +4629,6 @@
                             "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                           },
                           "dataPath": "ОтдельноеСвойствоСОтдельнымСпискомЗначений",
-                          "items": []
-                        },
-                        {
-                          "type": "LABEL_DECORATION",
-                          "id": 28,
-                          "name": "ОтдельныеЗначенияСведенияКомментарий",
-                          "title": {
-                            "content": [
-                              {
-                                "default": {
-                                  "tag": 2
-                                },
-                                "int": 1,
-                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                  "langKey": "ru",
-                                  "value": "Данное сведение входит только в один набор %1, и у него свой собственный список значений."
-                                }
-                              }
-                            ]
-                          },
-                          "dataPath": "",
                           "items": []
                         },
                         {
@@ -5476,40 +4672,16 @@
                                 },
                                 "dataPath": "",
                                 "items": [
-                                  [
-                                    {
-                                      "type": "RADIO_BUTTON_FIELD",
-                                      "id": 22,
-                                      "name": "ОбщиеЗначенияСведений",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                      },
-                                      "dataPath": "ОтдельноеСвойствоСОбщимСпискомЗначений",
-                                      "items": []
+                                  {
+                                    "type": "RADIO_BUTTON_FIELD",
+                                    "id": 22,
+                                    "name": "ОбщиеЗначенияСведений",
+                                    "title": {
+                                      "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                                     },
-                                    {
-                                      "type": "LABEL_DECORATION",
-                                      "id": 24,
-                                      "name": "ОбщиеЗначенияСведенийКомментарий",
-                                      "title": {
-                                        "content": [
-                                          {
-                                            "default": {
-                                              "tag": 2
-                                            },
-                                            "int": 1,
-                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                              "langKey": "ru",
-                                              "value": "У этого сведения общий список значений с другими сведениями, добавленными по образцу. С помощью этого варианта удобно выполнять централизованную настройку списка значений сразу для нескольких однотипных сведений (например, \"Цвет одежды\", \"Цвет обуви\" и пр.)."
-                                            }
-                                          }
-                                        ]
-                                      },
-                                      "dataPath": "",
-                                      "items": []
-                                    }
-                                  ],
-                                  []
+                                    "dataPath": "ОтдельноеСвойствоСОбщимСпискомЗначений",
+                                    "items": []
+                                  }
                                 ]
                               },
                               {
@@ -5532,40 +4704,16 @@
                                 },
                                 "dataPath": "",
                                 "items": [
-                                  [
-                                    {
-                                      "type": "RADIO_BUTTON_FIELD",
-                                      "id": 18,
-                                      "name": "ОбщееСведение",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                      },
-                                      "dataPath": "ОбщееСвойство",
-                                      "items": []
+                                  {
+                                    "type": "RADIO_BUTTON_FIELD",
+                                    "id": 18,
+                                    "name": "ОбщееСведение",
+                                    "title": {
+                                      "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                                     },
-                                    {
-                                      "type": "LABEL_DECORATION",
-                                      "id": 20,
-                                      "name": "ОбщееСведениеКомментарий",
-                                      "title": {
-                                        "content": [
-                                          {
-                                            "default": {
-                                              "tag": 2
-                                            },
-                                            "int": 1,
-                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                              "langKey": "ru",
-                                              "value": "Данное сведение входит сразу в несколько наборов. Этот вариант подходит для тех случаев, когда общим\nдолжен быть не только список значений, но и само сведение. В списках и отчетах по элементам различных\nсправочников и документов, общие сведения группируются и выводятся как одно сведение, в одной колонке или поле.\nНапример, с помощью общего сведения \"Цвет\" можно быстро отобрать всю желтую одежду и обувь."
-                                            }
-                                          }
-                                        ]
-                                      },
-                                      "dataPath": "",
-                                      "items": []
-                                    }
-                                  ],
-                                  []
+                                    "dataPath": "ОбщееСвойство",
+                                    "items": []
+                                  }
                                 ]
                               }
                             ],
@@ -5587,7 +4735,7 @@
                 "id": 1,
                 "name": "ОбщееСвойство",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "types": [
@@ -5620,7 +4768,7 @@
                 "id": 2,
                 "name": "ОтдельноеСвойствоСОбщимСпискомЗначений",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
@@ -5761,7 +4909,7 @@
                     "id": 18,
                     "name": "ЗависимостиРеквизитовРеквизит",
                     "title": {
-                      "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                     },
                     "dataPath": "ЗависимостиРеквизитов.Представление",
                     "items": []
@@ -5912,7 +5060,7 @@
         "objectBelonging": "OWN",
         "comment": "",
         "synonym": {
-          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
         },
         "supportVariant": "NOT_EDITABLE",
         "modules": [
@@ -5930,7 +5078,7 @@
         "data": {
           "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
           "title": {
-            "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+            "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
           },
           "handlers": [
             {
@@ -5963,7 +5111,7 @@
                   "id": 14,
                   "name": "РеквизитыОбъектаПредставление",
                   "title": {
-                    "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                    "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                   },
                   "dataPath": "РеквизитыОбъекта.Представление",
                   "items": []
@@ -6292,7 +5440,7 @@
               "objectBelonging": "OWN",
               "comment": "",
               "synonym": {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
               },
               "supportVariant": "NOT_EDITABLE",
               "owner": {
@@ -6652,7 +5800,7 @@
               "objectBelonging": "OWN",
               "comment": "",
               "synonym": {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
               },
               "supportVariant": "NOT_EDITABLE",
               "owner": {

--- a/src/test/resources/fixtures/ssl_3_2/ChartsOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.json
+++ b/src/test/resources/fixtures/ssl_3_2/ChartsOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.json
@@ -1,0 +1,6796 @@
+{"com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes": {
+  "attributes": [
+    [
+      {
+        "uuid": "1055d15b-8cb5-4ff0-a526-7fd20a08a96c",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.StandardAttribute.PredefinedDataName",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.СтандартныйРеквизит.ИмяПредопределенныхДанных"
+        },
+        "comment": "",
+        "synonym": {
+          "content": []
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "type": "CHART_OF_CHARACTERISTIC_TYPES",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                "length": 0,
+                "allowedLength": 0,
+                "description": {
+                  "value": {
+                    "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                    "nameRu": "КвалификаторыСтроки (0, Переменная)",
+                    "nameEn": "StringQualifiers (0, Variable)"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "ИмяПредопределенныхДанных",
+          "nameEn": "PredefinedDataName"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "1055d15b-8cb5-4ff0-a526-7fd20a08a96c",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.StandardAttribute.ValueType",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.СтандартныйРеквизит.ТипЗначения"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 7,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "BOOLEAN",
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "СправочникСсылка.ЗначенияСвойствОбъектов",
+                  "nameEn": "CatalogRef.ЗначенияСвойствОбъектов"
+                },
+                "variant": "METADATA",
+                "kind": "CATALOG"
+              },
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "СправочникСсылка.ЗначенияСвойствОбъектовИерархия",
+                  "nameEn": "CatalogRef.ЗначенияСвойствОбъектовИерархия"
+                },
+                "variant": "METADATA",
+                "kind": "CATALOG"
+              },
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "СправочникСсылка.Пользователи",
+                  "nameEn": "CatalogRef.Пользователи"
+                },
+                "variant": "METADATA",
+                "kind": "CATALOG"
+              },
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "DATE",
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER",
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+            }
+          ],
+          "composite": true,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 3,
+              "com.github._1c_syntax.bsl.types.qualifiers.DateQualifiers": {
+                "dateFractions": 2,
+                "description": {
+                  "value": {
+                    "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                    "nameRu": "КвалификаторыДаты (ДатаВремя)",
+                    "nameEn": "DateQualifiers (DateTime)"
+                  }
+                }
+              },
+              "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                "length": 1024,
+                "allowedLength": 0,
+                "description": {
+                  "value": {
+                    "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                    "nameRu": "КвалификаторыСтроки (1024, Переменная)",
+                    "nameEn": "StringQualifiers (1024, Variable)"
+                  }
+                }
+              },
+              "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                "precision": 17,
+                "scale": 5,
+                "nonNegative": false,
+                "description": {
+                  "value": {
+                    "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                    "nameRu": "КвалификаторыЧисла (17.5)",
+                    "nameEn": "NumberQualifiers (17.5)"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "ТипЗначения",
+          "nameEn": "ValueType"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "1055d15b-8cb5-4ff0-a526-7fd20a08a96c",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.StandardAttribute.Description",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.СтандартныйРеквизит.Наименование"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                "length": 150,
+                "allowedLength": 0,
+                "description": {}
+              }
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "Наименование",
+          "nameEn": "Description"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "1055d15b-8cb5-4ff0-a526-7fd20a08a96c",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.StandardAttribute.Code",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.СтандартныйРеквизит.Код"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                "precision": 0,
+                "scale": 0,
+                "nonNegative": false,
+                "description": {}
+              }
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "Код",
+          "nameEn": "Code"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "1055d15b-8cb5-4ff0-a526-7fd20a08a96c",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.StandardAttribute.IsFolder",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.СтандартныйРеквизит.ЭтоГруппа"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "BOOLEAN"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 0
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "ЭтоГруппа",
+          "nameEn": "IsFolder"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "1055d15b-8cb5-4ff0-a526-7fd20a08a96c",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.StandardAttribute.Parent",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.СтандартныйРеквизит.Родитель"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "ПланВидовХарактеристикСсылка.ДополнительныеРеквизитыИСведения",
+                  "nameEn": "ChartOfCharacteristicTypesRef.ДополнительныеРеквизитыИСведения"
+                },
+                "variant": "METADATA",
+                "kind": "CHART_OF_CHARACTERISTIC_TYPES"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "fullName": {
+          "nameRu": "Родитель",
+          "nameEn": "Parent"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": true
+      },
+      {
+        "uuid": "1055d15b-8cb5-4ff0-a526-7fd20a08a96c",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.StandardAttribute.Predefined",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.СтандартныйРеквизит.Предопределенный"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[5]/type"
+        },
+        "fullName": {
+          "nameRu": "Предопределенный",
+          "nameEn": "Predefined"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "1055d15b-8cb5-4ff0-a526-7fd20a08a96c",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.StandardAttribute.DeletionMark",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.СтандартныйРеквизит.ПометкаУдаления"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[5]/type"
+        },
+        "fullName": {
+          "nameRu": "ПометкаУдаления",
+          "nameEn": "DeletionMark"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "1055d15b-8cb5-4ff0-a526-7fd20a08a96c",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.StandardAttribute.Ref",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.СтандартныйРеквизит.Ссылка"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[6]/type"
+        },
+        "fullName": {
+          "nameRu": "Ссылка",
+          "nameEn": "Ref"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "8064eb3a-d56c-4517-9db0-b7300149c7c4",
+        "name": "Виден",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.Виден",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.Виден"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Виден"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[5]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "fe926c88-d792-4db3-abcf-3c94dfdcc407",
+        "name": "ВладелецДополнительныхЗначений",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.ВладелецДополнительныхЗначений",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.ВладелецДополнительныхЗначений"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Владелец дополнительных значений"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[6]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "b1c3a6c1-5245-4a65-8a45-13948be6f6a1",
+        "name": "ВыводитьВВидеГиперссылки",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.ВыводитьВВидеГиперссылки",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.ВыводитьВВидеГиперссылки"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Выводить в виде гиперссылки"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[5]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "bcbdba9e-0b29-4ea7-a7d5-1de819bf86ec",
+        "name": "ДополнительныеЗначенияИспользуются",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.ДополнительныеЗначенияИспользуются",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.ДополнительныеЗначенияИспользуются"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Дополнительные значения используются"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[5]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "e0c51555-1614-4aa7-a075-c5e1251579ba",
+        "name": "ДополнительныеЗначенияСВесом",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.ДополнительныеЗначенияСВесом",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.ДополнительныеЗначенияСВесом"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Значения дополнительно характеризуются весовым коэффициентом"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[5]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "c75a1c6d-fa33-4b57-b359-6253aff5f3e7",
+        "name": "Доступен",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.Доступен",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.Доступен"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Доступен"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[5]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "af88ea84-5742-4c9f-9a02-6d0f25186f72",
+        "name": "Заголовок",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.Заголовок",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.Заголовок"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Наименование"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                "length": 75,
+                "allowedLength": 0,
+                "description": {}
+              }
+            }
+          ]
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "51363236-c8eb-4eb7-9692-5c18edc9a5a8",
+        "name": "ЗаголовокФормыВыбораЗначения",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.ЗаголовокФормыВыбораЗначения",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.ЗаголовокФормыВыбораЗначения"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Заголовок формы выбора значения"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[3]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "e97edb4a-468d-499d-924d-aa4e5ee16548",
+        "name": "ЗаголовокФормыВыбораЗначенияЯзык1",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.ЗаголовокФормыВыбораЗначенияЯзык1",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.ЗаголовокФормыВыбораЗначенияЯзык1"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Заголовок формы выбора значения язык (дополнительный язык)"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[3]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "24366a86-0dae-4a68-a180-d8ea7656a286",
+        "name": "ЗаголовокФормыВыбораЗначенияЯзык2",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.ЗаголовокФормыВыбораЗначенияЯзык2",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.ЗаголовокФормыВыбораЗначенияЯзык2"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Заголовок формы выбора значения язык (дополнительный язык 2)"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[3]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "cb65fbad-69a0-47d8-b4a9-da49274c3eb7",
+        "name": "ЗаголовокФормыЗначения",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.ЗаголовокФормыЗначения",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.ЗаголовокФормыЗначения"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Заголовок формы значения"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[3]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "3c03f78e-c904-47da-a0a1-db5d6b9f7254",
+        "name": "ЗаголовокФормыЗначенияЯзык1",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.ЗаголовокФормыЗначенияЯзык1",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.ЗаголовокФормыЗначенияЯзык1"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Заголовок формы значения язык (дополнительный язык)"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[3]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "3bf03ed7-6581-4a11-8fc8-748f46c8dad7",
+        "name": "ЗаголовокФормыЗначенияЯзык2",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.ЗаголовокФормыЗначенияЯзык2",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.ЗаголовокФормыЗначенияЯзык2"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Заголовок формы значения язык (дополнительный язык 2)"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[3]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "0f28c616-162c-4dba-bd22-f7ea5d23ea5a",
+        "name": "ЗаголовокЯзык1",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.ЗаголовокЯзык1",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.ЗаголовокЯзык1"
+        },
+        "objectBelonging": "OWN",
+        "comment": "АПК:58",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Наименование  (дополнительный язык)"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[7]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "39bf2771-1d8b-44bb-8d8b-54d046589ebe",
+        "name": "ЗаголовокЯзык2",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.ЗаголовокЯзык2",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.ЗаголовокЯзык2"
+        },
+        "objectBelonging": "OWN",
+        "comment": "АПК:58",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Наименование (дополнительный язык 2)"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[7]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "872521e3-413c-45ac-a6ea-39fe1324bae8",
+        "name": "ЗаполнятьОбязательно",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.ЗаполнятьОбязательно",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.ЗаполнятьОбязательно"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Заполнять обязательно"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[5]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "f237a21e-066a-48e6-a5c4-5dc2487c7a3b",
+        "name": "ИдентификаторДляФормул",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.ИдентификаторДляФормул",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.ИдентификаторДляФормул"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Идентификатор для формул"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[3]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "8adebe50-a946-40c2-9258-b17efe787e0e",
+        "name": "Имя",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.Имя",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.Имя"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Имя"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                "length": 100,
+                "allowedLength": 0,
+                "description": {}
+              }
+            }
+          ]
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "8cad6cfd-91d0-4563-800a-d60c8a1b6a03",
+        "name": "Комментарий",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.Комментарий",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.Комментарий"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Комментарий"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "81ef02df-498d-4af0-8254-dc6730cbf140",
+        "name": "МногострочноеПолеВвода",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.МногострочноеПолеВвода",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.МногострочноеПолеВвода"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Многострочное поле ввода"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                "precision": 2,
+                "scale": 0,
+                "nonNegative": true,
+                "description": {}
+              }
+            }
+          ]
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "79ad09ba-875a-46bd-9cd9-9d084bf4f6ea",
+        "name": "НаборСвойств",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.НаборСвойств",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.НаборСвойств"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Набор свойств"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "СправочникСсылка.НаборыДополнительныхРеквизитовИСведений",
+                  "nameEn": "CatalogRef.НаборыДополнительныхРеквизитовИСведений"
+                },
+                "variant": "METADATA",
+                "kind": "CATALOG"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "2902460a-ed86-41cf-8e8f-895adab9a72f",
+        "name": "Подсказка",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.Подсказка",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.Подсказка"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Подсказка"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "d12c7296-36ab-41e0-83ef-143484958597",
+        "name": "ПодсказкаЯзык1",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.ПодсказкаЯзык1",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.ПодсказкаЯзык1"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Подсказка язык (дополнительный язык)"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "2b6c3bcd-7d2a-4e95-8066-99374002689b",
+        "name": "ПодсказкаЯзык2",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.ПодсказкаЯзык2",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.ПодсказкаЯзык2"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Подсказка язык (дополнительный язык 2)"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "402f2fe0-4d08-4701-9c8f-0c2bb75815ef",
+        "name": "ФорматСвойства",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.ФорматСвойства",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.ФорматСвойства"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Формат свойства"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "1a4ed7cf-3294-4a5c-9650-75b61d6b2531",
+        "name": "ЭтоДополнительноеСведение",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.ЭтоДополнительноеСведение",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.ЭтоДополнительноеСведение"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Это дополнительное сведение"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[5]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "73cc5b8b-4cba-4988-b2c6-d974dde9723d",
+        "name": "ВидСвойства",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.ВидСвойства",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.ВидСвойства"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Вид свойства"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "ПеречислениеСсылка.ВидыСвойств",
+                  "nameEn": "EnumRef.ВидыСвойств"
+                },
+                "variant": "METADATA",
+                "kind": "ENUM"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "1b9bbdb1-b8c0-4459-8b5c-656055482f00",
+        "name": "ЦветСвойства",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.ЦветСвойства",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.ЦветСвойства"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Цвет свойства"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "ПеречислениеСсылка.ЦветаСвойств",
+                  "nameEn": "EnumRef.ЦветаСвойств"
+                },
+                "variant": "METADATA",
+                "kind": "ENUM"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      }
+    ],
+    []
+  ],
+  "checkUnique": false,
+  "codeSeries": "WHOLE_CATALOG",
+  "commands": [],
+  "comment": "",
+  "description": "Дополнительные реквизиты и сведения",
+  "explanation": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+  },
+  "forms": [
+    [
+      {
+        "uuid": "f82d5bd6-4c74-4c23-978c-565aae3d752a",
+        "name": "ФормаЭлемента",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Form.ФормаЭлемента",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Форма.ФормаЭлемента"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Форма элемента"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/ChartsOfCharacteristicTypes/ДополнительныеРеквизитыИСведения/Forms/ФормаЭлемента/Ext/Form/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+          },
+          "handlers": [
+            [
+              {
+                "event": "AfterWrite",
+                "name": "ПослеЗаписи"
+              },
+              {
+                "event": "ChoiceProcessing",
+                "name": "ОбработкаВыбора"
+              },
+              {
+                "event": "AfterWriteAtServer",
+                "name": "ПослеЗаписиНаСервере"
+              },
+              {
+                "event": "NotificationProcessing",
+                "name": "ОбработкаОповещения"
+              },
+              {
+                "event": "OnReadAtServer",
+                "name": "ПриЧтенииНаСервере"
+              },
+              {
+                "event": "OnOpen",
+                "name": "ПриОткрытии"
+              },
+              {
+                "event": "BeforeWrite",
+                "name": "ПередЗаписью"
+              },
+              {
+                "event": "OnCreateAtServer",
+                "name": "ПриСозданииНаСервере"
+              },
+              {
+                "event": "BeforeWriteAtServer",
+                "name": "ПередЗаписьюНаСервере"
+              },
+              {
+                "event": "OnWriteAtServer",
+                "name": "ПриЗаписиНаСервере"
+              }
+            ],
+            []
+          ],
+          "items": [
+            [
+              {
+                "type": "PAGES",
+                "id": 200,
+                "name": "СтраницыПомощникКарточка",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Страницы помощник карточка"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "PAGE",
+                      "id": 202,
+                      "name": "ВыборРеквизита",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Выбор реквизита"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 336,
+                            "name": "ГруппаЗаголовок",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Заголовок"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "LABEL_DECORATION",
+                                  "id": 338,
+                                  "name": "ДекорацияЗаголовок",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Выберите %1 для включения в набор \"%2\":"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "COMMAND_BAR",
+                                  "id": 408,
+                                  "name": "ПанельЕще",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Панель еще"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    {
+                                      "type": "POPUP",
+                                      "id": 410,
+                                      "name": "ПодменюЕще",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Еще"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        {
+                                          "type": "COMMAND_BAR_BUTTON",
+                                          "id": 412,
+                                          "name": "НеиспользуемыеРеквизиты",
+                                          "title": {
+                                            "content": [
+                                              {
+                                                "default": {
+                                                  "tag": 2
+                                                },
+                                                "int": 1,
+                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                  "langKey": "ru",
+                                                  "value": "Неиспользуемые реквизиты"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "dataPath": "",
+                                          "items": []
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ],
+                              []
+                            ]
+                          },
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 341,
+                            "name": "ГруппаСодержимое",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Содержимое"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "USUAL_GROUP",
+                                  "id": 343,
+                                  "name": "ГруппаНаборыСвойств",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Наборы свойств"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    {
+                                      "type": "PAGES",
+                                      "id": 414,
+                                      "name": "СтраницыНаборыСвойств",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Страницы наборы свойств"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        [
+                                          {
+                                            "type": "PAGE",
+                                            "id": 416,
+                                            "name": "СтраницаВсеНаборы",
+                                            "title": {
+                                              "content": [
+                                                {
+                                                  "default": {
+                                                    "tag": 2
+                                                  },
+                                                  "int": 1,
+                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                    "langKey": "ru",
+                                                    "value": "Страница все наборы"
+                                                  }
+                                                }
+                                              ]
+                                            },
+                                            "dataPath": "",
+                                            "items": [
+                                              {
+                                                "type": "TABLE",
+                                                "id": 345,
+                                                "name": "НаборыСвойств",
+                                                "title": {
+                                                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                                },
+                                                "dataPath": "НаборыСвойств",
+                                                "items": [
+                                                  [
+                                                    {
+                                                      "type": "LABEL_FIELD",
+                                                      "id": 396,
+                                                      "name": "Представление",
+                                                      "title": {
+                                                        "content": [
+                                                          {
+                                                            "default": {
+                                                              "tag": 2
+                                                            },
+                                                            "int": 1,
+                                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                              "langKey": "ru",
+                                                              "value": "Представление набора"
+                                                            }
+                                                          }
+                                                        ]
+                                                      },
+                                                      "dataPath": "НаборыСвойств.Представление",
+                                                      "items": []
+                                                    },
+                                                    {
+                                                      "type": "LABEL_FIELD",
+                                                      "id": 399,
+                                                      "name": "Ссылка",
+                                                      "title": {
+                                                        "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                                      },
+                                                      "dataPath": "НаборыСвойств.Ссылка",
+                                                      "items": []
+                                                    }
+                                                  ],
+                                                  []
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "PAGE",
+                                            "id": 418,
+                                            "name": "СтраницаОбщиеНаборы",
+                                            "title": {
+                                              "content": [
+                                                {
+                                                  "default": {
+                                                    "tag": 2
+                                                  },
+                                                  "int": 1,
+                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                    "langKey": "ru",
+                                                    "value": "Страница общие наборы"
+                                                  }
+                                                }
+                                              ]
+                                            },
+                                            "dataPath": "",
+                                            "items": [
+                                              {
+                                                "type": "TABLE",
+                                                "id": 420,
+                                                "name": "ОбщиеНаборыСвойств",
+                                                "title": {
+                                                  "content": [
+                                                    {
+                                                      "default": {
+                                                        "tag": 2
+                                                      },
+                                                      "int": 1,
+                                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                        "langKey": "ru",
+                                                        "value": "Общие наборы свойств"
+                                                      }
+                                                    }
+                                                  ]
+                                                },
+                                                "dataPath": "ОбщиеНаборыСвойств",
+                                                "items": [
+                                                  {
+                                                    "type": "LABEL_FIELD",
+                                                    "id": 436,
+                                                    "name": "ОбщиеНаборыСвойствПредставление",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "Представление"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "ОбщиеНаборыСвойств.Представление",
+                                                    "items": []
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ],
+                                        []
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "USUAL_GROUP",
+                                  "id": 364,
+                                  "name": "РасшифровкаРеквизита",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Дополнительные реквизиты"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "TABLE",
+                                        "id": 366,
+                                        "name": "Свойства",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Свойства"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "Свойства",
+                                        "items": [
+                                          {
+                                            "type": "INPUT_FIELD",
+                                            "id": 379,
+                                            "name": "СвойстваЗаголовок",
+                                            "title": {
+                                              "content": [
+                                                {
+                                                  "default": {
+                                                    "tag": 2
+                                                  },
+                                                  "int": 1,
+                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                    "langKey": "ru",
+                                                    "value": "Реквизит"
+                                                  }
+                                                }
+                                              ]
+                                            },
+                                            "dataPath": "Свойства.Заголовок",
+                                            "items": []
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "USUAL_GROUP",
+                                        "id": 469,
+                                        "name": "ГруппаДополнительнаяИнформация",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Дополнительная информация"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": [
+                                          [
+                                            {
+                                              "type": "INPUT_FIELD",
+                                              "id": 384,
+                                              "name": "СписокДополнительныхРеквизитовТипЗначения",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                              },
+                                              "dataPath": "Items.Свойства.CurrentData.ТипЗначения",
+                                              "items": []
+                                            },
+                                            {
+                                              "type": "INPUT_FIELD",
+                                              "id": 387,
+                                              "name": "СписокДополнительныхРеквизитовПодсказка",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Всплывающая подсказка"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "Items.Свойства.CurrentData.Подсказка",
+                                              "items": []
+                                            },
+                                            {
+                                              "type": "INPUT_FIELD",
+                                              "id": 390,
+                                              "name": "СписокДополнительныхРеквизитовЗаголовокФормыЗначения",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                              },
+                                              "dataPath": "Items.Свойства.CurrentData.ЗаголовокФормыЗначения",
+                                              "items": []
+                                            },
+                                            {
+                                              "type": "INPUT_FIELD",
+                                              "id": 393,
+                                              "name": "СписокДополнительныхРеквизитовЗаголовокФормыВыбораЗначения",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                              },
+                                              "dataPath": "Items.Свойства.CurrentData.ЗаголовокФормыВыбораЗначения",
+                                              "items": []
+                                            }
+                                          ],
+                                          []
+                                        ]
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                }
+                              ],
+                              []
+                            ]
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "PAGE",
+                      "id": 204,
+                      "name": "ВыборДействия",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Выбор действия"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        {
+                          "type": "RADIO_BUTTON_FIELD",
+                          "id": 237,
+                          "name": "РежимДобавленияРеквизита",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Выберите вариант добавления дополнительного %1 \"%2\" в набор \"%3\""
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "РежимДобавленияРеквизита",
+                          "items": []
+                        }
+                      ]
+                    },
+                    {
+                      "type": "PAGE",
+                      "id": 206,
+                      "name": "КарточкаРеквизита",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Карточка реквизита"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 79,
+                            "name": "ГруппаНаименованиеРеквизита",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Наименование реквизита"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 1,
+                                  "name": "Заголовок",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[7]/synonym"
+                                  },
+                                  "dataPath": "Объект.Заголовок",
+                                  "items": []
+                                },
+                                {
+                                  "type": "RADIO_BUTTON_FIELD",
+                                  "id": 20,
+                                  "name": "ВидСвойства",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[27]/synonym"
+                                  },
+                                  "dataPath": "ВидСвойства",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          },
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 43,
+                            "name": "ТипЗначенияРеквизита",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Тип значения реквизита"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "USUAL_GROUP",
+                                  "id": 471,
+                                  "name": "ГруппаТипЗначения",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Тип значения"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "INPUT_FIELD",
+                                        "id": 5,
+                                        "name": "ТипЗначения",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                        },
+                                        "dataPath": "Объект.ValueType",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "HYPERLINK",
+                                        "id": 37,
+                                        "name": "РедактироватьФорматЗначения",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Формат"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                },
+                                {
+                                  "type": "USUAL_GROUP",
+                                  "id": 476,
+                                  "name": "ГруппаПояснениеТипаЗначения",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Пояснение типа значения"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "PICTURE_DECORATION",
+                                        "id": 478,
+                                        "name": "КартинкаПояснение",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "LABEL_DECORATION",
+                                        "id": 473,
+                                        "name": "ПояснениеОДлинеСтроки",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Максимальная длина строки составляет 1024 символа"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                }
+                              ],
+                              []
+                            ]
+                          },
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 38,
+                            "name": "ГруппаМногострочность",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Многострочность"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "USUAL_GROUP",
+                                  "id": 448,
+                                  "name": "ГруппаОднострочноеПолеВводаНастройки",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Однострочное поле ввода настройки"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "RADIO_BUTTON_FIELD",
+                                        "id": 442,
+                                        "name": "ОднострочныйВид",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Представление реквизита"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "ПредставлениеРеквизита",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "CHECK_BOX_FIELD",
+                                        "id": 445,
+                                        "name": "ВыводитьВВидеГиперссылки",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                        },
+                                        "dataPath": "Объект.ВыводитьВВидеГиперссылки",
+                                        "items": []
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                },
+                                {
+                                  "type": "USUAL_GROUP",
+                                  "id": 46,
+                                  "name": "ГруппаМногострочноеПолеВводаНастройки",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Многострочное поле ввода настройки"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "RADIO_BUTTON_FIELD",
+                                        "id": 450,
+                                        "name": "МногострочныйВид",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                        },
+                                        "dataPath": "ПредставлениеРеквизита",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "INPUT_FIELD",
+                                        "id": 41,
+                                        "name": "МногострочноеПолеВводаЧисло",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "  строк"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "МногострочноеПолеВводаЧисло",
+                                        "items": []
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                }
+                              ],
+                              []
+                            ]
+                          },
+                          {
+                            "type": "PAGES",
+                            "id": 167,
+                            "name": "Страницы",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Страницы"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "PAGE",
+                                  "id": 169,
+                                  "name": "ГлавнаяСтраница",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Главное"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "USUAL_GROUP",
+                                        "id": 498,
+                                        "name": "ГруппаЦветаСвойств",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Цвета свойств"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": [
+                                          [
+                                            {
+                                              "type": "LABEL_DECORATION",
+                                              "id": 500,
+                                              "name": "ДекорацияЦветСвойства",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Цвет:"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "",
+                                              "items": []
+                                            },
+                                            {
+                                              "type": "COMMAND_BAR",
+                                              "id": 503,
+                                              "name": "КоманднаяПанельЦветаСвойств",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Командная панель цвета свойств"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "",
+                                              "items": [
+                                                {
+                                                  "type": "BUTTON_GROUP",
+                                                  "id": 505,
+                                                  "name": "ГруппаЦвета",
+                                                  "title": {
+                                                    "content": [
+                                                      {
+                                                        "default": {
+                                                          "tag": 2
+                                                        },
+                                                        "int": 1,
+                                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                          "langKey": "ru",
+                                                          "value": "Цвета"
+                                                        }
+                                                      }
+                                                    ]
+                                                  },
+                                                  "dataPath": "",
+                                                  "items": [
+                                                    [
+                                                      {
+                                                        "type": "COMMAND_BAR_BUTTON",
+                                                        "id": 507,
+                                                        "name": "СвойствоСерое",
+                                                        "title": {
+                                                          "content": [
+                                                            {
+                                                              "default": {
+                                                                "tag": 2
+                                                              },
+                                                              "int": 1,
+                                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                "langKey": "ru",
+                                                                "value": "Свойство серое"
+                                                              }
+                                                            }
+                                                          ]
+                                                        },
+                                                        "dataPath": "",
+                                                        "items": []
+                                                      },
+                                                      {
+                                                        "type": "COMMAND_BAR_BUTTON",
+                                                        "id": 517,
+                                                        "name": "СвойствоЗеленое",
+                                                        "title": {
+                                                          "content": [
+                                                            {
+                                                              "default": {
+                                                                "tag": 2
+                                                              },
+                                                              "int": 1,
+                                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                "langKey": "ru",
+                                                                "value": "Свойство зеленое"
+                                                              }
+                                                            }
+                                                          ]
+                                                        },
+                                                        "dataPath": "",
+                                                        "items": []
+                                                      },
+                                                      {
+                                                        "type": "COMMAND_BAR_BUTTON",
+                                                        "id": 515,
+                                                        "name": "СвойствоЖелтое",
+                                                        "title": {
+                                                          "content": [
+                                                            {
+                                                              "default": {
+                                                                "tag": 2
+                                                              },
+                                                              "int": 1,
+                                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                "langKey": "ru",
+                                                                "value": "Свойство желтое"
+                                                              }
+                                                            }
+                                                          ]
+                                                        },
+                                                        "dataPath": "",
+                                                        "items": []
+                                                      },
+                                                      {
+                                                        "type": "COMMAND_BAR_BUTTON",
+                                                        "id": 513,
+                                                        "name": "СвойствоОранжевое",
+                                                        "title": {
+                                                          "content": [
+                                                            {
+                                                              "default": {
+                                                                "tag": 2
+                                                              },
+                                                              "int": 1,
+                                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                "langKey": "ru",
+                                                                "value": "Свойство оранжевое"
+                                                              }
+                                                            }
+                                                          ]
+                                                        },
+                                                        "dataPath": "",
+                                                        "items": []
+                                                      },
+                                                      {
+                                                        "type": "COMMAND_BAR_BUTTON",
+                                                        "id": 511,
+                                                        "name": "СвойствоКрасное",
+                                                        "title": {
+                                                          "content": [
+                                                            {
+                                                              "default": {
+                                                                "tag": 2
+                                                              },
+                                                              "int": 1,
+                                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                "langKey": "ru",
+                                                                "value": "Свойство красное"
+                                                              }
+                                                            }
+                                                          ]
+                                                        },
+                                                        "dataPath": "",
+                                                        "items": []
+                                                      },
+                                                      {
+                                                        "type": "COMMAND_BAR_BUTTON",
+                                                        "id": 523,
+                                                        "name": "СвойствоФиолетовое",
+                                                        "title": {
+                                                          "content": [
+                                                            {
+                                                              "default": {
+                                                                "tag": 2
+                                                              },
+                                                              "int": 1,
+                                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                "langKey": "ru",
+                                                                "value": "Свойство фиолетовое"
+                                                              }
+                                                            }
+                                                          ]
+                                                        },
+                                                        "dataPath": "",
+                                                        "items": []
+                                                      },
+                                                      {
+                                                        "type": "COMMAND_BAR_BUTTON",
+                                                        "id": 519,
+                                                        "name": "СвойствоСинее",
+                                                        "title": {
+                                                          "content": [
+                                                            {
+                                                              "default": {
+                                                                "tag": 2
+                                                              },
+                                                              "int": 1,
+                                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                "langKey": "ru",
+                                                                "value": "Свойство синее"
+                                                              }
+                                                            }
+                                                          ]
+                                                        },
+                                                        "dataPath": "",
+                                                        "items": []
+                                                      },
+                                                      {
+                                                        "type": "COMMAND_BAR_BUTTON",
+                                                        "id": 509,
+                                                        "name": "СвойствоЛаймовое",
+                                                        "title": {
+                                                          "content": [
+                                                            {
+                                                              "default": {
+                                                                "tag": 2
+                                                              },
+                                                              "int": 1,
+                                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                "langKey": "ru",
+                                                                "value": "Свойство лаймовое"
+                                                              }
+                                                            }
+                                                          ]
+                                                        },
+                                                        "dataPath": "",
+                                                        "items": []
+                                                      },
+                                                      {
+                                                        "type": "COMMAND_BAR_BUTTON",
+                                                        "id": 525,
+                                                        "name": "СвойствоРозовое",
+                                                        "title": {
+                                                          "content": [
+                                                            {
+                                                              "default": {
+                                                                "tag": 2
+                                                              },
+                                                              "int": 1,
+                                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                "langKey": "ru",
+                                                                "value": "Свойство розовое"
+                                                              }
+                                                            }
+                                                          ]
+                                                        },
+                                                        "dataPath": "",
+                                                        "items": []
+                                                      },
+                                                      {
+                                                        "type": "COMMAND_BAR_BUTTON",
+                                                        "id": 521,
+                                                        "name": "СвойствоГолубое",
+                                                        "title": {
+                                                          "content": [
+                                                            {
+                                                              "default": {
+                                                                "tag": 2
+                                                              },
+                                                              "int": 1,
+                                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                "langKey": "ru",
+                                                                "value": "Свойство голубое"
+                                                              }
+                                                            }
+                                                          ]
+                                                        },
+                                                        "dataPath": "",
+                                                        "items": []
+                                                      }
+                                                    ],
+                                                    []
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ],
+                                          []
+                                        ]
+                                      },
+                                      {
+                                        "type": "USUAL_GROUP",
+                                        "id": 324,
+                                        "name": "ГруппаСвойстваИЗависимости",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Свойства и зависимости"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": [
+                                          [
+                                            {
+                                              "type": "USUAL_GROUP",
+                                              "id": 463,
+                                              "name": "ГруппаВиден",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/synonym"
+                                              },
+                                              "dataPath": "",
+                                              "items": [
+                                                [
+                                                  {
+                                                    "type": "LABEL_DECORATION",
+                                                    "id": 402,
+                                                    "name": "Виден",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "Виден:"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": []
+                                                  },
+                                                  {
+                                                    "type": "LABEL_DECORATION",
+                                                    "id": 333,
+                                                    "name": "ЗадатьУсловиеВидимости",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "всегда"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": []
+                                                  }
+                                                ],
+                                                []
+                                              ]
+                                            },
+                                            {
+                                              "type": "USUAL_GROUP",
+                                              "id": 465,
+                                              "name": "ГруппаДоступен",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[6]/synonym"
+                                              },
+                                              "dataPath": "",
+                                              "items": [
+                                                [
+                                                  {
+                                                    "type": "LABEL_DECORATION",
+                                                    "id": 405,
+                                                    "name": "Доступен",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "Доступен:"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": []
+                                                  },
+                                                  {
+                                                    "type": "LABEL_DECORATION",
+                                                    "id": 194,
+                                                    "name": "ЗадатьУсловиеДоступности",
+                                                    "title": {
+                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": []
+                                                  }
+                                                ],
+                                                []
+                                              ]
+                                            },
+                                            {
+                                              "type": "USUAL_GROUP",
+                                              "id": 467,
+                                              "name": "ГруппаЗаполнятьОбязательно",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[16]/synonym"
+                                              },
+                                              "dataPath": "",
+                                              "items": [
+                                                [
+                                                  {
+                                                    "type": "CHECK_BOX_FIELD",
+                                                    "id": 184,
+                                                    "name": "ЗаполнятьОбязательно",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "Заполнять обязательно:"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "Объект.ЗаполнятьОбязательно",
+                                                    "items": []
+                                                  },
+                                                  {
+                                                    "type": "LABEL_DECORATION",
+                                                    "id": 197,
+                                                    "name": "ЗадатьУсловиеЗаполнения",
+                                                    "title": {
+                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": []
+                                                  }
+                                                ],
+                                                []
+                                              ]
+                                            }
+                                          ],
+                                          []
+                                        ]
+                                      },
+                                      {
+                                        "type": "USUAL_GROUP",
+                                        "id": 107,
+                                        "name": "ОстальныеРеквизиты",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Остальные реквизиты"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": [
+                                          [
+                                            {
+                                              "type": "USUAL_GROUP",
+                                              "id": 481,
+                                              "name": "ГруппаИдентификаторДляФормул",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[17]/synonym"
+                                              },
+                                              "dataPath": "",
+                                              "items": [
+                                                [
+                                                  {
+                                                    "type": "INPUT_FIELD",
+                                                    "id": 483,
+                                                    "name": "ИдентификаторДляФормул",
+                                                    "title": {
+                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                                    },
+                                                    "dataPath": "Объект.ИдентификаторДляФормул",
+                                                    "items": []
+                                                  },
+                                                  {
+                                                    "type": "USUAL_BUTTON",
+                                                    "id": 486,
+                                                    "name": "ЗаполнитьИдентификаторДляФормул",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "Заполнить идентификатор для формул"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": []
+                                                  }
+                                                ],
+                                                []
+                                              ]
+                                            },
+                                            {
+                                              "type": "INPUT_FIELD",
+                                              "id": 30,
+                                              "name": "Подсказка",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                              },
+                                              "dataPath": "Объект.Подсказка",
+                                              "items": []
+                                            },
+                                            {
+                                              "type": "USUAL_GROUP",
+                                              "id": 32,
+                                              "name": "ГруппаЗаголовкиФормЗначений",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Заголовки форм значений"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "",
+                                              "items": [
+                                                [
+                                                  {
+                                                    "type": "INPUT_FIELD",
+                                                    "id": 33,
+                                                    "name": "ЗаголовокФормыЗначения",
+                                                    "title": {
+                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                                    },
+                                                    "dataPath": "Объект.ЗаголовокФормыЗначения",
+                                                    "items": []
+                                                  },
+                                                  {
+                                                    "type": "INPUT_FIELD",
+                                                    "id": 35,
+                                                    "name": "ЗаголовокФормыВыбораЗначения",
+                                                    "title": {
+                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                                    },
+                                                    "dataPath": "Объект.ЗаголовокФормыВыбораЗначения",
+                                                    "items": []
+                                                  }
+                                                ],
+                                                []
+                                              ]
+                                            },
+                                            {
+                                              "type": "INPUT_FIELD",
+                                              "id": 28,
+                                              "name": "Комментарий",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                              },
+                                              "dataPath": "Объект.Комментарий",
+                                              "items": []
+                                            }
+                                          ],
+                                          []
+                                        ]
+                                      },
+                                      {
+                                        "type": "USUAL_GROUP",
+                                        "id": 96,
+                                        "name": "УточнениеНаборов",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Уточнение наборов"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": [
+                                          [
+                                            {
+                                              "type": "LABEL_DECORATION",
+                                              "id": 99,
+                                              "name": "УточнениеНаборовКомментарий",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Общий реквизит входит в набор \"Расходный кассовый ордер\" "
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "",
+                                              "items": []
+                                            },
+                                            {
+                                              "type": "USUAL_BUTTON",
+                                              "id": 106,
+                                              "name": "УточнениеНаборовИзменить",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Изменить..."
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "",
+                                              "items": []
+                                            }
+                                          ],
+                                          []
+                                        ]
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                },
+                                {
+                                  "type": "PAGE",
+                                  "id": 182,
+                                  "name": "СтраницаЗначения",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Значения"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "PAGES",
+                                        "id": 287,
+                                        "name": "СтраницыЗначенияРеквизита",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Страницы значения реквизита"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": [
+                                          [
+                                            {
+                                              "type": "PAGE",
+                                              "id": 56,
+                                              "name": "ДополнительныеЗначения",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Дополнительные значения:"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "",
+                                              "items": [
+                                                {
+                                                  "type": "TABLE",
+                                                  "id": 57,
+                                                  "name": "Значения",
+                                                  "title": {
+                                                    "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                                  },
+                                                  "dataPath": "Значения",
+                                                  "items": [
+                                                    [
+                                                      {
+                                                        "type": "LABEL_FIELD",
+                                                        "id": 60,
+                                                        "name": "ЗначенияНаименование",
+                                                        "title": {
+                                                          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[7]/synonym"
+                                                        },
+                                                        "dataPath": "Значения.Наименование",
+                                                        "items": []
+                                                      },
+                                                      {
+                                                        "type": "LABEL_FIELD",
+                                                        "id": 83,
+                                                        "name": "ЗначенияВес",
+                                                        "title": {
+                                                          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                                        },
+                                                        "dataPath": "Значения.Вес",
+                                                        "items": []
+                                                      },
+                                                      {
+                                                        "type": "LABEL_FIELD",
+                                                        "id": 460,
+                                                        "name": "ЗначенияСсылка",
+                                                        "title": {
+                                                          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                                        },
+                                                        "dataPath": "Значения.Ссылка",
+                                                        "items": []
+                                                      }
+                                                    ],
+                                                    []
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "type": "PAGE",
+                                              "id": 289,
+                                              "name": "СтраницаДеревоЗначений",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Страница дерево значений"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "",
+                                              "items": [
+                                                {
+                                                  "type": "TABLE",
+                                                  "id": 291,
+                                                  "name": "ЗначенияДополнительногоРеквизита",
+                                                  "title": {
+                                                    "content": [
+                                                      {
+                                                        "default": {
+                                                          "tag": 2
+                                                        },
+                                                        "int": 1,
+                                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                          "langKey": "ru",
+                                                          "value": "Значения дополнительного реквизита"
+                                                        }
+                                                      }
+                                                    ]
+                                                  },
+                                                  "dataPath": "ЗначенияДополнительныхРеквизитов",
+                                                  "items": [
+                                                    [
+                                                      {
+                                                        "type": "INPUT_FIELD",
+                                                        "id": 304,
+                                                        "name": "ЗначенияДополнительногоРеквизитаНаименование",
+                                                        "title": {
+                                                          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[7]/synonym"
+                                                        },
+                                                        "dataPath": "ЗначенияДополнительныхРеквизитов.Наименование",
+                                                        "items": []
+                                                      },
+                                                      {
+                                                        "type": "INPUT_FIELD",
+                                                        "id": 307,
+                                                        "name": "ЗначенияДополнительногоРеквизитаВес",
+                                                        "title": {
+                                                          "content": [
+                                                            {
+                                                              "default": {
+                                                                "tag": 2
+                                                              },
+                                                              "int": 1,
+                                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                "langKey": "ru",
+                                                                "value": "Весовой коэффициент"
+                                                              }
+                                                            }
+                                                          ]
+                                                        },
+                                                        "dataPath": "ЗначенияДополнительныхРеквизитов.Вес",
+                                                        "items": []
+                                                      }
+                                                    ],
+                                                    []
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ],
+                                          []
+                                        ]
+                                      },
+                                      {
+                                        "type": "CHECK_BOX_FIELD",
+                                        "id": 69,
+                                        "name": "ДополнительныеЗначенияСВесом",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                        },
+                                        "dataPath": "Объект.ДополнительныеЗначенияСВесом",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "USUAL_GROUP",
+                                        "id": 89,
+                                        "name": "УточнениеСпискаЗначений",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Уточнение списка значений"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": [
+                                          [
+                                            {
+                                              "type": "LABEL_DECORATION",
+                                              "id": 87,
+                                              "name": "УточнениеСпискаЗначенийКомментарий",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Список значений общий с реквизитом \"Цвет\" набора \"Номенклатура (сумки)\" "
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "",
+                                              "items": []
+                                            },
+                                            {
+                                              "type": "USUAL_BUTTON",
+                                              "id": 105,
+                                              "name": "УточнениеСпискаЗначенийИзменить",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                              },
+                                              "dataPath": "",
+                                              "items": []
+                                            }
+                                          ],
+                                          []
+                                        ]
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                }
+                              ],
+                              []
+                            ]
+                          },
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 455,
+                            "name": "ГруппаДляРазработчиков",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Для разработчиков"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 457,
+                                "name": "Имя",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                },
+                                "dataPath": "Объект.Имя",
+                                "items": []
+                              }
+                            ]
+                          }
+                        ],
+                        []
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 227,
+                "name": "КоманднаяПанельПомощника",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Командная панель помощника"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "COMMAND_BAR",
+                      "id": 229,
+                      "name": "КоманднаяПанельЛево",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Командная панель лево"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        {
+                          "type": "COMMAND_BAR_BUTTON",
+                          "id": 233,
+                          "name": "КомандаНазад",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "< Назад"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": []
+                        }
+                      ]
+                    },
+                    {
+                      "type": "COMMAND_BAR",
+                      "id": 231,
+                      "name": "КоманднаяПанельПраво",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Командная панель право"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "COMMAND_BAR_BUTTON",
+                            "id": 235,
+                            "name": "КомандаДалее",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Далее >"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "COMMAND_BAR_BUTTON",
+                            "id": 242,
+                            "name": "Закрыть",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Закрыть"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "Объект",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "ПланВидовХарактеристикОбъект.ДополнительныеРеквизитыИСведения",
+                          "nameEn": "ChartOfCharacteristicTypesObject.ДополнительныеРеквизитыИСведения"
+                        },
+                        "variant": "METADATA",
+                        "kind": "CHART_OF_CHARACTERISTIC_TYPES"
+                      }
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 3,
+                "name": "ВидСвойства",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[27]/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[27]/type"
+                }
+              },
+              {
+                "id": 2,
+                "name": "СписокНаборов",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "VALUE_LIST"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 7,
+                "name": "МногострочноеПолеВвода",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[5]/type"
+                }
+              },
+              {
+                "id": 8,
+                "name": "МногострочноеПолеВводаЧисло",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Многострочное поле ввода число"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[20]/type"
+                }
+              },
+              {
+                "id": 9,
+                "name": "Значения",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "DYNAMIC_LIST"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 10,
+                "name": "ПоказатьУточнениеНабора",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[5]/type"
+                }
+              },
+              {
+                "id": 4,
+                "name": "ТекущийНаборСвойств",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[21]/type"
+                }
+              },
+              {
+                "id": 13,
+                "name": "ПереданныеПараметрыФормы",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "types": [],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 14,
+                "name": "РежимДобавленияРеквизита",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Режим добавления реквизита"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              },
+              {
+                "id": 15,
+                "name": "РежимПомощника",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[5]/type"
+                }
+              },
+              {
+                "id": 16,
+                "name": "ЗначенияДополнительныхРеквизитов",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Значения дополнительных реквизитов"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "VALUE_TREE"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 17,
+                "name": "ПустаяСсылка",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[6]/type"
+                }
+              },
+              {
+                "id": 18,
+                "name": "УсловияЗависимостиРеквизитов",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 19,
+                "name": "ИзмененыУсловияЗависимостиРеквизитов",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[5]/type"
+                }
+              },
+              {
+                "id": 20,
+                "name": "ВыбранныйНаборСвойств",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[21]/type"
+                }
+              },
+              {
+                "id": 21,
+                "name": "НаборыСвойств",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[6]/type"
+                }
+              },
+              {
+                "id": 22,
+                "name": "Свойства",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "VALUE_TABLE"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 23,
+                "name": "ОбщиеНаборыСвойств",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[6]/type"
+                }
+              },
+              {
+                "id": 24,
+                "name": "ПредставлениеРеквизита",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              },
+              {
+                "id": 5,
+                "name": "ТекущийЗаголовок",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              },
+              {
+                "id": 25,
+                "name": "ПоказатьНеиспользуемыеРеквизиты",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[5]/type"
+                }
+              },
+              {
+                "id": 26,
+                "name": "ТекущийНаборВерсияДанных",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "7fba41a5-4faa-412b-b367-b30ced0314c0",
+        "name": "ФормаСписка",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Form.ФормаСписка",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Форма.ФормаСписка"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Форма списка"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/ChartsOfCharacteristicTypes/ДополнительныеРеквизитыИСведения/Forms/ФормаСписка/Ext/Form/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+          },
+          "handlers": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[8]"
+            }
+          ],
+          "items": [
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 16,
+                "name": "ГруппаПользовательскихНастроек",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Группа пользовательских настроек"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": []
+              },
+              {
+                "type": "COMMAND_BAR",
+                "id": 14,
+                "name": "КоманднаяПанель",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Командная панель"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": []
+              },
+              {
+                "type": "TABLE",
+                "id": 1,
+                "name": "Список",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Список"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "Список",
+                "items": [
+                  [
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 4,
+                      "name": "Наименование",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[7]/synonym"
+                      },
+                      "dataPath": "Список.Description",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 6,
+                      "name": "ТипЗначения",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                      },
+                      "dataPath": "Список.ValueType",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 11,
+                      "name": "Ссылка",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.Ref",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            {
+              "id": 1,
+              "name": "Список",
+              "title": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "type": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[6]/type"
+              }
+            }
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "37333d0b-3589-4b8b-bf6c-e605e0287b66",
+        "name": "РазблокированиеРеквизитов",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Form.РазблокированиеРеквизитов",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Форма.РазблокированиеРеквизитов"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Разблокирование реквизитов"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/ChartsOfCharacteristicTypes/ДополнительныеРеквизитыИСведения/Forms/РазблокированиеРеквизитов/Ext/Form/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+          },
+          "handlers": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[8]"
+            }
+          ],
+          "items": [
+            {
+              "type": "PAGES",
+              "id": 1,
+              "name": "ДиалогиПользователя",
+              "title": {
+                "content": [
+                  {
+                    "default": {
+                      "tag": 2
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                      "langKey": "ru",
+                      "value": "Диалоги пользователя"
+                    }
+                  }
+                ]
+              },
+              "dataPath": "",
+              "items": [
+                [
+                  {
+                    "type": "PAGE",
+                    "id": 2,
+                    "name": "ОбъектНеИспользуется",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Объект не используется"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "",
+                    "items": [
+                      {
+                        "type": "PAGES",
+                        "id": 12,
+                        "name": "Пояснения",
+                        "title": {
+                          "content": [
+                            {
+                              "default": {
+                                "tag": 2
+                              },
+                              "int": 1,
+                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                "langKey": "ru",
+                                "value": "Пояснения"
+                              }
+                            }
+                          ]
+                        },
+                        "dataPath": "",
+                        "items": [
+                          [
+                            {
+                              "type": "PAGE",
+                              "id": 22,
+                              "name": "ПояснениеДополнительногоРеквизита",
+                              "title": {
+                                "content": [
+                                  {
+                                    "default": {
+                                      "tag": 2
+                                    },
+                                    "int": 1,
+                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                      "langKey": "ru",
+                                      "value": "Пояснение дополнительного реквизита"
+                                    }
+                                  }
+                                ]
+                              },
+                              "dataPath": "",
+                              "items": [
+                                {
+                                  "type": "LABEL_DECORATION",
+                                  "id": 23,
+                                  "name": "ТекстПоясненияДополнительногоРеквизита",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Дополнительный реквизит не используется в документах приложения.\n\nТип значения и имя дополнительного реквизита можно изменять."
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                }
+                              ]
+                            },
+                            {
+                              "type": "PAGE",
+                              "id": 25,
+                              "name": "ПояснениеДополнительногоСведения",
+                              "title": {
+                                "content": [
+                                  {
+                                    "default": {
+                                      "tag": 2
+                                    },
+                                    "int": 1,
+                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                      "langKey": "ru",
+                                      "value": "Пояснение дополнительного сведения"
+                                    }
+                                  }
+                                ]
+                              },
+                              "dataPath": "",
+                              "items": [
+                                {
+                                  "type": "LABEL_DECORATION",
+                                  "id": 26,
+                                  "name": "ТекстПоясненияДополнительногоСведения",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Дополнительное сведение не используется в информационной базе.\n\nТип значения и имя дополнительного сведения можно изменять."
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                }
+                              ]
+                            }
+                          ],
+                          []
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "PAGE",
+                    "id": 3,
+                    "name": "ОбъектИспользуется",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Объект используется"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "",
+                    "items": [
+                      {
+                        "type": "PAGES",
+                        "id": 17,
+                        "name": "Предупреждения",
+                        "title": {
+                          "content": [
+                            {
+                              "default": {
+                                "tag": 2
+                              },
+                              "int": 1,
+                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                "langKey": "ru",
+                                "value": "Предупреждения"
+                              }
+                            }
+                          ]
+                        },
+                        "dataPath": "",
+                        "items": [
+                          [
+                            {
+                              "type": "PAGE",
+                              "id": 18,
+                              "name": "ПредупреждениеДополнительногоРеквизита",
+                              "title": {
+                                "content": [
+                                  {
+                                    "default": {
+                                      "tag": 2
+                                    },
+                                    "int": 1,
+                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                      "langKey": "ru",
+                                      "value": "Предупреждение дополнительного реквизита"
+                                    }
+                                  }
+                                ]
+                              },
+                              "dataPath": "",
+                              "items": [
+                                {
+                                  "type": "LABEL_DECORATION",
+                                  "id": 6,
+                                  "name": "ТекстПредупрежденияДополнительногоРеквизита",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Внимание! Дополнительный реквизит уже используется в информационной базе.\n\nИзменение типа значения дополнительного реквизита может привести к потере ранее установленных значений его текущего типа."
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                }
+                              ]
+                            },
+                            {
+                              "type": "PAGE",
+                              "id": 19,
+                              "name": "ПредупреждениеДополнительногоСведения",
+                              "title": {
+                                "content": [
+                                  {
+                                    "default": {
+                                      "tag": 2
+                                    },
+                                    "int": 1,
+                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                      "langKey": "ru",
+                                      "value": "Предупреждение дополнительного сведения"
+                                    }
+                                  }
+                                ]
+                              },
+                              "dataPath": "",
+                              "items": [
+                                {
+                                  "type": "LABEL_DECORATION",
+                                  "id": 20,
+                                  "name": "ТекстПредупрежденияДополнительногоСведения",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Внимание! Дополнительное сведение уже используется в информационной базе.\n\nИзменение типа значения дополнительного сведения может привести к потере ранее установленных значений его текущего типа."
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                }
+                              ]
+                            }
+                          ],
+                          []
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                []
+              ]
+            }
+          ],
+          "attributes": []
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "1813c469-da20-46a6-8947-6815b66f64c1",
+        "name": "ИзменениеНастройкиСвойства",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Form.ИзменениеНастройкиСвойства",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Форма.ИзменениеНастройкиСвойства"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Изменение настройки свойства"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/ChartsOfCharacteristicTypes/ДополнительныеРеквизитыИСведения/Forms/ИзменениеНастро_киСво_ства/Ext/Form/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "content": [
+              {
+                "default": {
+                  "tag": 2
+                },
+                "int": 1,
+                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                  "langKey": "ru",
+                  "value": "Изменить настройку дополнительного реквизита"
+                }
+              }
+            ]
+          },
+          "handlers": [
+            [
+              {
+                "event": "BeforeClose",
+                "name": "ПередЗакрытием"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[8]"
+              }
+            ],
+            []
+          ],
+          "items": [
+            {
+              "type": "PAGES",
+              "id": 40,
+              "name": "ТипыСвойства",
+              "title": {
+                "content": [
+                  {
+                    "default": {
+                      "tag": 2
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                      "langKey": "ru",
+                      "value": "Типы свойства"
+                    }
+                  }
+                ]
+              },
+              "dataPath": "",
+              "items": [
+                [
+                  {
+                    "type": "PAGE",
+                    "id": 17,
+                    "name": "ДополнительныйРеквизит",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Дополнительный реквизит"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 52,
+                          "name": "РеквизитПредупреждение",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Реквизит предупреждение"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "PICTURE_DECORATION",
+                                "id": 48,
+                                "name": "РеквизитПредупреждениеКартинка",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Реквизит предупреждение картинка"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": []
+                              },
+                              {
+                                "type": "LABEL_DECORATION",
+                                "id": 50,
+                                "name": "РеквизитПредупреждениеКомментарий",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Перенастройка дополнительного реквизита необратима и может занять длительное время, в зависимости от числа документов, в которых заполнен этот реквизит. \nВместо этого можно добавить новый реквизит со своим списком значений, и выполнить вручную постепенный переход от использования этого реквизита к новому (очистить значения этого реквизита и заполнить значения нового)."
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": []
+                              }
+                            ],
+                            []
+                          ]
+                        },
+                        {
+                          "type": "RADIO_BUTTON_FIELD",
+                          "id": 8,
+                          "name": "ОтдельныеЗначенияРеквизита",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Отдельное свойство с отдельным списком значений"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "ОтдельноеСвойствоСОтдельнымСпискомЗначений",
+                          "items": []
+                        },
+                        {
+                          "type": "LABEL_DECORATION",
+                          "id": 14,
+                          "name": "ОтдельныеЗначенияРеквизитаКомментарий",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Данный реквизит входит только в один набор %1, и у него свой собственный список значений."
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": []
+                        },
+                        {
+                          "type": "PAGES",
+                          "id": 30,
+                          "name": "ВидыРеквизита",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Виды реквизита"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "PAGE",
+                                "id": 32,
+                                "name": "ВидОбщиеЗначенияРеквизитов",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Вид общие значения реквизитов"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "RADIO_BUTTON_FIELD",
+                                      "id": 6,
+                                      "name": "ОбщиеЗначенияРеквизитов",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Отдельное свойство с общим списком значений"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "ОтдельноеСвойствоСОбщимСпискомЗначений",
+                                      "items": []
+                                    },
+                                    {
+                                      "type": "LABEL_DECORATION",
+                                      "id": 12,
+                                      "name": "ОбщиеЗначенияРеквизитовКомментарий",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "У данного реквизита общий список значений с другими реквизитами, добавленными по образцу. С помощью этого варианта удобно выполнять централизованную настройку списка значений сразу для нескольких однотипных реквизитов (например, \"Цвет одежды\", \"Цвет обуви\" и пр.)."
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": []
+                                    }
+                                  ],
+                                  []
+                                ]
+                              },
+                              {
+                                "type": "PAGE",
+                                "id": 31,
+                                "name": "ВидОбщийРеквизит",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Вид общий реквизит"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "RADIO_BUTTON_FIELD",
+                                      "id": 4,
+                                      "name": "ОбщийРеквизит",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Общее свойство"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "ОбщееСвойство",
+                                      "items": []
+                                    },
+                                    {
+                                      "type": "LABEL_DECORATION",
+                                      "id": 10,
+                                      "name": "ОбщийРеквизитКомментарий",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Данный реквизит входит сразу в несколько наборов. Этот вариант подходит для тех случаев, когда общим\nдолжен быть не только список значений, но и сам реквизит. В списках и отчетах по элементам различных\nсправочников и документов, общие реквизиты группируются и выводятся как один реквизит, в одной колонке или поле.\nНапример, с помощью общего реквизита \"Цвет\" можно быстро отобрать всю желтую одежду и обувь."
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": []
+                                    }
+                                  ],
+                                  []
+                                ]
+                              }
+                            ],
+                            []
+                          ]
+                        }
+                      ],
+                      []
+                    ]
+                  },
+                  {
+                    "type": "PAGE",
+                    "id": 16,
+                    "name": "ДополнительноеСведение",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Дополнительное сведение"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 54,
+                          "name": "СведениеПредупреждение",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Сведение предупреждение"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "PICTURE_DECORATION",
+                                "id": 56,
+                                "name": "СведениеПредупреждениеКартинка",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Сведение предупреждение картинка"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": []
+                              },
+                              {
+                                "type": "LABEL_DECORATION",
+                                "id": 58,
+                                "name": "СведениеПредупреждениеКомментарий",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Перенастройка дополнительного сведения необратима и может занять длительное время, в зависимости от числа документов, в которых заполнено это сведение.\nВместо этого можно добавить новое сведение со своим списком значений, и выполнить вручную постепенный переход от использования этого сведения к новому (очистить значения этого сведения и заполнить значения нового)."
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": []
+                              }
+                            ],
+                            []
+                          ]
+                        },
+                        {
+                          "type": "RADIO_BUTTON_FIELD",
+                          "id": 26,
+                          "name": "ОтдельныеЗначенияСведения",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                          },
+                          "dataPath": "ОтдельноеСвойствоСОтдельнымСпискомЗначений",
+                          "items": []
+                        },
+                        {
+                          "type": "LABEL_DECORATION",
+                          "id": 28,
+                          "name": "ОтдельныеЗначенияСведенияКомментарий",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Данное сведение входит только в один набор %1, и у него свой собственный список значений."
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": []
+                        },
+                        {
+                          "type": "PAGES",
+                          "id": 33,
+                          "name": "ВидыСведения",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Виды сведения"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "PAGE",
+                                "id": 39,
+                                "name": "ВидОбщиеЗначенияСведений",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Вид общие значения сведений"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "RADIO_BUTTON_FIELD",
+                                      "id": 22,
+                                      "name": "ОбщиеЗначенияСведений",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                      },
+                                      "dataPath": "ОтдельноеСвойствоСОбщимСпискомЗначений",
+                                      "items": []
+                                    },
+                                    {
+                                      "type": "LABEL_DECORATION",
+                                      "id": 24,
+                                      "name": "ОбщиеЗначенияСведенийКомментарий",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "У этого сведения общий список значений с другими сведениями, добавленными по образцу. С помощью этого варианта удобно выполнять централизованную настройку списка значений сразу для нескольких однотипных сведений (например, \"Цвет одежды\", \"Цвет обуви\" и пр.)."
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": []
+                                    }
+                                  ],
+                                  []
+                                ]
+                              },
+                              {
+                                "type": "PAGE",
+                                "id": 34,
+                                "name": "ВидОбщееСведение",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Вид общее сведение"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "RADIO_BUTTON_FIELD",
+                                      "id": 18,
+                                      "name": "ОбщееСведение",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                      },
+                                      "dataPath": "ОбщееСвойство",
+                                      "items": []
+                                    },
+                                    {
+                                      "type": "LABEL_DECORATION",
+                                      "id": 20,
+                                      "name": "ОбщееСведениеКомментарий",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Данное сведение входит сразу в несколько наборов. Этот вариант подходит для тех случаев, когда общим\nдолжен быть не только список значений, но и само сведение. В списках и отчетах по элементам различных\nсправочников и документов, общие сведения группируются и выводятся как одно сведение, в одной колонке или поле.\nНапример, с помощью общего сведения \"Цвет\" можно быстро отобрать всю желтую одежду и обувь."
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": []
+                                    }
+                                  ],
+                                  []
+                                ]
+                              }
+                            ],
+                            []
+                          ]
+                        }
+                      ],
+                      []
+                    ]
+                  }
+                ],
+                []
+              ]
+            }
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "ОбщееСвойство",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                        "precision": 1,
+                        "scale": 0,
+                        "nonNegative": true,
+                        "description": {}
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 2,
+                "name": "ОтдельноеСвойствоСОбщимСпискомЗначений",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 3,
+                "name": "ОтдельноеСвойствоСОтдельнымСпискомЗначений",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 4,
+                "name": "Свойство",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[6]/type"
+                }
+              },
+              {
+                "id": 5,
+                "name": "ЭтоДополнительноеСведение",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[5]/type"
+                }
+              },
+              {
+                "id": 6,
+                "name": "ТекущийНаборСвойств",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[21]/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "64e702e9-8934-4356-a1b2-be0e8b390630",
+        "name": "ЗависимостьРеквизитов",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Form.ЗависимостьРеквизитов",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Форма.ЗависимостьРеквизитов"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Зависимость реквизитов"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/ChartsOfCharacteristicTypes/ДополнительныеРеквизитыИСведения/Forms/ЗависимостьРеквизитов/Ext/Form/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[5]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+          },
+          "handlers": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[4]"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[8]"
+              }
+            ],
+            []
+          ],
+          "items": [
+            {
+              "type": "TABLE",
+              "id": 5,
+              "name": "ЗависимостиРеквизитов",
+              "title": {
+                "content": [
+                  {
+                    "default": {
+                      "tag": 2
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                      "langKey": "ru",
+                      "value": "Зависит от значения свойств и реквизитов"
+                    }
+                  }
+                ]
+              },
+              "dataPath": "ЗависимостиРеквизитов",
+              "items": [
+                [
+                  {
+                    "type": "INPUT_FIELD",
+                    "id": 18,
+                    "name": "ЗависимостиРеквизитовРеквизит",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                    },
+                    "dataPath": "ЗависимостиРеквизитов.Представление",
+                    "items": []
+                  },
+                  {
+                    "type": "INPUT_FIELD",
+                    "id": 21,
+                    "name": "ЗависимостиРеквизитовВидСравнения",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Вид сравнения"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "ЗависимостиРеквизитов.Условие",
+                    "items": []
+                  },
+                  {
+                    "type": "INPUT_FIELD",
+                    "id": 24,
+                    "name": "ЗависимостиРеквизитовПравоеЗначение",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Значение"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "ЗависимостиРеквизитов.Значение",
+                    "items": []
+                  }
+                ],
+                []
+              ]
+            }
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "ЗависимостиРеквизитов",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Зависимости реквизитов"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[18]/type"
+                }
+              },
+              {
+                "id": 2,
+                "name": "РеквизитыОбъектаВХранилище",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              },
+              {
+                "id": 3,
+                "name": "НастраиваемоеСвойство",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              },
+              {
+                "id": 4,
+                "name": "ДобавлениеСтроки",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[5]/type"
+                }
+              },
+              {
+                "id": 5,
+                "name": "НажатаОтмена",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[5]/type"
+                }
+              },
+              {
+                "id": 6,
+                "name": "НаборСвойств",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[21]/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "74880ac4-bdd3-48e6-82a0-a2103da42723",
+        "name": "ВыборРеквизита",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Form.ВыборРеквизита",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Форма.ВыборРеквизита"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/ChartsOfCharacteristicTypes/ДополнительныеРеквизитыИСведения/Forms/ВыборРеквизита/Ext/Form/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+          },
+          "handlers": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[8]"
+            }
+          ],
+          "items": [
+            {
+              "type": "TABLE",
+              "id": 1,
+              "name": "РеквизитыОбъекта",
+              "title": {
+                "content": [
+                  {
+                    "default": {
+                      "tag": 2
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                      "langKey": "ru",
+                      "value": "Реквизиты объекта"
+                    }
+                  }
+                ]
+              },
+              "dataPath": "РеквизитыОбъекта",
+              "items": [
+                {
+                  "type": "INPUT_FIELD",
+                  "id": 14,
+                  "name": "РеквизитыОбъектаПредставление",
+                  "title": {
+                    "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  },
+                  "dataPath": "РеквизитыОбъекта.Представление",
+                  "items": []
+                }
+              ]
+            }
+          ],
+          "attributes": [
+            {
+              "id": 1,
+              "name": "РеквизитыОбъекта",
+              "title": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+              },
+              "type": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[18]/type"
+              }
+            }
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      }
+    ],
+    []
+  ],
+  "mdoReference": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+  },
+  "mdoType": "CHART_OF_CHARACTERISTIC_TYPES",
+  "moduleTypes": [
+    [
+      "ManagerModule",
+      [
+        "src/test/resources/ext/designer/ssl_3_2/src/cf/ChartsOfCharacteristicTypes/ДополнительныеРеквизитыИСведения/Ext/ManagerModule.bsl"
+      ]
+    ],
+    [
+      "ObjectModule",
+      [
+        "src/test/resources/ext/designer/ssl_3_2/src/cf/ChartsOfCharacteristicTypes/ДополнительныеРеквизитыИСведения/Ext/ObjectModule.bsl"
+      ]
+    ]
+  ],
+  "modules": [
+    {
+      "moduleType": "ManagerModule",
+      "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/ChartsOfCharacteristicTypes/ДополнительныеРеквизитыИСведения/Ext/ManagerModule.bsl",
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "isProtected": false
+    },
+    {
+      "moduleType": "ObjectModule",
+      "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/ChartsOfCharacteristicTypes/ДополнительныеРеквизитыИСведения/Ext/ObjectModule.bsl",
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "isProtected": false
+    }
+  ],
+  "name": "ДополнительныеРеквизитыИСведения",
+  "objectBelonging": "OWN",
+  "possibleRights": [
+    {
+      "default": {
+        "tag": 4
+      },
+      "int": 25,
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INSERT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "DELETE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "VIEW",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "EDIT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INPUT_BY_STRING",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_DELETE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_INSERT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_SET_DELETION_MARK",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_CLEAR_DELETION_MARK",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_DELETE_MARKED",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_DELETE_PREDEFINED_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_SET_DELETION_MARK_PREDEFINED_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_CLEAR_DELETION_MARK_PREDEFINED_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_DELETE_MARKED_PREDEFINED_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "VIEW_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ_DATA_HISTORY_OF_MISSING_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_OF_MISSING_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_SETTINGS",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_VERSION_COMMENT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "EDIT_DATA_HISTORY_VERSION_COMMENT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "SWITCH_TO_DATA_HISTORY_VERSION"
+    }
+  ],
+  "predefinedValues": [],
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "content": [
+      {
+        "default": {
+          "tag": 2
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+          "langKey": "ru",
+          "value": "Дополнительные реквизиты и сведения"
+        }
+      }
+    ]
+  },
+  "tabularSections": [
+    [
+      {
+        "uuid": "d6b72e00-018a-4fdc-b6a4-06dcecf89809",
+        "name": "ЗависимостиДополнительныхРеквизитов",
+        "mdoReference": {
+          "type": "TABULAR_SECTION",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.TabularSection.ЗависимостиДополнительныхРеквизитов",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.ТабличнаяЧасть.ЗависимостиДополнительныхРеквизитов"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Зависимости дополнительных реквизитов"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "attributes": [
+          [
+            {
+              "uuid": "d6b72e00-018a-4fdc-b6a4-06dcecf89809",
+              "mdoReference": {
+                "type": "STANDARD_ATTRIBUTE",
+                "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.TabularSection.ЗависимостиДополнительныхРеквизитов.StandardAttribute.LineNumber",
+                "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.ТабличнаяЧасть.ЗависимостиДополнительныхРеквизитов.СтандартныйРеквизит.НомерСтроки"
+              },
+              "comment": "",
+              "synonym": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/tabularSections/c/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+              },
+              "passwordMode": false,
+              "kind": "STANDARD",
+              "type": {
+                "types": [
+                  {
+                    "default": {
+                      "tag": 4
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER"
+                  }
+                ],
+                "composite": false,
+                "qualifiers": [
+                  {
+                    "default": {
+                      "tag": 4
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                      "precision": 5,
+                      "scale": 0,
+                      "nonNegative": false,
+                      "description": {}
+                    }
+                  }
+                ]
+              },
+              "fullName": {
+                "nameRu": "НомерСтроки",
+                "nameEn": "LineNumber"
+              },
+              "format": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "editFormat": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "markNegatives": false,
+              "mask": "",
+              "multiLine": false,
+              "extendedEdit": false,
+              "fillFromFillingValue": false
+            },
+            {
+              "uuid": "9f816562-57f0-473f-8c85-14f7521ffd7f",
+              "name": "ЗависимоеСвойство",
+              "mdoReference": {
+                "type": "ATTRIBUTE",
+                "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.TabularSection.ЗависимостиДополнительныхРеквизитов.Attribute.ЗависимоеСвойство",
+                "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.ТабличнаяЧасть.ЗависимостиДополнительныхРеквизитов.Реквизит.ЗависимоеСвойство"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "content": [
+                  {
+                    "default": {
+                      "tag": 2
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                      "langKey": "ru",
+                      "value": "Зависимое свойство"
+                    }
+                  }
+                ]
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/tabularSections/c/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+              },
+              "passwordMode": false,
+              "kind": "CUSTOM",
+              "indexing": "DONT_INDEX",
+              "type": {
+                "types": [
+                  {
+                    "default": {
+                      "tag": 4
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+                  }
+                ],
+                "composite": false,
+                "qualifiers": [
+                  {
+                    "default": {
+                      "tag": 4
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                      "length": 25,
+                      "allowedLength": 0,
+                      "description": {}
+                    }
+                  }
+                ]
+              },
+              "format": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "editFormat": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "markNegatives": false,
+              "mask": "",
+              "multiLine": false,
+              "extendedEdit": false,
+              "fillFromFillingValue": false
+            },
+            {
+              "uuid": "14077038-2e41-4a05-a476-99f6f88a5c29",
+              "name": "НаборСвойств",
+              "mdoReference": {
+                "type": "ATTRIBUTE",
+                "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.TabularSection.ЗависимостиДополнительныхРеквизитов.Attribute.НаборСвойств",
+                "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.ТабличнаяЧасть.ЗависимостиДополнительныхРеквизитов.Реквизит.НаборСвойств"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[21]/synonym"
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/tabularSections/c/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+              },
+              "passwordMode": false,
+              "kind": "CUSTOM",
+              "indexing": "DONT_INDEX",
+              "type": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[21]/type"
+              },
+              "format": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "editFormat": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "markNegatives": false,
+              "mask": "",
+              "multiLine": false,
+              "extendedEdit": false,
+              "fillFromFillingValue": false
+            },
+            {
+              "uuid": "917b0acc-88fe-4afc-b19b-6da69e060393",
+              "name": "Реквизит",
+              "mdoReference": {
+                "type": "ATTRIBUTE",
+                "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.TabularSection.ЗависимостиДополнительныхРеквизитов.Attribute.Реквизит",
+                "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.ТабличнаяЧасть.ЗависимостиДополнительныхРеквизитов.Реквизит.Реквизит"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/tabularSections/c/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+              },
+              "passwordMode": false,
+              "kind": "CUSTOM",
+              "indexing": "DONT_INDEX",
+              "type": {
+                "types": [
+                  {
+                    "default": {
+                      "tag": 4
+                    },
+                    "int": 2,
+                    "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[6]/type/types/java.util.CollSer/com.github._1c_syntax.bsl.types.value.CustomValueType"
+                    },
+                    "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+                  }
+                ],
+                "composite": true,
+                "qualifiers": [
+                  {
+                    "default": {
+                      "tag": 4
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                      "length": 99,
+                      "allowedLength": 0,
+                      "description": {}
+                    }
+                  }
+                ]
+              },
+              "format": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "editFormat": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "markNegatives": false,
+              "mask": "",
+              "multiLine": false,
+              "extendedEdit": false,
+              "fillFromFillingValue": false
+            },
+            {
+              "uuid": "a091b76e-8ba4-4534-bbb0-9990e69b8603",
+              "name": "Условие",
+              "mdoReference": {
+                "type": "ATTRIBUTE",
+                "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.TabularSection.ЗависимостиДополнительныхРеквизитов.Attribute.Условие",
+                "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.ТабличнаяЧасть.ЗависимостиДополнительныхРеквизитов.Реквизит.Условие"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "content": [
+                  {
+                    "default": {
+                      "tag": 2
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                      "langKey": "ru",
+                      "value": "Условие"
+                    }
+                  }
+                ]
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/tabularSections/c/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+              },
+              "passwordMode": false,
+              "kind": "CUSTOM",
+              "indexing": "DONT_INDEX",
+              "type": {
+                "types": [
+                  {
+                    "default": {
+                      "tag": 4
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+                  }
+                ],
+                "composite": false,
+                "qualifiers": [
+                  {
+                    "default": {
+                      "tag": 4
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                      "length": 20,
+                      "allowedLength": 0,
+                      "description": {}
+                    }
+                  }
+                ]
+              },
+              "format": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "editFormat": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "markNegatives": false,
+              "mask": "",
+              "multiLine": false,
+              "extendedEdit": false,
+              "fillFromFillingValue": false
+            },
+            {
+              "uuid": "867ee5d2-7566-4052-a311-b56e7e46b90d",
+              "name": "Значение",
+              "mdoReference": {
+                "type": "ATTRIBUTE",
+                "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.TabularSection.ЗависимостиДополнительныхРеквизитов.Attribute.Значение",
+                "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.ТабличнаяЧасть.ЗависимостиДополнительныхРеквизитов.Реквизит.Значение"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[5]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/tabularSections/c/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+              },
+              "passwordMode": false,
+              "kind": "CUSTOM",
+              "indexing": "DONT_INDEX",
+              "type": {
+                "types": [
+                  {
+                    "default": {
+                      "tag": 4
+                    },
+                    "int": 5,
+                    "com.github._1c_syntax.bsl.types.value.MDOValueType": "ANY_REF",
+                    "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "BOOLEAN",
+                    "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "DATE",
+                    "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER",
+                    "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+                  }
+                ],
+                "composite": true,
+                "qualifiers": [
+                  {
+                    "default": {
+                      "tag": 4
+                    },
+                    "int": 3,
+                    "com.github._1c_syntax.bsl.types.qualifiers.DateQualifiers": {
+                      "dateFractions": 1,
+                      "description": {
+                        "value": {
+                          "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                          "nameRu": "КвалификаторыДаты (Дата)",
+                          "nameEn": "DateQualifiers (Date)"
+                        }
+                      }
+                    },
+                    "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                      "length": 50,
+                      "allowedLength": 0,
+                      "description": {
+                        "value": {
+                          "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                          "nameRu": "КвалификаторыСтроки (50, Переменная)",
+                          "nameEn": "StringQualifiers (50, Variable)"
+                        }
+                      }
+                    },
+                    "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                      "precision": 10,
+                      "scale": 0,
+                      "nonNegative": false,
+                      "description": {
+                        "value": {
+                          "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                          "nameRu": "КвалификаторыЧисла (10.0)",
+                          "nameEn": "NumberQualifiers (10.0)"
+                        }
+                      }
+                    }
+                  }
+                ]
+              },
+              "format": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "editFormat": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "markNegatives": false,
+              "mask": "",
+              "multiLine": false,
+              "extendedEdit": false,
+              "fillFromFillingValue": false
+            }
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "8f51328b-73a8-46fb-b6db-7b7a84c05c2a",
+        "name": "Представления",
+        "mdoReference": {
+          "type": "TABULAR_SECTION",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.TabularSection.Представления",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.ТабличнаяЧасть.Представления"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Представления"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "attributes": [
+          [
+            {
+              "uuid": "8f51328b-73a8-46fb-b6db-7b7a84c05c2a",
+              "mdoReference": {
+                "type": "STANDARD_ATTRIBUTE",
+                "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.TabularSection.Представления.StandardAttribute.LineNumber",
+                "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.ТабличнаяЧасть.Представления.СтандартныйРеквизит.НомерСтроки"
+              },
+              "comment": "",
+              "synonym": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/tabularSections/c/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection[2]/mdoReference"
+              },
+              "passwordMode": false,
+              "kind": "STANDARD",
+              "type": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/tabularSections/c/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+              },
+              "fullName": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/tabularSections/c/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/fullName"
+              },
+              "format": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "editFormat": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "markNegatives": false,
+              "mask": "",
+              "multiLine": false,
+              "extendedEdit": false,
+              "fillFromFillingValue": false
+            },
+            {
+              "uuid": "0f0f5b42-2407-44e6-85d7-26ace96b2cd9",
+              "name": "КодЯзыка",
+              "mdoReference": {
+                "type": "ATTRIBUTE",
+                "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.TabularSection.Представления.Attribute.КодЯзыка",
+                "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.ТабличнаяЧасть.Представления.Реквизит.КодЯзыка"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "content": [
+                  {
+                    "default": {
+                      "tag": 2
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                      "langKey": "ru",
+                      "value": "Код языка"
+                    }
+                  }
+                ]
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/tabularSections/c/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection[2]/mdoReference"
+              },
+              "passwordMode": false,
+              "kind": "CUSTOM",
+              "indexing": "DONT_INDEX",
+              "type": {
+                "types": [
+                  {
+                    "default": {
+                      "tag": 4
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+                  }
+                ],
+                "composite": false,
+                "qualifiers": [
+                  {
+                    "default": {
+                      "tag": 4
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                      "length": 10,
+                      "allowedLength": 0,
+                      "description": {
+                        "value": {
+                          "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                          "nameRu": "КвалификаторыСтроки (10, Переменная)",
+                          "nameEn": "StringQualifiers (10, Variable)"
+                        }
+                      }
+                    }
+                  }
+                ]
+              },
+              "format": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "editFormat": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "markNegatives": false,
+              "mask": "",
+              "multiLine": false,
+              "extendedEdit": false,
+              "fillFromFillingValue": false
+            },
+            {
+              "uuid": "ffec426d-2556-46d6-b313-aeca43581865",
+              "name": "Заголовок",
+              "mdoReference": {
+                "type": "ATTRIBUTE",
+                "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.TabularSection.Представления.Attribute.Заголовок",
+                "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.ТабличнаяЧасть.Представления.Реквизит.Заголовок"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/tabularSections/c/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection[2]/mdoReference"
+              },
+              "passwordMode": false,
+              "kind": "CUSTOM",
+              "indexing": "DONT_INDEX",
+              "type": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[7]/type"
+              },
+              "format": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "editFormat": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "markNegatives": false,
+              "mask": "",
+              "multiLine": false,
+              "extendedEdit": false,
+              "fillFromFillingValue": false
+            },
+            {
+              "uuid": "f32e0941-2061-4e12-bdae-fcb65f91ac28",
+              "name": "Подсказка",
+              "mdoReference": {
+                "type": "ATTRIBUTE",
+                "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.TabularSection.Представления.Attribute.Подсказка",
+                "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.ТабличнаяЧасть.Представления.Реквизит.Подсказка"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[22]/synonym"
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/tabularSections/c/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection[2]/mdoReference"
+              },
+              "passwordMode": false,
+              "kind": "CUSTOM",
+              "indexing": "DONT_INDEX",
+              "type": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+              },
+              "format": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "editFormat": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "markNegatives": false,
+              "mask": "",
+              "multiLine": false,
+              "extendedEdit": false,
+              "fillFromFillingValue": false
+            },
+            {
+              "uuid": "6f0e0f44-db5a-4a13-9131-866b77b90f14",
+              "name": "ЗаголовокФормыЗначения",
+              "mdoReference": {
+                "type": "ATTRIBUTE",
+                "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.TabularSection.Представления.Attribute.ЗаголовокФормыЗначения",
+                "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.ТабличнаяЧасть.Представления.Реквизит.ЗаголовокФормыЗначения"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[11]/synonym"
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/tabularSections/c/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection[2]/mdoReference"
+              },
+              "passwordMode": false,
+              "kind": "CUSTOM",
+              "indexing": "DONT_INDEX",
+              "type": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[3]/type"
+              },
+              "format": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "editFormat": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "markNegatives": false,
+              "mask": "",
+              "multiLine": false,
+              "extendedEdit": false,
+              "fillFromFillingValue": false
+            },
+            {
+              "uuid": "9415e0aa-391f-4798-ad7d-3b854a756de8",
+              "name": "ЗаголовокФормыВыбораЗначения",
+              "mdoReference": {
+                "type": "ATTRIBUTE",
+                "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.TabularSection.Представления.Attribute.ЗаголовокФормыВыбораЗначения",
+                "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.ТабличнаяЧасть.Представления.Реквизит.ЗаголовокФормыВыбораЗначения"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[8]/synonym"
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/tabularSections/c/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection[2]/mdoReference"
+              },
+              "passwordMode": false,
+              "kind": "CUSTOM",
+              "indexing": "DONT_INDEX",
+              "type": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[3]/type"
+              },
+              "format": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "editFormat": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "markNegatives": false,
+              "mask": "",
+              "multiLine": false,
+              "extendedEdit": false,
+              "fillFromFillingValue": false
+            }
+          ],
+          []
+        ]
+      }
+    ],
+    []
+  ],
+  "templates": [],
+  "uuid": "1055d15b-8cb5-4ff0-a526-7fd20a08a96c",
+  "valueType": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[2]/type"
+  }
+}}

--- a/src/test/resources/fixtures/ssl_3_2/ChartsOfCharacteristicTypes.ДополнительныеРеквизитыИСведения_edt.json
+++ b/src/test/resources/fixtures/ssl_3_2/ChartsOfCharacteristicTypes.ДополнительныеРеквизитыИСведения_edt.json
@@ -1,0 +1,6772 @@
+{"com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes": {
+  "attributes": [
+    [
+      {
+        "uuid": "1055d15b-8cb5-4ff0-a526-7fd20a08a96c",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.StandardAttribute.PredefinedDataName",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.СтандартныйРеквизит.ИмяПредопределенныхДанных"
+        },
+        "comment": "",
+        "synonym": {
+          "content": []
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "type": "CHART_OF_CHARACTERISTIC_TYPES",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                "length": 0,
+                "allowedLength": 0,
+                "description": {
+                  "value": {
+                    "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                    "nameRu": "КвалификаторыСтроки (0, Переменная)",
+                    "nameEn": "StringQualifiers (0, Variable)"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "ИмяПредопределенныхДанных",
+          "nameEn": "PredefinedDataName"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "1055d15b-8cb5-4ff0-a526-7fd20a08a96c",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.StandardAttribute.ValueType",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.СтандартныйРеквизит.ТипЗначения"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 7,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "BOOLEAN",
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "СправочникСсылка.ЗначенияСвойствОбъектов",
+                  "nameEn": "CatalogRef.ЗначенияСвойствОбъектов"
+                },
+                "variant": "METADATA",
+                "kind": "CATALOG"
+              },
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "СправочникСсылка.ЗначенияСвойствОбъектовИерархия",
+                  "nameEn": "CatalogRef.ЗначенияСвойствОбъектовИерархия"
+                },
+                "variant": "METADATA",
+                "kind": "CATALOG"
+              },
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "СправочникСсылка.Пользователи",
+                  "nameEn": "CatalogRef.Пользователи"
+                },
+                "variant": "METADATA",
+                "kind": "CATALOG"
+              },
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "DATE",
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER",
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+            }
+          ],
+          "composite": true,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 3,
+              "com.github._1c_syntax.bsl.types.qualifiers.DateQualifiers": {
+                "dateFractions": 2,
+                "description": {
+                  "value": {
+                    "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                    "nameRu": "КвалификаторыДаты (ДатаВремя)",
+                    "nameEn": "DateQualifiers (DateTime)"
+                  }
+                }
+              },
+              "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                "length": 1024,
+                "allowedLength": 0,
+                "description": {
+                  "value": {
+                    "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                    "nameRu": "КвалификаторыСтроки (1024, Переменная)",
+                    "nameEn": "StringQualifiers (1024, Variable)"
+                  }
+                }
+              },
+              "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                "precision": 17,
+                "scale": 5,
+                "nonNegative": false,
+                "description": {
+                  "value": {
+                    "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                    "nameRu": "КвалификаторыЧисла (17.5)",
+                    "nameEn": "NumberQualifiers (17.5)"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "ТипЗначения",
+          "nameEn": "ValueType"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "1055d15b-8cb5-4ff0-a526-7fd20a08a96c",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.StandardAttribute.Description",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.СтандартныйРеквизит.Наименование"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                "length": 150,
+                "allowedLength": 0,
+                "description": {}
+              }
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "Наименование",
+          "nameEn": "Description"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "1055d15b-8cb5-4ff0-a526-7fd20a08a96c",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.StandardAttribute.Code",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.СтандартныйРеквизит.Код"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                "precision": 0,
+                "scale": 0,
+                "nonNegative": false,
+                "description": {}
+              }
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "Код",
+          "nameEn": "Code"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "1055d15b-8cb5-4ff0-a526-7fd20a08a96c",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.StandardAttribute.IsFolder",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.СтандартныйРеквизит.ЭтоГруппа"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "BOOLEAN"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 0
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "ЭтоГруппа",
+          "nameEn": "IsFolder"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "1055d15b-8cb5-4ff0-a526-7fd20a08a96c",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.StandardAttribute.Parent",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.СтандартныйРеквизит.Родитель"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "ПланВидовХарактеристикСсылка.ДополнительныеРеквизитыИСведения",
+                  "nameEn": "ChartOfCharacteristicTypesRef.ДополнительныеРеквизитыИСведения"
+                },
+                "variant": "METADATA",
+                "kind": "CHART_OF_CHARACTERISTIC_TYPES"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "fullName": {
+          "nameRu": "Родитель",
+          "nameEn": "Parent"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": true
+      },
+      {
+        "uuid": "1055d15b-8cb5-4ff0-a526-7fd20a08a96c",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.StandardAttribute.Predefined",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.СтандартныйРеквизит.Предопределенный"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[5]/type"
+        },
+        "fullName": {
+          "nameRu": "Предопределенный",
+          "nameEn": "Predefined"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "1055d15b-8cb5-4ff0-a526-7fd20a08a96c",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.StandardAttribute.DeletionMark",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.СтандартныйРеквизит.ПометкаУдаления"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[5]/type"
+        },
+        "fullName": {
+          "nameRu": "ПометкаУдаления",
+          "nameEn": "DeletionMark"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "1055d15b-8cb5-4ff0-a526-7fd20a08a96c",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.StandardAttribute.Ref",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.СтандартныйРеквизит.Ссылка"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[6]/type"
+        },
+        "fullName": {
+          "nameRu": "Ссылка",
+          "nameEn": "Ref"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "8064eb3a-d56c-4517-9db0-b7300149c7c4",
+        "name": "Виден",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.Виден",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.Виден"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Виден"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[5]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "fe926c88-d792-4db3-abcf-3c94dfdcc407",
+        "name": "ВладелецДополнительныхЗначений",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.ВладелецДополнительныхЗначений",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.ВладелецДополнительныхЗначений"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Владелец дополнительных значений"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[6]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "b1c3a6c1-5245-4a65-8a45-13948be6f6a1",
+        "name": "ВыводитьВВидеГиперссылки",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.ВыводитьВВидеГиперссылки",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.ВыводитьВВидеГиперссылки"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Выводить в виде гиперссылки"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[5]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "bcbdba9e-0b29-4ea7-a7d5-1de819bf86ec",
+        "name": "ДополнительныеЗначенияИспользуются",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.ДополнительныеЗначенияИспользуются",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.ДополнительныеЗначенияИспользуются"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Дополнительные значения используются"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[5]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "e0c51555-1614-4aa7-a075-c5e1251579ba",
+        "name": "ДополнительныеЗначенияСВесом",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.ДополнительныеЗначенияСВесом",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.ДополнительныеЗначенияСВесом"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Значения дополнительно характеризуются весовым коэффициентом"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[5]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "c75a1c6d-fa33-4b57-b359-6253aff5f3e7",
+        "name": "Доступен",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.Доступен",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.Доступен"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Доступен"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[5]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "af88ea84-5742-4c9f-9a02-6d0f25186f72",
+        "name": "Заголовок",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.Заголовок",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.Заголовок"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Наименование"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                "length": 75,
+                "allowedLength": 0,
+                "description": {}
+              }
+            }
+          ]
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "51363236-c8eb-4eb7-9692-5c18edc9a5a8",
+        "name": "ЗаголовокФормыВыбораЗначения",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.ЗаголовокФормыВыбораЗначения",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.ЗаголовокФормыВыбораЗначения"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Заголовок формы выбора значения"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[3]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "e97edb4a-468d-499d-924d-aa4e5ee16548",
+        "name": "ЗаголовокФормыВыбораЗначенияЯзык1",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.ЗаголовокФормыВыбораЗначенияЯзык1",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.ЗаголовокФормыВыбораЗначенияЯзык1"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Заголовок формы выбора значения язык (дополнительный язык)"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[3]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "24366a86-0dae-4a68-a180-d8ea7656a286",
+        "name": "ЗаголовокФормыВыбораЗначенияЯзык2",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.ЗаголовокФормыВыбораЗначенияЯзык2",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.ЗаголовокФормыВыбораЗначенияЯзык2"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Заголовок формы выбора значения язык (дополнительный язык 2)"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[3]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "cb65fbad-69a0-47d8-b4a9-da49274c3eb7",
+        "name": "ЗаголовокФормыЗначения",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.ЗаголовокФормыЗначения",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.ЗаголовокФормыЗначения"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Заголовок формы значения"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[3]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "3c03f78e-c904-47da-a0a1-db5d6b9f7254",
+        "name": "ЗаголовокФормыЗначенияЯзык1",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.ЗаголовокФормыЗначенияЯзык1",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.ЗаголовокФормыЗначенияЯзык1"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Заголовок формы значения язык (дополнительный язык)"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[3]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "3bf03ed7-6581-4a11-8fc8-748f46c8dad7",
+        "name": "ЗаголовокФормыЗначенияЯзык2",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.ЗаголовокФормыЗначенияЯзык2",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.ЗаголовокФормыЗначенияЯзык2"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Заголовок формы значения язык (дополнительный язык 2)"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[3]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "0f28c616-162c-4dba-bd22-f7ea5d23ea5a",
+        "name": "ЗаголовокЯзык1",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.ЗаголовокЯзык1",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.ЗаголовокЯзык1"
+        },
+        "objectBelonging": "OWN",
+        "comment": "АПК:58",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Наименование  (дополнительный язык)"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[7]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "39bf2771-1d8b-44bb-8d8b-54d046589ebe",
+        "name": "ЗаголовокЯзык2",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.ЗаголовокЯзык2",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.ЗаголовокЯзык2"
+        },
+        "objectBelonging": "OWN",
+        "comment": "АПК:58",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Наименование (дополнительный язык 2)"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[7]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "872521e3-413c-45ac-a6ea-39fe1324bae8",
+        "name": "ЗаполнятьОбязательно",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.ЗаполнятьОбязательно",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.ЗаполнятьОбязательно"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Заполнять обязательно"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[5]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "f237a21e-066a-48e6-a5c4-5dc2487c7a3b",
+        "name": "ИдентификаторДляФормул",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.ИдентификаторДляФормул",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.ИдентификаторДляФормул"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Идентификатор для формул"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[3]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "8adebe50-a946-40c2-9258-b17efe787e0e",
+        "name": "Имя",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.Имя",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.Имя"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Имя"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                "length": 100,
+                "allowedLength": 0,
+                "description": {}
+              }
+            }
+          ]
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "8cad6cfd-91d0-4563-800a-d60c8a1b6a03",
+        "name": "Комментарий",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.Комментарий",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.Комментарий"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Комментарий"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "81ef02df-498d-4af0-8254-dc6730cbf140",
+        "name": "МногострочноеПолеВвода",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.МногострочноеПолеВвода",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.МногострочноеПолеВвода"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Многострочное поле ввода"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                "precision": 2,
+                "scale": 0,
+                "nonNegative": true,
+                "description": {}
+              }
+            }
+          ]
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "79ad09ba-875a-46bd-9cd9-9d084bf4f6ea",
+        "name": "НаборСвойств",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.НаборСвойств",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.НаборСвойств"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Набор свойств"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "СправочникСсылка.НаборыДополнительныхРеквизитовИСведений",
+                  "nameEn": "CatalogRef.НаборыДополнительныхРеквизитовИСведений"
+                },
+                "variant": "METADATA",
+                "kind": "CATALOG"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "2902460a-ed86-41cf-8e8f-895adab9a72f",
+        "name": "Подсказка",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.Подсказка",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.Подсказка"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Подсказка"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "d12c7296-36ab-41e0-83ef-143484958597",
+        "name": "ПодсказкаЯзык1",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.ПодсказкаЯзык1",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.ПодсказкаЯзык1"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Подсказка язык (дополнительный язык)"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "2b6c3bcd-7d2a-4e95-8066-99374002689b",
+        "name": "ПодсказкаЯзык2",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.ПодсказкаЯзык2",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.ПодсказкаЯзык2"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Подсказка язык (дополнительный язык 2)"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "402f2fe0-4d08-4701-9c8f-0c2bb75815ef",
+        "name": "ФорматСвойства",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.ФорматСвойства",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.ФорматСвойства"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Формат свойства"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "1a4ed7cf-3294-4a5c-9650-75b61d6b2531",
+        "name": "ЭтоДополнительноеСведение",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.ЭтоДополнительноеСведение",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.ЭтоДополнительноеСведение"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Это дополнительное сведение"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[5]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "73cc5b8b-4cba-4988-b2c6-d974dde9723d",
+        "name": "ВидСвойства",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.ВидСвойства",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.ВидСвойства"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Вид свойства"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "ПеречислениеСсылка.ВидыСвойств",
+                  "nameEn": "EnumRef.ВидыСвойств"
+                },
+                "variant": "METADATA",
+                "kind": "ENUM"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "1b9bbdb1-b8c0-4459-8b5c-656055482f00",
+        "name": "ЦветСвойства",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Attribute.ЦветСвойства",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Реквизит.ЦветСвойства"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Цвет свойства"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "ПеречислениеСсылка.ЦветаСвойств",
+                  "nameEn": "EnumRef.ЦветаСвойств"
+                },
+                "variant": "METADATA",
+                "kind": "ENUM"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      }
+    ],
+    []
+  ],
+  "checkUnique": false,
+  "codeSeries": "WHOLE_CATALOG",
+  "commands": [],
+  "comment": "",
+  "description": "Дополнительные реквизиты и сведения",
+  "explanation": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+  },
+  "forms": [
+    [
+      {
+        "uuid": "f82d5bd6-4c74-4c23-978c-565aae3d752a",
+        "name": "ФормаЭлемента",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Form.ФормаЭлемента",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Форма.ФормаЭлемента"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Форма элемента"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/ChartsOfCharacteristicTypes/ДополнительныеРеквизитыИСведения/Forms/ФормаЭлемента/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+          },
+          "handlers": [
+            [
+              {
+                "event": "ChoiceProcessing",
+                "name": "ОбработкаВыбора"
+              },
+              {
+                "event": "NotificationProcessing",
+                "name": "ОбработкаОповещения"
+              },
+              {
+                "event": "OnOpen",
+                "name": "ПриОткрытии"
+              },
+              {
+                "event": "OnCreateAtServer",
+                "name": "ПриСозданииНаСервере"
+              }
+            ],
+            []
+          ],
+          "items": [
+            [
+              {
+                "type": "PAGES",
+                "id": 200,
+                "name": "СтраницыПомощникКарточка",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Страницы помощник карточка"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "PAGE",
+                      "id": 202,
+                      "name": "ВыборРеквизита",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Выбор реквизита"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 336,
+                            "name": "ГруппаЗаголовок",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Заголовок"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "LABEL",
+                                  "id": 338,
+                                  "name": "ДекорацияЗаголовок",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Выберите %1 для включения в набор \"%2\":"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "COMMAND_BAR",
+                                  "id": 408,
+                                  "name": "ПанельЕще",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Панель еще"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    {
+                                      "type": "POPUP",
+                                      "id": 410,
+                                      "name": "ПодменюЕще",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Еще"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        {
+                                          "type": "BUTTON",
+                                          "id": 412,
+                                          "name": "НеиспользуемыеРеквизиты",
+                                          "title": {
+                                            "content": [
+                                              {
+                                                "default": {
+                                                  "tag": 2
+                                                },
+                                                "int": 1,
+                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                  "langKey": "ru",
+                                                  "value": "Неиспользуемые реквизиты"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "dataPath": "",
+                                          "items": []
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ],
+                              []
+                            ]
+                          },
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 341,
+                            "name": "ГруппаСодержимое",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Содержимое"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "USUAL_GROUP",
+                                  "id": 343,
+                                  "name": "ГруппаНаборыСвойств",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Наборы свойств"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    {
+                                      "type": "PAGES",
+                                      "id": 414,
+                                      "name": "СтраницыНаборыСвойств",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Страницы наборы свойств"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        [
+                                          {
+                                            "type": "PAGE",
+                                            "id": 416,
+                                            "name": "СтраницаВсеНаборы",
+                                            "title": {
+                                              "content": [
+                                                {
+                                                  "default": {
+                                                    "tag": 2
+                                                  },
+                                                  "int": 1,
+                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                    "langKey": "ru",
+                                                    "value": "Страница все наборы"
+                                                  }
+                                                }
+                                              ]
+                                            },
+                                            "dataPath": "",
+                                            "items": [
+                                              {
+                                                "type": "TABLE",
+                                                "id": 345,
+                                                "name": "НаборыСвойств",
+                                                "title": {
+                                                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                                },
+                                                "dataPath": "НаборыСвойств",
+                                                "items": [
+                                                  [
+                                                    {
+                                                      "type": "LABEL_FIELD",
+                                                      "id": 396,
+                                                      "name": "Представление",
+                                                      "title": {
+                                                        "content": [
+                                                          {
+                                                            "default": {
+                                                              "tag": 2
+                                                            },
+                                                            "int": 1,
+                                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                              "langKey": "ru",
+                                                              "value": "Представление набора"
+                                                            }
+                                                          }
+                                                        ]
+                                                      },
+                                                      "dataPath": "НаборыСвойств.Представление",
+                                                      "items": []
+                                                    },
+                                                    {
+                                                      "type": "LABEL_FIELD",
+                                                      "id": 399,
+                                                      "name": "Ссылка",
+                                                      "title": {
+                                                        "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                                      },
+                                                      "dataPath": "НаборыСвойств.Ссылка",
+                                                      "items": []
+                                                    }
+                                                  ],
+                                                  []
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "PAGE",
+                                            "id": 418,
+                                            "name": "СтраницаОбщиеНаборы",
+                                            "title": {
+                                              "content": [
+                                                {
+                                                  "default": {
+                                                    "tag": 2
+                                                  },
+                                                  "int": 1,
+                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                    "langKey": "ru",
+                                                    "value": "Страница общие наборы"
+                                                  }
+                                                }
+                                              ]
+                                            },
+                                            "dataPath": "",
+                                            "items": [
+                                              {
+                                                "type": "TABLE",
+                                                "id": 420,
+                                                "name": "ОбщиеНаборыСвойств",
+                                                "title": {
+                                                  "content": [
+                                                    {
+                                                      "default": {
+                                                        "tag": 2
+                                                      },
+                                                      "int": 1,
+                                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                        "langKey": "ru",
+                                                        "value": "Общие наборы свойств"
+                                                      }
+                                                    }
+                                                  ]
+                                                },
+                                                "dataPath": "ОбщиеНаборыСвойств",
+                                                "items": [
+                                                  {
+                                                    "type": "LABEL_FIELD",
+                                                    "id": 436,
+                                                    "name": "ОбщиеНаборыСвойствПредставление",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "Представление"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "ОбщиеНаборыСвойств.Представление",
+                                                    "items": []
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ],
+                                        []
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "USUAL_GROUP",
+                                  "id": 364,
+                                  "name": "РасшифровкаРеквизита",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Дополнительные реквизиты"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "TABLE",
+                                        "id": 366,
+                                        "name": "Свойства",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Свойства"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "Свойства",
+                                        "items": [
+                                          {
+                                            "type": "INPUT_FIELD",
+                                            "id": 379,
+                                            "name": "СвойстваЗаголовок",
+                                            "title": {
+                                              "content": [
+                                                {
+                                                  "default": {
+                                                    "tag": 2
+                                                  },
+                                                  "int": 1,
+                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                    "langKey": "ru",
+                                                    "value": "Реквизит"
+                                                  }
+                                                }
+                                              ]
+                                            },
+                                            "dataPath": "Свойства.Заголовок",
+                                            "items": []
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "USUAL_GROUP",
+                                        "id": 469,
+                                        "name": "ГруппаДополнительнаяИнформация",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Дополнительная информация"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": [
+                                          [
+                                            {
+                                              "type": "INPUT_FIELD",
+                                              "id": 384,
+                                              "name": "СписокДополнительныхРеквизитовТипЗначения",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                              },
+                                              "dataPath": "Items.Свойства.CurrentData.ТипЗначения",
+                                              "items": []
+                                            },
+                                            {
+                                              "type": "INPUT_FIELD",
+                                              "id": 387,
+                                              "name": "СписокДополнительныхРеквизитовПодсказка",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Всплывающая подсказка"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "Items.Свойства.CurrentData.Подсказка",
+                                              "items": []
+                                            },
+                                            {
+                                              "type": "INPUT_FIELD",
+                                              "id": 390,
+                                              "name": "СписокДополнительныхРеквизитовЗаголовокФормыЗначения",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                              },
+                                              "dataPath": "Items.Свойства.CurrentData.ЗаголовокФормыЗначения",
+                                              "items": []
+                                            },
+                                            {
+                                              "type": "INPUT_FIELD",
+                                              "id": 393,
+                                              "name": "СписокДополнительныхРеквизитовЗаголовокФормыВыбораЗначения",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                              },
+                                              "dataPath": "Items.Свойства.CurrentData.ЗаголовокФормыВыбораЗначения",
+                                              "items": []
+                                            }
+                                          ],
+                                          []
+                                        ]
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                }
+                              ],
+                              []
+                            ]
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "PAGE",
+                      "id": 204,
+                      "name": "ВыборДействия",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Выбор действия"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        {
+                          "type": "RADIO_BUTTON_FIELD",
+                          "id": 237,
+                          "name": "РежимДобавленияРеквизита",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Выберите вариант добавления дополнительного %1 \"%2\" в набор \"%3\""
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "РежимДобавленияРеквизита",
+                          "items": []
+                        }
+                      ]
+                    },
+                    {
+                      "type": "PAGE",
+                      "id": 206,
+                      "name": "КарточкаРеквизита",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Карточка реквизита"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 79,
+                            "name": "ГруппаНаименованиеРеквизита",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Наименование реквизита"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 1,
+                                  "name": "Заголовок",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[7]/synonym"
+                                  },
+                                  "dataPath": "Объект.Заголовок",
+                                  "items": []
+                                },
+                                {
+                                  "type": "RADIO_BUTTON_FIELD",
+                                  "id": 20,
+                                  "name": "ВидСвойства",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[27]/synonym"
+                                  },
+                                  "dataPath": "ВидСвойства",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          },
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 43,
+                            "name": "ТипЗначенияРеквизита",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Тип значения реквизита"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "USUAL_GROUP",
+                                  "id": 471,
+                                  "name": "ГруппаТипЗначения",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Тип значения"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "INPUT_FIELD",
+                                        "id": 5,
+                                        "name": "ТипЗначения",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                        },
+                                        "dataPath": "Объект.ValueType",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "HYPERLINK",
+                                        "id": 37,
+                                        "name": "РедактироватьФорматЗначения",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Формат"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                },
+                                {
+                                  "type": "USUAL_GROUP",
+                                  "id": 476,
+                                  "name": "ГруппаПояснениеТипаЗначения",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Пояснение типа значения"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "DECORATION",
+                                        "id": 478,
+                                        "name": "КартинкаПояснение",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "LABEL",
+                                        "id": 473,
+                                        "name": "ПояснениеОДлинеСтроки",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Максимальная длина строки составляет 1024 символа"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                }
+                              ],
+                              []
+                            ]
+                          },
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 38,
+                            "name": "ГруппаМногострочность",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Многострочность"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "USUAL_GROUP",
+                                  "id": 448,
+                                  "name": "ГруппаОднострочноеПолеВводаНастройки",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Однострочное поле ввода настройки"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "RADIO_BUTTON_FIELD",
+                                        "id": 442,
+                                        "name": "ОднострочныйВид",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Представление реквизита"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "ПредставлениеРеквизита",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "CHECK_BOX_FIELD",
+                                        "id": 445,
+                                        "name": "ВыводитьВВидеГиперссылки",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                        },
+                                        "dataPath": "Объект.ВыводитьВВидеГиперссылки",
+                                        "items": []
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                },
+                                {
+                                  "type": "USUAL_GROUP",
+                                  "id": 46,
+                                  "name": "ГруппаМногострочноеПолеВводаНастройки",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Многострочное поле ввода настройки"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "RADIO_BUTTON_FIELD",
+                                        "id": 450,
+                                        "name": "МногострочныйВид",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                        },
+                                        "dataPath": "ПредставлениеРеквизита",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "INPUT_FIELD",
+                                        "id": 41,
+                                        "name": "МногострочноеПолеВводаЧисло",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "  строк"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "МногострочноеПолеВводаЧисло",
+                                        "items": []
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                }
+                              ],
+                              []
+                            ]
+                          },
+                          {
+                            "type": "PAGES",
+                            "id": 167,
+                            "name": "Страницы",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Страницы"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "PAGE",
+                                  "id": 169,
+                                  "name": "ГлавнаяСтраница",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Главное"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "USUAL_GROUP",
+                                        "id": 498,
+                                        "name": "ГруппаЦветаСвойств",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Цвета свойств"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": [
+                                          [
+                                            {
+                                              "type": "LABEL",
+                                              "id": 500,
+                                              "name": "ДекорацияЦветСвойства",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Цвет:"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "",
+                                              "items": []
+                                            },
+                                            {
+                                              "type": "COMMAND_BAR",
+                                              "id": 503,
+                                              "name": "КоманднаяПанельЦветаСвойств",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Командная панель цвета свойств"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "",
+                                              "items": [
+                                                {
+                                                  "type": "FORM_GROUP",
+                                                  "id": 505,
+                                                  "name": "ГруппаЦвета",
+                                                  "title": {
+                                                    "content": [
+                                                      {
+                                                        "default": {
+                                                          "tag": 2
+                                                        },
+                                                        "int": 1,
+                                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                          "langKey": "ru",
+                                                          "value": "Цвета"
+                                                        }
+                                                      }
+                                                    ]
+                                                  },
+                                                  "dataPath": "",
+                                                  "items": [
+                                                    [
+                                                      {
+                                                        "type": "BUTTON",
+                                                        "id": 507,
+                                                        "name": "СвойствоСерое",
+                                                        "title": {
+                                                          "content": [
+                                                            {
+                                                              "default": {
+                                                                "tag": 2
+                                                              },
+                                                              "int": 1,
+                                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                "langKey": "ru",
+                                                                "value": "Свойство серое"
+                                                              }
+                                                            }
+                                                          ]
+                                                        },
+                                                        "dataPath": "",
+                                                        "items": []
+                                                      },
+                                                      {
+                                                        "type": "BUTTON",
+                                                        "id": 517,
+                                                        "name": "СвойствоЗеленое",
+                                                        "title": {
+                                                          "content": [
+                                                            {
+                                                              "default": {
+                                                                "tag": 2
+                                                              },
+                                                              "int": 1,
+                                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                "langKey": "ru",
+                                                                "value": "Свойство зеленое"
+                                                              }
+                                                            }
+                                                          ]
+                                                        },
+                                                        "dataPath": "",
+                                                        "items": []
+                                                      },
+                                                      {
+                                                        "type": "BUTTON",
+                                                        "id": 515,
+                                                        "name": "СвойствоЖелтое",
+                                                        "title": {
+                                                          "content": [
+                                                            {
+                                                              "default": {
+                                                                "tag": 2
+                                                              },
+                                                              "int": 1,
+                                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                "langKey": "ru",
+                                                                "value": "Свойство желтое"
+                                                              }
+                                                            }
+                                                          ]
+                                                        },
+                                                        "dataPath": "",
+                                                        "items": []
+                                                      },
+                                                      {
+                                                        "type": "BUTTON",
+                                                        "id": 513,
+                                                        "name": "СвойствоОранжевое",
+                                                        "title": {
+                                                          "content": [
+                                                            {
+                                                              "default": {
+                                                                "tag": 2
+                                                              },
+                                                              "int": 1,
+                                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                "langKey": "ru",
+                                                                "value": "Свойство оранжевое"
+                                                              }
+                                                            }
+                                                          ]
+                                                        },
+                                                        "dataPath": "",
+                                                        "items": []
+                                                      },
+                                                      {
+                                                        "type": "BUTTON",
+                                                        "id": 511,
+                                                        "name": "СвойствоКрасное",
+                                                        "title": {
+                                                          "content": [
+                                                            {
+                                                              "default": {
+                                                                "tag": 2
+                                                              },
+                                                              "int": 1,
+                                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                "langKey": "ru",
+                                                                "value": "Свойство красное"
+                                                              }
+                                                            }
+                                                          ]
+                                                        },
+                                                        "dataPath": "",
+                                                        "items": []
+                                                      },
+                                                      {
+                                                        "type": "BUTTON",
+                                                        "id": 523,
+                                                        "name": "СвойствоФиолетовое",
+                                                        "title": {
+                                                          "content": [
+                                                            {
+                                                              "default": {
+                                                                "tag": 2
+                                                              },
+                                                              "int": 1,
+                                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                "langKey": "ru",
+                                                                "value": "Свойство фиолетовое"
+                                                              }
+                                                            }
+                                                          ]
+                                                        },
+                                                        "dataPath": "",
+                                                        "items": []
+                                                      },
+                                                      {
+                                                        "type": "BUTTON",
+                                                        "id": 519,
+                                                        "name": "СвойствоСинее",
+                                                        "title": {
+                                                          "content": [
+                                                            {
+                                                              "default": {
+                                                                "tag": 2
+                                                              },
+                                                              "int": 1,
+                                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                "langKey": "ru",
+                                                                "value": "Свойство синее"
+                                                              }
+                                                            }
+                                                          ]
+                                                        },
+                                                        "dataPath": "",
+                                                        "items": []
+                                                      },
+                                                      {
+                                                        "type": "BUTTON",
+                                                        "id": 509,
+                                                        "name": "СвойствоЛаймовое",
+                                                        "title": {
+                                                          "content": [
+                                                            {
+                                                              "default": {
+                                                                "tag": 2
+                                                              },
+                                                              "int": 1,
+                                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                "langKey": "ru",
+                                                                "value": "Свойство лаймовое"
+                                                              }
+                                                            }
+                                                          ]
+                                                        },
+                                                        "dataPath": "",
+                                                        "items": []
+                                                      },
+                                                      {
+                                                        "type": "BUTTON",
+                                                        "id": 525,
+                                                        "name": "СвойствоРозовое",
+                                                        "title": {
+                                                          "content": [
+                                                            {
+                                                              "default": {
+                                                                "tag": 2
+                                                              },
+                                                              "int": 1,
+                                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                "langKey": "ru",
+                                                                "value": "Свойство розовое"
+                                                              }
+                                                            }
+                                                          ]
+                                                        },
+                                                        "dataPath": "",
+                                                        "items": []
+                                                      },
+                                                      {
+                                                        "type": "BUTTON",
+                                                        "id": 521,
+                                                        "name": "СвойствоГолубое",
+                                                        "title": {
+                                                          "content": [
+                                                            {
+                                                              "default": {
+                                                                "tag": 2
+                                                              },
+                                                              "int": 1,
+                                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                "langKey": "ru",
+                                                                "value": "Свойство голубое"
+                                                              }
+                                                            }
+                                                          ]
+                                                        },
+                                                        "dataPath": "",
+                                                        "items": []
+                                                      }
+                                                    ],
+                                                    []
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ],
+                                          []
+                                        ]
+                                      },
+                                      {
+                                        "type": "USUAL_GROUP",
+                                        "id": 324,
+                                        "name": "ГруппаСвойстваИЗависимости",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Свойства и зависимости"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": [
+                                          [
+                                            {
+                                              "type": "USUAL_GROUP",
+                                              "id": 463,
+                                              "name": "ГруппаВиден",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/synonym"
+                                              },
+                                              "dataPath": "",
+                                              "items": [
+                                                [
+                                                  {
+                                                    "type": "LABEL",
+                                                    "id": 402,
+                                                    "name": "Виден",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "Виден:"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": []
+                                                  },
+                                                  {
+                                                    "type": "LABEL",
+                                                    "id": 333,
+                                                    "name": "ЗадатьУсловиеВидимости",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "всегда"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": []
+                                                  }
+                                                ],
+                                                []
+                                              ]
+                                            },
+                                            {
+                                              "type": "USUAL_GROUP",
+                                              "id": 465,
+                                              "name": "ГруппаДоступен",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[6]/synonym"
+                                              },
+                                              "dataPath": "",
+                                              "items": [
+                                                [
+                                                  {
+                                                    "type": "LABEL",
+                                                    "id": 405,
+                                                    "name": "Доступен",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "Доступен:"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": []
+                                                  },
+                                                  {
+                                                    "type": "LABEL",
+                                                    "id": 194,
+                                                    "name": "ЗадатьУсловиеДоступности",
+                                                    "title": {
+                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": []
+                                                  }
+                                                ],
+                                                []
+                                              ]
+                                            },
+                                            {
+                                              "type": "USUAL_GROUP",
+                                              "id": 467,
+                                              "name": "ГруппаЗаполнятьОбязательно",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[16]/synonym"
+                                              },
+                                              "dataPath": "",
+                                              "items": [
+                                                [
+                                                  {
+                                                    "type": "CHECK_BOX_FIELD",
+                                                    "id": 184,
+                                                    "name": "ЗаполнятьОбязательно",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "Заполнять обязательно:"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "Объект.ЗаполнятьОбязательно",
+                                                    "items": []
+                                                  },
+                                                  {
+                                                    "type": "LABEL",
+                                                    "id": 197,
+                                                    "name": "ЗадатьУсловиеЗаполнения",
+                                                    "title": {
+                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": []
+                                                  }
+                                                ],
+                                                []
+                                              ]
+                                            }
+                                          ],
+                                          []
+                                        ]
+                                      },
+                                      {
+                                        "type": "USUAL_GROUP",
+                                        "id": 107,
+                                        "name": "ОстальныеРеквизиты",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Остальные реквизиты"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": [
+                                          [
+                                            {
+                                              "type": "USUAL_GROUP",
+                                              "id": 481,
+                                              "name": "ГруппаИдентификаторДляФормул",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[17]/synonym"
+                                              },
+                                              "dataPath": "",
+                                              "items": [
+                                                [
+                                                  {
+                                                    "type": "INPUT_FIELD",
+                                                    "id": 483,
+                                                    "name": "ИдентификаторДляФормул",
+                                                    "title": {
+                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                                    },
+                                                    "dataPath": "Объект.ИдентификаторДляФормул",
+                                                    "items": []
+                                                  },
+                                                  {
+                                                    "type": "USUAL_BUTTON",
+                                                    "id": 486,
+                                                    "name": "ЗаполнитьИдентификаторДляФормул",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "Заполнить идентификатор для формул"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": []
+                                                  }
+                                                ],
+                                                []
+                                              ]
+                                            },
+                                            {
+                                              "type": "INPUT_FIELD",
+                                              "id": 30,
+                                              "name": "Подсказка",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                              },
+                                              "dataPath": "Объект.Подсказка",
+                                              "items": []
+                                            },
+                                            {
+                                              "type": "USUAL_GROUP",
+                                              "id": 32,
+                                              "name": "ГруппаЗаголовкиФормЗначений",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Заголовки форм значений"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "",
+                                              "items": [
+                                                [
+                                                  {
+                                                    "type": "INPUT_FIELD",
+                                                    "id": 33,
+                                                    "name": "ЗаголовокФормыЗначения",
+                                                    "title": {
+                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                                    },
+                                                    "dataPath": "Объект.ЗаголовокФормыЗначения",
+                                                    "items": []
+                                                  },
+                                                  {
+                                                    "type": "INPUT_FIELD",
+                                                    "id": 35,
+                                                    "name": "ЗаголовокФормыВыбораЗначения",
+                                                    "title": {
+                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                                    },
+                                                    "dataPath": "Объект.ЗаголовокФормыВыбораЗначения",
+                                                    "items": []
+                                                  }
+                                                ],
+                                                []
+                                              ]
+                                            },
+                                            {
+                                              "type": "INPUT_FIELD",
+                                              "id": 28,
+                                              "name": "Комментарий",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                              },
+                                              "dataPath": "Объект.Комментарий",
+                                              "items": []
+                                            }
+                                          ],
+                                          []
+                                        ]
+                                      },
+                                      {
+                                        "type": "USUAL_GROUP",
+                                        "id": 96,
+                                        "name": "УточнениеНаборов",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Уточнение наборов"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": [
+                                          [
+                                            {
+                                              "type": "LABEL",
+                                              "id": 99,
+                                              "name": "УточнениеНаборовКомментарий",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Общий реквизит входит в набор \"Расходный кассовый ордер\" "
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "",
+                                              "items": []
+                                            },
+                                            {
+                                              "type": "USUAL_BUTTON",
+                                              "id": 106,
+                                              "name": "УточнениеНаборовИзменить",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Изменить..."
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "",
+                                              "items": []
+                                            }
+                                          ],
+                                          []
+                                        ]
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                },
+                                {
+                                  "type": "PAGE",
+                                  "id": 182,
+                                  "name": "СтраницаЗначения",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Значения"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "PAGES",
+                                        "id": 287,
+                                        "name": "СтраницыЗначенияРеквизита",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Страницы значения реквизита"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": [
+                                          [
+                                            {
+                                              "type": "PAGE",
+                                              "id": 56,
+                                              "name": "ДополнительныеЗначения",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Дополнительные значения:"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "",
+                                              "items": [
+                                                {
+                                                  "type": "TABLE",
+                                                  "id": 57,
+                                                  "name": "Значения",
+                                                  "title": {
+                                                    "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                                  },
+                                                  "dataPath": "Значения",
+                                                  "items": [
+                                                    [
+                                                      {
+                                                        "type": "LABEL_FIELD",
+                                                        "id": 60,
+                                                        "name": "ЗначенияНаименование",
+                                                        "title": {
+                                                          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[7]/synonym"
+                                                        },
+                                                        "dataPath": "Значения.Наименование",
+                                                        "items": []
+                                                      },
+                                                      {
+                                                        "type": "LABEL_FIELD",
+                                                        "id": 83,
+                                                        "name": "ЗначенияВес",
+                                                        "title": {
+                                                          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                                        },
+                                                        "dataPath": "Значения.Вес",
+                                                        "items": []
+                                                      },
+                                                      {
+                                                        "type": "LABEL_FIELD",
+                                                        "id": 460,
+                                                        "name": "ЗначенияСсылка",
+                                                        "title": {
+                                                          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                                        },
+                                                        "dataPath": "Значения.Ссылка",
+                                                        "items": []
+                                                      }
+                                                    ],
+                                                    []
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "type": "PAGE",
+                                              "id": 289,
+                                              "name": "СтраницаДеревоЗначений",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Страница дерево значений"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "",
+                                              "items": [
+                                                {
+                                                  "type": "TABLE",
+                                                  "id": 291,
+                                                  "name": "ЗначенияДополнительногоРеквизита",
+                                                  "title": {
+                                                    "content": [
+                                                      {
+                                                        "default": {
+                                                          "tag": 2
+                                                        },
+                                                        "int": 1,
+                                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                          "langKey": "ru",
+                                                          "value": "Значения дополнительного реквизита"
+                                                        }
+                                                      }
+                                                    ]
+                                                  },
+                                                  "dataPath": "ЗначенияДополнительныхРеквизитов",
+                                                  "items": [
+                                                    [
+                                                      {
+                                                        "type": "INPUT_FIELD",
+                                                        "id": 304,
+                                                        "name": "ЗначенияДополнительногоРеквизитаНаименование",
+                                                        "title": {
+                                                          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[7]/synonym"
+                                                        },
+                                                        "dataPath": "ЗначенияДополнительныхРеквизитов.Наименование",
+                                                        "items": []
+                                                      },
+                                                      {
+                                                        "type": "INPUT_FIELD",
+                                                        "id": 307,
+                                                        "name": "ЗначенияДополнительногоРеквизитаВес",
+                                                        "title": {
+                                                          "content": [
+                                                            {
+                                                              "default": {
+                                                                "tag": 2
+                                                              },
+                                                              "int": 1,
+                                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                "langKey": "ru",
+                                                                "value": "Весовой коэффициент"
+                                                              }
+                                                            }
+                                                          ]
+                                                        },
+                                                        "dataPath": "ЗначенияДополнительныхРеквизитов.Вес",
+                                                        "items": []
+                                                      }
+                                                    ],
+                                                    []
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ],
+                                          []
+                                        ]
+                                      },
+                                      {
+                                        "type": "CHECK_BOX_FIELD",
+                                        "id": 69,
+                                        "name": "ДополнительныеЗначенияСВесом",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                        },
+                                        "dataPath": "Объект.ДополнительныеЗначенияСВесом",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "USUAL_GROUP",
+                                        "id": 89,
+                                        "name": "УточнениеСпискаЗначений",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Уточнение списка значений"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": [
+                                          [
+                                            {
+                                              "type": "LABEL",
+                                              "id": 87,
+                                              "name": "УточнениеСпискаЗначенийКомментарий",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Список значений общий с реквизитом \"Цвет\" набора \"Номенклатура (сумки)\" "
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "",
+                                              "items": []
+                                            },
+                                            {
+                                              "type": "USUAL_BUTTON",
+                                              "id": 105,
+                                              "name": "УточнениеСпискаЗначенийИзменить",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                              },
+                                              "dataPath": "",
+                                              "items": []
+                                            }
+                                          ],
+                                          []
+                                        ]
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                }
+                              ],
+                              []
+                            ]
+                          },
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 455,
+                            "name": "ГруппаДляРазработчиков",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Для разработчиков"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 457,
+                                "name": "Имя",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                },
+                                "dataPath": "Объект.Имя",
+                                "items": []
+                              }
+                            ]
+                          }
+                        ],
+                        []
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 227,
+                "name": "КоманднаяПанельПомощника",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Командная панель помощника"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "COMMAND_BAR",
+                      "id": 229,
+                      "name": "КоманднаяПанельЛево",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Командная панель лево"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        {
+                          "type": "BUTTON",
+                          "id": 233,
+                          "name": "КомандаНазад",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "< Назад"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": []
+                        }
+                      ]
+                    },
+                    {
+                      "type": "COMMAND_BAR",
+                      "id": 231,
+                      "name": "КоманднаяПанельПраво",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Командная панель право"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "BUTTON",
+                            "id": 235,
+                            "name": "КомандаДалее",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Далее >"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "BUTTON",
+                            "id": 242,
+                            "name": "Закрыть",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Закрыть"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "Объект",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "ПланВидовХарактеристикОбъект.ДополнительныеРеквизитыИСведения",
+                          "nameEn": "ChartOfCharacteristicTypesObject.ДополнительныеРеквизитыИСведения"
+                        },
+                        "variant": "METADATA",
+                        "kind": "CHART_OF_CHARACTERISTIC_TYPES"
+                      }
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 3,
+                "name": "ВидСвойства",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[27]/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[27]/type"
+                }
+              },
+              {
+                "id": 2,
+                "name": "СписокНаборов",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "VALUE_LIST"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 7,
+                "name": "МногострочноеПолеВвода",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[5]/type"
+                }
+              },
+              {
+                "id": 8,
+                "name": "МногострочноеПолеВводаЧисло",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Многострочное поле ввода число"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[20]/type"
+                }
+              },
+              {
+                "id": 9,
+                "name": "Значения",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "DYNAMIC_LIST"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 10,
+                "name": "ПоказатьУточнениеНабора",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[5]/type"
+                }
+              },
+              {
+                "id": 4,
+                "name": "ТекущийНаборСвойств",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[21]/type"
+                }
+              },
+              {
+                "id": 13,
+                "name": "ПереданныеПараметрыФормы",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "types": [],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 14,
+                "name": "РежимДобавленияРеквизита",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Режим добавления реквизита"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              },
+              {
+                "id": 15,
+                "name": "РежимПомощника",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[5]/type"
+                }
+              },
+              {
+                "id": 16,
+                "name": "ЗначенияДополнительныхРеквизитов",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Значения дополнительных реквизитов"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "VALUE_TREE"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 17,
+                "name": "ПустаяСсылка",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[6]/type"
+                }
+              },
+              {
+                "id": 18,
+                "name": "УсловияЗависимостиРеквизитов",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 19,
+                "name": "ИзмененыУсловияЗависимостиРеквизитов",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[5]/type"
+                }
+              },
+              {
+                "id": 20,
+                "name": "ВыбранныйНаборСвойств",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[21]/type"
+                }
+              },
+              {
+                "id": 21,
+                "name": "НаборыСвойств",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[6]/type"
+                }
+              },
+              {
+                "id": 22,
+                "name": "Свойства",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "VALUE_TABLE"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 23,
+                "name": "ОбщиеНаборыСвойств",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[6]/type"
+                }
+              },
+              {
+                "id": 24,
+                "name": "ПредставлениеРеквизита",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              },
+              {
+                "id": 5,
+                "name": "ТекущийЗаголовок",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              },
+              {
+                "id": 25,
+                "name": "ПоказатьНеиспользуемыеРеквизиты",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[5]/type"
+                }
+              },
+              {
+                "id": 26,
+                "name": "ТекущийНаборВерсияДанных",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "7fba41a5-4faa-412b-b367-b30ced0314c0",
+        "name": "ФормаСписка",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Form.ФормаСписка",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Форма.ФормаСписка"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Форма списка"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/ChartsOfCharacteristicTypes/ДополнительныеРеквизитыИСведения/Forms/ФормаСписка/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+          },
+          "handlers": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[4]"
+            }
+          ],
+          "items": [
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 16,
+                "name": "ГруппаПользовательскихНастроек",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Группа пользовательских настроек"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": []
+              },
+              {
+                "type": "COMMAND_BAR",
+                "id": 14,
+                "name": "КоманднаяПанель",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Командная панель"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": []
+              },
+              {
+                "type": "TABLE",
+                "id": 1,
+                "name": "Список",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Список"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "Список",
+                "items": [
+                  [
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 4,
+                      "name": "Наименование",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[7]/synonym"
+                      },
+                      "dataPath": "Список.Description",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 6,
+                      "name": "ТипЗначения",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                      },
+                      "dataPath": "Список.ValueType",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 11,
+                      "name": "Ссылка",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.Ref",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            {
+              "id": 1,
+              "name": "Список",
+              "title": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "type": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[6]/type"
+              }
+            }
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "37333d0b-3589-4b8b-bf6c-e605e0287b66",
+        "name": "РазблокированиеРеквизитов",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Form.РазблокированиеРеквизитов",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Форма.РазблокированиеРеквизитов"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Разблокирование реквизитов"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/ChartsOfCharacteristicTypes/ДополнительныеРеквизитыИСведения/Forms/РазблокированиеРеквизитов/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+          },
+          "handlers": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[4]"
+            }
+          ],
+          "items": [
+            {
+              "type": "PAGES",
+              "id": 1,
+              "name": "ДиалогиПользователя",
+              "title": {
+                "content": [
+                  {
+                    "default": {
+                      "tag": 2
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                      "langKey": "ru",
+                      "value": "Диалоги пользователя"
+                    }
+                  }
+                ]
+              },
+              "dataPath": "",
+              "items": [
+                [
+                  {
+                    "type": "PAGE",
+                    "id": 2,
+                    "name": "ОбъектНеИспользуется",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Объект не используется"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "",
+                    "items": [
+                      {
+                        "type": "PAGES",
+                        "id": 12,
+                        "name": "Пояснения",
+                        "title": {
+                          "content": [
+                            {
+                              "default": {
+                                "tag": 2
+                              },
+                              "int": 1,
+                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                "langKey": "ru",
+                                "value": "Пояснения"
+                              }
+                            }
+                          ]
+                        },
+                        "dataPath": "",
+                        "items": [
+                          [
+                            {
+                              "type": "PAGE",
+                              "id": 22,
+                              "name": "ПояснениеДополнительногоРеквизита",
+                              "title": {
+                                "content": [
+                                  {
+                                    "default": {
+                                      "tag": 2
+                                    },
+                                    "int": 1,
+                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                      "langKey": "ru",
+                                      "value": "Пояснение дополнительного реквизита"
+                                    }
+                                  }
+                                ]
+                              },
+                              "dataPath": "",
+                              "items": [
+                                {
+                                  "type": "LABEL",
+                                  "id": 23,
+                                  "name": "ТекстПоясненияДополнительногоРеквизита",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Дополнительный реквизит не используется в документах приложения.\n\nТип значения и имя дополнительного реквизита можно изменять."
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                }
+                              ]
+                            },
+                            {
+                              "type": "PAGE",
+                              "id": 25,
+                              "name": "ПояснениеДополнительногоСведения",
+                              "title": {
+                                "content": [
+                                  {
+                                    "default": {
+                                      "tag": 2
+                                    },
+                                    "int": 1,
+                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                      "langKey": "ru",
+                                      "value": "Пояснение дополнительного сведения"
+                                    }
+                                  }
+                                ]
+                              },
+                              "dataPath": "",
+                              "items": [
+                                {
+                                  "type": "LABEL",
+                                  "id": 26,
+                                  "name": "ТекстПоясненияДополнительногоСведения",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Дополнительное сведение не используется в информационной базе.\n\nТип значения и имя дополнительного сведения можно изменять."
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                }
+                              ]
+                            }
+                          ],
+                          []
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "PAGE",
+                    "id": 3,
+                    "name": "ОбъектИспользуется",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Объект используется"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "",
+                    "items": [
+                      {
+                        "type": "PAGES",
+                        "id": 17,
+                        "name": "Предупреждения",
+                        "title": {
+                          "content": [
+                            {
+                              "default": {
+                                "tag": 2
+                              },
+                              "int": 1,
+                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                "langKey": "ru",
+                                "value": "Предупреждения"
+                              }
+                            }
+                          ]
+                        },
+                        "dataPath": "",
+                        "items": [
+                          [
+                            {
+                              "type": "PAGE",
+                              "id": 18,
+                              "name": "ПредупреждениеДополнительногоРеквизита",
+                              "title": {
+                                "content": [
+                                  {
+                                    "default": {
+                                      "tag": 2
+                                    },
+                                    "int": 1,
+                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                      "langKey": "ru",
+                                      "value": "Предупреждение дополнительного реквизита"
+                                    }
+                                  }
+                                ]
+                              },
+                              "dataPath": "",
+                              "items": [
+                                {
+                                  "type": "LABEL",
+                                  "id": 6,
+                                  "name": "ТекстПредупрежденияДополнительногоРеквизита",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Внимание! Дополнительный реквизит уже используется в информационной базе.\n\nИзменение типа значения дополнительного реквизита может привести к потере ранее установленных значений его текущего типа."
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                }
+                              ]
+                            },
+                            {
+                              "type": "PAGE",
+                              "id": 19,
+                              "name": "ПредупреждениеДополнительногоСведения",
+                              "title": {
+                                "content": [
+                                  {
+                                    "default": {
+                                      "tag": 2
+                                    },
+                                    "int": 1,
+                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                      "langKey": "ru",
+                                      "value": "Предупреждение дополнительного сведения"
+                                    }
+                                  }
+                                ]
+                              },
+                              "dataPath": "",
+                              "items": [
+                                {
+                                  "type": "LABEL",
+                                  "id": 20,
+                                  "name": "ТекстПредупрежденияДополнительногоСведения",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Внимание! Дополнительное сведение уже используется в информационной базе.\n\nИзменение типа значения дополнительного сведения может привести к потере ранее установленных значений его текущего типа."
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                }
+                              ]
+                            }
+                          ],
+                          []
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                []
+              ]
+            }
+          ],
+          "attributes": []
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "1813c469-da20-46a6-8947-6815b66f64c1",
+        "name": "ИзменениеНастройкиСвойства",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Form.ИзменениеНастройкиСвойства",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Форма.ИзменениеНастройкиСвойства"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Изменение настройки свойства"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/ChartsOfCharacteristicTypes/ДополнительныеРеквизитыИСведения/Forms/ИзменениеНастро_киСво_ства/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "content": [
+              {
+                "default": {
+                  "tag": 2
+                },
+                "int": 1,
+                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                  "langKey": "ru",
+                  "value": "Изменить настройку дополнительного реквизита"
+                }
+              }
+            ]
+          },
+          "handlers": [
+            [
+              {
+                "event": "BeforeClose",
+                "name": "ПередЗакрытием"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[4]"
+              }
+            ],
+            []
+          ],
+          "items": [
+            {
+              "type": "PAGES",
+              "id": 40,
+              "name": "ТипыСвойства",
+              "title": {
+                "content": [
+                  {
+                    "default": {
+                      "tag": 2
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                      "langKey": "ru",
+                      "value": "Типы свойства"
+                    }
+                  }
+                ]
+              },
+              "dataPath": "",
+              "items": [
+                [
+                  {
+                    "type": "PAGE",
+                    "id": 17,
+                    "name": "ДополнительныйРеквизит",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Дополнительный реквизит"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 52,
+                          "name": "РеквизитПредупреждение",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Реквизит предупреждение"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "DECORATION",
+                                "id": 48,
+                                "name": "РеквизитПредупреждениеКартинка",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Реквизит предупреждение картинка"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": []
+                              },
+                              {
+                                "type": "LABEL",
+                                "id": 50,
+                                "name": "РеквизитПредупреждениеКомментарий",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Перенастройка дополнительного реквизита необратима и может занять длительное время, в зависимости от числа документов, в которых заполнен этот реквизит. \nВместо этого можно добавить новый реквизит со своим списком значений, и выполнить вручную постепенный переход от использования этого реквизита к новому (очистить значения этого реквизита и заполнить значения нового)."
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": []
+                              }
+                            ],
+                            []
+                          ]
+                        },
+                        {
+                          "type": "RADIO_BUTTON_FIELD",
+                          "id": 8,
+                          "name": "ОтдельныеЗначенияРеквизита",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Отдельное свойство с отдельным списком значений"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "ОтдельноеСвойствоСОтдельнымСпискомЗначений",
+                          "items": []
+                        },
+                        {
+                          "type": "LABEL",
+                          "id": 14,
+                          "name": "ОтдельныеЗначенияРеквизитаКомментарий",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Данный реквизит входит только в один набор %1, и у него свой собственный список значений."
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": []
+                        },
+                        {
+                          "type": "PAGES",
+                          "id": 30,
+                          "name": "ВидыРеквизита",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Виды реквизита"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "PAGE",
+                                "id": 32,
+                                "name": "ВидОбщиеЗначенияРеквизитов",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Вид общие значения реквизитов"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "RADIO_BUTTON_FIELD",
+                                      "id": 6,
+                                      "name": "ОбщиеЗначенияРеквизитов",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Отдельное свойство с общим списком значений"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "ОтдельноеСвойствоСОбщимСпискомЗначений",
+                                      "items": []
+                                    },
+                                    {
+                                      "type": "LABEL",
+                                      "id": 12,
+                                      "name": "ОбщиеЗначенияРеквизитовКомментарий",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "У данного реквизита общий список значений с другими реквизитами, добавленными по образцу. С помощью этого варианта удобно выполнять централизованную настройку списка значений сразу для нескольких однотипных реквизитов (например, \"Цвет одежды\", \"Цвет обуви\" и пр.)."
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": []
+                                    }
+                                  ],
+                                  []
+                                ]
+                              },
+                              {
+                                "type": "PAGE",
+                                "id": 31,
+                                "name": "ВидОбщийРеквизит",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Вид общий реквизит"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "RADIO_BUTTON_FIELD",
+                                      "id": 4,
+                                      "name": "ОбщийРеквизит",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Общее свойство"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "ОбщееСвойство",
+                                      "items": []
+                                    },
+                                    {
+                                      "type": "LABEL",
+                                      "id": 10,
+                                      "name": "ОбщийРеквизитКомментарий",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Данный реквизит входит сразу в несколько наборов. Этот вариант подходит для тех случаев, когда общим\nдолжен быть не только список значений, но и сам реквизит. В списках и отчетах по элементам различных\nсправочников и документов, общие реквизиты группируются и выводятся как один реквизит, в одной колонке или поле.\nНапример, с помощью общего реквизита \"Цвет\" можно быстро отобрать всю желтую одежду и обувь."
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": []
+                                    }
+                                  ],
+                                  []
+                                ]
+                              }
+                            ],
+                            []
+                          ]
+                        }
+                      ],
+                      []
+                    ]
+                  },
+                  {
+                    "type": "PAGE",
+                    "id": 16,
+                    "name": "ДополнительноеСведение",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Дополнительное сведение"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 54,
+                          "name": "СведениеПредупреждение",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Сведение предупреждение"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "DECORATION",
+                                "id": 56,
+                                "name": "СведениеПредупреждениеКартинка",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Сведение предупреждение картинка"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": []
+                              },
+                              {
+                                "type": "LABEL",
+                                "id": 58,
+                                "name": "СведениеПредупреждениеКомментарий",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Перенастройка дополнительного сведения необратима и может занять длительное время, в зависимости от числа документов, в которых заполнено это сведение.\nВместо этого можно добавить новое сведение со своим списком значений, и выполнить вручную постепенный переход от использования этого сведения к новому (очистить значения этого сведения и заполнить значения нового)."
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": []
+                              }
+                            ],
+                            []
+                          ]
+                        },
+                        {
+                          "type": "RADIO_BUTTON_FIELD",
+                          "id": 26,
+                          "name": "ОтдельныеЗначенияСведения",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                          },
+                          "dataPath": "ОтдельноеСвойствоСОтдельнымСпискомЗначений",
+                          "items": []
+                        },
+                        {
+                          "type": "LABEL",
+                          "id": 28,
+                          "name": "ОтдельныеЗначенияСведенияКомментарий",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Данное сведение входит только в один набор %1, и у него свой собственный список значений."
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": []
+                        },
+                        {
+                          "type": "PAGES",
+                          "id": 33,
+                          "name": "ВидыСведения",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Виды сведения"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "PAGE",
+                                "id": 39,
+                                "name": "ВидОбщиеЗначенияСведений",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Вид общие значения сведений"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "RADIO_BUTTON_FIELD",
+                                      "id": 22,
+                                      "name": "ОбщиеЗначенияСведений",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                      },
+                                      "dataPath": "ОтдельноеСвойствоСОбщимСпискомЗначений",
+                                      "items": []
+                                    },
+                                    {
+                                      "type": "LABEL",
+                                      "id": 24,
+                                      "name": "ОбщиеЗначенияСведенийКомментарий",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "У этого сведения общий список значений с другими сведениями, добавленными по образцу. С помощью этого варианта удобно выполнять централизованную настройку списка значений сразу для нескольких однотипных сведений (например, \"Цвет одежды\", \"Цвет обуви\" и пр.)."
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": []
+                                    }
+                                  ],
+                                  []
+                                ]
+                              },
+                              {
+                                "type": "PAGE",
+                                "id": 34,
+                                "name": "ВидОбщееСведение",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Вид общее сведение"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "RADIO_BUTTON_FIELD",
+                                      "id": 18,
+                                      "name": "ОбщееСведение",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                      },
+                                      "dataPath": "ОбщееСвойство",
+                                      "items": []
+                                    },
+                                    {
+                                      "type": "LABEL",
+                                      "id": 20,
+                                      "name": "ОбщееСведениеКомментарий",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Данное сведение входит сразу в несколько наборов. Этот вариант подходит для тех случаев, когда общим\nдолжен быть не только список значений, но и само сведение. В списках и отчетах по элементам различных\nсправочников и документов, общие сведения группируются и выводятся как одно сведение, в одной колонке или поле.\nНапример, с помощью общего сведения \"Цвет\" можно быстро отобрать всю желтую одежду и обувь."
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": []
+                                    }
+                                  ],
+                                  []
+                                ]
+                              }
+                            ],
+                            []
+                          ]
+                        }
+                      ],
+                      []
+                    ]
+                  }
+                ],
+                []
+              ]
+            }
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "ОбщееСвойство",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                        "precision": 1,
+                        "scale": 0,
+                        "nonNegative": true,
+                        "description": {}
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 2,
+                "name": "ОтдельноеСвойствоСОбщимСпискомЗначений",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 3,
+                "name": "ОтдельноеСвойствоСОтдельнымСпискомЗначений",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 4,
+                "name": "Свойство",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[6]/type"
+                }
+              },
+              {
+                "id": 5,
+                "name": "ЭтоДополнительноеСведение",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[5]/type"
+                }
+              },
+              {
+                "id": 6,
+                "name": "ТекущийНаборСвойств",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[21]/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "64e702e9-8934-4356-a1b2-be0e8b390630",
+        "name": "ЗависимостьРеквизитов",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Form.ЗависимостьРеквизитов",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Форма.ЗависимостьРеквизитов"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Зависимость реквизитов"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/ChartsOfCharacteristicTypes/ДополнительныеРеквизитыИСведения/Forms/ЗависимостьРеквизитов/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[5]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+          },
+          "handlers": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[2]"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[4]"
+              }
+            ],
+            []
+          ],
+          "items": [
+            {
+              "type": "TABLE",
+              "id": 5,
+              "name": "ЗависимостиРеквизитов",
+              "title": {
+                "content": [
+                  {
+                    "default": {
+                      "tag": 2
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                      "langKey": "ru",
+                      "value": "Зависит от значения свойств и реквизитов"
+                    }
+                  }
+                ]
+              },
+              "dataPath": "ЗависимостиРеквизитов",
+              "items": [
+                [
+                  {
+                    "type": "INPUT_FIELD",
+                    "id": 18,
+                    "name": "ЗависимостиРеквизитовРеквизит",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                    },
+                    "dataPath": "ЗависимостиРеквизитов.Представление",
+                    "items": []
+                  },
+                  {
+                    "type": "INPUT_FIELD",
+                    "id": 21,
+                    "name": "ЗависимостиРеквизитовВидСравнения",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Вид сравнения"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "ЗависимостиРеквизитов.Условие",
+                    "items": []
+                  },
+                  {
+                    "type": "INPUT_FIELD",
+                    "id": 24,
+                    "name": "ЗависимостиРеквизитовПравоеЗначение",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Значение"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "ЗависимостиРеквизитов.Значение",
+                    "items": []
+                  }
+                ],
+                []
+              ]
+            }
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "ЗависимостиРеквизитов",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Зависимости реквизитов"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[18]/type"
+                }
+              },
+              {
+                "id": 2,
+                "name": "РеквизитыОбъектаВХранилище",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              },
+              {
+                "id": 3,
+                "name": "НастраиваемоеСвойство",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              },
+              {
+                "id": 4,
+                "name": "ДобавлениеСтроки",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[5]/type"
+                }
+              },
+              {
+                "id": 5,
+                "name": "НажатаОтмена",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[5]/type"
+                }
+              },
+              {
+                "id": 6,
+                "name": "НаборСвойств",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[21]/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "74880ac4-bdd3-48e6-82a0-a2103da42723",
+        "name": "ВыборРеквизита",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.Form.ВыборРеквизита",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.Форма.ВыборРеквизита"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/ChartsOfCharacteristicTypes/ДополнительныеРеквизитыИСведения/Forms/ВыборРеквизита/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+          },
+          "handlers": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[4]"
+            }
+          ],
+          "items": [
+            {
+              "type": "TABLE",
+              "id": 1,
+              "name": "РеквизитыОбъекта",
+              "title": {
+                "content": [
+                  {
+                    "default": {
+                      "tag": 2
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                      "langKey": "ru",
+                      "value": "Реквизиты объекта"
+                    }
+                  }
+                ]
+              },
+              "dataPath": "РеквизитыОбъекта",
+              "items": [
+                {
+                  "type": "INPUT_FIELD",
+                  "id": 14,
+                  "name": "РеквизитыОбъектаПредставление",
+                  "title": {
+                    "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  },
+                  "dataPath": "РеквизитыОбъекта.Представление",
+                  "items": []
+                }
+              ]
+            }
+          ],
+          "attributes": [
+            {
+              "id": 1,
+              "name": "РеквизитыОбъекта",
+              "title": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+              },
+              "type": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[18]/type"
+              }
+            }
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      }
+    ],
+    []
+  ],
+  "mdoReference": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+  },
+  "mdoType": "CHART_OF_CHARACTERISTIC_TYPES",
+  "moduleTypes": [
+    [
+      "ManagerModule",
+      [
+        "src/test/resources/ext/edt/ssl_3_2/configuration/src/ChartsOfCharacteristicTypes/ДополнительныеРеквизитыИСведения/ManagerModule.bsl"
+      ]
+    ],
+    [
+      "ObjectModule",
+      [
+        "src/test/resources/ext/edt/ssl_3_2/configuration/src/ChartsOfCharacteristicTypes/ДополнительныеРеквизитыИСведения/ObjectModule.bsl"
+      ]
+    ]
+  ],
+  "modules": [
+    {
+      "moduleType": "ManagerModule",
+      "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/ChartsOfCharacteristicTypes/ДополнительныеРеквизитыИСведения/ManagerModule.bsl",
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "isProtected": false
+    },
+    {
+      "moduleType": "ObjectModule",
+      "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/ChartsOfCharacteristicTypes/ДополнительныеРеквизитыИСведения/ObjectModule.bsl",
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "isProtected": false
+    }
+  ],
+  "name": "ДополнительныеРеквизитыИСведения",
+  "objectBelonging": "OWN",
+  "possibleRights": [
+    {
+      "default": {
+        "tag": 4
+      },
+      "int": 25,
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INSERT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "DELETE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "VIEW",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "EDIT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INPUT_BY_STRING",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_DELETE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_INSERT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_SET_DELETION_MARK",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_CLEAR_DELETION_MARK",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_DELETE_MARKED",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_DELETE_PREDEFINED_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_SET_DELETION_MARK_PREDEFINED_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_CLEAR_DELETION_MARK_PREDEFINED_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_DELETE_MARKED_PREDEFINED_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "VIEW_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ_DATA_HISTORY_OF_MISSING_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_OF_MISSING_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_SETTINGS",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_VERSION_COMMENT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "EDIT_DATA_HISTORY_VERSION_COMMENT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "SWITCH_TO_DATA_HISTORY_VERSION"
+    }
+  ],
+  "predefinedValues": [],
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "content": [
+      {
+        "default": {
+          "tag": 2
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+          "langKey": "ru",
+          "value": "Дополнительные реквизиты и сведения"
+        }
+      }
+    ]
+  },
+  "tabularSections": [
+    [
+      {
+        "uuid": "d6b72e00-018a-4fdc-b6a4-06dcecf89809",
+        "name": "ЗависимостиДополнительныхРеквизитов",
+        "mdoReference": {
+          "type": "TABULAR_SECTION",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.TabularSection.ЗависимостиДополнительныхРеквизитов",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.ТабличнаяЧасть.ЗависимостиДополнительныхРеквизитов"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Зависимости дополнительных реквизитов"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "attributes": [
+          [
+            {
+              "uuid": "d6b72e00-018a-4fdc-b6a4-06dcecf89809",
+              "mdoReference": {
+                "type": "STANDARD_ATTRIBUTE",
+                "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.TabularSection.ЗависимостиДополнительныхРеквизитов.StandardAttribute.LineNumber",
+                "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.ТабличнаяЧасть.ЗависимостиДополнительныхРеквизитов.СтандартныйРеквизит.НомерСтроки"
+              },
+              "comment": "",
+              "synonym": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/tabularSections/c/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+              },
+              "passwordMode": false,
+              "kind": "STANDARD",
+              "type": {
+                "types": [
+                  {
+                    "default": {
+                      "tag": 4
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER"
+                  }
+                ],
+                "composite": false,
+                "qualifiers": [
+                  {
+                    "default": {
+                      "tag": 4
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                      "precision": 5,
+                      "scale": 0,
+                      "nonNegative": false,
+                      "description": {}
+                    }
+                  }
+                ]
+              },
+              "fullName": {
+                "nameRu": "НомерСтроки",
+                "nameEn": "LineNumber"
+              },
+              "format": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "editFormat": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "markNegatives": false,
+              "mask": "",
+              "multiLine": false,
+              "extendedEdit": false,
+              "fillFromFillingValue": false
+            },
+            {
+              "uuid": "9f816562-57f0-473f-8c85-14f7521ffd7f",
+              "name": "ЗависимоеСвойство",
+              "mdoReference": {
+                "type": "ATTRIBUTE",
+                "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.TabularSection.ЗависимостиДополнительныхРеквизитов.Attribute.ЗависимоеСвойство",
+                "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.ТабличнаяЧасть.ЗависимостиДополнительныхРеквизитов.Реквизит.ЗависимоеСвойство"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "content": [
+                  {
+                    "default": {
+                      "tag": 2
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                      "langKey": "ru",
+                      "value": "Зависимое свойство"
+                    }
+                  }
+                ]
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/tabularSections/c/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+              },
+              "passwordMode": false,
+              "kind": "CUSTOM",
+              "indexing": "DONT_INDEX",
+              "type": {
+                "types": [
+                  {
+                    "default": {
+                      "tag": 4
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+                  }
+                ],
+                "composite": false,
+                "qualifiers": [
+                  {
+                    "default": {
+                      "tag": 4
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                      "length": 25,
+                      "allowedLength": 0,
+                      "description": {}
+                    }
+                  }
+                ]
+              },
+              "format": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "editFormat": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "markNegatives": false,
+              "mask": "",
+              "multiLine": false,
+              "extendedEdit": false,
+              "fillFromFillingValue": false
+            },
+            {
+              "uuid": "14077038-2e41-4a05-a476-99f6f88a5c29",
+              "name": "НаборСвойств",
+              "mdoReference": {
+                "type": "ATTRIBUTE",
+                "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.TabularSection.ЗависимостиДополнительныхРеквизитов.Attribute.НаборСвойств",
+                "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.ТабличнаяЧасть.ЗависимостиДополнительныхРеквизитов.Реквизит.НаборСвойств"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[21]/synonym"
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/tabularSections/c/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+              },
+              "passwordMode": false,
+              "kind": "CUSTOM",
+              "indexing": "DONT_INDEX",
+              "type": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[21]/type"
+              },
+              "format": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "editFormat": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "markNegatives": false,
+              "mask": "",
+              "multiLine": false,
+              "extendedEdit": false,
+              "fillFromFillingValue": false
+            },
+            {
+              "uuid": "917b0acc-88fe-4afc-b19b-6da69e060393",
+              "name": "Реквизит",
+              "mdoReference": {
+                "type": "ATTRIBUTE",
+                "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.TabularSection.ЗависимостиДополнительныхРеквизитов.Attribute.Реквизит",
+                "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.ТабличнаяЧасть.ЗависимостиДополнительныхРеквизитов.Реквизит.Реквизит"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/tabularSections/c/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+              },
+              "passwordMode": false,
+              "kind": "CUSTOM",
+              "indexing": "DONT_INDEX",
+              "type": {
+                "types": [
+                  {
+                    "default": {
+                      "tag": 4
+                    },
+                    "int": 2,
+                    "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[6]/type/types/java.util.CollSer/com.github._1c_syntax.bsl.types.value.CustomValueType"
+                    },
+                    "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+                  }
+                ],
+                "composite": true,
+                "qualifiers": [
+                  {
+                    "default": {
+                      "tag": 4
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                      "length": 99,
+                      "allowedLength": 0,
+                      "description": {}
+                    }
+                  }
+                ]
+              },
+              "format": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "editFormat": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "markNegatives": false,
+              "mask": "",
+              "multiLine": false,
+              "extendedEdit": false,
+              "fillFromFillingValue": false
+            },
+            {
+              "uuid": "a091b76e-8ba4-4534-bbb0-9990e69b8603",
+              "name": "Условие",
+              "mdoReference": {
+                "type": "ATTRIBUTE",
+                "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.TabularSection.ЗависимостиДополнительныхРеквизитов.Attribute.Условие",
+                "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.ТабличнаяЧасть.ЗависимостиДополнительныхРеквизитов.Реквизит.Условие"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "content": [
+                  {
+                    "default": {
+                      "tag": 2
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                      "langKey": "ru",
+                      "value": "Условие"
+                    }
+                  }
+                ]
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/tabularSections/c/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+              },
+              "passwordMode": false,
+              "kind": "CUSTOM",
+              "indexing": "DONT_INDEX",
+              "type": {
+                "types": [
+                  {
+                    "default": {
+                      "tag": 4
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+                  }
+                ],
+                "composite": false,
+                "qualifiers": [
+                  {
+                    "default": {
+                      "tag": 4
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                      "length": 20,
+                      "allowedLength": 0,
+                      "description": {}
+                    }
+                  }
+                ]
+              },
+              "format": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "editFormat": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "markNegatives": false,
+              "mask": "",
+              "multiLine": false,
+              "extendedEdit": false,
+              "fillFromFillingValue": false
+            },
+            {
+              "uuid": "867ee5d2-7566-4052-a311-b56e7e46b90d",
+              "name": "Значение",
+              "mdoReference": {
+                "type": "ATTRIBUTE",
+                "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.TabularSection.ЗависимостиДополнительныхРеквизитов.Attribute.Значение",
+                "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.ТабличнаяЧасть.ЗависимостиДополнительныхРеквизитов.Реквизит.Значение"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[5]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/tabularSections/c/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+              },
+              "passwordMode": false,
+              "kind": "CUSTOM",
+              "indexing": "DONT_INDEX",
+              "type": {
+                "types": [
+                  {
+                    "default": {
+                      "tag": 4
+                    },
+                    "int": 5,
+                    "com.github._1c_syntax.bsl.types.value.MDOValueType": "ANY_REF",
+                    "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "BOOLEAN",
+                    "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "DATE",
+                    "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER",
+                    "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+                  }
+                ],
+                "composite": true,
+                "qualifiers": [
+                  {
+                    "default": {
+                      "tag": 4
+                    },
+                    "int": 3,
+                    "com.github._1c_syntax.bsl.types.qualifiers.DateQualifiers": {
+                      "dateFractions": 1,
+                      "description": {
+                        "value": {
+                          "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                          "nameRu": "КвалификаторыДаты (Дата)",
+                          "nameEn": "DateQualifiers (Date)"
+                        }
+                      }
+                    },
+                    "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                      "length": 50,
+                      "allowedLength": 0,
+                      "description": {
+                        "value": {
+                          "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                          "nameRu": "КвалификаторыСтроки (50, Переменная)",
+                          "nameEn": "StringQualifiers (50, Variable)"
+                        }
+                      }
+                    },
+                    "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                      "precision": 10,
+                      "scale": 0,
+                      "nonNegative": false,
+                      "description": {
+                        "value": {
+                          "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                          "nameRu": "КвалификаторыЧисла (10.0)",
+                          "nameEn": "NumberQualifiers (10.0)"
+                        }
+                      }
+                    }
+                  }
+                ]
+              },
+              "format": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "editFormat": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "markNegatives": false,
+              "mask": "",
+              "multiLine": false,
+              "extendedEdit": false,
+              "fillFromFillingValue": false
+            }
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "8f51328b-73a8-46fb-b6db-7b7a84c05c2a",
+        "name": "Представления",
+        "mdoReference": {
+          "type": "TABULAR_SECTION",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.TabularSection.Представления",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.ТабличнаяЧасть.Представления"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Представления"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "attributes": [
+          [
+            {
+              "uuid": "8f51328b-73a8-46fb-b6db-7b7a84c05c2a",
+              "mdoReference": {
+                "type": "STANDARD_ATTRIBUTE",
+                "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.TabularSection.Представления.StandardAttribute.LineNumber",
+                "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.ТабличнаяЧасть.Представления.СтандартныйРеквизит.НомерСтроки"
+              },
+              "comment": "",
+              "synonym": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/tabularSections/c/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection[2]/mdoReference"
+              },
+              "passwordMode": false,
+              "kind": "STANDARD",
+              "type": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/tabularSections/c/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+              },
+              "fullName": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/tabularSections/c/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/fullName"
+              },
+              "format": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "editFormat": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "markNegatives": false,
+              "mask": "",
+              "multiLine": false,
+              "extendedEdit": false,
+              "fillFromFillingValue": false
+            },
+            {
+              "uuid": "0f0f5b42-2407-44e6-85d7-26ace96b2cd9",
+              "name": "КодЯзыка",
+              "mdoReference": {
+                "type": "ATTRIBUTE",
+                "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.TabularSection.Представления.Attribute.КодЯзыка",
+                "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.ТабличнаяЧасть.Представления.Реквизит.КодЯзыка"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "content": [
+                  {
+                    "default": {
+                      "tag": 2
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                      "langKey": "ru",
+                      "value": "Код языка"
+                    }
+                  }
+                ]
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/tabularSections/c/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection[2]/mdoReference"
+              },
+              "passwordMode": false,
+              "kind": "CUSTOM",
+              "indexing": "DONT_INDEX",
+              "type": {
+                "types": [
+                  {
+                    "default": {
+                      "tag": 4
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+                  }
+                ],
+                "composite": false,
+                "qualifiers": [
+                  {
+                    "default": {
+                      "tag": 4
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                      "length": 10,
+                      "allowedLength": 0,
+                      "description": {
+                        "value": {
+                          "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                          "nameRu": "КвалификаторыСтроки (10, Переменная)",
+                          "nameEn": "StringQualifiers (10, Variable)"
+                        }
+                      }
+                    }
+                  }
+                ]
+              },
+              "format": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "editFormat": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "markNegatives": false,
+              "mask": "",
+              "multiLine": false,
+              "extendedEdit": false,
+              "fillFromFillingValue": false
+            },
+            {
+              "uuid": "ffec426d-2556-46d6-b313-aeca43581865",
+              "name": "Заголовок",
+              "mdoReference": {
+                "type": "ATTRIBUTE",
+                "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.TabularSection.Представления.Attribute.Заголовок",
+                "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.ТабличнаяЧасть.Представления.Реквизит.Заголовок"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/tabularSections/c/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection[2]/mdoReference"
+              },
+              "passwordMode": false,
+              "kind": "CUSTOM",
+              "indexing": "DONT_INDEX",
+              "type": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[7]/type"
+              },
+              "format": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "editFormat": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "markNegatives": false,
+              "mask": "",
+              "multiLine": false,
+              "extendedEdit": false,
+              "fillFromFillingValue": false
+            },
+            {
+              "uuid": "f32e0941-2061-4e12-bdae-fcb65f91ac28",
+              "name": "Подсказка",
+              "mdoReference": {
+                "type": "ATTRIBUTE",
+                "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.TabularSection.Представления.Attribute.Подсказка",
+                "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.ТабличнаяЧасть.Представления.Реквизит.Подсказка"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[22]/synonym"
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/tabularSections/c/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection[2]/mdoReference"
+              },
+              "passwordMode": false,
+              "kind": "CUSTOM",
+              "indexing": "DONT_INDEX",
+              "type": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+              },
+              "format": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "editFormat": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "markNegatives": false,
+              "mask": "",
+              "multiLine": false,
+              "extendedEdit": false,
+              "fillFromFillingValue": false
+            },
+            {
+              "uuid": "6f0e0f44-db5a-4a13-9131-866b77b90f14",
+              "name": "ЗаголовокФормыЗначения",
+              "mdoReference": {
+                "type": "ATTRIBUTE",
+                "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.TabularSection.Представления.Attribute.ЗаголовокФормыЗначения",
+                "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.ТабличнаяЧасть.Представления.Реквизит.ЗаголовокФормыЗначения"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[11]/synonym"
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/tabularSections/c/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection[2]/mdoReference"
+              },
+              "passwordMode": false,
+              "kind": "CUSTOM",
+              "indexing": "DONT_INDEX",
+              "type": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[3]/type"
+              },
+              "format": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "editFormat": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "markNegatives": false,
+              "mask": "",
+              "multiLine": false,
+              "extendedEdit": false,
+              "fillFromFillingValue": false
+            },
+            {
+              "uuid": "9415e0aa-391f-4798-ad7d-3b854a756de8",
+              "name": "ЗаголовокФормыВыбораЗначения",
+              "mdoReference": {
+                "type": "ATTRIBUTE",
+                "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения.TabularSection.Представления.Attribute.ЗаголовокФормыВыбораЗначения",
+                "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения.ТабличнаяЧасть.Представления.Реквизит.ЗаголовокФормыВыбораЗначения"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[8]/synonym"
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/tabularSections/c/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection[2]/mdoReference"
+              },
+              "passwordMode": false,
+              "kind": "CUSTOM",
+              "indexing": "DONT_INDEX",
+              "type": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[3]/type"
+              },
+              "format": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "editFormat": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "markNegatives": false,
+              "mask": "",
+              "multiLine": false,
+              "extendedEdit": false,
+              "fillFromFillingValue": false
+            }
+          ],
+          []
+        ]
+      }
+    ],
+    []
+  ],
+  "templates": [],
+  "uuid": "1055d15b-8cb5-4ff0-a526-7fd20a08a96c",
+  "valueType": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[2]/type"
+  }
+}}

--- a/src/test/resources/fixtures/ssl_3_2/ChartsOfCharacteristicTypes.ДополнительныеРеквизитыИСведения_edt.json
+++ b/src/test/resources/fixtures/ssl_3_2/ChartsOfCharacteristicTypes.ДополнительныеРеквизитыИСведения_edt.json
@@ -1994,536 +1994,52 @@
             []
           ],
           "items": [
-            [
-              {
-                "type": "PAGES",
-                "id": 200,
-                "name": "СтраницыПомощникКарточка",
-                "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Страницы помощник карточка"
-                      }
+            {
+              "type": "PAGES",
+              "id": 200,
+              "name": "СтраницыПомощникКарточка",
+              "title": {
+                "content": [
+                  {
+                    "default": {
+                      "tag": 2
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                      "langKey": "ru",
+                      "value": "Страницы помощник карточка"
                     }
-                  ]
-                },
-                "dataPath": "",
-                "items": [
-                  [
-                    {
-                      "type": "PAGE",
-                      "id": 202,
-                      "name": "ВыборРеквизита",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Выбор реквизита"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "USUAL_GROUP",
-                            "id": 336,
-                            "name": "ГруппаЗаголовок",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Заголовок"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": [
-                              [
-                                {
-                                  "type": "LABEL",
-                                  "id": 338,
-                                  "name": "ДекорацияЗаголовок",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Выберите %1 для включения в набор \"%2\":"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": []
-                                },
-                                {
-                                  "type": "COMMAND_BAR",
-                                  "id": 408,
-                                  "name": "ПанельЕще",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Панель еще"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": [
-                                    {
-                                      "type": "POPUP",
-                                      "id": 410,
-                                      "name": "ПодменюЕще",
-                                      "title": {
-                                        "content": [
-                                          {
-                                            "default": {
-                                              "tag": 2
-                                            },
-                                            "int": 1,
-                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                              "langKey": "ru",
-                                              "value": "Еще"
-                                            }
-                                          }
-                                        ]
-                                      },
-                                      "dataPath": "",
-                                      "items": [
-                                        {
-                                          "type": "BUTTON",
-                                          "id": 412,
-                                          "name": "НеиспользуемыеРеквизиты",
-                                          "title": {
-                                            "content": [
-                                              {
-                                                "default": {
-                                                  "tag": 2
-                                                },
-                                                "int": 1,
-                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                  "langKey": "ru",
-                                                  "value": "Неиспользуемые реквизиты"
-                                                }
-                                              }
-                                            ]
-                                          },
-                                          "dataPath": "",
-                                          "items": []
-                                        }
-                                      ]
-                                    }
-                                  ]
-                                }
-                              ],
-                              []
-                            ]
+                  }
+                ]
+              },
+              "dataPath": "",
+              "items": [
+                [
+                  {
+                    "type": "PAGE",
+                    "id": 202,
+                    "name": "ВыборРеквизита",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
                           },
-                          {
-                            "type": "USUAL_GROUP",
-                            "id": 341,
-                            "name": "ГруппаСодержимое",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Содержимое"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": [
-                              [
-                                {
-                                  "type": "USUAL_GROUP",
-                                  "id": 343,
-                                  "name": "ГруппаНаборыСвойств",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Наборы свойств"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": [
-                                    {
-                                      "type": "PAGES",
-                                      "id": 414,
-                                      "name": "СтраницыНаборыСвойств",
-                                      "title": {
-                                        "content": [
-                                          {
-                                            "default": {
-                                              "tag": 2
-                                            },
-                                            "int": 1,
-                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                              "langKey": "ru",
-                                              "value": "Страницы наборы свойств"
-                                            }
-                                          }
-                                        ]
-                                      },
-                                      "dataPath": "",
-                                      "items": [
-                                        [
-                                          {
-                                            "type": "PAGE",
-                                            "id": 416,
-                                            "name": "СтраницаВсеНаборы",
-                                            "title": {
-                                              "content": [
-                                                {
-                                                  "default": {
-                                                    "tag": 2
-                                                  },
-                                                  "int": 1,
-                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                    "langKey": "ru",
-                                                    "value": "Страница все наборы"
-                                                  }
-                                                }
-                                              ]
-                                            },
-                                            "dataPath": "",
-                                            "items": [
-                                              {
-                                                "type": "TABLE",
-                                                "id": 345,
-                                                "name": "НаборыСвойств",
-                                                "title": {
-                                                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                                },
-                                                "dataPath": "НаборыСвойств",
-                                                "items": [
-                                                  [
-                                                    {
-                                                      "type": "LABEL_FIELD",
-                                                      "id": 396,
-                                                      "name": "Представление",
-                                                      "title": {
-                                                        "content": [
-                                                          {
-                                                            "default": {
-                                                              "tag": 2
-                                                            },
-                                                            "int": 1,
-                                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                              "langKey": "ru",
-                                                              "value": "Представление набора"
-                                                            }
-                                                          }
-                                                        ]
-                                                      },
-                                                      "dataPath": "НаборыСвойств.Представление",
-                                                      "items": []
-                                                    },
-                                                    {
-                                                      "type": "LABEL_FIELD",
-                                                      "id": 399,
-                                                      "name": "Ссылка",
-                                                      "title": {
-                                                        "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                                      },
-                                                      "dataPath": "НаборыСвойств.Ссылка",
-                                                      "items": []
-                                                    }
-                                                  ],
-                                                  []
-                                                ]
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "type": "PAGE",
-                                            "id": 418,
-                                            "name": "СтраницаОбщиеНаборы",
-                                            "title": {
-                                              "content": [
-                                                {
-                                                  "default": {
-                                                    "tag": 2
-                                                  },
-                                                  "int": 1,
-                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                    "langKey": "ru",
-                                                    "value": "Страница общие наборы"
-                                                  }
-                                                }
-                                              ]
-                                            },
-                                            "dataPath": "",
-                                            "items": [
-                                              {
-                                                "type": "TABLE",
-                                                "id": 420,
-                                                "name": "ОбщиеНаборыСвойств",
-                                                "title": {
-                                                  "content": [
-                                                    {
-                                                      "default": {
-                                                        "tag": 2
-                                                      },
-                                                      "int": 1,
-                                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                        "langKey": "ru",
-                                                        "value": "Общие наборы свойств"
-                                                      }
-                                                    }
-                                                  ]
-                                                },
-                                                "dataPath": "ОбщиеНаборыСвойств",
-                                                "items": [
-                                                  {
-                                                    "type": "LABEL_FIELD",
-                                                    "id": 436,
-                                                    "name": "ОбщиеНаборыСвойствПредставление",
-                                                    "title": {
-                                                      "content": [
-                                                        {
-                                                          "default": {
-                                                            "tag": 2
-                                                          },
-                                                          "int": 1,
-                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                            "langKey": "ru",
-                                                            "value": "Представление"
-                                                          }
-                                                        }
-                                                      ]
-                                                    },
-                                                    "dataPath": "ОбщиеНаборыСвойств.Представление",
-                                                    "items": []
-                                                  }
-                                                ]
-                                              }
-                                            ]
-                                          }
-                                        ],
-                                        []
-                                      ]
-                                    }
-                                  ]
-                                },
-                                {
-                                  "type": "USUAL_GROUP",
-                                  "id": 364,
-                                  "name": "РасшифровкаРеквизита",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Дополнительные реквизиты"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": [
-                                    [
-                                      {
-                                        "type": "TABLE",
-                                        "id": 366,
-                                        "name": "Свойства",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Свойства"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "Свойства",
-                                        "items": [
-                                          {
-                                            "type": "INPUT_FIELD",
-                                            "id": 379,
-                                            "name": "СвойстваЗаголовок",
-                                            "title": {
-                                              "content": [
-                                                {
-                                                  "default": {
-                                                    "tag": 2
-                                                  },
-                                                  "int": 1,
-                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                    "langKey": "ru",
-                                                    "value": "Реквизит"
-                                                  }
-                                                }
-                                              ]
-                                            },
-                                            "dataPath": "Свойства.Заголовок",
-                                            "items": []
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "USUAL_GROUP",
-                                        "id": 469,
-                                        "name": "ГруппаДополнительнаяИнформация",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Дополнительная информация"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "",
-                                        "items": [
-                                          [
-                                            {
-                                              "type": "INPUT_FIELD",
-                                              "id": 384,
-                                              "name": "СписокДополнительныхРеквизитовТипЗначения",
-                                              "title": {
-                                                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                              },
-                                              "dataPath": "Items.Свойства.CurrentData.ТипЗначения",
-                                              "items": []
-                                            },
-                                            {
-                                              "type": "INPUT_FIELD",
-                                              "id": 387,
-                                              "name": "СписокДополнительныхРеквизитовПодсказка",
-                                              "title": {
-                                                "content": [
-                                                  {
-                                                    "default": {
-                                                      "tag": 2
-                                                    },
-                                                    "int": 1,
-                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                      "langKey": "ru",
-                                                      "value": "Всплывающая подсказка"
-                                                    }
-                                                  }
-                                                ]
-                                              },
-                                              "dataPath": "Items.Свойства.CurrentData.Подсказка",
-                                              "items": []
-                                            },
-                                            {
-                                              "type": "INPUT_FIELD",
-                                              "id": 390,
-                                              "name": "СписокДополнительныхРеквизитовЗаголовокФормыЗначения",
-                                              "title": {
-                                                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                              },
-                                              "dataPath": "Items.Свойства.CurrentData.ЗаголовокФормыЗначения",
-                                              "items": []
-                                            },
-                                            {
-                                              "type": "INPUT_FIELD",
-                                              "id": 393,
-                                              "name": "СписокДополнительныхРеквизитовЗаголовокФормыВыбораЗначения",
-                                              "title": {
-                                                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                              },
-                                              "dataPath": "Items.Свойства.CurrentData.ЗаголовокФормыВыбораЗначения",
-                                              "items": []
-                                            }
-                                          ],
-                                          []
-                                        ]
-                                      }
-                                    ],
-                                    []
-                                  ]
-                                }
-                              ],
-                              []
-                            ]
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Выбор реквизита"
                           }
-                        ],
-                        []
+                        }
                       ]
                     },
-                    {
-                      "type": "PAGE",
-                      "id": 204,
-                      "name": "ВыборДействия",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Выбор действия"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
+                    "dataPath": "",
+                    "items": [
+                      [
                         {
-                          "type": "RADIO_BUTTON_FIELD",
-                          "id": 237,
-                          "name": "РежимДобавленияРеквизита",
+                          "type": "USUAL_GROUP",
+                          "id": 336,
+                          "name": "ГруппаЗаголовок",
                           "title": {
                             "content": [
                               {
@@ -2533,356 +2049,471 @@
                                 "int": 1,
                                 "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                                   "langKey": "ru",
-                                  "value": "Выберите вариант добавления дополнительного %1 \"%2\" в набор \"%3\""
+                                  "value": "Заголовок"
                                 }
                               }
                             ]
                           },
-                          "dataPath": "РежимДобавленияРеквизита",
-                          "items": []
+                          "dataPath": "",
+                          "items": [
+                            {
+                              "type": "LABEL",
+                              "id": 338,
+                              "name": "ДекорацияЗаголовок",
+                              "title": {
+                                "content": [
+                                  {
+                                    "default": {
+                                      "tag": 2
+                                    },
+                                    "int": 1,
+                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                      "langKey": "ru",
+                                      "value": "Выберите %1 для включения в набор \"%2\":"
+                                    }
+                                  }
+                                ]
+                              },
+                              "dataPath": "",
+                              "items": []
+                            }
+                          ]
+                        },
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 634,
+                          "name": "ГруппаОсновное",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Основное"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "USUAL_GROUP",
+                                "id": 636,
+                                "name": "ЛеваяКолонкаВыбор",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Левая колонка выбор"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  {
+                                    "type": "PAGES",
+                                    "id": 414,
+                                    "name": "СтраницыНаборыСвойств",
+                                    "title": {
+                                      "content": [
+                                        {
+                                          "default": {
+                                            "tag": 2
+                                          },
+                                          "int": 1,
+                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                            "langKey": "ru",
+                                            "value": "Страницы наборы свойств"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    "dataPath": "",
+                                    "items": [
+                                      [
+                                        {
+                                          "type": "PAGE",
+                                          "id": 416,
+                                          "name": "СтраницаВсеНаборы",
+                                          "title": {
+                                            "content": [
+                                              {
+                                                "default": {
+                                                  "tag": 2
+                                                },
+                                                "int": 1,
+                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                  "langKey": "ru",
+                                                  "value": "Страница все наборы"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "dataPath": "",
+                                          "items": [
+                                            {
+                                              "type": "TABLE",
+                                              "id": 345,
+                                              "name": "НаборыСвойств",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Наборы свойств"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "НаборыСвойств",
+                                              "items": [
+                                                [
+                                                  {
+                                                    "type": "LABEL_FIELD",
+                                                    "id": 396,
+                                                    "name": "Представление",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "Представление набора"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "НаборыСвойств.Представление",
+                                                    "items": []
+                                                  },
+                                                  {
+                                                    "type": "LABEL_FIELD",
+                                                    "id": 399,
+                                                    "name": "Ссылка",
+                                                    "title": {
+                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                                    },
+                                                    "dataPath": "НаборыСвойств.Ссылка",
+                                                    "items": []
+                                                  }
+                                                ],
+                                                []
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "type": "PAGE",
+                                          "id": 418,
+                                          "name": "СтраницаОбщиеНаборы",
+                                          "title": {
+                                            "content": [
+                                              {
+                                                "default": {
+                                                  "tag": 2
+                                                },
+                                                "int": 1,
+                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                  "langKey": "ru",
+                                                  "value": "Страница общие наборы"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "dataPath": "",
+                                          "items": [
+                                            {
+                                              "type": "TABLE",
+                                              "id": 420,
+                                              "name": "ОбщиеНаборыСвойств",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                              },
+                                              "dataPath": "ОбщиеНаборыСвойств",
+                                              "items": [
+                                                {
+                                                  "type": "LABEL_FIELD",
+                                                  "id": 436,
+                                                  "name": "ОбщиеНаборыСвойствПредставление",
+                                                  "title": {
+                                                    "content": [
+                                                      {
+                                                        "default": {
+                                                          "tag": 2
+                                                        },
+                                                        "int": 1,
+                                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                          "langKey": "ru",
+                                                          "value": "Представление"
+                                                        }
+                                                      }
+                                                    ]
+                                                  },
+                                                  "dataPath": "ОбщиеНаборыСвойств.Представление",
+                                                  "items": []
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ],
+                                      []
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "USUAL_GROUP",
+                                "id": 638,
+                                "name": "ПраваяКолонкаВыбор",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Правая колонка выбор"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "TABLE",
+                                      "id": 366,
+                                      "name": "Свойства",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Свойства"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "Свойства",
+                                      "items": [
+                                        {
+                                          "type": "INPUT_FIELD",
+                                          "id": 379,
+                                          "name": "СвойстваЗаголовок",
+                                          "title": {
+                                            "content": [
+                                              {
+                                                "default": {
+                                                  "tag": 2
+                                                },
+                                                "int": 1,
+                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                  "langKey": "ru",
+                                                  "value": "Реквизит"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "dataPath": "Свойства.Заголовок",
+                                          "items": []
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "USUAL_GROUP",
+                                      "id": 469,
+                                      "name": "ГруппаДополнительнаяИнформация",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Дополнительная информация"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        [
+                                          {
+                                            "type": "INPUT_FIELD",
+                                            "id": 384,
+                                            "name": "СписокДополнительныхРеквизитовТипЗначения",
+                                            "title": {
+                                              "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                            },
+                                            "dataPath": "Items.Свойства.CurrentData.ТипЗначения",
+                                            "items": []
+                                          },
+                                          {
+                                            "type": "INPUT_FIELD",
+                                            "id": 387,
+                                            "name": "СписокДополнительныхРеквизитовПодсказка",
+                                            "title": {
+                                              "content": [
+                                                {
+                                                  "default": {
+                                                    "tag": 2
+                                                  },
+                                                  "int": 1,
+                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                    "langKey": "ru",
+                                                    "value": "Всплывающая подсказка"
+                                                  }
+                                                }
+                                              ]
+                                            },
+                                            "dataPath": "Items.Свойства.CurrentData.Подсказка",
+                                            "items": []
+                                          },
+                                          {
+                                            "type": "INPUT_FIELD",
+                                            "id": 390,
+                                            "name": "СписокДополнительныхРеквизитовЗаголовокФормыЗначения",
+                                            "title": {
+                                              "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                            },
+                                            "dataPath": "Items.Свойства.CurrentData.ЗаголовокФормыЗначения",
+                                            "items": []
+                                          },
+                                          {
+                                            "type": "INPUT_FIELD",
+                                            "id": 393,
+                                            "name": "СписокДополнительныхРеквизитовЗаголовокФормыВыбораЗначения",
+                                            "title": {
+                                              "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                            },
+                                            "dataPath": "Items.Свойства.CurrentData.ЗаголовокФормыВыбораЗначения",
+                                            "items": []
+                                          }
+                                        ],
+                                        []
+                                      ]
+                                    }
+                                  ],
+                                  []
+                                ]
+                              }
+                            ],
+                            []
+                          ]
+                        }
+                      ],
+                      []
+                    ]
+                  },
+                  {
+                    "type": "PAGE",
+                    "id": 204,
+                    "name": "ВыборДействия",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Выбор действия"
+                          }
                         }
                       ]
                     },
-                    {
-                      "type": "PAGE",
-                      "id": 206,
-                      "name": "КарточкаРеквизита",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Карточка реквизита"
+                    "dataPath": "",
+                    "items": [
+                      {
+                        "type": "RADIO_BUTTON_FIELD",
+                        "id": 237,
+                        "name": "РежимДобавленияРеквизита",
+                        "title": {
+                          "content": [
+                            {
+                              "default": {
+                                "tag": 2
+                              },
+                              "int": 1,
+                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                "langKey": "ru",
+                                "value": "Выберите вариант добавления дополнительного %1 \"%2\" в набор \"%3\""
+                              }
                             }
+                          ]
+                        },
+                        "dataPath": "РежимДобавленияРеквизита",
+                        "items": []
+                      }
+                    ]
+                  },
+                  {
+                    "type": "PAGE",
+                    "id": 206,
+                    "name": "КарточкаРеквизита",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Карточка реквизита"
                           }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "USUAL_GROUP",
-                            "id": 79,
-                            "name": "ГруппаНаименованиеРеквизита",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Наименование реквизита"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": [
-                              [
-                                {
-                                  "type": "INPUT_FIELD",
-                                  "id": 1,
-                                  "name": "Заголовок",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[7]/synonym"
-                                  },
-                                  "dataPath": "Объект.Заголовок",
-                                  "items": []
-                                },
-                                {
-                                  "type": "RADIO_BUTTON_FIELD",
-                                  "id": 20,
-                                  "name": "ВидСвойства",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[27]/synonym"
-                                  },
-                                  "dataPath": "ВидСвойства",
-                                  "items": []
-                                }
-                              ],
-                              []
-                            ]
-                          },
-                          {
-                            "type": "USUAL_GROUP",
-                            "id": 43,
-                            "name": "ТипЗначенияРеквизита",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Тип значения реквизита"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": [
-                              [
-                                {
-                                  "type": "USUAL_GROUP",
-                                  "id": 471,
-                                  "name": "ГруппаТипЗначения",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Тип значения"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": [
-                                    [
-                                      {
-                                        "type": "INPUT_FIELD",
-                                        "id": 5,
-                                        "name": "ТипЗначения",
-                                        "title": {
-                                          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                        },
-                                        "dataPath": "Объект.ValueType",
-                                        "items": []
-                                      },
-                                      {
-                                        "type": "HYPERLINK",
-                                        "id": 37,
-                                        "name": "РедактироватьФорматЗначения",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Формат"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "",
-                                        "items": []
-                                      }
-                                    ],
-                                    []
-                                  ]
-                                },
-                                {
-                                  "type": "USUAL_GROUP",
-                                  "id": 476,
-                                  "name": "ГруппаПояснениеТипаЗначения",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Пояснение типа значения"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": [
-                                    [
-                                      {
-                                        "type": "DECORATION",
-                                        "id": 478,
-                                        "name": "КартинкаПояснение",
-                                        "title": {
-                                          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                        },
-                                        "dataPath": "",
-                                        "items": []
-                                      },
-                                      {
-                                        "type": "LABEL",
-                                        "id": 473,
-                                        "name": "ПояснениеОДлинеСтроки",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Максимальная длина строки составляет 1024 символа"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "",
-                                        "items": []
-                                      }
-                                    ],
-                                    []
-                                  ]
-                                }
-                              ],
-                              []
-                            ]
-                          },
-                          {
-                            "type": "USUAL_GROUP",
-                            "id": 38,
-                            "name": "ГруппаМногострочность",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Многострочность"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": [
-                              [
-                                {
-                                  "type": "USUAL_GROUP",
-                                  "id": 448,
-                                  "name": "ГруппаОднострочноеПолеВводаНастройки",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Однострочное поле ввода настройки"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": [
-                                    [
-                                      {
-                                        "type": "RADIO_BUTTON_FIELD",
-                                        "id": 442,
-                                        "name": "ОднострочныйВид",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Представление реквизита"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "ПредставлениеРеквизита",
-                                        "items": []
-                                      },
-                                      {
-                                        "type": "CHECK_BOX_FIELD",
-                                        "id": 445,
-                                        "name": "ВыводитьВВидеГиперссылки",
-                                        "title": {
-                                          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                        },
-                                        "dataPath": "Объект.ВыводитьВВидеГиперссылки",
-                                        "items": []
-                                      }
-                                    ],
-                                    []
-                                  ]
-                                },
-                                {
-                                  "type": "USUAL_GROUP",
-                                  "id": 46,
-                                  "name": "ГруппаМногострочноеПолеВводаНастройки",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Многострочное поле ввода настройки"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": [
-                                    [
-                                      {
-                                        "type": "RADIO_BUTTON_FIELD",
-                                        "id": 450,
-                                        "name": "МногострочныйВид",
-                                        "title": {
-                                          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                        },
-                                        "dataPath": "ПредставлениеРеквизита",
-                                        "items": []
-                                      },
-                                      {
-                                        "type": "INPUT_FIELD",
-                                        "id": 41,
-                                        "name": "МногострочноеПолеВводаЧисло",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "  строк"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "МногострочноеПолеВводаЧисло",
-                                        "items": []
-                                      }
-                                    ],
-                                    []
-                                  ]
-                                }
-                              ],
-                              []
-                            ]
-                          },
+                        }
+                      ]
+                    },
+                    "dataPath": "",
+                    "items": [
+                      {
+                        "type": "USUAL_GROUP",
+                        "id": 650,
+                        "name": "ГруппаОсновноеКарточка",
+                        "title": {
+                          "content": [
+                            {
+                              "default": {
+                                "tag": 2
+                              },
+                              "int": 1,
+                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                "langKey": "ru",
+                                "value": "Основное карточка"
+                              }
+                            }
+                          ]
+                        },
+                        "dataPath": "",
+                        "items": [
                           {
                             "type": "PAGES",
                             "id": 167,
@@ -2906,25 +2537,179 @@
                               [
                                 {
                                   "type": "PAGE",
-                                  "id": 169,
-                                  "name": "ГлавнаяСтраница",
+                                  "id": 656,
+                                  "name": "СтраницаОсновное",
                                   "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Главное"
-                                        }
-                                      }
-                                    ]
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                                   },
                                   "dataPath": "",
                                   "items": [
                                     [
+                                      {
+                                        "type": "USUAL_GROUP",
+                                        "id": 79,
+                                        "name": "ГруппаНаименованиеРеквизита",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Наименование реквизита"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": [
+                                          [
+                                            {
+                                              "type": "RADIO_BUTTON_FIELD",
+                                              "id": 20,
+                                              "name": "ВидСвойства",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Вид свойств"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "ВидСвойства",
+                                              "items": []
+                                            },
+                                            {
+                                              "type": "INPUT_FIELD",
+                                              "id": 1,
+                                              "name": "Заголовок",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[7]/synonym"
+                                              },
+                                              "dataPath": "Объект.Заголовок",
+                                              "items": []
+                                            }
+                                          ],
+                                          []
+                                        ]
+                                      },
+                                      {
+                                        "type": "USUAL_GROUP",
+                                        "id": 860,
+                                        "name": "ГруппаТипЗначения",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Тип значения"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": [
+                                          {
+                                            "type": "INPUT_FIELD",
+                                            "id": 5,
+                                            "name": "ТипЗначения",
+                                            "title": {
+                                              "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                            },
+                                            "dataPath": "Объект.ValueType",
+                                            "items": []
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "USUAL_GROUP",
+                                        "id": 38,
+                                        "name": "ГруппаМногострочность",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Многострочность"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": [
+                                          [
+                                            {
+                                              "type": "RADIO_BUTTON_FIELD",
+                                              "id": 576,
+                                              "name": "ПолеПереключатель",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Вид поля"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "ПредставлениеРеквизита",
+                                              "items": []
+                                            },
+                                            {
+                                              "type": "INPUT_FIELD",
+                                              "id": 41,
+                                              "name": "МногострочноеПолеВводаЧисло",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Высота поля"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "МногострочноеПолеВводаЧисло",
+                                              "items": []
+                                            },
+                                            {
+                                              "type": "CHECK_BOX_FIELD",
+                                              "id": 445,
+                                              "name": "ВыводитьВВидеГиперссылки",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                              },
+                                              "dataPath": "Объект.ВыводитьВВидеГиперссылки",
+                                              "items": []
+                                            }
+                                          ],
+                                          []
+                                        ]
+                                      },
                                       {
                                         "type": "USUAL_GROUP",
                                         "id": 498,
@@ -2945,287 +2730,27 @@
                                         },
                                         "dataPath": "",
                                         "items": [
-                                          [
-                                            {
-                                              "type": "LABEL",
-                                              "id": 500,
-                                              "name": "ДекорацияЦветСвойства",
-                                              "title": {
-                                                "content": [
-                                                  {
-                                                    "default": {
-                                                      "tag": 2
-                                                    },
-                                                    "int": 1,
-                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                      "langKey": "ru",
-                                                      "value": "Цвет:"
-                                                    }
-                                                  }
-                                                ]
-                                              },
-                                              "dataPath": "",
-                                              "items": []
-                                            },
-                                            {
-                                              "type": "COMMAND_BAR",
-                                              "id": 503,
-                                              "name": "КоманднаяПанельЦветаСвойств",
-                                              "title": {
-                                                "content": [
-                                                  {
-                                                    "default": {
-                                                      "tag": 2
-                                                    },
-                                                    "int": 1,
-                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                      "langKey": "ru",
-                                                      "value": "Командная панель цвета свойств"
-                                                    }
-                                                  }
-                                                ]
-                                              },
-                                              "dataPath": "",
-                                              "items": [
+                                          {
+                                            "type": "INPUT_FIELD",
+                                            "id": 703,
+                                            "name": "ЦветМетки",
+                                            "title": {
+                                              "content": [
                                                 {
-                                                  "type": "FORM_GROUP",
-                                                  "id": 505,
-                                                  "name": "ГруппаЦвета",
-                                                  "title": {
-                                                    "content": [
-                                                      {
-                                                        "default": {
-                                                          "tag": 2
-                                                        },
-                                                        "int": 1,
-                                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                          "langKey": "ru",
-                                                          "value": "Цвета"
-                                                        }
-                                                      }
-                                                    ]
+                                                  "default": {
+                                                    "tag": 2
                                                   },
-                                                  "dataPath": "",
-                                                  "items": [
-                                                    [
-                                                      {
-                                                        "type": "BUTTON",
-                                                        "id": 507,
-                                                        "name": "СвойствоСерое",
-                                                        "title": {
-                                                          "content": [
-                                                            {
-                                                              "default": {
-                                                                "tag": 2
-                                                              },
-                                                              "int": 1,
-                                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                                "langKey": "ru",
-                                                                "value": "Свойство серое"
-                                                              }
-                                                            }
-                                                          ]
-                                                        },
-                                                        "dataPath": "",
-                                                        "items": []
-                                                      },
-                                                      {
-                                                        "type": "BUTTON",
-                                                        "id": 517,
-                                                        "name": "СвойствоЗеленое",
-                                                        "title": {
-                                                          "content": [
-                                                            {
-                                                              "default": {
-                                                                "tag": 2
-                                                              },
-                                                              "int": 1,
-                                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                                "langKey": "ru",
-                                                                "value": "Свойство зеленое"
-                                                              }
-                                                            }
-                                                          ]
-                                                        },
-                                                        "dataPath": "",
-                                                        "items": []
-                                                      },
-                                                      {
-                                                        "type": "BUTTON",
-                                                        "id": 515,
-                                                        "name": "СвойствоЖелтое",
-                                                        "title": {
-                                                          "content": [
-                                                            {
-                                                              "default": {
-                                                                "tag": 2
-                                                              },
-                                                              "int": 1,
-                                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                                "langKey": "ru",
-                                                                "value": "Свойство желтое"
-                                                              }
-                                                            }
-                                                          ]
-                                                        },
-                                                        "dataPath": "",
-                                                        "items": []
-                                                      },
-                                                      {
-                                                        "type": "BUTTON",
-                                                        "id": 513,
-                                                        "name": "СвойствоОранжевое",
-                                                        "title": {
-                                                          "content": [
-                                                            {
-                                                              "default": {
-                                                                "tag": 2
-                                                              },
-                                                              "int": 1,
-                                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                                "langKey": "ru",
-                                                                "value": "Свойство оранжевое"
-                                                              }
-                                                            }
-                                                          ]
-                                                        },
-                                                        "dataPath": "",
-                                                        "items": []
-                                                      },
-                                                      {
-                                                        "type": "BUTTON",
-                                                        "id": 511,
-                                                        "name": "СвойствоКрасное",
-                                                        "title": {
-                                                          "content": [
-                                                            {
-                                                              "default": {
-                                                                "tag": 2
-                                                              },
-                                                              "int": 1,
-                                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                                "langKey": "ru",
-                                                                "value": "Свойство красное"
-                                                              }
-                                                            }
-                                                          ]
-                                                        },
-                                                        "dataPath": "",
-                                                        "items": []
-                                                      },
-                                                      {
-                                                        "type": "BUTTON",
-                                                        "id": 523,
-                                                        "name": "СвойствоФиолетовое",
-                                                        "title": {
-                                                          "content": [
-                                                            {
-                                                              "default": {
-                                                                "tag": 2
-                                                              },
-                                                              "int": 1,
-                                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                                "langKey": "ru",
-                                                                "value": "Свойство фиолетовое"
-                                                              }
-                                                            }
-                                                          ]
-                                                        },
-                                                        "dataPath": "",
-                                                        "items": []
-                                                      },
-                                                      {
-                                                        "type": "BUTTON",
-                                                        "id": 519,
-                                                        "name": "СвойствоСинее",
-                                                        "title": {
-                                                          "content": [
-                                                            {
-                                                              "default": {
-                                                                "tag": 2
-                                                              },
-                                                              "int": 1,
-                                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                                "langKey": "ru",
-                                                                "value": "Свойство синее"
-                                                              }
-                                                            }
-                                                          ]
-                                                        },
-                                                        "dataPath": "",
-                                                        "items": []
-                                                      },
-                                                      {
-                                                        "type": "BUTTON",
-                                                        "id": 509,
-                                                        "name": "СвойствоЛаймовое",
-                                                        "title": {
-                                                          "content": [
-                                                            {
-                                                              "default": {
-                                                                "tag": 2
-                                                              },
-                                                              "int": 1,
-                                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                                "langKey": "ru",
-                                                                "value": "Свойство лаймовое"
-                                                              }
-                                                            }
-                                                          ]
-                                                        },
-                                                        "dataPath": "",
-                                                        "items": []
-                                                      },
-                                                      {
-                                                        "type": "BUTTON",
-                                                        "id": 525,
-                                                        "name": "СвойствоРозовое",
-                                                        "title": {
-                                                          "content": [
-                                                            {
-                                                              "default": {
-                                                                "tag": 2
-                                                              },
-                                                              "int": 1,
-                                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                                "langKey": "ru",
-                                                                "value": "Свойство розовое"
-                                                              }
-                                                            }
-                                                          ]
-                                                        },
-                                                        "dataPath": "",
-                                                        "items": []
-                                                      },
-                                                      {
-                                                        "type": "BUTTON",
-                                                        "id": 521,
-                                                        "name": "СвойствоГолубое",
-                                                        "title": {
-                                                          "content": [
-                                                            {
-                                                              "default": {
-                                                                "tag": 2
-                                                              },
-                                                              "int": 1,
-                                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                                "langKey": "ru",
-                                                                "value": "Свойство голубое"
-                                                              }
-                                                            }
-                                                          ]
-                                                        },
-                                                        "dataPath": "",
-                                                        "items": []
-                                                      }
-                                                    ],
-                                                    []
-                                                  ]
+                                                  "int": 1,
+                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                    "langKey": "ru",
+                                                    "value": "Цвет"
+                                                  }
                                                 }
                                               ]
-                                            }
-                                          ],
-                                          []
+                                            },
+                                            "dataPath": "Объект.ЦветСвойства",
+                                            "items": []
+                                          }
                                         ]
                                       },
                                       {
@@ -3249,6 +2774,51 @@
                                         "dataPath": "",
                                         "items": [
                                           [
+                                            {
+                                              "type": "USUAL_GROUP",
+                                              "id": 467,
+                                              "name": "ГруппаЗаполнятьОбязательно",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[16]/synonym"
+                                              },
+                                              "dataPath": "",
+                                              "items": [
+                                                [
+                                                  {
+                                                    "type": "CHECK_BOX_FIELD",
+                                                    "id": 184,
+                                                    "name": "ЗаполнятьОбязательно",
+                                                    "title": {
+                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[16]/synonym"
+                                                    },
+                                                    "dataPath": "Объект.ЗаполнятьОбязательно",
+                                                    "items": []
+                                                  },
+                                                  {
+                                                    "type": "LABEL",
+                                                    "id": 670,
+                                                    "name": "ЗадатьУсловиеЗаполнения",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "всегда"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": []
+                                                  }
+                                                ],
+                                                []
+                                              ]
+                                            },
                                             {
                                               "type": "USUAL_GROUP",
                                               "id": 463,
@@ -3282,21 +2852,10 @@
                                                   },
                                                   {
                                                     "type": "LABEL",
-                                                    "id": 333,
+                                                    "id": 664,
                                                     "name": "ЗадатьУсловиеВидимости",
                                                     "title": {
-                                                      "content": [
-                                                        {
-                                                          "default": {
-                                                            "tag": 2
-                                                          },
-                                                          "int": 1,
-                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                            "langKey": "ru",
-                                                            "value": "всегда"
-                                                          }
-                                                        }
-                                                      ]
+                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                                                     },
                                                     "dataPath": "",
                                                     "items": []
@@ -3338,10 +2897,10 @@
                                                   },
                                                   {
                                                     "type": "LABEL",
-                                                    "id": 194,
+                                                    "id": 667,
                                                     "name": "ЗадатьУсловиеДоступности",
                                                     "title": {
-                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                                                     },
                                                     "dataPath": "",
                                                     "items": []
@@ -3349,186 +2908,6 @@
                                                 ],
                                                 []
                                               ]
-                                            },
-                                            {
-                                              "type": "USUAL_GROUP",
-                                              "id": 467,
-                                              "name": "ГруппаЗаполнятьОбязательно",
-                                              "title": {
-                                                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[16]/synonym"
-                                              },
-                                              "dataPath": "",
-                                              "items": [
-                                                [
-                                                  {
-                                                    "type": "CHECK_BOX_FIELD",
-                                                    "id": 184,
-                                                    "name": "ЗаполнятьОбязательно",
-                                                    "title": {
-                                                      "content": [
-                                                        {
-                                                          "default": {
-                                                            "tag": 2
-                                                          },
-                                                          "int": 1,
-                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                            "langKey": "ru",
-                                                            "value": "Заполнять обязательно:"
-                                                          }
-                                                        }
-                                                      ]
-                                                    },
-                                                    "dataPath": "Объект.ЗаполнятьОбязательно",
-                                                    "items": []
-                                                  },
-                                                  {
-                                                    "type": "LABEL",
-                                                    "id": 197,
-                                                    "name": "ЗадатьУсловиеЗаполнения",
-                                                    "title": {
-                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                                                    },
-                                                    "dataPath": "",
-                                                    "items": []
-                                                  }
-                                                ],
-                                                []
-                                              ]
-                                            }
-                                          ],
-                                          []
-                                        ]
-                                      },
-                                      {
-                                        "type": "USUAL_GROUP",
-                                        "id": 107,
-                                        "name": "ОстальныеРеквизиты",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Остальные реквизиты"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "",
-                                        "items": [
-                                          [
-                                            {
-                                              "type": "USUAL_GROUP",
-                                              "id": 481,
-                                              "name": "ГруппаИдентификаторДляФормул",
-                                              "title": {
-                                                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[17]/synonym"
-                                              },
-                                              "dataPath": "",
-                                              "items": [
-                                                [
-                                                  {
-                                                    "type": "INPUT_FIELD",
-                                                    "id": 483,
-                                                    "name": "ИдентификаторДляФормул",
-                                                    "title": {
-                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                                    },
-                                                    "dataPath": "Объект.ИдентификаторДляФормул",
-                                                    "items": []
-                                                  },
-                                                  {
-                                                    "type": "USUAL_BUTTON",
-                                                    "id": 486,
-                                                    "name": "ЗаполнитьИдентификаторДляФормул",
-                                                    "title": {
-                                                      "content": [
-                                                        {
-                                                          "default": {
-                                                            "tag": 2
-                                                          },
-                                                          "int": 1,
-                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                            "langKey": "ru",
-                                                            "value": "Заполнить идентификатор для формул"
-                                                          }
-                                                        }
-                                                      ]
-                                                    },
-                                                    "dataPath": "",
-                                                    "items": []
-                                                  }
-                                                ],
-                                                []
-                                              ]
-                                            },
-                                            {
-                                              "type": "INPUT_FIELD",
-                                              "id": 30,
-                                              "name": "Подсказка",
-                                              "title": {
-                                                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                                              },
-                                              "dataPath": "Объект.Подсказка",
-                                              "items": []
-                                            },
-                                            {
-                                              "type": "USUAL_GROUP",
-                                              "id": 32,
-                                              "name": "ГруппаЗаголовкиФормЗначений",
-                                              "title": {
-                                                "content": [
-                                                  {
-                                                    "default": {
-                                                      "tag": 2
-                                                    },
-                                                    "int": 1,
-                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                      "langKey": "ru",
-                                                      "value": "Заголовки форм значений"
-                                                    }
-                                                  }
-                                                ]
-                                              },
-                                              "dataPath": "",
-                                              "items": [
-                                                [
-                                                  {
-                                                    "type": "INPUT_FIELD",
-                                                    "id": 33,
-                                                    "name": "ЗаголовокФормыЗначения",
-                                                    "title": {
-                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                                    },
-                                                    "dataPath": "Объект.ЗаголовокФормыЗначения",
-                                                    "items": []
-                                                  },
-                                                  {
-                                                    "type": "INPUT_FIELD",
-                                                    "id": 35,
-                                                    "name": "ЗаголовокФормыВыбораЗначения",
-                                                    "title": {
-                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                                    },
-                                                    "dataPath": "Объект.ЗаголовокФормыВыбораЗначения",
-                                                    "items": []
-                                                  }
-                                                ],
-                                                []
-                                              ]
-                                            },
-                                            {
-                                              "type": "INPUT_FIELD",
-                                              "id": 28,
-                                              "name": "Комментарий",
-                                              "title": {
-                                                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                              },
-                                              "dataPath": "Объект.Комментарий",
-                                              "items": []
                                             }
                                           ],
                                           []
@@ -3672,7 +3051,7 @@
                                                   "id": 57,
                                                   "name": "Значения",
                                                   "title": {
-                                                    "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                                    "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                                                   },
                                                   "dataPath": "Значения",
                                                   "items": [
@@ -3746,7 +3125,7 @@
                                                         "int": 1,
                                                         "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                                                           "langKey": "ru",
-                                                          "value": "Значения дополнительного реквизита"
+                                                          "value": "Значения дополнительных реквизитов"
                                                         }
                                                       }
                                                     ]
@@ -3852,7 +3231,7 @@
                                               "id": 105,
                                               "name": "УточнениеСпискаЗначенийИзменить",
                                               "title": {
-                                                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[6]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                                               },
                                               "dataPath": "",
                                               "items": []
@@ -3864,188 +3243,129 @@
                                     ],
                                     []
                                   ]
+                                },
+                                {
+                                  "type": "PAGE",
+                                  "id": 592,
+                                  "name": "СтраницаПрочее",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Прочее"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "INPUT_FIELD",
+                                        "id": 30,
+                                        "name": "Подсказка",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                        },
+                                        "dataPath": "Объект.Подсказка",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "USUAL_GROUP",
+                                        "id": 32,
+                                        "name": "ГруппаЗаголовкиФормЗначений",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Заголовки форм значений"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": [
+                                          [
+                                            {
+                                              "type": "INPUT_FIELD",
+                                              "id": 33,
+                                              "name": "ЗаголовокФормыЗначения",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                              },
+                                              "dataPath": "Объект.ЗаголовокФормыЗначения",
+                                              "items": []
+                                            },
+                                            {
+                                              "type": "INPUT_FIELD",
+                                              "id": 35,
+                                              "name": "ЗаголовокФормыВыбораЗначения",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                              },
+                                              "dataPath": "Объект.ЗаголовокФормыВыбораЗначения",
+                                              "items": []
+                                            }
+                                          ],
+                                          []
+                                        ]
+                                      },
+                                      {
+                                        "type": "INPUT_FIELD",
+                                        "id": 28,
+                                        "name": "Комментарий",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                        },
+                                        "dataPath": "Объект.Комментарий",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "INPUT_FIELD",
+                                        "id": 483,
+                                        "name": "ИдентификаторДляФормул",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                        },
+                                        "dataPath": "Объект.ИдентификаторДляФормул",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "INPUT_FIELD",
+                                        "id": 457,
+                                        "name": "Имя",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                        },
+                                        "dataPath": "Объект.Имя",
+                                        "items": []
+                                      }
+                                    ],
+                                    []
+                                  ]
                                 }
                               ],
                               []
                             ]
-                          },
-                          {
-                            "type": "USUAL_GROUP",
-                            "id": 455,
-                            "name": "ГруппаДляРазработчиков",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Для разработчиков"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": [
-                              {
-                                "type": "INPUT_FIELD",
-                                "id": 457,
-                                "name": "Имя",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                },
-                                "dataPath": "Объект.Имя",
-                                "items": []
-                              }
-                            ]
                           }
-                        ],
-                        []
-                      ]
-                    }
-                  ],
-                  []
-                ]
-              },
-              {
-                "type": "USUAL_GROUP",
-                "id": 227,
-                "name": "КоманднаяПанельПомощника",
-                "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Командная панель помощника"
+                        ]
                       }
-                    }
-                  ]
-                },
-                "dataPath": "",
-                "items": [
-                  [
-                    {
-                      "type": "COMMAND_BAR",
-                      "id": 229,
-                      "name": "КоманднаяПанельЛево",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Командная панель лево"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
-                        {
-                          "type": "BUTTON",
-                          "id": 233,
-                          "name": "КомандаНазад",
-                          "title": {
-                            "content": [
-                              {
-                                "default": {
-                                  "tag": 2
-                                },
-                                "int": 1,
-                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                  "langKey": "ru",
-                                  "value": "< Назад"
-                                }
-                              }
-                            ]
-                          },
-                          "dataPath": "",
-                          "items": []
-                        }
-                      ]
-                    },
-                    {
-                      "type": "COMMAND_BAR",
-                      "id": 231,
-                      "name": "КоманднаяПанельПраво",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Командная панель право"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "BUTTON",
-                            "id": 235,
-                            "name": "КомандаДалее",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Далее >"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "BUTTON",
-                            "id": 242,
-                            "name": "Закрыть",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Закрыть"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": []
-                          }
-                        ],
-                        []
-                      ]
-                    }
-                  ],
-                  []
-                ]
-              }
-            ],
-            []
+                    ]
+                  }
+                ],
+                []
+              ]
+            }
           ],
           "attributes": [
             [
@@ -4141,7 +3461,7 @@
                 "id": 9,
                 "name": "Значения",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                 },
                 "type": {
                   "types": [
@@ -4224,18 +3544,7 @@
                 "id": 16,
                 "name": "ЗначенияДополнительныхРеквизитов",
                 "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Значения дополнительных реквизитов"
-                      }
-                    }
-                  ]
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "types": [
@@ -4295,7 +3604,7 @@
                 "id": 21,
                 "name": "НаборыСвойств",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[6]/type"
@@ -4305,7 +3614,7 @@
                 "id": 22,
                 "name": "Свойства",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "types": [
@@ -4325,7 +3634,18 @@
                 "id": 23,
                 "name": "ОбщиеНаборыСвойств",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Общие наборы свойств"
+                      }
+                    }
+                  ]
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[6]/type"
@@ -4335,7 +3655,18 @@
                 "id": 24,
                 "name": "ПредставлениеРеквизита",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Представление реквизита"
+                      }
+                    }
+                  ]
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
@@ -4457,27 +3788,6 @@
                 "items": []
               },
               {
-                "type": "COMMAND_BAR",
-                "id": 14,
-                "name": "КоманднаяПанель",
-                "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Командная панель"
-                      }
-                    }
-                  ]
-                },
-                "dataPath": "",
-                "items": []
-              },
-              {
                 "type": "TABLE",
                 "id": 1,
                 "name": "Список",
@@ -4513,7 +3823,7 @@
                       "id": 6,
                       "name": "ТипЗначения",
                       "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                       },
                       "dataPath": "Список.ValueType",
                       "items": []
@@ -5064,8 +4374,8 @@
                               },
                               {
                                 "type": "LABEL",
-                                "id": 50,
-                                "name": "РеквизитПредупреждениеКомментарий",
+                                "id": 98,
+                                "name": "ДекорацияПредупреждение",
                                 "title": {
                                   "content": [
                                     {
@@ -5109,27 +4419,6 @@
                           "items": []
                         },
                         {
-                          "type": "LABEL",
-                          "id": 14,
-                          "name": "ОтдельныеЗначенияРеквизитаКомментарий",
-                          "title": {
-                            "content": [
-                              {
-                                "default": {
-                                  "tag": 2
-                                },
-                                "int": 1,
-                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                  "langKey": "ru",
-                                  "value": "Данный реквизит входит только в один набор %1, и у него свой собственный список значений."
-                                }
-                              }
-                            ]
-                          },
-                          "dataPath": "",
-                          "items": []
-                        },
-                        {
                           "type": "PAGES",
                           "id": 30,
                           "name": "ВидыРеквизита",
@@ -5170,51 +4459,27 @@
                                 },
                                 "dataPath": "",
                                 "items": [
-                                  [
-                                    {
-                                      "type": "RADIO_BUTTON_FIELD",
-                                      "id": 6,
-                                      "name": "ОбщиеЗначенияРеквизитов",
-                                      "title": {
-                                        "content": [
-                                          {
-                                            "default": {
-                                              "tag": 2
-                                            },
-                                            "int": 1,
-                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                              "langKey": "ru",
-                                              "value": "Отдельное свойство с общим списком значений"
-                                            }
+                                  {
+                                    "type": "RADIO_BUTTON_FIELD",
+                                    "id": 6,
+                                    "name": "ОбщиеЗначенияРеквизитов",
+                                    "title": {
+                                      "content": [
+                                        {
+                                          "default": {
+                                            "tag": 2
+                                          },
+                                          "int": 1,
+                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                            "langKey": "ru",
+                                            "value": "Отдельное свойство с общим списком значений"
                                           }
-                                        ]
-                                      },
-                                      "dataPath": "ОтдельноеСвойствоСОбщимСпискомЗначений",
-                                      "items": []
+                                        }
+                                      ]
                                     },
-                                    {
-                                      "type": "LABEL",
-                                      "id": 12,
-                                      "name": "ОбщиеЗначенияРеквизитовКомментарий",
-                                      "title": {
-                                        "content": [
-                                          {
-                                            "default": {
-                                              "tag": 2
-                                            },
-                                            "int": 1,
-                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                              "langKey": "ru",
-                                              "value": "У данного реквизита общий список значений с другими реквизитами, добавленными по образцу. С помощью этого варианта удобно выполнять централизованную настройку списка значений сразу для нескольких однотипных реквизитов (например, \"Цвет одежды\", \"Цвет обуви\" и пр.)."
-                                            }
-                                          }
-                                        ]
-                                      },
-                                      "dataPath": "",
-                                      "items": []
-                                    }
-                                  ],
-                                  []
+                                    "dataPath": "ОтдельноеСвойствоСОбщимСпискомЗначений",
+                                    "items": []
+                                  }
                                 ]
                               },
                               {
@@ -5237,51 +4502,27 @@
                                 },
                                 "dataPath": "",
                                 "items": [
-                                  [
-                                    {
-                                      "type": "RADIO_BUTTON_FIELD",
-                                      "id": 4,
-                                      "name": "ОбщийРеквизит",
-                                      "title": {
-                                        "content": [
-                                          {
-                                            "default": {
-                                              "tag": 2
-                                            },
-                                            "int": 1,
-                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                              "langKey": "ru",
-                                              "value": "Общее свойство"
-                                            }
+                                  {
+                                    "type": "RADIO_BUTTON_FIELD",
+                                    "id": 4,
+                                    "name": "ОбщийРеквизит",
+                                    "title": {
+                                      "content": [
+                                        {
+                                          "default": {
+                                            "tag": 2
+                                          },
+                                          "int": 1,
+                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                            "langKey": "ru",
+                                            "value": "Общее свойство"
                                           }
-                                        ]
-                                      },
-                                      "dataPath": "ОбщееСвойство",
-                                      "items": []
+                                        }
+                                      ]
                                     },
-                                    {
-                                      "type": "LABEL",
-                                      "id": 10,
-                                      "name": "ОбщийРеквизитКомментарий",
-                                      "title": {
-                                        "content": [
-                                          {
-                                            "default": {
-                                              "tag": 2
-                                            },
-                                            "int": 1,
-                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                              "langKey": "ru",
-                                              "value": "Данный реквизит входит сразу в несколько наборов. Этот вариант подходит для тех случаев, когда общим\nдолжен быть не только список значений, но и сам реквизит. В списках и отчетах по элементам различных\nсправочников и документов, общие реквизиты группируются и выводятся как один реквизит, в одной колонке или поле.\nНапример, с помощью общего реквизита \"Цвет\" можно быстро отобрать всю желтую одежду и обувь."
-                                            }
-                                          }
-                                        ]
-                                      },
-                                      "dataPath": "",
-                                      "items": []
-                                    }
-                                  ],
-                                  []
+                                    "dataPath": "ОбщееСвойство",
+                                    "items": []
+                                  }
                                 ]
                               }
                             ],
@@ -5333,51 +4574,27 @@
                           },
                           "dataPath": "",
                           "items": [
-                            [
-                              {
-                                "type": "DECORATION",
-                                "id": 56,
-                                "name": "СведениеПредупреждениеКартинка",
-                                "title": {
-                                  "content": [
-                                    {
-                                      "default": {
-                                        "tag": 2
-                                      },
-                                      "int": 1,
-                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                        "langKey": "ru",
-                                        "value": "Сведение предупреждение картинка"
-                                      }
+                            {
+                              "type": "DECORATION",
+                              "id": 56,
+                              "name": "СведениеПредупреждениеКартинка",
+                              "title": {
+                                "content": [
+                                  {
+                                    "default": {
+                                      "tag": 2
+                                    },
+                                    "int": 1,
+                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                      "langKey": "ru",
+                                      "value": "Сведение предупреждение картинка"
                                     }
-                                  ]
-                                },
-                                "dataPath": "",
-                                "items": []
+                                  }
+                                ]
                               },
-                              {
-                                "type": "LABEL",
-                                "id": 58,
-                                "name": "СведениеПредупреждениеКомментарий",
-                                "title": {
-                                  "content": [
-                                    {
-                                      "default": {
-                                        "tag": 2
-                                      },
-                                      "int": 1,
-                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                        "langKey": "ru",
-                                        "value": "Перенастройка дополнительного сведения необратима и может занять длительное время, в зависимости от числа документов, в которых заполнено это сведение.\nВместо этого можно добавить новое сведение со своим списком значений, и выполнить вручную постепенный переход от использования этого сведения к новому (очистить значения этого сведения и заполнить значения нового)."
-                                      }
-                                    }
-                                  ]
-                                },
-                                "dataPath": "",
-                                "items": []
-                              }
-                            ],
-                            []
+                              "dataPath": "",
+                              "items": []
+                            }
                           ]
                         },
                         {
@@ -5388,27 +4605,6 @@
                             "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                           },
                           "dataPath": "ОтдельноеСвойствоСОтдельнымСпискомЗначений",
-                          "items": []
-                        },
-                        {
-                          "type": "LABEL",
-                          "id": 28,
-                          "name": "ОтдельныеЗначенияСведенияКомментарий",
-                          "title": {
-                            "content": [
-                              {
-                                "default": {
-                                  "tag": 2
-                                },
-                                "int": 1,
-                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                  "langKey": "ru",
-                                  "value": "Данное сведение входит только в один набор %1, и у него свой собственный список значений."
-                                }
-                              }
-                            ]
-                          },
-                          "dataPath": "",
                           "items": []
                         },
                         {
@@ -5452,40 +4648,16 @@
                                 },
                                 "dataPath": "",
                                 "items": [
-                                  [
-                                    {
-                                      "type": "RADIO_BUTTON_FIELD",
-                                      "id": 22,
-                                      "name": "ОбщиеЗначенияСведений",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                      },
-                                      "dataPath": "ОтдельноеСвойствоСОбщимСпискомЗначений",
-                                      "items": []
+                                  {
+                                    "type": "RADIO_BUTTON_FIELD",
+                                    "id": 22,
+                                    "name": "ОбщиеЗначенияСведений",
+                                    "title": {
+                                      "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                                     },
-                                    {
-                                      "type": "LABEL",
-                                      "id": 24,
-                                      "name": "ОбщиеЗначенияСведенийКомментарий",
-                                      "title": {
-                                        "content": [
-                                          {
-                                            "default": {
-                                              "tag": 2
-                                            },
-                                            "int": 1,
-                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                              "langKey": "ru",
-                                              "value": "У этого сведения общий список значений с другими сведениями, добавленными по образцу. С помощью этого варианта удобно выполнять централизованную настройку списка значений сразу для нескольких однотипных сведений (например, \"Цвет одежды\", \"Цвет обуви\" и пр.)."
-                                            }
-                                          }
-                                        ]
-                                      },
-                                      "dataPath": "",
-                                      "items": []
-                                    }
-                                  ],
-                                  []
+                                    "dataPath": "ОтдельноеСвойствоСОбщимСпискомЗначений",
+                                    "items": []
+                                  }
                                 ]
                               },
                               {
@@ -5508,40 +4680,16 @@
                                 },
                                 "dataPath": "",
                                 "items": [
-                                  [
-                                    {
-                                      "type": "RADIO_BUTTON_FIELD",
-                                      "id": 18,
-                                      "name": "ОбщееСведение",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                      },
-                                      "dataPath": "ОбщееСвойство",
-                                      "items": []
+                                  {
+                                    "type": "RADIO_BUTTON_FIELD",
+                                    "id": 18,
+                                    "name": "ОбщееСведение",
+                                    "title": {
+                                      "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                                     },
-                                    {
-                                      "type": "LABEL",
-                                      "id": 20,
-                                      "name": "ОбщееСведениеКомментарий",
-                                      "title": {
-                                        "content": [
-                                          {
-                                            "default": {
-                                              "tag": 2
-                                            },
-                                            "int": 1,
-                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                              "langKey": "ru",
-                                              "value": "Данное сведение входит сразу в несколько наборов. Этот вариант подходит для тех случаев, когда общим\nдолжен быть не только список значений, но и само сведение. В списках и отчетах по элементам различных\nсправочников и документов, общие сведения группируются и выводятся как одно сведение, в одной колонке или поле.\nНапример, с помощью общего сведения \"Цвет\" можно быстро отобрать всю желтую одежду и обувь."
-                                            }
-                                          }
-                                        ]
-                                      },
-                                      "dataPath": "",
-                                      "items": []
-                                    }
-                                  ],
-                                  []
+                                    "dataPath": "ОбщееСвойство",
+                                    "items": []
+                                  }
                                 ]
                               }
                             ],
@@ -5563,7 +4711,7 @@
                 "id": 1,
                 "name": "ОбщееСвойство",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "types": [
@@ -5596,7 +4744,7 @@
                 "id": 2,
                 "name": "ОтдельноеСвойствоСОбщимСпискомЗначений",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
@@ -5737,7 +4885,7 @@
                     "id": 18,
                     "name": "ЗависимостиРеквизитовРеквизит",
                     "title": {
-                      "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                     },
                     "dataPath": "ЗависимостиРеквизитов.Представление",
                     "items": []
@@ -5888,7 +5036,7 @@
         "objectBelonging": "OWN",
         "comment": "",
         "synonym": {
-          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
         },
         "supportVariant": "NOT_EDITABLE",
         "modules": [
@@ -5906,7 +5054,7 @@
         "data": {
           "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
           "title": {
-            "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+            "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
           },
           "handlers": [
             {
@@ -5939,7 +5087,7 @@
                   "id": 14,
                   "name": "РеквизитыОбъектаПредставление",
                   "title": {
-                    "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                    "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                   },
                   "dataPath": "РеквизитыОбъекта.Представление",
                   "items": []
@@ -6268,7 +5416,7 @@
               "objectBelonging": "OWN",
               "comment": "",
               "synonym": {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
               },
               "supportVariant": "NOT_EDITABLE",
               "owner": {
@@ -6628,7 +5776,7 @@
               "objectBelonging": "OWN",
               "comment": "",
               "synonym": {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
               },
               "supportVariant": "NOT_EDITABLE",
               "owner": {

--- a/src/test/resources/fixtures/ssl_3_2/CommandGroups.Печать.json
+++ b/src/test/resources/fixtures/ssl_3_2/CommandGroups.Печать.json
@@ -1,0 +1,28 @@
+{"com.github._1c_syntax.bsl.mdo.CommandGroup": {
+  "comment": "Печать",
+  "description": "Печать",
+  "mdoReference": {
+    "type": "COMMAND_GROUP",
+    "mdoRef": "CommandGroup.Печать",
+    "mdoRefRu": "ГруппаКоманд.Печать"
+  },
+  "mdoType": "COMMAND_GROUP",
+  "name": "Печать",
+  "objectBelonging": "OWN",
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "content": [
+      {
+        "default": {
+          "tag": 2
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+          "langKey": "ru",
+          "value": "Печать"
+        }
+      }
+    ]
+  },
+  "uuid": "ac39b903-0c60-417e-a50f-49ed375424f5"
+}}

--- a/src/test/resources/fixtures/ssl_3_2/CommonAttributes.ОбластьДанныхВспомогательныеДанные.json
+++ b/src/test/resources/fixtures/ssl_3_2/CommonAttributes.ОбластьДанныхВспомогательныеДанные.json
@@ -1,0 +1,243 @@
+{"com.github._1c_syntax.bsl.mdo.CommonAttribute": {
+  "authenticationSeparation": "DONT_USE",
+  "autoUse": "DONT_USE",
+  "comment": "",
+  "conditionalSeparation": {
+    "type": "CONSTANT",
+    "mdoRef": "Constant.ИспользоватьРазделениеПоОбластямДанных",
+    "mdoRefRu": "Константа.ИспользоватьРазделениеПоОбластямДанных"
+  },
+  "configurationExtensionsSeparation": "DONT_USE",
+  "content": [
+    [
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ИспользованиеПоставляемыхДополнительныхОтчетовИОбработокВОбластяхДанных",
+          "mdoRefRu": "РегистрСведений.ИспользованиеПоставляемыхДополнительныхОтчетовИОбработокВОбластяхДанных"
+        },
+        "use": "USE"
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ПрогрессОбновления",
+          "mdoRefRu": "РегистрСведений.ПрогрессОбновления"
+        },
+        "use": "USE"
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ОбработчикиОбновления",
+          "mdoRefRu": "РегистрСведений.ОбработчикиОбновления"
+        },
+        "use": "USE"
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.СеансыОбменовДанными",
+          "mdoRefRu": "Справочник.СеансыОбменовДанными"
+        },
+        "use": "USE"
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.БезопасноеХранилищеДанныхОбластейДанных",
+          "mdoRefRu": "РегистрСведений.БезопасноеХранилищеДанныхОбластейДанных"
+        },
+        "use": "USE"
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ОтложенноеОбновлениеЗавершеноУспешно",
+          "mdoRefRu": "Константа.ОтложенноеОбновлениеЗавершеноУспешно"
+        },
+        "use": "USE"
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ОчередьИзвлеченияТекста",
+          "mdoRefRu": "РегистрСведений.ОчередьИзвлеченияТекста"
+        },
+        "use": "USE"
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ПотокиОбновления",
+          "mdoRefRu": "РегистрСведений.ПотокиОбновления"
+        },
+        "use": "USE"
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.СведенияОБлокируемыхОбъектах",
+          "mdoRefRu": "Константа.СведенияОБлокируемыхОбъектах"
+        },
+        "use": "USE"
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СостоянияОбменовДаннымиОбластейДанных",
+          "mdoRefRu": "РегистрСведений.СостоянияОбменовДаннымиОбластейДанных"
+        },
+        "use": "USE"
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СостоянияУспешныхОбменовДаннымиОбластейДанных",
+          "mdoRefRu": "РегистрСведений.СостоянияУспешныхОбменовДаннымиОбластейДанных"
+        },
+        "use": "USE"
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ПериодическиеСерверныеОповещения",
+          "mdoRefRu": "РегистрСведений.ПериодическиеСерверныеОповещения"
+        },
+        "use": "USE"
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СообщенияОбменаДаннымиОбластейДанных",
+          "mdoRefRu": "РегистрСведений.СообщенияОбменаДаннымиОбластейДанных"
+        },
+        "use": "USE"
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ОчередьИнсталляцииПоставляемыхДополнительныхОтчетовИОбработокВОбластиДанных",
+          "mdoRefRu": "РегистрСведений.ОчередьИнсталляцииПоставляемыхДополнительныхОтчетовИОбработокВОбластиДанных"
+        },
+        "use": "USE"
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ОтправленныеСерверныеОповещения",
+          "mdoRefRu": "РегистрСведений.ОтправленныеСерверныеОповещения"
+        },
+        "use": "USE"
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СвойстваРасширений",
+          "mdoRefRu": "РегистрСведений.СвойстваРасширений"
+        },
+        "use": "USE"
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.СведенияОбОбновленииИБ",
+          "mdoRefRu": "Константа.СведенияОбОбновленииИБ"
+        },
+        "use": "USE"
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ВерсииПодсистемОбластейДанных",
+          "mdoRefRu": "РегистрСведений.ВерсииПодсистемОбластейДанных"
+        },
+        "use": "USE"
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.БлокировкиСеансовОбластейДанных",
+          "mdoRefRu": "РегистрСведений.БлокировкиСеансовОбластейДанных"
+        },
+        "use": "USE"
+      }
+    ],
+    []
+  ],
+  "dataSeparation": "SEPARATE",
+  "dataSeparationUse": {
+    "type": "SESSION_PARAMETER",
+    "mdoRef": "SessionParameter.ОбластьДанныхИспользование",
+    "mdoRefRu": "ПараметрСеанса.ОбластьДанныхИспользование"
+  },
+  "dataSeparationValue": {
+    "type": "SESSION_PARAMETER",
+    "mdoRef": "SessionParameter.ОбластьДанныхЗначение",
+    "mdoRefRu": "ПараметрСеанса.ОбластьДанныхЗначение"
+  },
+  "description": "Область данных вспомогательные данные",
+  "indexing": "DONT_INDEX",
+  "mdoReference": {
+    "type": "COMMON_ATTRIBUTE",
+    "mdoRef": "CommonAttribute.ОбластьДанныхВспомогательныеДанные",
+    "mdoRefRu": "ОбщийРеквизит.ОбластьДанныхВспомогательныеДанные"
+  },
+  "mdoType": "COMMON_ATTRIBUTE",
+  "name": "ОбластьДанныхВспомогательныеДанные",
+  "objectBelonging": "OWN",
+  "passwordMode": false,
+  "possibleRights": [
+    {
+      "default": {
+        "tag": 4
+      },
+      "int": 2,
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "VIEW",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "EDIT"
+    }
+  ],
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "content": [
+      {
+        "default": {
+          "tag": 2
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+          "langKey": "ru",
+          "value": "Область данных вспомогательные данные"
+        }
+      }
+    ]
+  },
+  "usersSeparation": "DONT_USE",
+  "uuid": "530a3164-4ef1-4b3b-8269-13764ef4bf15",
+  "valueType": {
+    "types": [
+      {
+        "default": {
+          "tag": 4
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER"
+      }
+    ],
+    "composite": false,
+    "qualifiers": [
+      {
+        "default": {
+          "tag": 4
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+          "precision": 7,
+          "scale": 0,
+          "nonNegative": true,
+          "description": {}
+        }
+      }
+    ]
+  }
+}}

--- a/src/test/resources/fixtures/ssl_3_2/CommonCommands.ОтправитьПисьмо.json
+++ b/src/test/resources/fixtures/ssl_3_2/CommonCommands.ОтправитьПисьмо.json
@@ -1,0 +1,56 @@
+{"com.github._1c_syntax.bsl.mdo.CommonCommand": {
+  "comment": "",
+  "description": "Отправить письмо...",
+  "mdoReference": {
+    "type": "COMMON_COMMAND",
+    "mdoRef": "CommonCommand.ОтправитьПисьмо",
+    "mdoRefRu": "ОбщаяКоманда.ОтправитьПисьмо"
+  },
+  "mdoType": "COMMON_COMMAND",
+  "moduleTypes": [
+    [
+      "CommandModule",
+      [
+        "src/test/resources/ext/designer/ssl_3_2/src/cf/CommonCommands/ОтправитьПисьмо/Ext/CommandModule.bsl"
+      ]
+    ]
+  ],
+  "modules": [
+    {
+      "moduleType": "CommandModule",
+      "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/CommonCommands/ОтправитьПисьмо/Ext/CommandModule.bsl",
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.CommonCommand/mdoReference"
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "isProtected": false
+    }
+  ],
+  "name": "ОтправитьПисьмо",
+  "objectBelonging": "OWN",
+  "possibleRights": [
+    {
+      "default": {
+        "tag": 4
+      },
+      "int": 1,
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "VIEW"
+    }
+  ],
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "content": [
+      {
+        "default": {
+          "tag": 2
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+          "langKey": "ru",
+          "value": "Отправить письмо..."
+        }
+      }
+    ]
+  },
+  "uuid": "477ab478-b336-4bac-898f-e20e3a4039b5"
+}}

--- a/src/test/resources/fixtures/ssl_3_2/CommonCommands.ОтправитьПисьмо_edt.json
+++ b/src/test/resources/fixtures/ssl_3_2/CommonCommands.ОтправитьПисьмо_edt.json
@@ -1,0 +1,56 @@
+{"com.github._1c_syntax.bsl.mdo.CommonCommand": {
+  "comment": "",
+  "description": "Отправить письмо...",
+  "mdoReference": {
+    "type": "COMMON_COMMAND",
+    "mdoRef": "CommonCommand.ОтправитьПисьмо",
+    "mdoRefRu": "ОбщаяКоманда.ОтправитьПисьмо"
+  },
+  "mdoType": "COMMON_COMMAND",
+  "moduleTypes": [
+    [
+      "CommandModule",
+      [
+        "src/test/resources/ext/edt/ssl_3_2/configuration/src/CommonCommands/ОтправитьПисьмо/CommandModule.bsl"
+      ]
+    ]
+  ],
+  "modules": [
+    {
+      "moduleType": "CommandModule",
+      "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/CommonCommands/ОтправитьПисьмо/CommandModule.bsl",
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.CommonCommand/mdoReference"
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "isProtected": false
+    }
+  ],
+  "name": "ОтправитьПисьмо",
+  "objectBelonging": "OWN",
+  "possibleRights": [
+    {
+      "default": {
+        "tag": 4
+      },
+      "int": 1,
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "VIEW"
+    }
+  ],
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "content": [
+      {
+        "default": {
+          "tag": 2
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+          "langKey": "ru",
+          "value": "Отправить письмо..."
+        }
+      }
+    ]
+  },
+  "uuid": "477ab478-b336-4bac-898f-e20e3a4039b5"
+}}

--- a/src/test/resources/fixtures/ssl_3_2/CommonForms.Вопрос.json
+++ b/src/test/resources/fixtures/ssl_3_2/CommonForms.Вопрос.json
@@ -1,0 +1,347 @@
+{"com.github._1c_syntax.bsl.mdo.CommonForm": {
+  "comment": "",
+  "data": {
+    "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+    "title": {
+      "content": []
+    },
+    "handlers": [
+      [
+        {
+          "event": "OnOpen",
+          "name": "ПриОткрытии"
+        },
+        {
+          "event": "OnCreateAtServer",
+          "name": "ПриСозданииНаСервере"
+        }
+      ],
+      []
+    ],
+    "items": [
+      {
+        "type": "USUAL_GROUP",
+        "id": 15,
+        "name": "Колонки",
+        "title": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Колонки"
+              }
+            }
+          ]
+        },
+        "dataPath": "",
+        "items": [
+          [
+            {
+              "type": "PICTURE_DECORATION",
+              "id": 5,
+              "name": "Предупреждение",
+              "title": {
+                "content": [
+                  {
+                    "default": {
+                      "tag": 2
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                      "langKey": "ru",
+                      "value": "Предупреждение"
+                    }
+                  }
+                ]
+              },
+              "dataPath": "",
+              "items": []
+            },
+            {
+              "type": "USUAL_GROUP",
+              "id": 16,
+              "name": "Строки",
+              "title": {
+                "content": [
+                  {
+                    "default": {
+                      "tag": 2
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                      "langKey": "ru",
+                      "value": "Строки"
+                    }
+                  }
+                ]
+              },
+              "dataPath": "",
+              "items": [
+                [
+                  {
+                    "type": "USUAL_GROUP",
+                    "id": 26,
+                    "name": "ТекстСообщенияФорматированнаяСтрокаГруппа",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Текст сообщения форматированная строка (группа)"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "",
+                    "items": [
+                      {
+                        "type": "LABEL_DECORATION",
+                        "id": 23,
+                        "name": "ТекстСообщенияФорматированнаяСтрока",
+                        "title": {
+                          "@reference": "/com.github._1c_syntax.bsl.mdo.CommonForm/data/title"
+                        },
+                        "dataPath": "",
+                        "items": []
+                      }
+                    ]
+                  },
+                  {
+                    "type": "INPUT_FIELD",
+                    "id": 10,
+                    "name": "МногострочныйТекстСообщения",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.CommonForm/data/title"
+                    },
+                    "dataPath": "ТекстСообщения",
+                    "items": []
+                  },
+                  {
+                    "type": "CHECK_BOX_FIELD",
+                    "id": 3,
+                    "name": "БольшеНеЗадаватьЭтотВопрос",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Больше не задавать этот вопрос"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "БольшеНеЗадаватьЭтотВопрос",
+                    "items": []
+                  }
+                ],
+                []
+              ]
+            }
+          ],
+          []
+        ]
+      }
+    ],
+    "attributes": [
+      [
+        {
+          "id": 1,
+          "name": "СоответствиеКнопокИВозвращаемыхЗначений",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.CommonForm/data/title"
+          },
+          "type": {
+            "types": [
+              {
+                "default": {
+                  "tag": 4
+                },
+                "int": 0
+              }
+            ],
+            "composite": false,
+            "qualifiers": []
+          }
+        },
+        {
+          "id": 3,
+          "name": "БольшеНеЗадаватьЭтотВопрос",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.CommonForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+          },
+          "type": {
+            "types": [
+              {
+                "default": {
+                  "tag": 4
+                },
+                "int": 1,
+                "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "BOOLEAN"
+              }
+            ],
+            "composite": false,
+            "qualifiers": []
+          }
+        },
+        {
+          "id": 4,
+          "name": "ОжиданиеСчетчик",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.CommonForm/data/title"
+          },
+          "type": {
+            "types": [
+              {
+                "default": {
+                  "tag": 4
+                },
+                "int": 1,
+                "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER"
+              }
+            ],
+            "composite": false,
+            "qualifiers": [
+              {
+                "default": {
+                  "tag": 4
+                },
+                "int": 1,
+                "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                  "precision": 5,
+                  "scale": 0,
+                  "nonNegative": true,
+                  "description": {}
+                }
+              }
+            ]
+          }
+        },
+        {
+          "id": 5,
+          "name": "ОжиданиеИмяКнопки",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.CommonForm/data/title"
+          },
+          "type": {
+            "types": [
+              {
+                "default": {
+                  "tag": 4
+                },
+                "int": 1,
+                "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+              }
+            ],
+            "composite": false,
+            "qualifiers": [
+              {
+                "default": {
+                  "tag": 4
+                },
+                "int": 1,
+                "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                  "length": 0,
+                  "allowedLength": 0,
+                  "description": {
+                    "value": {
+                      "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                      "nameRu": "КвалификаторыСтроки (0, Переменная)",
+                      "nameEn": "StringQualifiers (0, Variable)"
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "id": 6,
+          "name": "ОжиданиеЗаголовокКнопки",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.CommonForm/data/title"
+          },
+          "type": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.CommonForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+          }
+        },
+        {
+          "id": 2,
+          "name": "ТекстСообщения",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.CommonForm/data/title"
+          },
+          "type": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.CommonForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+          }
+        }
+      ],
+      []
+    ]
+  },
+  "description": "Вопрос",
+  "formType": "MANAGED",
+  "mdoReference": {
+    "type": "COMMON_FORM",
+    "mdoRef": "CommonForm.Вопрос",
+    "mdoRefRu": "ОбщаяФорма.Вопрос"
+  },
+  "mdoType": "COMMON_FORM",
+  "moduleTypes": [
+    [
+      "FormModule",
+      [
+        "src/test/resources/ext/designer/ssl_3_2/src/cf/CommonForms/Вопрос/Ext/Form/Module.bsl"
+      ]
+    ]
+  ],
+  "modules": [
+    {
+      "moduleType": "FormModule",
+      "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/CommonForms/Вопрос/Ext/Form/Module.bsl",
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.CommonForm/mdoReference"
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "isProtected": false
+    }
+  ],
+  "name": "Вопрос",
+  "objectBelonging": "OWN",
+  "possibleRights": [
+    {
+      "default": {
+        "tag": 4
+      },
+      "int": 1,
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "VIEW"
+    }
+  ],
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "content": [
+      {
+        "default": {
+          "tag": 2
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+          "langKey": "ru",
+          "value": "Вопрос"
+        }
+      }
+    ]
+  },
+  "uuid": "573f1753-9194-4aaf-9217-5cac70ff108f"
+}}

--- a/src/test/resources/fixtures/ssl_3_2/CommonForms.Вопрос.json
+++ b/src/test/resources/fixtures/ssl_3_2/CommonForms.Вопрос.json
@@ -85,7 +85,7 @@
                   {
                     "type": "USUAL_GROUP",
                     "id": 26,
-                    "name": "ТекстСообщенияФорматированнаяСтрокаГруппа",
+                    "name": "ТекстСообщения",
                     "title": {
                       "content": [
                         {
@@ -95,34 +95,37 @@
                           "int": 1,
                           "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                             "langKey": "ru",
-                            "value": "Текст сообщения форматированная строка (группа)"
+                            "value": "Текст сообщения"
                           }
                         }
                       ]
                     },
                     "dataPath": "",
                     "items": [
-                      {
-                        "type": "LABEL_DECORATION",
-                        "id": 23,
-                        "name": "ТекстСообщенияФорматированнаяСтрока",
-                        "title": {
-                          "@reference": "/com.github._1c_syntax.bsl.mdo.CommonForm/data/title"
+                      [
+                        {
+                          "type": "LABEL_DECORATION",
+                          "id": 23,
+                          "name": "ТекстСообщенияНадпись",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.CommonForm/data/title"
+                          },
+                          "dataPath": "",
+                          "items": []
                         },
-                        "dataPath": "",
-                        "items": []
-                      }
+                        {
+                          "type": "INPUT_FIELD",
+                          "id": 10,
+                          "name": "ТекстСообщенияПолеВвода",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.CommonForm/data/title"
+                          },
+                          "dataPath": "ТекстСообщения",
+                          "items": []
+                        }
+                      ],
+                      []
                     ]
-                  },
-                  {
-                    "type": "INPUT_FIELD",
-                    "id": 10,
-                    "name": "МногострочныйТекстСообщения",
-                    "title": {
-                      "@reference": "/com.github._1c_syntax.bsl.mdo.CommonForm/data/title"
-                    },
-                    "dataPath": "ТекстСообщения",
-                    "items": []
                   },
                   {
                     "type": "CHECK_BOX_FIELD",
@@ -179,7 +182,7 @@
           "id": 3,
           "name": "БольшеНеЗадаватьЭтотВопрос",
           "title": {
-            "@reference": "/com.github._1c_syntax.bsl.mdo.CommonForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+            "@reference": "/com.github._1c_syntax.bsl.mdo.CommonForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
           },
           "type": {
             "types": [

--- a/src/test/resources/fixtures/ssl_3_2/CommonForms.Вопрос_edt.json
+++ b/src/test/resources/fixtures/ssl_3_2/CommonForms.Вопрос_edt.json
@@ -85,7 +85,7 @@
                   {
                     "type": "USUAL_GROUP",
                     "id": 26,
-                    "name": "ТекстСообщенияФорматированнаяСтрокаГруппа",
+                    "name": "ТекстСообщения",
                     "title": {
                       "content": [
                         {
@@ -95,34 +95,37 @@
                           "int": 1,
                           "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                             "langKey": "ru",
-                            "value": "Текст сообщения форматированная строка (группа)"
+                            "value": "Текст сообщения"
                           }
                         }
                       ]
                     },
                     "dataPath": "",
                     "items": [
-                      {
-                        "type": "LABEL",
-                        "id": 23,
-                        "name": "ТекстСообщенияФорматированнаяСтрока",
-                        "title": {
-                          "@reference": "/com.github._1c_syntax.bsl.mdo.CommonForm/data/title"
+                      [
+                        {
+                          "type": "LABEL",
+                          "id": 23,
+                          "name": "ТекстСообщенияНадпись",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.CommonForm/data/title"
+                          },
+                          "dataPath": "",
+                          "items": []
                         },
-                        "dataPath": "",
-                        "items": []
-                      }
+                        {
+                          "type": "INPUT_FIELD",
+                          "id": 10,
+                          "name": "ТекстСообщенияПолеВвода",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.CommonForm/data/title"
+                          },
+                          "dataPath": "ТекстСообщения",
+                          "items": []
+                        }
+                      ],
+                      []
                     ]
-                  },
-                  {
-                    "type": "INPUT_FIELD",
-                    "id": 10,
-                    "name": "МногострочныйТекстСообщения",
-                    "title": {
-                      "@reference": "/com.github._1c_syntax.bsl.mdo.CommonForm/data/title"
-                    },
-                    "dataPath": "ТекстСообщения",
-                    "items": []
                   },
                   {
                     "type": "CHECK_BOX_FIELD",
@@ -179,7 +182,7 @@
           "id": 3,
           "name": "БольшеНеЗадаватьЭтотВопрос",
           "title": {
-            "@reference": "/com.github._1c_syntax.bsl.mdo.CommonForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+            "@reference": "/com.github._1c_syntax.bsl.mdo.CommonForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
           },
           "type": {
             "types": [

--- a/src/test/resources/fixtures/ssl_3_2/CommonForms.Вопрос_edt.json
+++ b/src/test/resources/fixtures/ssl_3_2/CommonForms.Вопрос_edt.json
@@ -1,0 +1,347 @@
+{"com.github._1c_syntax.bsl.mdo.CommonForm": {
+  "comment": "",
+  "data": {
+    "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+    "title": {
+      "content": []
+    },
+    "handlers": [
+      [
+        {
+          "event": "OnOpen",
+          "name": "ПриОткрытии"
+        },
+        {
+          "event": "OnCreateAtServer",
+          "name": "ПриСозданииНаСервере"
+        }
+      ],
+      []
+    ],
+    "items": [
+      {
+        "type": "USUAL_GROUP",
+        "id": 15,
+        "name": "Колонки",
+        "title": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Колонки"
+              }
+            }
+          ]
+        },
+        "dataPath": "",
+        "items": [
+          [
+            {
+              "type": "DECORATION",
+              "id": 5,
+              "name": "Предупреждение",
+              "title": {
+                "content": [
+                  {
+                    "default": {
+                      "tag": 2
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                      "langKey": "ru",
+                      "value": "Предупреждение"
+                    }
+                  }
+                ]
+              },
+              "dataPath": "",
+              "items": []
+            },
+            {
+              "type": "USUAL_GROUP",
+              "id": 16,
+              "name": "Строки",
+              "title": {
+                "content": [
+                  {
+                    "default": {
+                      "tag": 2
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                      "langKey": "ru",
+                      "value": "Строки"
+                    }
+                  }
+                ]
+              },
+              "dataPath": "",
+              "items": [
+                [
+                  {
+                    "type": "USUAL_GROUP",
+                    "id": 26,
+                    "name": "ТекстСообщенияФорматированнаяСтрокаГруппа",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Текст сообщения форматированная строка (группа)"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "",
+                    "items": [
+                      {
+                        "type": "LABEL",
+                        "id": 23,
+                        "name": "ТекстСообщенияФорматированнаяСтрока",
+                        "title": {
+                          "@reference": "/com.github._1c_syntax.bsl.mdo.CommonForm/data/title"
+                        },
+                        "dataPath": "",
+                        "items": []
+                      }
+                    ]
+                  },
+                  {
+                    "type": "INPUT_FIELD",
+                    "id": 10,
+                    "name": "МногострочныйТекстСообщения",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.CommonForm/data/title"
+                    },
+                    "dataPath": "ТекстСообщения",
+                    "items": []
+                  },
+                  {
+                    "type": "CHECK_BOX_FIELD",
+                    "id": 3,
+                    "name": "БольшеНеЗадаватьЭтотВопрос",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Больше не задавать этот вопрос"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "БольшеНеЗадаватьЭтотВопрос",
+                    "items": []
+                  }
+                ],
+                []
+              ]
+            }
+          ],
+          []
+        ]
+      }
+    ],
+    "attributes": [
+      [
+        {
+          "id": 1,
+          "name": "СоответствиеКнопокИВозвращаемыхЗначений",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.CommonForm/data/title"
+          },
+          "type": {
+            "types": [
+              {
+                "default": {
+                  "tag": 4
+                },
+                "int": 0
+              }
+            ],
+            "composite": false,
+            "qualifiers": []
+          }
+        },
+        {
+          "id": 3,
+          "name": "БольшеНеЗадаватьЭтотВопрос",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.CommonForm/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+          },
+          "type": {
+            "types": [
+              {
+                "default": {
+                  "tag": 4
+                },
+                "int": 1,
+                "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "BOOLEAN"
+              }
+            ],
+            "composite": false,
+            "qualifiers": []
+          }
+        },
+        {
+          "id": 4,
+          "name": "ОжиданиеСчетчик",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.CommonForm/data/title"
+          },
+          "type": {
+            "types": [
+              {
+                "default": {
+                  "tag": 4
+                },
+                "int": 1,
+                "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER"
+              }
+            ],
+            "composite": false,
+            "qualifiers": [
+              {
+                "default": {
+                  "tag": 4
+                },
+                "int": 1,
+                "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                  "precision": 5,
+                  "scale": 0,
+                  "nonNegative": true,
+                  "description": {}
+                }
+              }
+            ]
+          }
+        },
+        {
+          "id": 5,
+          "name": "ОжиданиеИмяКнопки",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.CommonForm/data/title"
+          },
+          "type": {
+            "types": [
+              {
+                "default": {
+                  "tag": 4
+                },
+                "int": 1,
+                "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+              }
+            ],
+            "composite": false,
+            "qualifiers": [
+              {
+                "default": {
+                  "tag": 4
+                },
+                "int": 1,
+                "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                  "length": 0,
+                  "allowedLength": 0,
+                  "description": {
+                    "value": {
+                      "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                      "nameRu": "КвалификаторыСтроки (0, Переменная)",
+                      "nameEn": "StringQualifiers (0, Variable)"
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "id": 6,
+          "name": "ОжиданиеЗаголовокКнопки",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.CommonForm/data/title"
+          },
+          "type": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.CommonForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+          }
+        },
+        {
+          "id": 2,
+          "name": "ТекстСообщения",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.CommonForm/data/title"
+          },
+          "type": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.CommonForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+          }
+        }
+      ],
+      []
+    ]
+  },
+  "description": "Вопрос",
+  "formType": "MANAGED",
+  "mdoReference": {
+    "type": "COMMON_FORM",
+    "mdoRef": "CommonForm.Вопрос",
+    "mdoRefRu": "ОбщаяФорма.Вопрос"
+  },
+  "mdoType": "COMMON_FORM",
+  "moduleTypes": [
+    [
+      "FormModule",
+      [
+        "src/test/resources/ext/edt/ssl_3_2/configuration/src/CommonForms/Вопрос/Module.bsl"
+      ]
+    ]
+  ],
+  "modules": [
+    {
+      "moduleType": "FormModule",
+      "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/CommonForms/Вопрос/Module.bsl",
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.CommonForm/mdoReference"
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "isProtected": false
+    }
+  ],
+  "name": "Вопрос",
+  "objectBelonging": "OWN",
+  "possibleRights": [
+    {
+      "default": {
+        "tag": 4
+      },
+      "int": 1,
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "VIEW"
+    }
+  ],
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "content": [
+      {
+        "default": {
+          "tag": 2
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+          "langKey": "ru",
+          "value": "Вопрос"
+        }
+      }
+    ]
+  },
+  "uuid": "573f1753-9194-4aaf-9217-5cac70ff108f"
+}}

--- a/src/test/resources/fixtures/ssl_3_2/CommonModules.АвтономнаяРабота.json
+++ b/src/test/resources/fixtures/ssl_3_2/CommonModules.АвтономнаяРабота.json
@@ -1,0 +1,50 @@
+{"com.github._1c_syntax.bsl.mdo.CommonModule": {
+  "clientManagedApplication": false,
+  "clientOrdinaryApplication": true,
+  "comment": "",
+  "description": "Автономная работа",
+  "externalConnection": true,
+  "global": false,
+  "mdoReference": {
+    "type": "COMMON_MODULE",
+    "mdoRef": "CommonModule.АвтономнаяРабота",
+    "mdoRefRu": "ОбщийМодуль.АвтономнаяРабота"
+  },
+  "mdoType": "COMMON_MODULE",
+  "moduleType": "CommonModule",
+  "moduleTypes": [
+    [
+      "CommonModule",
+      [
+        "src/test/resources/ext/designer/ssl_3_2/src/cf/CommonModules/АвтономнаяРабота/Ext/Module.bsl"
+      ]
+    ]
+  ],
+  "name": "АвтономнаяРабота",
+  "objectBelonging": "OWN",
+  "owner": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.CommonModule/mdoReference"
+  },
+  "privileged": false,
+  "protected": false,
+  "returnValuesReuse": "DONT_USE",
+  "server": true,
+  "serverCall": false,
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "content": [
+      {
+        "default": {
+          "tag": 2
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+          "langKey": "ru",
+          "value": "Автономная работа"
+        }
+      }
+    ]
+  },
+  "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/CommonModules/АвтономнаяРабота/Ext/Module.bsl",
+  "uuid": "a5cc5ae2-be80-4957-8aca-9e477433dfcc"
+}}

--- a/src/test/resources/fixtures/ssl_3_2/CommonModules.АвтономнаяРабота_edt.json
+++ b/src/test/resources/fixtures/ssl_3_2/CommonModules.АвтономнаяРабота_edt.json
@@ -1,0 +1,50 @@
+{"com.github._1c_syntax.bsl.mdo.CommonModule": {
+  "clientManagedApplication": false,
+  "clientOrdinaryApplication": true,
+  "comment": "",
+  "description": "Автономная работа",
+  "externalConnection": true,
+  "global": false,
+  "mdoReference": {
+    "type": "COMMON_MODULE",
+    "mdoRef": "CommonModule.АвтономнаяРабота",
+    "mdoRefRu": "ОбщийМодуль.АвтономнаяРабота"
+  },
+  "mdoType": "COMMON_MODULE",
+  "moduleType": "CommonModule",
+  "moduleTypes": [
+    [
+      "CommonModule",
+      [
+        "src/test/resources/ext/edt/ssl_3_2/configuration/src/CommonModules/АвтономнаяРабота/Module.bsl"
+      ]
+    ]
+  ],
+  "name": "АвтономнаяРабота",
+  "objectBelonging": "OWN",
+  "owner": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.CommonModule/mdoReference"
+  },
+  "privileged": false,
+  "protected": false,
+  "returnValuesReuse": "DONT_USE",
+  "server": true,
+  "serverCall": false,
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "content": [
+      {
+        "default": {
+          "tag": 2
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+          "langKey": "ru",
+          "value": "Автономная работа"
+        }
+      }
+    ]
+  },
+  "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/CommonModules/АвтономнаяРабота/Module.bsl",
+  "uuid": "a5cc5ae2-be80-4957-8aca-9e477433dfcc"
+}}

--- a/src/test/resources/fixtures/ssl_3_2/CommonPictures.GoogleMaps.json
+++ b/src/test/resources/fixtures/ssl_3_2/CommonPictures.GoogleMaps.json
@@ -1,0 +1,30 @@
+{"com.github._1c_syntax.bsl.mdo.CommonPicture": {
+  "availabilityForAppearance": false,
+  "availabilityForChoice": false,
+  "comment": "",
+  "description": "Google maps",
+  "mdoReference": {
+    "type": "COMMON_PICTURE",
+    "mdoRef": "CommonPicture.GoogleMaps",
+    "mdoRefRu": "ОбщаяКартинка.GoogleMaps"
+  },
+  "mdoType": "COMMON_PICTURE",
+  "name": "GoogleMaps",
+  "objectBelonging": "OWN",
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "content": [
+      {
+        "default": {
+          "tag": 2
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+          "langKey": "ru",
+          "value": "Google maps"
+        }
+      }
+    ]
+  },
+  "uuid": "5a88f624-7b7e-43fe-8bc4-ae85d832a855"
+}}

--- a/src/test/resources/fixtures/ssl_3_2/CommonTemplates.СтруктураПодчиненности.json
+++ b/src/test/resources/fixtures/ssl_3_2/CommonTemplates.СтруктураПодчиненности.json
@@ -1,0 +1,32 @@
+{"com.github._1c_syntax.bsl.mdo.CommonTemplate": {
+  "comment": "",
+  "data": {
+    "@class": "com.github._1c_syntax.bsl.mdo.storage.EmptyTemplateData"
+  },
+  "description": "Структура подчиненности",
+  "mdoReference": {
+    "type": "COMMON_TEMPLATE",
+    "mdoRef": "CommonTemplate.СтруктураПодчиненности",
+    "mdoRefRu": "ОбщийМакет.СтруктураПодчиненности"
+  },
+  "mdoType": "COMMON_TEMPLATE",
+  "name": "СтруктураПодчиненности",
+  "objectBelonging": "OWN",
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "content": [
+      {
+        "default": {
+          "tag": 2
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+          "langKey": "ru",
+          "value": "Структура подчиненности"
+        }
+      }
+    ]
+  },
+  "templateType": "SPREADSHEET_DOCUMENT",
+  "uuid": "7a62d031-c340-4b1e-90af-fff697a2e979"
+}}

--- a/src/test/resources/fixtures/ssl_3_2/Configuration.json
+++ b/src/test/resources/fixtures/ssl_3_2/Configuration.json
@@ -1,0 +1,1811 @@
+{"com.github._1c_syntax.bsl.mdclasses.Configuration": {
+  "XDTOPackages": [
+    {
+      "uuid": "b8a93cce-56e4-4507-b281-5c525a466a0f",
+      "name": "ПакетXDTO1",
+      "mdoReference": {
+        "type": "XDTO_PACKAGE",
+        "mdoRef": "XDTOPackage.ПакетXDTO1",
+        "mdoRefRu": "ПакетXDTO.ПакетXDTO1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE",
+      "namespace": "http://v8.1c.ru/edi/edi_stnd/EnterpriseData/1.8",
+      "data": {
+        "targetNamespace": "http://v8.1c.ru/edi/edi_stnd/EnterpriseData/1.8",
+        "imports": [
+          [
+            2
+          ],
+          [
+            2
+          ]
+        ],
+        "valueTypes": [
+          [
+            278
+          ],
+          [
+            278
+          ]
+        ],
+        "objectTypes": [
+          [
+            737
+          ],
+          [
+            737
+          ]
+        ],
+        "properties": [
+          {
+            "name": "performance",
+            "type": "d2p1:Performance",
+            "lowerBound": 0,
+            "upperBound": 0,
+            "nillable": false,
+            "form": "Attribute",
+            "typeDef": []
+          }
+        ]
+      }
+    }
+  ],
+  "accountingRegisters": [
+    {
+      "uuid": "e5930f2f-15d9-48a1-ac69-379ad990b02a",
+      "name": "РегистрБухгалтерии1",
+      "mdoReference": {
+        "type": "ACCOUNTING_REGISTER",
+        "mdoRef": "AccountingRegister.РегистрБухгалтерии1",
+        "mdoRefRu": "РегистрБухгалтерии.РегистрБухгалтерии1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": [
+          [
+            "ru",
+            "Регистр бухгалтерии"
+          ],
+          [
+            "en",
+            "Accounting register"
+          ]
+        ]
+      },
+      "supportVariant": "NONE",
+      "modules": [
+        0
+      ],
+      "commands": [],
+      "attributes": [],
+      "resources": [
+        {
+          "uuid": "e88df8bd-bf97-41a4-88fc-09c84a51824b",
+          "name": "Ресурс1",
+          "mdoReference": {
+            "type": "RESOURCE",
+            "mdoRef": "AccountingRegister.РегистрБухгалтерии1.Resource.Ресурс1",
+            "mdoRefRu": "РегистрБухгалтерии.РегистрБухгалтерии1.Ресурс.Ресурс1"
+          },
+          "objectBelonging": "OWN",
+          "comment": "",
+          "synonym": {
+            "content": []
+          },
+          "supportVariant": "NONE",
+          "owner": {
+            "type": "ACCOUNTING_REGISTER",
+            "mdoRef": "AccountingRegister.РегистрБухгалтерии1",
+            "mdoRefRu": "РегистрБухгалтерии.РегистрБухгалтерии1"
+          },
+          "passwordMode": false,
+          "kind": "CUSTOM",
+          "indexing": "DONT_INDEX"
+        }
+      ],
+      "dimensions": [
+        {
+          "uuid": "902c08a9-e457-436a-b0fb-b996f0d9bb00",
+          "name": "Измерение1",
+          "mdoReference": {
+            "type": "DIMENSION",
+            "mdoRef": "AccountingRegister.РегистрБухгалтерии1.Dimension.Измерение1",
+            "mdoRefRu": "РегистрБухгалтерии.РегистрБухгалтерии1.Измерение.Измерение1"
+          },
+          "objectBelonging": "OWN",
+          "comment": "",
+          "synonym": {
+            "content": []
+          },
+          "supportVariant": "NONE",
+          "owner": {
+            "type": "ACCOUNTING_REGISTER",
+            "mdoRef": "AccountingRegister.РегистрБухгалтерии1",
+            "mdoRefRu": "РегистрБухгалтерии.РегистрБухгалтерии1"
+          },
+          "passwordMode": false,
+          "kind": "CUSTOM",
+          "indexing": "INDEX",
+          "master": false,
+          "denyIncompleteValues": false,
+          "useInTotals": true
+        }
+      ],
+      "forms": [],
+      "templates": []
+    }
+  ],
+  "accumulationRegisters": [
+    {
+      "uuid": "8ea07f36-d671-4649-bc7a-94daa939e77f",
+      "name": "РегистрНакопления1",
+      "mdoReference": {
+        "type": "ACCUMULATION_REGISTER",
+        "mdoRef": "AccumulationRegister.РегистрНакопления1",
+        "mdoRefRu": "РегистрНакопления.РегистрНакопления1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": [
+          [
+            "ru",
+            "Регистр накопления"
+          ]
+        ]
+      },
+      "supportVariant": "NONE",
+      "modules": [
+        0
+      ],
+      "commands": [],
+      "attributes": [],
+      "resources": [
+        {
+          "uuid": "a187a281-f5cd-4e1c-8f3f-37212a840339",
+          "name": "Ресурс1",
+          "mdoReference": {
+            "type": "RESOURCE",
+            "mdoRef": "AccumulationRegister.РегистрНакопления1.Resource.Ресурс1",
+            "mdoRefRu": "РегистрНакопления.РегистрНакопления1.Ресурс.Ресурс1"
+          },
+          "objectBelonging": "OWN",
+          "comment": "",
+          "synonym": {
+            "content": []
+          },
+          "supportVariant": "NONE",
+          "owner": {
+            "type": "ACCUMULATION_REGISTER",
+            "mdoRef": "AccumulationRegister.РегистрНакопления1",
+            "mdoRefRu": "РегистрНакопления.РегистрНакопления1"
+          },
+          "passwordMode": false,
+          "kind": "CUSTOM",
+          "indexing": "DONT_INDEX"
+        }
+      ],
+      "dimensions": [
+        {
+          "uuid": "461cae93-fe90-4bbb-8f79-0963e2d39ec5",
+          "name": "Измерение1",
+          "mdoReference": {
+            "type": "DIMENSION",
+            "mdoRef": "AccumulationRegister.РегистрНакопления1.Dimension.Измерение1",
+            "mdoRefRu": "РегистрНакопления.РегистрНакопления1.Измерение.Измерение1"
+          },
+          "objectBelonging": "OWN",
+          "comment": "",
+          "synonym": {
+            "content": []
+          },
+          "supportVariant": "NONE",
+          "owner": {
+            "type": "ACCUMULATION_REGISTER",
+            "mdoRef": "AccumulationRegister.РегистрНакопления1",
+            "mdoRefRu": "РегистрНакопления.РегистрНакопления1"
+          },
+          "passwordMode": false,
+          "kind": "CUSTOM",
+          "indexing": "DONT_INDEX",
+          "master": false,
+          "denyIncompleteValues": false,
+          "useInTotals": true
+        }
+      ],
+      "forms": [],
+      "templates": []
+    }
+  ],
+  "bots": [],
+  "briefInformation": {
+    "content": [
+      [
+        "ru",
+        "Краткая информация"
+      ],
+      [
+        "en",
+        "Short info"
+      ]
+    ]
+  },
+  "businessProcesses": [
+    {
+      "uuid": "560a32ca-028d-4b88-b6f2-6b7212bf31f8",
+      "name": "БизнесПроцесс1",
+      "mdoReference": {
+        "type": "BUSINESS_PROCESS",
+        "mdoRef": "BusinessProcess.БизнесПроцесс1",
+        "mdoRefRu": "БизнесПроцесс.БизнесПроцесс1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE",
+      "modules": [
+        1
+      ],
+      "commands": [],
+      "attributes": [],
+      "tabularSections": [],
+      "forms": [],
+      "templates": []
+    }
+  ],
+  "calculationRegisters": [
+    {
+      "uuid": "90587c7d-b950-4476-ac14-426e4a83d9c4",
+      "name": "РегистрРасчета1",
+      "mdoReference": {
+        "type": "CALCULATION_REGISTER",
+        "mdoRef": "CalculationRegister.РегистрРасчета1",
+        "mdoRefRu": "РегистрРасчета.РегистрРасчета1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE",
+      "modules": [
+        0
+      ],
+      "commands": [],
+      "attributes": [],
+      "resources": [
+        {
+          "uuid": "86f41061-e298-4da5-8d28-489a349d55fc",
+          "name": "Ресурс1",
+          "mdoReference": {
+            "type": "RESOURCE",
+            "mdoRef": "CalculationRegister.РегистрРасчета1.Resource.Ресурс1",
+            "mdoRefRu": "РегистрРасчета.РегистрРасчета1.Ресурс.Ресурс1"
+          },
+          "objectBelonging": "OWN",
+          "comment": "",
+          "synonym": {
+            "content": []
+          },
+          "supportVariant": "NONE",
+          "owner": {
+            "type": "CALCULATION_REGISTER",
+            "mdoRef": "CalculationRegister.РегистрРасчета1",
+            "mdoRefRu": "РегистрРасчета.РегистрРасчета1"
+          },
+          "passwordMode": false,
+          "kind": "CUSTOM",
+          "indexing": "DONT_INDEX"
+        }
+      ],
+      "dimensions": [
+        {
+          "uuid": "f3e7cca5-4902-4ad5-96c7-db8336f52c6e",
+          "name": "Измерение1",
+          "mdoReference": {
+            "type": "DIMENSION",
+            "mdoRef": "CalculationRegister.РегистрРасчета1.Dimension.Измерение1",
+            "mdoRefRu": "РегистрРасчета.РегистрРасчета1.Измерение.Измерение1"
+          },
+          "objectBelonging": "OWN",
+          "comment": "",
+          "synonym": {
+            "content": []
+          },
+          "supportVariant": "NONE",
+          "owner": {
+            "type": "CALCULATION_REGISTER",
+            "mdoRef": "CalculationRegister.РегистрРасчета1",
+            "mdoRefRu": "РегистрРасчета.РегистрРасчета1"
+          },
+          "passwordMode": false,
+          "kind": "CUSTOM",
+          "indexing": "DONT_INDEX",
+          "master": false,
+          "denyIncompleteValues": true,
+          "useInTotals": true
+        }
+      ],
+      "forms": [],
+      "templates": [],
+      "recalculations": [
+        {
+          "uuid": "16b54095-8711-4ef1-a38b-93d12f6f6e93",
+          "name": "Перерасчет",
+          "mdoReference": {
+            "type": "RECALCULATION",
+            "mdoRef": "CalculationRegister.РегистрРасчета1.Recalculation.Перерасчет",
+            "mdoRefRu": "РегистрРасчета.РегистрРасчета1.Перерасчет.Перерасчет"
+          },
+          "objectBelonging": "OWN",
+          "comment": "",
+          "synonym": {
+            "content": [
+              [
+                "ru",
+                "Перерасчет"
+              ]
+            ]
+          },
+          "supportVariant": "NONE",
+          "owner": {
+            "type": "CALCULATION_REGISTER",
+            "mdoRef": "CalculationRegister.РегистрРасчета1",
+            "mdoRefRu": "РегистрРасчета.РегистрРасчета1"
+          },
+          "modules": [
+            1
+          ]
+        }
+      ]
+    }
+  ],
+  "catalogs": [
+    {
+      "uuid": "eeef463d-d5e7-42f2-ae53-10279661f59d",
+      "name": "Справочник1",
+      "mdoReference": {
+        "type": "CATALOG",
+        "mdoRef": "Catalog.Справочник1",
+        "mdoRefRu": "Справочник.Справочник1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE",
+      "modules": [
+        2
+      ],
+      "commands": [
+        {
+          "uuid": "342ec3c7-82d4-42bb-a5ff-8a756f110744",
+          "name": "Команда1",
+          "mdoReference": {
+            "type": "COMMAND",
+            "mdoRef": "Catalog.Справочник1.Command.Команда1",
+            "mdoRefRu": "Справочник.Справочник1.Команда.Команда1"
+          },
+          "objectBelonging": "OWN",
+          "comment": "",
+          "synonym": {
+            "content": []
+          },
+          "supportVariant": "NONE",
+          "modules": [
+            1
+          ],
+          "owner": {
+            "type": "CATALOG",
+            "mdoRef": "Catalog.Справочник1",
+            "mdoRefRu": "Справочник.Справочник1"
+          }
+        }
+      ],
+      "attributes": [
+        [
+          3
+        ],
+        [
+          3
+        ]
+      ],
+      "tabularSections": [
+        {
+          "uuid": "451202c5-b1af-4bce-a705-0b5570071588",
+          "name": "ТабличнаяЧасть1",
+          "mdoReference": {
+            "type": "TABULAR_SECTION",
+            "mdoRef": "Catalog.Справочник1.TabularSection.ТабличнаяЧасть1",
+            "mdoRefRu": "Справочник.Справочник1.ТабличнаяЧасть.ТабличнаяЧасть1"
+          },
+          "objectBelonging": "OWN",
+          "comment": "",
+          "synonym": {
+            "content": []
+          },
+          "supportVariant": "NONE",
+          "owner": {
+            "type": "CATALOG",
+            "mdoRef": "Catalog.Справочник1",
+            "mdoRefRu": "Справочник.Справочник1"
+          },
+          "attributes": [
+            [
+              2
+            ],
+            [
+              2
+            ]
+          ]
+        }
+      ],
+      "forms": [
+        [
+          3
+        ],
+        [
+          3
+        ]
+      ],
+      "templates": [
+        {
+          "uuid": "42def71b-52cc-4e34-8a08-82f0dfcd47bf",
+          "name": "Макет",
+          "mdoReference": {
+            "type": "TEMPLATE",
+            "mdoRef": "Catalog.Справочник1.Template.Макет",
+            "mdoRefRu": "Справочник.Справочник1.Макет.Макет"
+          },
+          "objectBelonging": "OWN",
+          "comment": "",
+          "synonym": {
+            "content": [
+              [
+                "ru",
+                "Макет"
+              ]
+            ]
+          },
+          "supportVariant": "NONE",
+          "modules": [],
+          "templateType": "SPREADSHEET_DOCUMENT",
+          "data": {
+            "@class": "com.github._1c_syntax.bsl.mdo.storage.EmptyTemplateData"
+          },
+          "owner": {
+            "type": "CATALOG",
+            "mdoRef": "Catalog.Справочник1",
+            "mdoRefRu": "Справочник.Справочник1"
+          }
+        }
+      ]
+    }
+  ],
+  "chartsOfAccounts": [
+    {
+      "uuid": "2766f353-abd2-4e7f-9a95-53f05c83f5d4",
+      "name": "ПланСчетов1",
+      "mdoReference": {
+        "type": "CHART_OF_ACCOUNTS",
+        "mdoRef": "ChartOfAccounts.ПланСчетов1",
+        "mdoRefRu": "ПланСчетов.ПланСчетов1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE",
+      "modules": [
+        1
+      ],
+      "commands": [],
+      "attributes": [],
+      "tabularSections": [],
+      "forms": [],
+      "templates": [],
+      "accountingFlags": [
+        {
+          "uuid": "957a5154-1e63-49e1-8e99-3893490da6f6",
+          "name": "ПризнакУчета",
+          "mdoReference": {
+            "type": "ACCOUNTING_FLAG",
+            "mdoRef": "ChartOfAccounts.ПланСчетов1.AccountingFlag.ПризнакУчета",
+            "mdoRefRu": "ПланСчетов.ПланСчетов1.ПризнакУчета.ПризнакУчета"
+          },
+          "objectBelonging": "OWN",
+          "comment": "",
+          "synonym": {
+            "content": [
+              [
+                "ru",
+                "Признак учета"
+              ]
+            ]
+          },
+          "supportVariant": "NONE",
+          "owner": {
+            "type": "CHART_OF_ACCOUNTS",
+            "mdoRef": "ChartOfAccounts.ПланСчетов1",
+            "mdoRefRu": "ПланСчетов.ПланСчетов1"
+          },
+          "passwordMode": false,
+          "kind": "CUSTOM",
+          "indexing": "DONT_INDEX"
+        }
+      ],
+      "extDimensionAccountingFlags": [
+        {
+          "uuid": "4f04d72a-e3e9-4e9b-96da-7d0e1ad989e6",
+          "name": "ПризнакУчета",
+          "mdoReference": {
+            "type": "EXT_DIMENSION_ACCOUNTING_FLAG",
+            "mdoRef": "ChartOfAccounts.ПланСчетов1.ExtDimensionAccountingFlag.ПризнакУчета",
+            "mdoRefRu": "ПланСчетов.ПланСчетов1.ПризнакУчетаСубконто.ПризнакУчета"
+          },
+          "objectBelonging": "OWN",
+          "comment": "",
+          "synonym": {
+            "content": [
+              [
+                "ru",
+                "Признак учета"
+              ]
+            ]
+          },
+          "supportVariant": "NONE",
+          "owner": {
+            "type": "CHART_OF_ACCOUNTS",
+            "mdoRef": "ChartOfAccounts.ПланСчетов1",
+            "mdoRefRu": "ПланСчетов.ПланСчетов1"
+          },
+          "passwordMode": false,
+          "kind": "CUSTOM",
+          "indexing": "DONT_INDEX"
+        }
+      ]
+    }
+  ],
+  "chartsOfCalculationTypes": [
+    {
+      "uuid": "1755c534-9ccd-49c4-9f8b-2aa066424aaa",
+      "name": "ПланВидовРасчета1",
+      "mdoReference": {
+        "type": "CHART_OF_CALCULATION_TYPES",
+        "mdoRef": "ChartOfCalculationTypes.ПланВидовРасчета1",
+        "mdoRefRu": "ПланВидовРасчета.ПланВидовРасчета1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE",
+      "modules": [
+        0
+      ],
+      "commands": [],
+      "attributes": [],
+      "tabularSections": [],
+      "forms": [],
+      "templates": []
+    }
+  ],
+  "chartsOfCharacteristicTypes": [
+    {
+      "uuid": "f53a24c3-f1dc-43b7-8dcf-eeb8c0b7f452",
+      "name": "ПланВидовХарактеристик1",
+      "mdoReference": {
+        "type": "CHART_OF_CHARACTERISTIC_TYPES",
+        "mdoRef": "ChartOfCharacteristicTypes.ПланВидовХарактеристик1",
+        "mdoRefRu": "ПланВидовХарактеристик.ПланВидовХарактеристик1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE",
+      "modules": [
+        2
+      ],
+      "commands": [],
+      "attributes": [],
+      "tabularSections": [],
+      "forms": [],
+      "templates": []
+    }
+  ],
+  "children": [
+    [
+      64
+    ],
+    [
+      64
+    ]
+  ],
+  "commandGroups": [
+    {
+      "uuid": "9bd3b0b1-b276-4b0e-9811-44a41ebb0c7c",
+      "name": "ГруппаКоманд1",
+      "mdoReference": {
+        "type": "COMMAND_GROUP",
+        "mdoRef": "CommandGroup.ГруппаКоманд1",
+        "mdoRefRu": "ГруппаКоманд.ГруппаКоманд1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE"
+    }
+  ],
+  "comment": "",
+  "commonAttributes": [
+    {
+      "uuid": "d4f0c0ac-ed26-4085-a1b4-e52314b973ad",
+      "name": "ОбщийРеквизит1",
+      "mdoReference": {
+        "type": "COMMON_ATTRIBUTE",
+        "mdoRef": "CommonAttribute.ОбщийРеквизит1",
+        "mdoRefRu": "ОбщийРеквизит.ОбщийРеквизит1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE",
+      "autoUse": "USE",
+      "passwordMode": false,
+      "indexing": "DONT_INDEX",
+      "dataSeparation": "DONT_USE",
+      "dataSeparationValue": {
+        "type": "UNKNOWN",
+        "mdoRef": "",
+        "mdoRefRu": ""
+      },
+      "dataSeparationUse": {
+        "type": "UNKNOWN",
+        "mdoRef": "",
+        "mdoRefRu": ""
+      },
+      "conditionalSeparation": {
+        "type": "UNKNOWN",
+        "mdoRef": "",
+        "mdoRefRu": ""
+      },
+      "usersSeparation": "DONT_USE",
+      "authenticationSeparation": "DONT_USE",
+      "configurationExtensionsSeparation": "DONT_USE",
+      "content": [
+        [
+          2
+        ],
+        [
+          2
+        ]
+      ]
+    }
+  ],
+  "commonCommands": [
+    {
+      "uuid": "a608f796-f58e-4f8a-b63f-272342b32f35",
+      "name": "ОбщаяКоманда1",
+      "mdoReference": {
+        "type": "COMMON_COMMAND",
+        "mdoRef": "CommonCommand.ОбщаяКоманда1",
+        "mdoRefRu": "ОбщаяКоманда.ОбщаяКоманда1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE",
+      "modules": [
+        1
+      ]
+    }
+  ],
+  "commonForms": [
+    {
+      "uuid": "5ac59104-28a5-40b1-ab5b-2857fb41991a",
+      "name": "Форма",
+      "mdoReference": {
+        "type": "COMMON_FORM",
+        "mdoRef": "CommonForm.Форма",
+        "mdoRefRu": "ОбщаяФорма.Форма"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": [
+          [
+            "ru",
+            "Форма"
+          ]
+        ]
+      },
+      "supportVariant": "NONE",
+      "modules": [
+        1
+      ],
+      "formType": "MANAGED",
+      "data": {
+        "@class": "com.github._1c_syntax.bsl.mdo.storage.EmptyFormData"
+      }
+    }
+  ],
+  "commonModules": [
+    [
+      6
+    ],
+    [
+      6
+    ]
+  ],
+  "commonPictures": [
+    {
+      "uuid": "db84513d-2535-494b-843e-6d8931cb2f82",
+      "name": "ОбщаяКартинка1",
+      "mdoReference": {
+        "type": "COMMON_PICTURE",
+        "mdoRef": "CommonPicture.ОбщаяКартинка1",
+        "mdoRefRu": "ОбщаяКартинка.ОбщаяКартинка1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE",
+      "availabilityForChoice": false,
+      "availabilityForAppearance": false
+    }
+  ],
+  "commonTemplates": [
+    [
+      10
+    ],
+    [
+      10
+    ]
+  ],
+  "compatibilityMode": {
+    "minor": 3,
+    "version": 10
+  },
+  "configurationExtensionCompatibilityMode": {
+    "minor": 3,
+    "version": 10
+  },
+  "configurationSource": "DESIGNER",
+  "constants": [
+    {
+      "uuid": "61e6a6f2-7057-4e93-96c3-7bd2559217f4",
+      "name": "Константа1",
+      "mdoReference": {
+        "type": "CONSTANT",
+        "mdoRef": "Constant.Константа1",
+        "mdoRefRu": "Константа.Константа1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE",
+      "modules": [
+        1
+      ],
+      "passwordMode": false
+    }
+  ],
+  "copyrights": {
+    "content": []
+  },
+  "dataLockControlMode": "AUTOMATIC",
+  "dataProcessors": [
+    {
+      "uuid": "a7c57ba0-75d8-487d-b8ea-ae5083d8a503",
+      "name": "Обработка1",
+      "mdoReference": {
+        "type": "DATA_PROCESSOR",
+        "mdoRef": "DataProcessor.Обработка1",
+        "mdoRefRu": "Обработка.Обработка1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE",
+      "modules": [
+        0
+      ],
+      "commands": [],
+      "attributes": [],
+      "tabularSections": [],
+      "forms": [
+        [
+          2
+        ],
+        [
+          2
+        ]
+      ],
+      "templates": []
+    }
+  ],
+  "defaultLanguage": {
+    "type": "LANGUAGE",
+    "mdoRef": "Language.Русский",
+    "mdoRefRu": "Язык.Русский"
+  },
+  "defaultRunMode": "MANAGED_APPLICATION",
+  "definedTypes": [
+    {
+      "uuid": "e8c616d9-4957-48ab-a917-afb6847f6840",
+      "name": "ОпределяемыйТип1",
+      "mdoReference": {
+        "type": "DEFINED_TYPE",
+        "mdoRef": "DefinedType.ОпределяемыйТип1",
+        "mdoRefRu": "ОпределяемыйТип.ОпределяемыйТип1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE"
+    }
+  ],
+  "detailedInformation": {
+    "content": [
+      [
+        "ru",
+        "Подробная информация"
+      ],
+      [
+        "en",
+        "Detailed info"
+      ]
+    ]
+  },
+  "documentJournals": [
+    {
+      "uuid": "c6743657-4787-40de-9a45-2493c630f626",
+      "name": "ЖурналДокументов1",
+      "mdoReference": {
+        "type": "DOCUMENT_JOURNAL",
+        "mdoRef": "DocumentJournal.ЖурналДокументов1",
+        "mdoRefRu": "ЖурналДокументов.ЖурналДокументов1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE",
+      "modules": [
+        1
+      ],
+      "commands": [],
+      "columns": [
+        {
+          "uuid": "b52d063e-5d2c-498b-a333-4957277f47e3",
+          "name": "Графа",
+          "mdoReference": {
+            "type": "COLUMN",
+            "mdoRef": "DocumentJournal.ЖурналДокументов1.Column.Графа",
+            "mdoRefRu": "ЖурналДокументов.ЖурналДокументов1.Колонка.Графа"
+          },
+          "objectBelonging": "OWN",
+          "comment": "",
+          "synonym": {
+            "content": [
+              [
+                "ru",
+                "Графа"
+              ]
+            ]
+          },
+          "supportVariant": "NONE",
+          "owner": {
+            "type": "DOCUMENT_JOURNAL",
+            "mdoRef": "DocumentJournal.ЖурналДокументов1",
+            "mdoRefRu": "ЖурналДокументов.ЖурналДокументов1"
+          },
+          "passwordMode": false,
+          "kind": "CUSTOM",
+          "indexing": "DONT_INDEX"
+        }
+      ],
+      "forms": [],
+      "templates": [],
+      "registeredDocuments": [
+        {
+          "type": "DOCUMENT",
+          "mdoRef": "Document.Документ1",
+          "mdoRefRu": "Документ.Документ1"
+        }
+      ]
+    }
+  ],
+  "documentNumerators": [
+    {
+      "uuid": "e401f835-6bfc-4cd4-8d87-5e6b6332a3f6",
+      "name": "НумераторДокументов1",
+      "mdoReference": {
+        "type": "DOCUMENT_NUMERATOR",
+        "mdoRef": "DocumentNumerator.НумераторДокументов1",
+        "mdoRefRu": "НумераторДокументов.НумераторДокументов1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE"
+    }
+  ],
+  "documents": [
+    {
+      "uuid": "ce4fb46b-4af7-493e-9fcb-76ad8c4f8acd",
+      "name": "Документ1",
+      "mdoReference": {
+        "type": "DOCUMENT",
+        "mdoRef": "Document.Документ1",
+        "mdoRefRu": "Документ.Документ1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE",
+      "modules": [
+        2
+      ],
+      "commands": [
+        [
+          2
+        ],
+        [
+          2
+        ]
+      ],
+      "attributes": [
+        [
+          3
+        ],
+        [
+          3
+        ]
+      ],
+      "tabularSections": [
+        {
+          "uuid": "508fe2d9-44b0-4b34-a349-2b0bcae6adc4",
+          "name": "ТабличнаяЧасть1",
+          "mdoReference": {
+            "type": "TABULAR_SECTION",
+            "mdoRef": "Document.Документ1.TabularSection.ТабличнаяЧасть1",
+            "mdoRefRu": "Документ.Документ1.ТабличнаяЧасть.ТабличнаяЧасть1"
+          },
+          "objectBelonging": "OWN",
+          "comment": "",
+          "synonym": {
+            "content": []
+          },
+          "supportVariant": "NONE",
+          "owner": {
+            "type": "DOCUMENT",
+            "mdoRef": "Document.Документ1",
+            "mdoRefRu": "Документ.Документ1"
+          },
+          "attributes": [
+            [
+              2
+            ],
+            [
+              2
+            ]
+          ]
+        }
+      ],
+      "forms": [
+        [
+          3
+        ],
+        [
+          3
+        ]
+      ],
+      "templates": [],
+      "registerRecords": [
+        [
+          4
+        ],
+        [
+          4
+        ]
+      ]
+    }
+  ],
+  "enums": [
+    {
+      "uuid": "f11f3441-4b64-4344-b1a0-0e4b3e466e03",
+      "name": "Перечисление1",
+      "mdoReference": {
+        "type": "ENUM",
+        "mdoRef": "Enum.Перечисление1",
+        "mdoRefRu": "Перечисление.Перечисление1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE",
+      "modules": [
+        1
+      ],
+      "commands": [],
+      "forms": [],
+      "templates": [],
+      "enumValues": [
+        {
+          "uuid": "47a90ebe-6127-4041-bdd4-def343363004",
+          "name": "ЗначениеПеречисления1",
+          "mdoReference": {
+            "type": "ENUM_VALUE",
+            "mdoRef": "Enum.Перечисление1.EnumValue.ЗначениеПеречисления1",
+            "mdoRefRu": "Перечисление.Перечисление1.ЗначениеПеречисления.ЗначениеПеречисления1"
+          },
+          "objectBelonging": "OWN",
+          "comment": "",
+          "synonym": {
+            "content": []
+          },
+          "supportVariant": "NONE",
+          "owner": {
+            "type": "ENUM",
+            "mdoRef": "Enum.Перечисление1",
+            "mdoRefRu": "Перечисление.Перечисление1"
+          }
+        }
+      ]
+    }
+  ],
+  "eventSubscriptions": [
+    {
+      "uuid": "4da21a7b-3d07-4e6d-b91f-7e1c8ddcffcd",
+      "name": "ПодпискаНаСобытие1",
+      "mdoReference": {
+        "type": "EVENT_SUBSCRIPTION",
+        "mdoRef": "EventSubscription.ПодпискаНаСобытие1",
+        "mdoRefRu": "ПодпискаНаСобытие.ПодпискаНаСобытие1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE",
+      "handler": {
+        "methodPath": "CommonModule.ПростойОбщийМодуль.ПодпискаНаСобытие1ПередЗаписью",
+        "moduleName": "ПростойОбщийМодуль",
+        "methodName": "ПодпискаНаСобытие1ПередЗаписью"
+      },
+      "event": "BeforeWrite"
+    }
+  ],
+  "exchangePlans": [
+    {
+      "uuid": "242cb07d-3d2b-4689-b590-d3ed23ac9d10",
+      "name": "ПланОбмена1",
+      "mdoReference": {
+        "type": "EXCHANGE_PLAN",
+        "mdoRef": "ExchangePlan.ПланОбмена1",
+        "mdoRefRu": "ПланОбмена.ПланОбмена1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE",
+      "modules": [
+        1
+      ],
+      "commands": [],
+      "attributes": [],
+      "tabularSections": [],
+      "forms": [],
+      "templates": [],
+      "distributedInfoBase": false,
+      "includeConfigurationExtensions": false,
+      "content": [
+        [
+          2
+        ],
+        [
+          2
+        ]
+      ]
+    }
+  ],
+  "externalDataSources": [
+    {
+      "uuid": "2ceefe90-5a06-41ce-aac5-a3293a85946f",
+      "name": "ТекущаяСУБД",
+      "mdoReference": {
+        "type": "EXTERNAL_DATA_SOURCE",
+        "mdoRef": "ExternalDataSource.ТекущаяСУБД",
+        "mdoRefRu": "ВнешнийИсточникДанных.ТекущаяСУБД"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": [
+          [
+            "ru",
+            "Текущая СУБД"
+          ]
+        ]
+      },
+      "supportVariant": "NONE",
+      "tables": [
+        {
+          "uuid": "318e517a-2dd6-4cdf-a502-c8cd6e429ff6",
+          "name": "ИнформацияОбОшибках",
+          "mdoReference": {
+            "type": "EXTERNAL_DATA_SOURCE_TABLE",
+            "mdoRef": "ExternalDataSource.ТекущаяСУБД.Table.ИнформацияОбОшибках",
+            "mdoRefRu": "ВнешнийИсточникДанных.ТекущаяСУБД.Таблица.ИнформацияОбОшибках"
+          },
+          "objectBelonging": "OWN",
+          "comment": "",
+          "synonym": {
+            "content": [
+              [
+                "ru",
+                "Информация об ошибках"
+              ]
+            ]
+          },
+          "supportVariant": "NONE",
+          "owner": {
+            "type": "EXTERNAL_DATA_SOURCE",
+            "mdoRef": "ExternalDataSource.ТекущаяСУБД",
+            "mdoRefRu": "ВнешнийИсточникДанных.ТекущаяСУБД"
+          },
+          "modules": [
+            2
+          ],
+          "commands": [
+            {
+              "uuid": "ff4437b1-325e-47d7-87f7-9cf5e51460c5",
+              "name": "Command",
+              "mdoReference": {
+                "type": "COMMAND",
+                "mdoRef": "ExternalDataSource.ТекущаяСУБД.Table.ИнформацияОбОшибках.Command.Command",
+                "mdoRefRu": "ВнешнийИсточникДанных.ТекущаяСУБД.Таблица.ИнформацияОбОшибках.Команда.Command"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "content": [
+                  [
+                    "ru",
+                    "Command"
+                  ]
+                ]
+              },
+              "supportVariant": "NONE",
+              "modules": [
+                1
+              ],
+              "owner": {
+                "type": "EXTERNAL_DATA_SOURCE_TABLE",
+                "mdoRef": "ExternalDataSource.ТекущаяСУБД.Table.ИнформацияОбОшибках",
+                "mdoRefRu": "ВнешнийИсточникДанных.ТекущаяСУБД.Таблица.ИнформацияОбОшибках"
+              }
+            }
+          ],
+          "fields": [
+            [
+              8
+            ],
+            [
+              8
+            ]
+          ],
+          "forms": [
+            [
+              2
+            ],
+            [
+              2
+            ]
+          ],
+          "templates": [
+            {
+              "uuid": "28805bba-20fd-40dd-b442-1f7ca7dcf665",
+              "name": "Template",
+              "mdoReference": {
+                "type": "TEMPLATE",
+                "mdoRef": "ExternalDataSource.ТекущаяСУБД.Table.ИнформацияОбОшибках.Template.Template",
+                "mdoRefRu": "ВнешнийИсточникДанных.ТекущаяСУБД.Таблица.ИнформацияОбОшибках.Макет.Template"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "content": [
+                  [
+                    "ru",
+                    "Template"
+                  ]
+                ]
+              },
+              "supportVariant": "NONE",
+              "modules": [],
+              "templateType": "SPREADSHEET_DOCUMENT",
+              "data": {
+                "@class": "com.github._1c_syntax.bsl.mdo.storage.EmptyTemplateData"
+              },
+              "owner": {
+                "type": "EXTERNAL_DATA_SOURCE_TABLE",
+                "mdoRef": "ExternalDataSource.ТекущаяСУБД.Table.ИнформацияОбОшибках",
+                "mdoRefRu": "ВнешнийИсточникДанных.ТекущаяСУБД.Таблица.ИнформацияОбОшибках"
+              }
+            }
+          ],
+          "dataLockControlMode": "MANAGED"
+        }
+      ]
+    }
+  ],
+  "filterCriteria": [
+    {
+      "uuid": "6e9d3381-0607-43df-866d-14ee5d65a294",
+      "name": "КритерийОтбора1",
+      "mdoReference": {
+        "type": "FILTER_CRITERION",
+        "mdoRef": "FilterCriterion.КритерийОтбора1",
+        "mdoRefRu": "КритерийОтбора.КритерийОтбора1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE",
+      "modules": [
+        1
+      ],
+      "commands": [],
+      "forms": []
+    }
+  ],
+  "functionalOptions": [
+    {
+      "uuid": "d3b7fd71-6570-4047-91e0-b3df75dba08d",
+      "name": "ФункциональнаяОпция1",
+      "mdoReference": {
+        "type": "FUNCTIONAL_OPTION",
+        "mdoRef": "FunctionalOption.ФункциональнаяОпция1",
+        "mdoRefRu": "ФункциональнаяОпция.ФункциональнаяОпция1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE",
+      "location": {
+        "type": "CONSTANT",
+        "mdoRef": "Constant.Константа1",
+        "mdoRefRu": "Константа.Константа1"
+      },
+      "privilegedGetMode": true,
+      "content": []
+    }
+  ],
+  "functionalOptionsParameters": [
+    {
+      "uuid": "9fae7345-6220-4e5b-b4c1-84bb921a58b7",
+      "name": "ПараметрФункциональныхОпций",
+      "mdoReference": {
+        "type": "FUNCTIONAL_OPTIONS_PARAMETER",
+        "mdoRef": "FunctionalOptionsParameter.ПараметрФункциональныхОпций",
+        "mdoRefRu": "ПараметрФункциональныхОпций.ПараметрФункциональныхОпций"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": [
+          [
+            "ru",
+            "Параметр функциональных опций"
+          ]
+        ]
+      },
+      "supportVariant": "NONE",
+      "use": {
+        "type": "DIMENSION",
+        "mdoRef": "InformationRegister.РегистрСведений1.Dimension.Измерение1",
+        "mdoRefRu": "РегистрСведений.РегистрСведений1.Измерение.Измерение1"
+      }
+    }
+  ],
+  "httpServices": [
+    {
+      "uuid": "3f029e1e-5a9e-4446-b74f-cbcb79b1e2fe",
+      "name": "HTTPСервис1",
+      "mdoReference": {
+        "type": "HTTP_SERVICE",
+        "mdoRef": "HTTPService.HTTPСервис1",
+        "mdoRefRu": "HTTPСервис.HTTPСервис1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE",
+      "modules": [
+        1
+      ],
+      "urlTemplates": [
+        {
+          "uuid": "4d97db36-cfbf-4f11-9647-d95677380b8f",
+          "name": "ШаблонURL",
+          "mdoReference": {
+            "type": "HTTP_SERVICE_URL_TEMPLATE",
+            "mdoRef": "HTTPService.HTTPСервис1.URLTemplate.ШаблонURL",
+            "mdoRefRu": "HTTPСервис.HTTPСервис1.ШаблонURL.ШаблонURL"
+          },
+          "objectBelonging": "OWN",
+          "comment": "",
+          "synonym": {
+            "content": [
+              [
+                "ru",
+                "Шаблон URL"
+              ]
+            ]
+          },
+          "supportVariant": "NONE",
+          "owner": {
+            "type": "HTTP_SERVICE",
+            "mdoRef": "HTTPService.HTTPСервис1",
+            "mdoRefRu": "HTTPСервис.HTTPСервис1"
+          },
+          "methods": [
+            [
+              2
+            ],
+            [
+              2
+            ]
+          ]
+        }
+      ]
+    }
+  ],
+  "informationRegisters": [
+    [
+      2
+    ],
+    [
+      2
+    ]
+  ],
+  "integrationServices": [],
+  "interfaces": [
+    [
+      2
+    ],
+    [
+      2
+    ]
+  ],
+  "languages": [
+    [
+      3
+    ],
+    [
+      3
+    ]
+  ],
+  "mdoReference": {
+    "type": "CONFIGURATION",
+    "mdoRef": "Configuration.Конфигурация",
+    "mdoRefRu": "Конфигурация.Конфигурация"
+  },
+  "modalityUseMode": "USE",
+  "modules": [
+    3
+  ],
+  "name": "Конфигурация",
+  "objectAutonumerationMode": "NotAutoFree",
+  "objectBelonging": "OWN",
+  "reports": [
+    {
+      "uuid": "34d3754d-298c-4786-92f6-a487db249fc7",
+      "name": "Отчет1",
+      "mdoReference": {
+        "type": "REPORT",
+        "mdoRef": "Report.Отчет1",
+        "mdoRefRu": "Отчет.Отчет1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE",
+      "modules": [
+        2
+      ],
+      "commands": [],
+      "attributes": [],
+      "tabularSections": [],
+      "forms": [],
+      "templates": [
+        [
+          3
+        ],
+        [
+          3
+        ]
+      ]
+    }
+  ],
+  "roles": [
+    {
+      "uuid": "ecad0539-4f9f-491b-b0f2-f8f42d9a7c41",
+      "name": "Роль1",
+      "mdoReference": {
+        "type": "ROLE",
+        "mdoRef": "Role.Роль1",
+        "mdoRefRu": "Роль.Роль1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE",
+      "data": {
+        "setForNewObjects": false,
+        "setForAttributesByDefault": true,
+        "independentRightsOfChildObjects": false,
+        "objectRights": [
+          [
+            3
+          ],
+          [
+            3
+          ]
+        ]
+      }
+    }
+  ],
+  "scheduledJobs": [
+    {
+      "uuid": "0de0c839-4427-46d9-be68-302f88ac162c",
+      "name": "РегламентноеЗадание1",
+      "mdoReference": {
+        "type": "SCHEDULED_JOB",
+        "mdoRef": "ScheduledJob.РегламентноеЗадание1",
+        "mdoRefRu": "РегламентноеЗадание.РегламентноеЗадание1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE",
+      "methodName": {
+        "methodPath": "CommonModule.ПростойОбщийМодуль.РегламентноеЗадание1",
+        "moduleName": "ПростойОбщийМодуль",
+        "methodName": "РегламентноеЗадание1"
+      },
+      "description": "Описание Регламентное задание 1",
+      "key": "ПроверкаАктивностиСеансаУдаленияОбъектов",
+      "use": true,
+      "predefined": true,
+      "restartCountOnFailure": 3,
+      "restartIntervalOnFailure": 10
+    }
+  ],
+  "scriptVariant": "RUSSIAN",
+  "sequences": [
+    {
+      "uuid": "514bbcf4-7fc4-4a3e-9245-598fad397eec",
+      "name": "Последовательность1",
+      "mdoReference": {
+        "type": "SEQUENCE",
+        "mdoRef": "Sequence.Последовательность1",
+        "mdoRefRu": "Последовательность.Последовательность1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE",
+      "modules": [
+        1
+      ],
+      "dimensions": [
+        {
+          "uuid": "763b82dd-2fdb-4a02-a50b-3eb916c02d3d",
+          "name": "Измерение1",
+          "mdoReference": {
+            "type": "DIMENSION",
+            "mdoRef": "Sequence.Последовательность1.Dimension.Измерение1",
+            "mdoRefRu": "Последовательность.Последовательность1.Измерение.Измерение1"
+          },
+          "objectBelonging": "OWN",
+          "comment": "",
+          "synonym": {
+            "content": []
+          },
+          "supportVariant": "NONE",
+          "owner": {
+            "type": "SEQUENCE",
+            "mdoRef": "Sequence.Последовательность1",
+            "mdoRefRu": "Последовательность.Последовательность1"
+          },
+          "passwordMode": false,
+          "kind": "CUSTOM",
+          "indexing": "DONT_INDEX",
+          "master": false,
+          "denyIncompleteValues": false,
+          "useInTotals": true
+        }
+      ]
+    }
+  ],
+  "sessionParameters": [
+    {
+      "uuid": "66844df5-823b-40f1-ab8a-b07c1cb7462f",
+      "name": "ПараметрСеанса1",
+      "mdoReference": {
+        "type": "SESSION_PARAMETER",
+        "mdoRef": "SessionParameter.ПараметрСеанса1",
+        "mdoRefRu": "ПараметрСеанса.ПараметрСеанса1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE"
+    }
+  ],
+  "settingsStorages": [
+    {
+      "uuid": "e7a9947d-7565-4681-b75c-c9a229b45042",
+      "name": "ХранилищеНастроек1",
+      "mdoReference": {
+        "type": "SETTINGS_STORAGE",
+        "mdoRef": "SettingsStorage.ХранилищеНастроек1",
+        "mdoRefRu": "ХранилищеНастроек.ХранилищеНастроек1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE",
+      "modules": [
+        1
+      ],
+      "forms": [],
+      "templates": []
+    }
+  ],
+  "styleItems": [
+    {
+      "uuid": "68047ae8-62aa-4696-9780-d364feb3cc10",
+      "name": "ЭлементСтиля1",
+      "mdoReference": {
+        "type": "STYLE_ITEM",
+        "mdoRef": "StyleItem.ЭлементСтиля1",
+        "mdoRefRu": "ЭлементСтиля.ЭлементСтиля1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE"
+    }
+  ],
+  "styles": [
+    {
+      "uuid": "d6aaa851-cba7-486d-92f4-ab31b1628c6b",
+      "name": "Стиль",
+      "mdoReference": {
+        "type": "STYLE",
+        "mdoRef": "Style.Стиль",
+        "mdoRefRu": "Стиль.Стиль"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": [
+          [
+            "ru",
+            "Стиль"
+          ]
+        ]
+      },
+      "supportVariant": "NONE"
+    }
+  ],
+  "subsystems": [
+    [
+      2
+    ],
+    [
+      2
+    ]
+  ],
+  "supportVariant": "NONE",
+  "synchronousExtensionAndAddInCallUseMode": "USE_WITH_WARNINGS",
+  "synchronousPlatformExtensionAndAddInCallUseMode": "DONT_USE",
+  "synonym": {
+    "content": []
+  },
+  "tasks": [
+    {
+      "uuid": "c251fcec-ec02-4ef4-8f70-4d70db6631ea",
+      "name": "Задача1",
+      "mdoReference": {
+        "type": "TASK",
+        "mdoRef": "Task.Задача1",
+        "mdoRefRu": "Задача.Задача1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE",
+      "modules": [
+        0
+      ],
+      "commands": [],
+      "attributes": [],
+      "tabularSections": [],
+      "forms": [],
+      "templates": [],
+      "addressingAttributes": [
+        {
+          "uuid": "bf531047-7ec7-4c74-bfdb-917138b2127c",
+          "name": "РеквизитАдресации",
+          "mdoReference": {
+            "type": "TASK_ADDRESSING_ATTRIBUTE",
+            "mdoRef": "Task.Задача1.AddressingAttribute.РеквизитАдресации",
+            "mdoRefRu": "Задача.Задача1.РеквизитАдресации.РеквизитАдресации"
+          },
+          "objectBelonging": "OWN",
+          "comment": "",
+          "synonym": {
+            "content": [
+              [
+                "ru",
+                "Реквизит адресации"
+              ]
+            ]
+          },
+          "supportVariant": "NONE",
+          "owner": {
+            "type": "TASK",
+            "mdoRef": "Task.Задача1",
+            "mdoRefRu": "Задача.Задача1"
+          },
+          "passwordMode": false,
+          "kind": "CUSTOM",
+          "indexing": "DONT_INDEX",
+          "format": {
+            "content": []
+          },
+          "editFormat": {
+            "content": []
+          },
+          "toolTip": {
+            "content": []
+          },
+          "markNegatives": false,
+          "mask": "",
+          "multiLine": false,
+          "extendedEdit": false,
+          "fillFromFillingValue": false,
+          "choiceForm": {
+            "type": "UNKNOWN",
+            "mdoRef": "",
+            "mdoRefRu": ""
+          }
+        }
+      ]
+    }
+  ],
+  "useManagedFormInOrdinaryApplication": true,
+  "useOrdinaryFormInManagedApplication": true,
+  "uuid": "46c7c1d0-b04d-4295-9b04-ae3207c18d29",
+  "vendor": "",
+  "version": "",
+  "webServices": [
+    {
+      "uuid": "d7f9b06b-0799-486e-adff-c45a2d5b8101",
+      "name": "WebСервис1",
+      "mdoReference": {
+        "type": "WEB_SERVICE",
+        "mdoRef": "WebService.WebСервис1",
+        "mdoRefRu": "WebСервис.WebСервис1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE",
+      "modules": [
+        1
+      ],
+      "namespace": "http://test.test",
+      "descriptorFileName": "ws1.1cws",
+      "reuseSessions": "AUTO_USE",
+      "sessionMaxAge": 20,
+      "operations": [
+        [
+          2
+        ],
+        [
+          2
+        ]
+      ]
+    }
+  ],
+  "wsReferences": [
+    {
+      "uuid": "95b745f2-e1fa-4f94-b7f9-f3f0224fc8c7",
+      "name": "WSСсылка",
+      "mdoReference": {
+        "type": "WS_REFERENCE",
+        "mdoRef": "WSReference.WSСсылка",
+        "mdoRefRu": "WSСсылка.WSСсылка"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": [
+          [
+            "ru",
+            "WSСсылка"
+          ]
+        ]
+      },
+      "supportVariant": "NONE",
+      "locationURL": "http://ya.ru"
+    }
+  ]
+}}

--- a/src/test/resources/fixtures/ssl_3_2/Configuration_edt.json
+++ b/src/test/resources/fixtures/ssl_3_2/Configuration_edt.json
@@ -1,0 +1,1783 @@
+{"com.github._1c_syntax.bsl.mdclasses.Configuration": {
+  "XDTOPackages": [
+    {
+      "uuid": "b8a93cce-56e4-4507-b281-5c525a466a0f",
+      "name": "ПакетXDTO1",
+      "mdoReference": {
+        "type": "XDTO_PACKAGE",
+        "mdoRef": "XDTOPackage.ПакетXDTO1",
+        "mdoRefRu": "ПакетXDTO.ПакетXDTO1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE",
+      "namespace": "http://v8.1c.ru/edi/edi_stnd/EnterpriseData/1.8",
+      "data": {
+        "targetNamespace": "http://v8.1c.ru/edi/edi_stnd/EnterpriseData/1.8",
+        "imports": [
+          [
+            2
+          ],
+          [
+            2
+          ]
+        ],
+        "valueTypes": [
+          [
+            278
+          ],
+          [
+            278
+          ]
+        ],
+        "objectTypes": [
+          [
+            737
+          ],
+          [
+            737
+          ]
+        ],
+        "properties": [
+          {
+            "name": "performance",
+            "type": "d2p1:Performance",
+            "lowerBound": 0,
+            "upperBound": 0,
+            "nillable": false,
+            "form": "Attribute",
+            "typeDef": []
+          }
+        ]
+      }
+    }
+  ],
+  "accountingRegisters": [
+    {
+      "uuid": "e5930f2f-15d9-48a1-ac69-379ad990b02a",
+      "name": "РегистрБухгалтерии1",
+      "mdoReference": {
+        "type": "ACCOUNTING_REGISTER",
+        "mdoRef": "AccountingRegister.РегистрБухгалтерии1",
+        "mdoRefRu": "РегистрБухгалтерии.РегистрБухгалтерии1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": [
+          [
+            "en",
+            "Accounting register"
+          ],
+          [
+            "ru",
+            "Регистр бухгалтерии"
+          ]
+        ]
+      },
+      "supportVariant": "NONE",
+      "modules": [
+        0
+      ],
+      "commands": [],
+      "attributes": [],
+      "resources": [
+        {
+          "uuid": "e88df8bd-bf97-41a4-88fc-09c84a51824b",
+          "name": "Ресурс1",
+          "mdoReference": {
+            "type": "RESOURCE",
+            "mdoRef": "AccountingRegister.РегистрБухгалтерии1.Resource.Ресурс1",
+            "mdoRefRu": "РегистрБухгалтерии.РегистрБухгалтерии1.Ресурс.Ресурс1"
+          },
+          "objectBelonging": "OWN",
+          "comment": "",
+          "synonym": {
+            "content": []
+          },
+          "supportVariant": "NONE",
+          "owner": {
+            "type": "ACCOUNTING_REGISTER",
+            "mdoRef": "AccountingRegister.РегистрБухгалтерии1",
+            "mdoRefRu": "РегистрБухгалтерии.РегистрБухгалтерии1"
+          },
+          "passwordMode": false,
+          "kind": "CUSTOM",
+          "indexing": "DONT_INDEX"
+        }
+      ],
+      "dimensions": [
+        {
+          "uuid": "902c08a9-e457-436a-b0fb-b996f0d9bb00",
+          "name": "Измерение1",
+          "mdoReference": {
+            "type": "DIMENSION",
+            "mdoRef": "AccountingRegister.РегистрБухгалтерии1.Dimension.Измерение1",
+            "mdoRefRu": "РегистрБухгалтерии.РегистрБухгалтерии1.Измерение.Измерение1"
+          },
+          "objectBelonging": "OWN",
+          "comment": "",
+          "synonym": {
+            "content": []
+          },
+          "supportVariant": "NONE",
+          "owner": {
+            "type": "ACCOUNTING_REGISTER",
+            "mdoRef": "AccountingRegister.РегистрБухгалтерии1",
+            "mdoRefRu": "РегистрБухгалтерии.РегистрБухгалтерии1"
+          },
+          "passwordMode": false,
+          "kind": "CUSTOM",
+          "indexing": "INDEX",
+          "master": false,
+          "denyIncompleteValues": false,
+          "useInTotals": true
+        }
+      ],
+      "forms": [],
+      "templates": []
+    }
+  ],
+  "accumulationRegisters": [
+    {
+      "uuid": "8ea07f36-d671-4649-bc7a-94daa939e77f",
+      "name": "РегистрНакопления1",
+      "mdoReference": {
+        "type": "ACCUMULATION_REGISTER",
+        "mdoRef": "AccumulationRegister.РегистрНакопления1",
+        "mdoRefRu": "РегистрНакопления.РегистрНакопления1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": [
+          [
+            "ru",
+            "Регистр накопления"
+          ]
+        ]
+      },
+      "supportVariant": "NONE",
+      "modules": [
+        0
+      ],
+      "commands": [],
+      "attributes": [],
+      "resources": [
+        {
+          "uuid": "a187a281-f5cd-4e1c-8f3f-37212a840339",
+          "name": "Ресурс1",
+          "mdoReference": {
+            "type": "RESOURCE",
+            "mdoRef": "AccumulationRegister.РегистрНакопления1.Resource.Ресурс1",
+            "mdoRefRu": "РегистрНакопления.РегистрНакопления1.Ресурс.Ресурс1"
+          },
+          "objectBelonging": "OWN",
+          "comment": "",
+          "synonym": {
+            "content": []
+          },
+          "supportVariant": "NONE",
+          "owner": {
+            "type": "ACCUMULATION_REGISTER",
+            "mdoRef": "AccumulationRegister.РегистрНакопления1",
+            "mdoRefRu": "РегистрНакопления.РегистрНакопления1"
+          },
+          "passwordMode": false,
+          "kind": "CUSTOM",
+          "indexing": "DONT_INDEX"
+        }
+      ],
+      "dimensions": [
+        {
+          "uuid": "461cae93-fe90-4bbb-8f79-0963e2d39ec5",
+          "name": "Измерение1",
+          "mdoReference": {
+            "type": "DIMENSION",
+            "mdoRef": "AccumulationRegister.РегистрНакопления1.Dimension.Измерение1",
+            "mdoRefRu": "РегистрНакопления.РегистрНакопления1.Измерение.Измерение1"
+          },
+          "objectBelonging": "OWN",
+          "comment": "",
+          "synonym": {
+            "content": []
+          },
+          "supportVariant": "NONE",
+          "owner": {
+            "type": "ACCUMULATION_REGISTER",
+            "mdoRef": "AccumulationRegister.РегистрНакопления1",
+            "mdoRefRu": "РегистрНакопления.РегистрНакопления1"
+          },
+          "passwordMode": false,
+          "kind": "CUSTOM",
+          "indexing": "DONT_INDEX",
+          "master": false,
+          "denyIncompleteValues": false,
+          "useInTotals": true
+        }
+      ],
+      "forms": [],
+      "templates": []
+    }
+  ],
+  "bots": [],
+  "briefInformation": {
+    "content": [
+      [
+        "en",
+        "Short info"
+      ],
+      [
+        "ru",
+        "Краткая информация"
+      ]
+    ]
+  },
+  "businessProcesses": [
+    {
+      "uuid": "560a32ca-028d-4b88-b6f2-6b7212bf31f8",
+      "name": "БизнесПроцесс1",
+      "mdoReference": {
+        "type": "BUSINESS_PROCESS",
+        "mdoRef": "BusinessProcess.БизнесПроцесс1",
+        "mdoRefRu": "БизнесПроцесс.БизнесПроцесс1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE",
+      "modules": [
+        1
+      ],
+      "commands": [],
+      "attributes": [],
+      "tabularSections": [],
+      "forms": [],
+      "templates": []
+    }
+  ],
+  "calculationRegisters": [
+    {
+      "uuid": "90587c7d-b950-4476-ac14-426e4a83d9c4",
+      "name": "РегистрРасчета1",
+      "mdoReference": {
+        "type": "CALCULATION_REGISTER",
+        "mdoRef": "CalculationRegister.РегистрРасчета1",
+        "mdoRefRu": "РегистрРасчета.РегистрРасчета1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE",
+      "modules": [
+        0
+      ],
+      "commands": [],
+      "attributes": [],
+      "resources": [
+        {
+          "uuid": "86f41061-e298-4da5-8d28-489a349d55fc",
+          "name": "Ресурс1",
+          "mdoReference": {
+            "type": "RESOURCE",
+            "mdoRef": "CalculationRegister.РегистрРасчета1.Resource.Ресурс1",
+            "mdoRefRu": "РегистрРасчета.РегистрРасчета1.Ресурс.Ресурс1"
+          },
+          "objectBelonging": "OWN",
+          "comment": "",
+          "synonym": {
+            "content": []
+          },
+          "supportVariant": "NONE",
+          "owner": {
+            "type": "CALCULATION_REGISTER",
+            "mdoRef": "CalculationRegister.РегистрРасчета1",
+            "mdoRefRu": "РегистрРасчета.РегистрРасчета1"
+          },
+          "passwordMode": false,
+          "kind": "CUSTOM",
+          "indexing": "DONT_INDEX"
+        }
+      ],
+      "dimensions": [
+        {
+          "uuid": "f3e7cca5-4902-4ad5-96c7-db8336f52c6e",
+          "name": "Измерение1",
+          "mdoReference": {
+            "type": "DIMENSION",
+            "mdoRef": "CalculationRegister.РегистрРасчета1.Dimension.Измерение1",
+            "mdoRefRu": "РегистрРасчета.РегистрРасчета1.Измерение.Измерение1"
+          },
+          "objectBelonging": "OWN",
+          "comment": "",
+          "synonym": {
+            "content": []
+          },
+          "supportVariant": "NONE",
+          "owner": {
+            "type": "CALCULATION_REGISTER",
+            "mdoRef": "CalculationRegister.РегистрРасчета1",
+            "mdoRefRu": "РегистрРасчета.РегистрРасчета1"
+          },
+          "passwordMode": false,
+          "kind": "CUSTOM",
+          "indexing": "DONT_INDEX",
+          "master": false,
+          "denyIncompleteValues": true,
+          "useInTotals": true
+        }
+      ],
+      "forms": [],
+      "templates": [],
+      "recalculations": [
+        {
+          "uuid": "16b54095-8711-4ef1-a38b-93d12f6f6e93",
+          "name": "Перерасчет",
+          "mdoReference": {
+            "type": "RECALCULATION",
+            "mdoRef": "CalculationRegister.РегистрРасчета1.Recalculation.Перерасчет",
+            "mdoRefRu": "РегистрРасчета.РегистрРасчета1.Перерасчет.Перерасчет"
+          },
+          "objectBelonging": "OWN",
+          "comment": "",
+          "synonym": {
+            "content": [
+              [
+                "ru",
+                "Перерасчет"
+              ]
+            ]
+          },
+          "supportVariant": "NONE",
+          "owner": {
+            "type": "CALCULATION_REGISTER",
+            "mdoRef": "CalculationRegister.РегистрРасчета1",
+            "mdoRefRu": "РегистрРасчета.РегистрРасчета1"
+          },
+          "modules": [
+            1
+          ]
+        }
+      ]
+    }
+  ],
+  "catalogs": [
+    {
+      "uuid": "eeef463d-d5e7-42f2-ae53-10279661f59d",
+      "name": "Справочник1",
+      "mdoReference": {
+        "type": "CATALOG",
+        "mdoRef": "Catalog.Справочник1",
+        "mdoRefRu": "Справочник.Справочник1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE",
+      "modules": [
+        2
+      ],
+      "commands": [
+        {
+          "uuid": "342ec3c7-82d4-42bb-a5ff-8a756f110744",
+          "name": "Команда1",
+          "mdoReference": {
+            "type": "COMMAND",
+            "mdoRef": "Catalog.Справочник1.Command.Команда1",
+            "mdoRefRu": "Справочник.Справочник1.Команда.Команда1"
+          },
+          "objectBelonging": "OWN",
+          "comment": "",
+          "synonym": {
+            "content": []
+          },
+          "supportVariant": "NONE",
+          "modules": [
+            1
+          ],
+          "owner": {
+            "type": "CATALOG",
+            "mdoRef": "Catalog.Справочник1",
+            "mdoRefRu": "Справочник.Справочник1"
+          }
+        }
+      ],
+      "attributes": [
+        [
+          3
+        ],
+        [
+          3
+        ]
+      ],
+      "tabularSections": [
+        {
+          "uuid": "451202c5-b1af-4bce-a705-0b5570071588",
+          "name": "ТабличнаяЧасть1",
+          "mdoReference": {
+            "type": "TABULAR_SECTION",
+            "mdoRef": "Catalog.Справочник1.TabularSection.ТабличнаяЧасть1",
+            "mdoRefRu": "Справочник.Справочник1.ТабличнаяЧасть.ТабличнаяЧасть1"
+          },
+          "objectBelonging": "OWN",
+          "comment": "",
+          "synonym": {
+            "content": []
+          },
+          "supportVariant": "NONE",
+          "owner": {
+            "type": "CATALOG",
+            "mdoRef": "Catalog.Справочник1",
+            "mdoRefRu": "Справочник.Справочник1"
+          },
+          "attributes": [
+            [
+              2
+            ],
+            [
+              2
+            ]
+          ]
+        }
+      ],
+      "forms": [
+        [
+          3
+        ],
+        [
+          3
+        ]
+      ],
+      "templates": [
+        {
+          "uuid": "42def71b-52cc-4e34-8a08-82f0dfcd47bf",
+          "name": "Макет",
+          "mdoReference": {
+            "type": "TEMPLATE",
+            "mdoRef": "Catalog.Справочник1.Template.Макет",
+            "mdoRefRu": "Справочник.Справочник1.Макет.Макет"
+          },
+          "objectBelonging": "OWN",
+          "comment": "",
+          "synonym": {
+            "content": [
+              [
+                "ru",
+                "Макет"
+              ]
+            ]
+          },
+          "supportVariant": "NONE",
+          "modules": [],
+          "templateType": "SPREADSHEET_DOCUMENT",
+          "data": {
+            "@class": "com.github._1c_syntax.bsl.mdo.storage.EmptyTemplateData"
+          },
+          "owner": {
+            "type": "CATALOG",
+            "mdoRef": "Catalog.Справочник1",
+            "mdoRefRu": "Справочник.Справочник1"
+          }
+        }
+      ]
+    }
+  ],
+  "chartsOfAccounts": [
+    {
+      "uuid": "2766f353-abd2-4e7f-9a95-53f05c83f5d4",
+      "name": "ПланСчетов1",
+      "mdoReference": {
+        "type": "CHART_OF_ACCOUNTS",
+        "mdoRef": "ChartOfAccounts.ПланСчетов1",
+        "mdoRefRu": "ПланСчетов.ПланСчетов1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE",
+      "modules": [
+        1
+      ],
+      "commands": [],
+      "attributes": [],
+      "tabularSections": [],
+      "forms": [],
+      "templates": [],
+      "accountingFlags": [
+        {
+          "uuid": "957a5154-1e63-49e1-8e99-3893490da6f6",
+          "name": "ПризнакУчета",
+          "mdoReference": {
+            "type": "ACCOUNTING_FLAG",
+            "mdoRef": "ChartOfAccounts.ПланСчетов1.AccountingFlag.ПризнакУчета",
+            "mdoRefRu": "ПланСчетов.ПланСчетов1.ПризнакУчета.ПризнакУчета"
+          },
+          "objectBelonging": "OWN",
+          "comment": "",
+          "synonym": {
+            "content": [
+              [
+                "ru",
+                "Признак учета"
+              ]
+            ]
+          },
+          "supportVariant": "NONE",
+          "owner": {
+            "type": "CHART_OF_ACCOUNTS",
+            "mdoRef": "ChartOfAccounts.ПланСчетов1",
+            "mdoRefRu": "ПланСчетов.ПланСчетов1"
+          },
+          "passwordMode": false,
+          "kind": "CUSTOM",
+          "indexing": "DONT_INDEX"
+        }
+      ],
+      "extDimensionAccountingFlags": [
+        {
+          "uuid": "4f04d72a-e3e9-4e9b-96da-7d0e1ad989e6",
+          "name": "ПризнакУчета",
+          "mdoReference": {
+            "type": "EXT_DIMENSION_ACCOUNTING_FLAG",
+            "mdoRef": "ChartOfAccounts.ПланСчетов1.ExtDimensionAccountingFlag.ПризнакУчета",
+            "mdoRefRu": "ПланСчетов.ПланСчетов1.ПризнакУчетаСубконто.ПризнакУчета"
+          },
+          "objectBelonging": "OWN",
+          "comment": "",
+          "synonym": {
+            "content": [
+              [
+                "ru",
+                "Признак учета"
+              ]
+            ]
+          },
+          "supportVariant": "NONE",
+          "owner": {
+            "type": "CHART_OF_ACCOUNTS",
+            "mdoRef": "ChartOfAccounts.ПланСчетов1",
+            "mdoRefRu": "ПланСчетов.ПланСчетов1"
+          },
+          "passwordMode": false,
+          "kind": "CUSTOM",
+          "indexing": "DONT_INDEX"
+        }
+      ]
+    }
+  ],
+  "chartsOfCalculationTypes": [
+    {
+      "uuid": "1755c534-9ccd-49c4-9f8b-2aa066424aaa",
+      "name": "ПланВидовРасчета1",
+      "mdoReference": {
+        "type": "CHART_OF_CALCULATION_TYPES",
+        "mdoRef": "ChartOfCalculationTypes.ПланВидовРасчета1",
+        "mdoRefRu": "ПланВидовРасчета.ПланВидовРасчета1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE",
+      "modules": [
+        0
+      ],
+      "commands": [],
+      "attributes": [],
+      "tabularSections": [],
+      "forms": [],
+      "templates": []
+    }
+  ],
+  "chartsOfCharacteristicTypes": [
+    {
+      "uuid": "f53a24c3-f1dc-43b7-8dcf-eeb8c0b7f452",
+      "name": "ПланВидовХарактеристик1",
+      "mdoReference": {
+        "type": "CHART_OF_CHARACTERISTIC_TYPES",
+        "mdoRef": "ChartOfCharacteristicTypes.ПланВидовХарактеристик1",
+        "mdoRefRu": "ПланВидовХарактеристик.ПланВидовХарактеристик1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE",
+      "modules": [
+        2
+      ],
+      "commands": [],
+      "attributes": [],
+      "tabularSections": [],
+      "forms": [],
+      "templates": []
+    }
+  ],
+  "children": [
+    [
+      61
+    ],
+    [
+      61
+    ]
+  ],
+  "commandGroups": [
+    {
+      "uuid": "9bd3b0b1-b276-4b0e-9811-44a41ebb0c7c",
+      "name": "ГруппаКоманд1",
+      "mdoReference": {
+        "type": "COMMAND_GROUP",
+        "mdoRef": "CommandGroup.ГруппаКоманд1",
+        "mdoRefRu": "ГруппаКоманд.ГруппаКоманд1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE"
+    }
+  ],
+  "comment": "",
+  "commonAttributes": [
+    {
+      "uuid": "d4f0c0ac-ed26-4085-a1b4-e52314b973ad",
+      "name": "ОбщийРеквизит1",
+      "mdoReference": {
+        "type": "COMMON_ATTRIBUTE",
+        "mdoRef": "CommonAttribute.ОбщийРеквизит1",
+        "mdoRefRu": "ОбщийРеквизит.ОбщийРеквизит1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE",
+      "autoUse": "USE",
+      "passwordMode": false,
+      "indexing": "DONT_INDEX",
+      "dataSeparation": "DONT_USE",
+      "dataSeparationValue": {
+        "type": "UNKNOWN",
+        "mdoRef": "",
+        "mdoRefRu": ""
+      },
+      "dataSeparationUse": {
+        "type": "UNKNOWN",
+        "mdoRef": "",
+        "mdoRefRu": ""
+      },
+      "conditionalSeparation": {
+        "type": "UNKNOWN",
+        "mdoRef": "",
+        "mdoRefRu": ""
+      },
+      "usersSeparation": "DONT_USE",
+      "authenticationSeparation": "DONT_USE",
+      "configurationExtensionsSeparation": "DONT_USE",
+      "content": [
+        [
+          2
+        ],
+        [
+          2
+        ]
+      ]
+    }
+  ],
+  "commonCommands": [
+    {
+      "uuid": "a608f796-f58e-4f8a-b63f-272342b32f35",
+      "name": "ОбщаяКоманда1",
+      "mdoReference": {
+        "type": "COMMON_COMMAND",
+        "mdoRef": "CommonCommand.ОбщаяКоманда1",
+        "mdoRefRu": "ОбщаяКоманда.ОбщаяКоманда1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE",
+      "modules": [
+        1
+      ]
+    }
+  ],
+  "commonForms": [
+    {
+      "uuid": "5ac59104-28a5-40b1-ab5b-2857fb41991a",
+      "name": "Форма",
+      "mdoReference": {
+        "type": "COMMON_FORM",
+        "mdoRef": "CommonForm.Форма",
+        "mdoRefRu": "ОбщаяФорма.Форма"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": [
+          [
+            "ru",
+            "Форма"
+          ]
+        ]
+      },
+      "supportVariant": "NONE",
+      "modules": [
+        1
+      ],
+      "formType": "MANAGED",
+      "data": {
+        "@class": "com.github._1c_syntax.bsl.mdo.storage.EmptyFormData"
+      }
+    }
+  ],
+  "commonModules": [
+    [
+      6
+    ],
+    [
+      6
+    ]
+  ],
+  "commonPictures": [
+    {
+      "uuid": "db84513d-2535-494b-843e-6d8931cb2f82",
+      "name": "ОбщаяКартинка1",
+      "mdoReference": {
+        "type": "COMMON_PICTURE",
+        "mdoRef": "CommonPicture.ОбщаяКартинка1",
+        "mdoRefRu": "ОбщаяКартинка.ОбщаяКартинка1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE",
+      "availabilityForChoice": false,
+      "availabilityForAppearance": false
+    }
+  ],
+  "commonTemplates": [
+    [
+      10
+    ],
+    [
+      10
+    ]
+  ],
+  "compatibilityMode": {
+    "minor": 3,
+    "version": 10
+  },
+  "configurationExtensionCompatibilityMode": {
+    "minor": 3,
+    "version": 10
+  },
+  "configurationSource": "EDT",
+  "constants": [
+    {
+      "uuid": "61e6a6f2-7057-4e93-96c3-7bd2559217f4",
+      "name": "Константа1",
+      "mdoReference": {
+        "type": "CONSTANT",
+        "mdoRef": "Constant.Константа1",
+        "mdoRefRu": "Константа.Константа1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE",
+      "modules": [
+        1
+      ],
+      "passwordMode": false
+    }
+  ],
+  "copyrights": {
+    "content": []
+  },
+  "dataLockControlMode": "AUTOMATIC",
+  "dataProcessors": [
+    {
+      "uuid": "a7c57ba0-75d8-487d-b8ea-ae5083d8a503",
+      "name": "Обработка1",
+      "mdoReference": {
+        "type": "DATA_PROCESSOR",
+        "mdoRef": "DataProcessor.Обработка1",
+        "mdoRefRu": "Обработка.Обработка1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE",
+      "modules": [
+        0
+      ],
+      "commands": [],
+      "attributes": [],
+      "tabularSections": [],
+      "forms": [
+        [
+          2
+        ],
+        [
+          2
+        ]
+      ],
+      "templates": []
+    }
+  ],
+  "defaultLanguage": {
+    "type": "LANGUAGE",
+    "mdoRef": "Language.Русский",
+    "mdoRefRu": "Язык.Русский"
+  },
+  "defaultRunMode": "MANAGED_APPLICATION",
+  "definedTypes": [
+    {
+      "uuid": "e8c616d9-4957-48ab-a917-afb6847f6840",
+      "name": "ОпределяемыйТип1",
+      "mdoReference": {
+        "type": "DEFINED_TYPE",
+        "mdoRef": "DefinedType.ОпределяемыйТип1",
+        "mdoRefRu": "ОпределяемыйТип.ОпределяемыйТип1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE"
+    }
+  ],
+  "detailedInformation": {
+    "content": [
+      [
+        "en",
+        "Detailed info"
+      ],
+      [
+        "ru",
+        "Подробная информация"
+      ]
+    ]
+  },
+  "documentJournals": [
+    {
+      "uuid": "c6743657-4787-40de-9a45-2493c630f626",
+      "name": "ЖурналДокументов1",
+      "mdoReference": {
+        "type": "DOCUMENT_JOURNAL",
+        "mdoRef": "DocumentJournal.ЖурналДокументов1",
+        "mdoRefRu": "ЖурналДокументов.ЖурналДокументов1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE",
+      "modules": [
+        1
+      ],
+      "commands": [],
+      "columns": [
+        {
+          "uuid": "b52d063e-5d2c-498b-a333-4957277f47e3",
+          "name": "Графа",
+          "mdoReference": {
+            "type": "COLUMN",
+            "mdoRef": "DocumentJournal.ЖурналДокументов1.Column.Графа",
+            "mdoRefRu": "ЖурналДокументов.ЖурналДокументов1.Колонка.Графа"
+          },
+          "objectBelonging": "OWN",
+          "comment": "",
+          "synonym": {
+            "content": [
+              [
+                "ru",
+                "Графа"
+              ]
+            ]
+          },
+          "supportVariant": "NONE",
+          "owner": {
+            "type": "DOCUMENT_JOURNAL",
+            "mdoRef": "DocumentJournal.ЖурналДокументов1",
+            "mdoRefRu": "ЖурналДокументов.ЖурналДокументов1"
+          },
+          "passwordMode": false,
+          "kind": "CUSTOM",
+          "indexing": "DONT_INDEX"
+        }
+      ],
+      "forms": [],
+      "templates": [],
+      "registeredDocuments": [
+        {
+          "type": "DOCUMENT",
+          "mdoRef": "Document.Документ1",
+          "mdoRefRu": "Документ.Документ1"
+        }
+      ]
+    }
+  ],
+  "documentNumerators": [
+    {
+      "uuid": "e401f835-6bfc-4cd4-8d87-5e6b6332a3f6",
+      "name": "НумераторДокументов1",
+      "mdoReference": {
+        "type": "DOCUMENT_NUMERATOR",
+        "mdoRef": "DocumentNumerator.НумераторДокументов1",
+        "mdoRefRu": "НумераторДокументов.НумераторДокументов1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE"
+    }
+  ],
+  "documents": [
+    {
+      "uuid": "ce4fb46b-4af7-493e-9fcb-76ad8c4f8acd",
+      "name": "Документ1",
+      "mdoReference": {
+        "type": "DOCUMENT",
+        "mdoRef": "Document.Документ1",
+        "mdoRefRu": "Документ.Документ1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE",
+      "modules": [
+        2
+      ],
+      "commands": [
+        [
+          2
+        ],
+        [
+          2
+        ]
+      ],
+      "attributes": [
+        [
+          3
+        ],
+        [
+          3
+        ]
+      ],
+      "tabularSections": [
+        {
+          "uuid": "508fe2d9-44b0-4b34-a349-2b0bcae6adc4",
+          "name": "ТабличнаяЧасть1",
+          "mdoReference": {
+            "type": "TABULAR_SECTION",
+            "mdoRef": "Document.Документ1.TabularSection.ТабличнаяЧасть1",
+            "mdoRefRu": "Документ.Документ1.ТабличнаяЧасть.ТабличнаяЧасть1"
+          },
+          "objectBelonging": "OWN",
+          "comment": "",
+          "synonym": {
+            "content": []
+          },
+          "supportVariant": "NONE",
+          "owner": {
+            "type": "DOCUMENT",
+            "mdoRef": "Document.Документ1",
+            "mdoRefRu": "Документ.Документ1"
+          },
+          "attributes": [
+            [
+              2
+            ],
+            [
+              2
+            ]
+          ]
+        }
+      ],
+      "forms": [
+        [
+          3
+        ],
+        [
+          3
+        ]
+      ],
+      "templates": [],
+      "registerRecords": [
+        [
+          4
+        ],
+        [
+          4
+        ]
+      ]
+    }
+  ],
+  "enums": [
+    {
+      "uuid": "f11f3441-4b64-4344-b1a0-0e4b3e466e03",
+      "name": "Перечисление1",
+      "mdoReference": {
+        "type": "ENUM",
+        "mdoRef": "Enum.Перечисление1",
+        "mdoRefRu": "Перечисление.Перечисление1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE",
+      "modules": [
+        1
+      ],
+      "commands": [],
+      "forms": [],
+      "templates": [],
+      "enumValues": [
+        {
+          "uuid": "47a90ebe-6127-4041-bdd4-def343363004",
+          "name": "ЗначениеПеречисления1",
+          "mdoReference": {
+            "type": "ENUM_VALUE",
+            "mdoRef": "Enum.Перечисление1.EnumValue.ЗначениеПеречисления1",
+            "mdoRefRu": "Перечисление.Перечисление1.ЗначениеПеречисления.ЗначениеПеречисления1"
+          },
+          "objectBelonging": "OWN",
+          "comment": "",
+          "synonym": {
+            "content": []
+          },
+          "supportVariant": "NONE",
+          "owner": {
+            "type": "ENUM",
+            "mdoRef": "Enum.Перечисление1",
+            "mdoRefRu": "Перечисление.Перечисление1"
+          }
+        }
+      ]
+    }
+  ],
+  "eventSubscriptions": [
+    {
+      "uuid": "4da21a7b-3d07-4e6d-b91f-7e1c8ddcffcd",
+      "name": "ПодпискаНаСобытие1",
+      "mdoReference": {
+        "type": "EVENT_SUBSCRIPTION",
+        "mdoRef": "EventSubscription.ПодпискаНаСобытие1",
+        "mdoRefRu": "ПодпискаНаСобытие.ПодпискаНаСобытие1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE",
+      "handler": {
+        "methodPath": "CommonModule.ПростойОбщийМодуль.ПодпискаНаСобытие1ПередЗаписью",
+        "moduleName": "ПростойОбщийМодуль",
+        "methodName": "ПодпискаНаСобытие1ПередЗаписью"
+      },
+      "event": "BeforeWrite"
+    }
+  ],
+  "exchangePlans": [
+    {
+      "uuid": "242cb07d-3d2b-4689-b590-d3ed23ac9d10",
+      "name": "ПланОбмена1",
+      "mdoReference": {
+        "type": "EXCHANGE_PLAN",
+        "mdoRef": "ExchangePlan.ПланОбмена1",
+        "mdoRefRu": "ПланОбмена.ПланОбмена1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE",
+      "modules": [
+        1
+      ],
+      "commands": [],
+      "attributes": [],
+      "tabularSections": [],
+      "forms": [],
+      "templates": [],
+      "distributedInfoBase": false,
+      "includeConfigurationExtensions": false,
+      "content": [
+        [
+          2
+        ],
+        [
+          2
+        ]
+      ]
+    }
+  ],
+  "externalDataSources": [
+    {
+      "uuid": "2ceefe90-5a06-41ce-aac5-a3293a85946f",
+      "name": "ТекущаяСУБД",
+      "mdoReference": {
+        "type": "EXTERNAL_DATA_SOURCE",
+        "mdoRef": "ExternalDataSource.ТекущаяСУБД",
+        "mdoRefRu": "ВнешнийИсточникДанных.ТекущаяСУБД"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": [
+          [
+            "ru",
+            "Текущая СУБД"
+          ]
+        ]
+      },
+      "supportVariant": "NONE",
+      "tables": [
+        {
+          "uuid": "318e517a-2dd6-4cdf-a502-c8cd6e429ff6",
+          "name": "ИнформацияОбОшибках",
+          "mdoReference": {
+            "type": "EXTERNAL_DATA_SOURCE_TABLE",
+            "mdoRef": "ExternalDataSource.ТекущаяСУБД.Table.ИнформацияОбОшибках",
+            "mdoRefRu": "ВнешнийИсточникДанных.ТекущаяСУБД.Таблица.ИнформацияОбОшибках"
+          },
+          "objectBelonging": "OWN",
+          "comment": "",
+          "synonym": {
+            "content": [
+              [
+                "ru",
+                "Информация об ошибках"
+              ]
+            ]
+          },
+          "supportVariant": "NONE",
+          "owner": {
+            "type": "EXTERNAL_DATA_SOURCE",
+            "mdoRef": "ExternalDataSource.ТекущаяСУБД",
+            "mdoRefRu": "ВнешнийИсточникДанных.ТекущаяСУБД"
+          },
+          "modules": [
+            2
+          ],
+          "commands": [
+            {
+              "uuid": "ff4437b1-325e-47d7-87f7-9cf5e51460c5",
+              "name": "Command",
+              "mdoReference": {
+                "type": "COMMAND",
+                "mdoRef": "ExternalDataSource.ТекущаяСУБД.Table.ИнформацияОбОшибках.Command.Command",
+                "mdoRefRu": "ВнешнийИсточникДанных.ТекущаяСУБД.Таблица.ИнформацияОбОшибках.Команда.Command"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "content": [
+                  [
+                    "ru",
+                    "Command"
+                  ]
+                ]
+              },
+              "supportVariant": "NONE",
+              "modules": [
+                1
+              ],
+              "owner": {
+                "type": "EXTERNAL_DATA_SOURCE_TABLE",
+                "mdoRef": "ExternalDataSource.ТекущаяСУБД.Table.ИнформацияОбОшибках",
+                "mdoRefRu": "ВнешнийИсточникДанных.ТекущаяСУБД.Таблица.ИнформацияОбОшибках"
+              }
+            }
+          ],
+          "fields": [
+            [
+              8
+            ],
+            [
+              8
+            ]
+          ],
+          "forms": [
+            [
+              2
+            ],
+            [
+              2
+            ]
+          ],
+          "templates": [
+            {
+              "uuid": "28805bba-20fd-40dd-b442-1f7ca7dcf665",
+              "name": "Template",
+              "mdoReference": {
+                "type": "TEMPLATE",
+                "mdoRef": "ExternalDataSource.ТекущаяСУБД.Table.ИнформацияОбОшибках.Template.Template",
+                "mdoRefRu": "ВнешнийИсточникДанных.ТекущаяСУБД.Таблица.ИнформацияОбОшибках.Макет.Template"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "content": [
+                  [
+                    "ru",
+                    "Template"
+                  ]
+                ]
+              },
+              "supportVariant": "NONE",
+              "modules": [],
+              "templateType": "SPREADSHEET_DOCUMENT",
+              "data": {
+                "@class": "com.github._1c_syntax.bsl.mdo.storage.EmptyTemplateData"
+              },
+              "owner": {
+                "type": "EXTERNAL_DATA_SOURCE_TABLE",
+                "mdoRef": "ExternalDataSource.ТекущаяСУБД.Table.ИнформацияОбОшибках",
+                "mdoRefRu": "ВнешнийИсточникДанных.ТекущаяСУБД.Таблица.ИнформацияОбОшибках"
+              }
+            }
+          ],
+          "dataLockControlMode": "MANAGED"
+        }
+      ]
+    }
+  ],
+  "filterCriteria": [
+    {
+      "uuid": "6e9d3381-0607-43df-866d-14ee5d65a294",
+      "name": "КритерийОтбора1",
+      "mdoReference": {
+        "type": "FILTER_CRITERION",
+        "mdoRef": "FilterCriterion.КритерийОтбора1",
+        "mdoRefRu": "КритерийОтбора.КритерийОтбора1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE",
+      "modules": [
+        1
+      ],
+      "commands": [],
+      "forms": []
+    }
+  ],
+  "functionalOptions": [
+    {
+      "uuid": "d3b7fd71-6570-4047-91e0-b3df75dba08d",
+      "name": "ФункциональнаяОпция1",
+      "mdoReference": {
+        "type": "FUNCTIONAL_OPTION",
+        "mdoRef": "FunctionalOption.ФункциональнаяОпция1",
+        "mdoRefRu": "ФункциональнаяОпция.ФункциональнаяОпция1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE",
+      "location": {
+        "type": "CONSTANT",
+        "mdoRef": "Constant.Константа1",
+        "mdoRefRu": "Константа.Константа1"
+      },
+      "privilegedGetMode": true,
+      "content": []
+    }
+  ],
+  "functionalOptionsParameters": [
+    {
+      "uuid": "9fae7345-6220-4e5b-b4c1-84bb921a58b7",
+      "name": "ПараметрФункциональныхОпций",
+      "mdoReference": {
+        "type": "FUNCTIONAL_OPTIONS_PARAMETER",
+        "mdoRef": "FunctionalOptionsParameter.ПараметрФункциональныхОпций",
+        "mdoRefRu": "ПараметрФункциональныхОпций.ПараметрФункциональныхОпций"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": [
+          [
+            "ru",
+            "Параметр функциональных опций"
+          ]
+        ]
+      },
+      "supportVariant": "NONE",
+      "use": {
+        "type": "DIMENSION",
+        "mdoRef": "InformationRegister.РегистрСведений1.Dimension.Измерение1",
+        "mdoRefRu": "РегистрСведений.РегистрСведений1.Измерение.Измерение1"
+      }
+    }
+  ],
+  "httpServices": [
+    {
+      "uuid": "3f029e1e-5a9e-4446-b74f-cbcb79b1e2fe",
+      "name": "HTTPСервис1",
+      "mdoReference": {
+        "type": "HTTP_SERVICE",
+        "mdoRef": "HTTPService.HTTPСервис1",
+        "mdoRefRu": "HTTPСервис.HTTPСервис1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE",
+      "modules": [
+        1
+      ],
+      "urlTemplates": [
+        {
+          "uuid": "4d97db36-cfbf-4f11-9647-d95677380b8f",
+          "name": "ШаблонURL",
+          "mdoReference": {
+            "type": "HTTP_SERVICE_URL_TEMPLATE",
+            "mdoRef": "HTTPService.HTTPСервис1.URLTemplate.ШаблонURL",
+            "mdoRefRu": "HTTPСервис.HTTPСервис1.ШаблонURL.ШаблонURL"
+          },
+          "objectBelonging": "OWN",
+          "comment": "",
+          "synonym": {
+            "content": [
+              [
+                "ru",
+                "Шаблон URL"
+              ]
+            ]
+          },
+          "supportVariant": "NONE",
+          "owner": {
+            "type": "HTTP_SERVICE",
+            "mdoRef": "HTTPService.HTTPСервис1",
+            "mdoRefRu": "HTTPСервис.HTTPСервис1"
+          },
+          "methods": [
+            [
+              2
+            ],
+            [
+              2
+            ]
+          ]
+        }
+      ]
+    }
+  ],
+  "informationRegisters": [
+    [
+      2
+    ],
+    [
+      2
+    ]
+  ],
+  "integrationServices": [],
+  "interfaces": [],
+  "languages": [
+    [
+      3
+    ],
+    [
+      3
+    ]
+  ],
+  "mdoReference": {
+    "type": "CONFIGURATION",
+    "mdoRef": "Configuration.Конфигурация",
+    "mdoRefRu": "Конфигурация.Конфигурация"
+  },
+  "modalityUseMode": "USE",
+  "modules": [
+    3
+  ],
+  "name": "Конфигурация",
+  "objectAutonumerationMode": "NotAutoFree",
+  "objectBelonging": "OWN",
+  "reports": [
+    {
+      "uuid": "34d3754d-298c-4786-92f6-a487db249fc7",
+      "name": "Отчет1",
+      "mdoReference": {
+        "type": "REPORT",
+        "mdoRef": "Report.Отчет1",
+        "mdoRefRu": "Отчет.Отчет1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE",
+      "modules": [
+        2
+      ],
+      "commands": [],
+      "attributes": [],
+      "tabularSections": [],
+      "forms": [],
+      "templates": [
+        [
+          3
+        ],
+        [
+          3
+        ]
+      ]
+    }
+  ],
+  "roles": [
+    {
+      "uuid": "ecad0539-4f9f-491b-b0f2-f8f42d9a7c41",
+      "name": "Роль1",
+      "mdoReference": {
+        "type": "ROLE",
+        "mdoRef": "Role.Роль1",
+        "mdoRefRu": "Роль.Роль1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE",
+      "data": {
+        "setForNewObjects": false,
+        "setForAttributesByDefault": true,
+        "independentRightsOfChildObjects": false,
+        "objectRights": [
+          [
+            3
+          ],
+          [
+            3
+          ]
+        ]
+      }
+    }
+  ],
+  "scheduledJobs": [
+    {
+      "uuid": "0de0c839-4427-46d9-be68-302f88ac162c",
+      "name": "РегламентноеЗадание1",
+      "mdoReference": {
+        "type": "SCHEDULED_JOB",
+        "mdoRef": "ScheduledJob.РегламентноеЗадание1",
+        "mdoRefRu": "РегламентноеЗадание.РегламентноеЗадание1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE",
+      "methodName": {
+        "methodPath": "CommonModule.ПростойОбщийМодуль.РегламентноеЗадание1",
+        "moduleName": "ПростойОбщийМодуль",
+        "methodName": "РегламентноеЗадание1"
+      },
+      "description": "Описание Регламентное задание 1",
+      "key": "ПроверкаАктивностиСеансаУдаленияОбъектов",
+      "use": true,
+      "predefined": true,
+      "restartCountOnFailure": 3,
+      "restartIntervalOnFailure": 10
+    }
+  ],
+  "scriptVariant": "RUSSIAN",
+  "sequences": [
+    {
+      "uuid": "514bbcf4-7fc4-4a3e-9245-598fad397eec",
+      "name": "Последовательность1",
+      "mdoReference": {
+        "type": "SEQUENCE",
+        "mdoRef": "Sequence.Последовательность1",
+        "mdoRefRu": "Последовательность.Последовательность1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE",
+      "modules": [
+        1
+      ],
+      "dimensions": [
+        {
+          "uuid": "763b82dd-2fdb-4a02-a50b-3eb916c02d3d",
+          "name": "Измерение1",
+          "mdoReference": {
+            "type": "DIMENSION",
+            "mdoRef": "Sequence.Последовательность1.Dimension.Измерение1",
+            "mdoRefRu": "Последовательность.Последовательность1.Измерение.Измерение1"
+          },
+          "objectBelonging": "OWN",
+          "comment": "",
+          "synonym": {
+            "content": []
+          },
+          "supportVariant": "NONE",
+          "owner": {
+            "type": "SEQUENCE",
+            "mdoRef": "Sequence.Последовательность1",
+            "mdoRefRu": "Последовательность.Последовательность1"
+          },
+          "passwordMode": false,
+          "kind": "CUSTOM",
+          "indexing": "DONT_INDEX",
+          "master": false,
+          "denyIncompleteValues": false,
+          "useInTotals": true
+        }
+      ]
+    }
+  ],
+  "sessionParameters": [
+    {
+      "uuid": "66844df5-823b-40f1-ab8a-b07c1cb7462f",
+      "name": "ПараметрСеанса1",
+      "mdoReference": {
+        "type": "SESSION_PARAMETER",
+        "mdoRef": "SessionParameter.ПараметрСеанса1",
+        "mdoRefRu": "ПараметрСеанса.ПараметрСеанса1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE"
+    }
+  ],
+  "settingsStorages": [
+    {
+      "uuid": "e7a9947d-7565-4681-b75c-c9a229b45042",
+      "name": "ХранилищеНастроек1",
+      "mdoReference": {
+        "type": "SETTINGS_STORAGE",
+        "mdoRef": "SettingsStorage.ХранилищеНастроек1",
+        "mdoRefRu": "ХранилищеНастроек.ХранилищеНастроек1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE",
+      "modules": [
+        1
+      ],
+      "forms": [],
+      "templates": []
+    }
+  ],
+  "styleItems": [
+    {
+      "uuid": "68047ae8-62aa-4696-9780-d364feb3cc10",
+      "name": "ЭлементСтиля1",
+      "mdoReference": {
+        "type": "STYLE_ITEM",
+        "mdoRef": "StyleItem.ЭлементСтиля1",
+        "mdoRefRu": "ЭлементСтиля.ЭлементСтиля1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE"
+    }
+  ],
+  "styles": [],
+  "subsystems": [
+    [
+      2
+    ],
+    [
+      2
+    ]
+  ],
+  "supportVariant": "NONE",
+  "synchronousExtensionAndAddInCallUseMode": "USE_WITH_WARNINGS",
+  "synchronousPlatformExtensionAndAddInCallUseMode": "DONT_USE",
+  "synonym": {
+    "content": []
+  },
+  "tasks": [
+    {
+      "uuid": "c251fcec-ec02-4ef4-8f70-4d70db6631ea",
+      "name": "Задача1",
+      "mdoReference": {
+        "type": "TASK",
+        "mdoRef": "Task.Задача1",
+        "mdoRefRu": "Задача.Задача1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE",
+      "modules": [
+        0
+      ],
+      "commands": [],
+      "attributes": [],
+      "tabularSections": [],
+      "forms": [],
+      "templates": [],
+      "addressingAttributes": [
+        {
+          "uuid": "bf531047-7ec7-4c74-bfdb-917138b2127c",
+          "name": "РеквизитАдресации",
+          "mdoReference": {
+            "type": "TASK_ADDRESSING_ATTRIBUTE",
+            "mdoRef": "Task.Задача1.AddressingAttribute.РеквизитАдресации",
+            "mdoRefRu": "Задача.Задача1.РеквизитАдресации.РеквизитАдресации"
+          },
+          "objectBelonging": "OWN",
+          "comment": "",
+          "synonym": {
+            "content": [
+              [
+                "ru",
+                "Реквизит адресации"
+              ]
+            ]
+          },
+          "supportVariant": "NONE",
+          "owner": {
+            "type": "TASK",
+            "mdoRef": "Task.Задача1",
+            "mdoRefRu": "Задача.Задача1"
+          },
+          "passwordMode": false,
+          "kind": "CUSTOM",
+          "indexing": "DONT_INDEX",
+          "format": {
+            "content": []
+          },
+          "editFormat": {
+            "content": []
+          },
+          "toolTip": {
+            "content": []
+          },
+          "markNegatives": false,
+          "mask": "",
+          "multiLine": false,
+          "extendedEdit": false,
+          "fillFromFillingValue": false,
+          "choiceForm": {
+            "type": "UNKNOWN",
+            "mdoRef": "",
+            "mdoRefRu": ""
+          }
+        }
+      ]
+    }
+  ],
+  "useManagedFormInOrdinaryApplication": true,
+  "useOrdinaryFormInManagedApplication": true,
+  "uuid": "46c7c1d0-b04d-4295-9b04-ae3207c18d29",
+  "vendor": "",
+  "version": "",
+  "webServices": [
+    {
+      "uuid": "d7f9b06b-0799-486e-adff-c45a2d5b8101",
+      "name": "WebСервис1",
+      "mdoReference": {
+        "type": "WEB_SERVICE",
+        "mdoRef": "WebService.WebСервис1",
+        "mdoRefRu": "WebСервис.WebСервис1"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": []
+      },
+      "supportVariant": "NONE",
+      "modules": [
+        1
+      ],
+      "namespace": "http://test.test",
+      "descriptorFileName": "ws1.1cws",
+      "reuseSessions": "AUTO_USE",
+      "sessionMaxAge": 20,
+      "operations": [
+        [
+          2
+        ],
+        [
+          2
+        ]
+      ]
+    }
+  ],
+  "wsReferences": [
+    {
+      "uuid": "95b745f2-e1fa-4f94-b7f9-f3f0224fc8c7",
+      "name": "WSСсылка",
+      "mdoReference": {
+        "type": "WS_REFERENCE",
+        "mdoRef": "WSReference.WSСсылка",
+        "mdoRefRu": "WSСсылка.WSСсылка"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": [
+          [
+            "ru",
+            "WSСсылка"
+          ]
+        ]
+      },
+      "supportVariant": "NONE",
+      "locationURL": "http://ya.ru"
+    }
+  ]
+}}

--- a/src/test/resources/fixtures/ssl_3_2/Constants.ЗаголовокСистемы.json
+++ b/src/test/resources/fixtures/ssl_3_2/Constants.ЗаголовокСистемы.json
@@ -1,0 +1,84 @@
+{"com.github._1c_syntax.bsl.mdo.Constant": {
+  "comment": "",
+  "description": "Заголовок приложения",
+  "explanation": {
+    "content": []
+  },
+  "mdoReference": {
+    "type": "CONSTANT",
+    "mdoRef": "Constant.ЗаголовокСистемы",
+    "mdoRefRu": "Константа.ЗаголовокСистемы"
+  },
+  "mdoType": "CONSTANT",
+  "moduleTypes": [],
+  "modules": [],
+  "name": "ЗаголовокСистемы",
+  "objectBelonging": "OWN",
+  "passwordMode": false,
+  "possibleRights": [
+    {
+      "default": {
+        "tag": 4
+      },
+      "int": 11,
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "VIEW",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "EDIT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "VIEW_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_SETTINGS",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_VERSION_COMMENT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "EDIT_DATA_HISTORY_VERSION_COMMENT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "SWITCH_TO_DATA_HISTORY_VERSION"
+    }
+  ],
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "content": [
+      {
+        "default": {
+          "tag": 2
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+          "langKey": "ru",
+          "value": "Заголовок приложения"
+        }
+      }
+    ]
+  },
+  "uuid": "a1875d63-4303-46f1-bdea-fc529b5891f3",
+  "valueType": {
+    "types": [
+      {
+        "default": {
+          "tag": 4
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+      }
+    ],
+    "composite": false,
+    "qualifiers": [
+      {
+        "default": {
+          "tag": 4
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+          "length": 0,
+          "allowedLength": 0,
+          "description": {
+            "value": {
+              "@class": "com.github._1c_syntax.bsl.types.MultiName",
+              "nameRu": "КвалификаторыСтроки (0, Переменная)",
+              "nameEn": "StringQualifiers (0, Variable)"
+            }
+          }
+        }
+      }
+    ]
+  }
+}}

--- a/src/test/resources/fixtures/ssl_3_2/DataProcessors.ЗагрузкаКурсовВалют.json
+++ b/src/test/resources/fixtures/ssl_3_2/DataProcessors.ЗагрузкаКурсовВалют.json
@@ -212,51 +212,9 @@
                 "items": [
                   [
                     {
-                      "type": "USUAL_BUTTON",
-                      "id": 32,
-                      "name": "ФормаЗагрузитьКурсыВалют",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Загрузить и закрыть"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "COMMAND_BAR",
-                      "id": 42,
-                      "name": "КоманднаяПанельЛевая",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Командная панель левая"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
                       "type": "INPUT_FIELD",
-                      "id": 2,
-                      "name": "НачалоПериода",
+                      "id": 106,
+                      "name": "Период",
                       "title": {
                         "content": [
                           {
@@ -266,18 +224,18 @@
                             "int": 1,
                             "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                               "langKey": "ru",
-                              "value": "С"
+                              "value": "Период"
                             }
                           }
                         ]
                       },
-                      "dataPath": "Объект.НачалоПериодаЗагрузки",
+                      "dataPath": "Период",
                       "items": []
                     },
                     {
-                      "type": "INPUT_FIELD",
-                      "id": 3,
-                      "name": "ОкончаниеПериода",
+                      "type": "USUAL_GROUP",
+                      "id": 145,
+                      "name": "КоманднаяПанельПраво",
                       "title": {
                         "content": [
                           {
@@ -287,100 +245,34 @@
                             "int": 1,
                             "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                               "langKey": "ru",
-                              "value": "По"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "Объект.ОкончаниеПериодаЗагрузки",
-                      "items": []
-                    },
-                    {
-                      "type": "COMMAND_BAR",
-                      "id": 44,
-                      "name": "КоманднаяПанельПравая",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Командная панель правая"
+                              "value": "Командная панель право"
                             }
                           }
                         ]
                       },
                       "dataPath": "",
                       "items": [
-                        [
-                          {
-                            "type": "COMMAND_BAR_BUTTON",
-                            "id": 35,
-                            "name": "ФормаВыбратьВсеВалюты",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Выбрать все валюты"
-                                  }
+                        {
+                          "type": "SEARCH_STRING_ADDITION",
+                          "id": 87,
+                          "name": "СтрокаПоиска",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Поиск"
                                 }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": []
+                              }
+                            ]
                           },
-                          {
-                            "type": "COMMAND_BAR_BUTTON",
-                            "id": 36,
-                            "name": "ФормаСнятьВыбор",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Снять выбор"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "SEARCH_STRING_ADDITION",
-                            "id": 87,
-                            "name": "СтрокаПоиска",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Поиск"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": []
-                          }
-                        ],
-                        []
+                          "dataPath": "",
+                          "items": []
+                        }
                       ]
                     }
                   ],
@@ -449,16 +341,6 @@
                           "dataPath": "Объект.СписокВалют",
                           "items": [
                             [
-                              {
-                                "type": "CHECK_BOX_FIELD",
-                                "id": 33,
-                                "name": "Загружать",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
-                                },
-                                "dataPath": "Объект.СписокВалют.Загружать",
-                                "items": []
-                              },
                               {
                                 "type": "LABEL_FIELD",
                                 "id": 9,
@@ -550,16 +432,6 @@
                                   "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
                                 },
                                 "dataPath": "Объект.СписокВалют.Кратность",
-                                "items": []
-                              },
-                              {
-                                "type": "INPUT_FIELD",
-                                "id": 84,
-                                "name": "СписокВалютОтступ",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
-                                },
-                                "dataPath": "Объект.СписокВалют.Отступ",
                                 "items": []
                               }
                             ],
@@ -692,6 +564,26 @@
                       },
                       "int": 1,
                       "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "BOOLEAN"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 3,
+                "name": "Период",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "STANDARD_PERIOD"
                     }
                   ],
                   "composite": false,
@@ -905,6 +797,10 @@
             [
               {
                 "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler"
+              },
+              {
+                "event": "BeforeClose",
+                "name": "ПередЗакрытием"
               },
               {
                 "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[2]"
@@ -1559,7 +1455,7 @@
                     "id": 4,
                     "name": "КодВалюты",
                     "title": {
-                      "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                     },
                     "dataPath": "Валюты.КодВалютыЦифровой",
                     "items": []
@@ -1569,7 +1465,7 @@
                     "id": 6,
                     "name": "КраткоеНаименование",
                     "title": {
-                      "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                     },
                     "dataPath": "Валюты.КодВалютыБуквенный",
                     "items": []
@@ -1925,7 +1821,7 @@
             "objectBelonging": "OWN",
             "comment": "",
             "synonym": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
             },
             "supportVariant": "NOT_EDITABLE",
             "owner": {

--- a/src/test/resources/fixtures/ssl_3_2/DataProcessors.ЗагрузкаКурсовВалют.json
+++ b/src/test/resources/fixtures/ssl_3_2/DataProcessors.ЗагрузкаКурсовВалют.json
@@ -1,0 +1,2389 @@
+{"com.github._1c_syntax.bsl.mdo.DataProcessor": {
+  "attributes": [
+    [
+      {
+        "uuid": "62f97480-7d4a-48f3-9d1d-612909b242c9",
+        "name": "НачалоПериодаЗагрузки",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "DataProcessor.ЗагрузкаКурсовВалют.Attribute.НачалоПериодаЗагрузки",
+          "mdoRefRu": "Обработка.ЗагрузкаКурсовВалют.Реквизит.НачалоПериодаЗагрузки"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Начало периода загрузки"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "type": "DATA_PROCESSOR",
+          "mdoRef": "DataProcessor.ЗагрузкаКурсовВалют",
+          "mdoRefRu": "Обработка.ЗагрузкаКурсовВалют"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "DATE"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.DateQualifiers": {
+                "dateFractions": 1,
+                "description": {
+                  "value": {
+                    "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                    "nameRu": "КвалификаторыДаты (Дата)",
+                    "nameEn": "DateQualifiers (Date)"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "format": {
+          "content": []
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "2b4f6e2f-6cc4-4c7c-98a6-786f3793366b",
+        "name": "ОкончаниеПериодаЗагрузки",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "DataProcessor.ЗагрузкаКурсовВалют.Attribute.ОкончаниеПериодаЗагрузки",
+          "mdoRefRu": "Обработка.ЗагрузкаКурсовВалют.Реквизит.ОкончаниеПериодаЗагрузки"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Окончание периода загрузки"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      }
+    ],
+    []
+  ],
+  "commands": [],
+  "comment": "",
+  "description": "Загрузка курсов валют",
+  "explanation": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+  },
+  "forms": [
+    [
+      {
+        "uuid": "6fcd2a3a-4d66-40e3-bde0-5c274b43783f",
+        "name": "Форма",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "DataProcessor.ЗагрузкаКурсовВалют.Form.Форма",
+          "mdoRefRu": "Обработка.ЗагрузкаКурсовВалют.Форма.Форма"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Форма"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/DataProcessors/ЗагрузкаКурсовВалют/Forms/Форма/Ext/Form/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+          },
+          "handlers": [
+            [
+              {
+                "event": "OnOpen",
+                "name": "ПриОткрытии"
+              },
+              {
+                "event": "OnCreateAtServer",
+                "name": "ПриСозданииНаСервере"
+              }
+            ],
+            []
+          ],
+          "items": [
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 43,
+                "name": "КоманднаяПанель",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Командная панель"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "USUAL_BUTTON",
+                      "id": 32,
+                      "name": "ФормаЗагрузитьКурсыВалют",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Загрузить и закрыть"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "COMMAND_BAR",
+                      "id": 42,
+                      "name": "КоманднаяПанельЛевая",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Командная панель левая"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 2,
+                      "name": "НачалоПериода",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "С"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "Объект.НачалоПериодаЗагрузки",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 3,
+                      "name": "ОкончаниеПериода",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "По"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "Объект.ОкончаниеПериодаЗагрузки",
+                      "items": []
+                    },
+                    {
+                      "type": "COMMAND_BAR",
+                      "id": 44,
+                      "name": "КоманднаяПанельПравая",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Командная панель правая"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "COMMAND_BAR_BUTTON",
+                            "id": 35,
+                            "name": "ФормаВыбратьВсеВалюты",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Выбрать все валюты"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "COMMAND_BAR_BUTTON",
+                            "id": 36,
+                            "name": "ФормаСнятьВыбор",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Снять выбор"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "SEARCH_STRING_ADDITION",
+                            "id": 87,
+                            "name": "СтрокаПоиска",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Поиск"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "PAGES",
+                "id": 63,
+                "name": "Страницы",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Страницы"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "PAGE",
+                      "id": 65,
+                      "name": "СтраницаСписокВалют",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Страница список валют"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        {
+                          "type": "TABLE",
+                          "id": 7,
+                          "name": "СписокВалют",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Валют"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "Объект.СписокВалют",
+                          "items": [
+                            [
+                              {
+                                "type": "CHECK_BOX_FIELD",
+                                "id": 33,
+                                "name": "Загружать",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+                                },
+                                "dataPath": "Объект.СписокВалют.Загружать",
+                                "items": []
+                              },
+                              {
+                                "type": "LABEL_FIELD",
+                                "id": 9,
+                                "name": "КодВалюты",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Цифр. код"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "Объект.СписокВалют.КодВалюты",
+                                "items": []
+                              },
+                              {
+                                "type": "LABEL_FIELD",
+                                "id": 40,
+                                "name": "СписокВалютСимвольныйКод",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Симв. код"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "Объект.СписокВалют.СимвольныйКод",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 38,
+                                "name": "СписокВалютПредставление",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Валюта"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "Объект.СписокВалют.Представление",
+                                "items": []
+                              },
+                              {
+                                "type": "LABEL_FIELD",
+                                "id": 11,
+                                "name": "ДатаКурса",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+                                },
+                                "dataPath": "Объект.СписокВалют.ДатаКурса",
+                                "items": []
+                              },
+                              {
+                                "type": "LABEL_FIELD",
+                                "id": 12,
+                                "name": "Курс",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+                                },
+                                "dataPath": "Объект.СписокВалют.Курс",
+                                "items": []
+                              },
+                              {
+                                "type": "LABEL_FIELD",
+                                "id": 13,
+                                "name": "Кратность",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+                                },
+                                "dataPath": "Объект.СписокВалют.Кратность",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 84,
+                                "name": "СписокВалютОтступ",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+                                },
+                                "dataPath": "Объект.СписокВалют.Отступ",
+                                "items": []
+                              }
+                            ],
+                            []
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "PAGE",
+                      "id": 67,
+                      "name": "СтраницаВыполняетсяЗагрузкаКурсов",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Страница выполняется загрузка курсов"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "PICTURE_DECORATION",
+                            "id": 69,
+                            "name": "КартинкаДлительнаяОперация",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Картинка длительная операция"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "LABEL_DECORATION",
+                            "id": 72,
+                            "name": "НадписьВыполняетсяЗагрузкаКурсовВалют",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Выполняется загрузка курсов валют..."
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "Объект",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "ОбработкаОбъект.ЗагрузкаКурсовВалют",
+                          "nameEn": "DataProcessorObject.ЗагрузкаКурсовВалют"
+                        },
+                        "variant": "METADATA",
+                        "kind": "DATA_PROCESSOR"
+                      }
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 0
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 2,
+                "name": "СообщитьЧтоКурсыАктуальны",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "BOOLEAN"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "569047c2-0879-4fba-a814-44812d21043b",
+        "name": "СообщенияОбОшибках",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "DataProcessor.ЗагрузкаКурсовВалют.Form.СообщенияОбОшибках",
+          "mdoRefRu": "Обработка.ЗагрузкаКурсовВалют.Форма.СообщенияОбОшибках"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Сообщения об ошибках"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/DataProcessors/ЗагрузкаКурсовВалют/Forms/СообщенияОбОшибках/Ext/Form/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "content": [
+              {
+                "default": {
+                  "tag": 2
+                },
+                "int": 1,
+                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                  "langKey": "ru",
+                  "value": "Подробнее"
+                }
+              }
+            ]
+          },
+          "handlers": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[2]"
+            }
+          ],
+          "items": [
+            {
+              "type": "INPUT_FIELD",
+              "id": 1,
+              "name": "Текст",
+              "title": {
+                "content": [
+                  {
+                    "default": {
+                      "tag": 2
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                      "langKey": "ru",
+                      "value": "Текст"
+                    }
+                  }
+                ]
+              },
+              "dataPath": "Текст",
+              "items": []
+            }
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "Объект",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 2,
+                "name": "Текст",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                        "length": 0,
+                        "allowedLength": 0,
+                        "description": {
+                          "value": {
+                            "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                            "nameRu": "КвалификаторыСтроки (0, Переменная)",
+                            "nameEn": "StringQualifiers (0, Variable)"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "0c3c4494-c037-431e-9eeb-9b6cfd7372c3",
+        "name": "ПараметрыПрописиВалюты_ru",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "DataProcessor.ЗагрузкаКурсовВалют.Form.ПараметрыПрописиВалюты_ru",
+          "mdoRefRu": "Обработка.ЗагрузкаКурсовВалют.Форма.ПараметрыПрописиВалюты_ru"
+        },
+        "objectBelonging": "OWN",
+        "comment": "АПК:58",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Параметры прописи валюты на русском языке"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/DataProcessors/ЗагрузкаКурсовВалют/Forms/ПараметрыПрописиВалюты_ru/Ext/Form/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+          },
+          "handlers": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[2]"
+              }
+            ],
+            []
+          ],
+          "items": [
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 9,
+                "name": "СклонениеЦелойЧасти",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Целая часть"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 13,
+                      "name": "ЦелаяЧастьРод",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Род"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "ЦелаяЧастьРод",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 10,
+                      "name": "ЦелаяЧастьОдин",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Один"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "ЦелаяЧастьОдин",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 11,
+                      "name": "ЦелаяЧастьДва",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Два"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "ЦелаяЧастьДва",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 12,
+                      "name": "ПолеПрописи3наРусском",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Пять"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "ЦелаяЧастьПять",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 55,
+                "name": "ГруппаПараметрыДробнойЧасти",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Дробная часть"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 14,
+                      "name": "СклонениеДробнойЧасти",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Склонение дробной части"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 18,
+                            "name": "ДробнаяЧастьРод",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                            },
+                            "dataPath": "ДробнаяЧастьРод",
+                            "items": []
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 17,
+                            "name": "ДробнаяЧастьОдин",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                            },
+                            "dataPath": "ДробнаяЧастьОдин",
+                            "items": []
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 16,
+                            "name": "ДробнаяЧастьДва",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                            },
+                            "dataPath": "ДробнаяЧастьДва",
+                            "items": []
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 15,
+                            "name": "ДробнаяЧастьПять",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                            },
+                            "dataPath": "ДробнаяЧастьПять",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 56,
+                      "name": "ГруппаЧислоРазрядовДробнойЧасти",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Число разрядов дробной части"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        {
+                          "type": "INPUT_FIELD",
+                          "id": 20,
+                          "name": "ДлинаДробнойЧасти",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                          },
+                          "dataPath": "ДлинаДробнойЧасти",
+                          "items": []
+                        }
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 61,
+                "name": "ГруппаПримерПрописи",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Пример прописи суммы"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 59,
+                      "name": "СуммаЧисло",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Сумма"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "СуммаЧисло",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 62,
+                      "name": "СуммаПрописью",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Сумма прописью"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "СуммаПрописью",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 2,
+                "name": "ЦелаяЧастьОдин",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Целая часть один"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                        "length": 25,
+                        "allowedLength": 0,
+                        "description": {}
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 3,
+                "name": "ЦелаяЧастьДва",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Целая часть два"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 4,
+                "name": "ЦелаяЧастьПять",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Целая часть пять"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 5,
+                "name": "ЦелаяЧастьРод",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Целая часть род"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[2]/type"
+                }
+              },
+              {
+                "id": 6,
+                "name": "ДробнаяЧастьОдин",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Дробная часть один"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 7,
+                "name": "ДробнаяЧастьДва",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Дробная часть два"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 8,
+                "name": "ДробнаяЧастьПять",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Дробная часть пять"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 9,
+                "name": "ДробнаяЧастьРод",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Дробная часть род"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 11,
+                "name": "ДлинаДробнойЧасти",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[2]/type"
+                }
+              },
+              {
+                "id": 10,
+                "name": "ЗависимыйКурсВалют",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[2]/type"
+                }
+              },
+              {
+                "id": 12,
+                "name": "СуммаЧисло",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Сумма число"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                        "precision": 10,
+                        "scale": 2,
+                        "nonNegative": true,
+                        "description": {}
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 13,
+                "name": "СуммаПрописью",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[2]/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "80512d95-5458-4934-98ae-a7b58099196b",
+        "name": "ПодборВалютИзКлассификатора",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "DataProcessor.ЗагрузкаКурсовВалют.Form.ПодборВалютИзКлассификатора",
+          "mdoRefRu": "Обработка.ЗагрузкаКурсовВалют.Форма.ПодборВалютИзКлассификатора"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Подбор валют из классификатора"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/DataProcessors/ЗагрузкаКурсовВалют/Forms/ПодборВалютИзКлассификатора/Ext/Form/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+          },
+          "handlers": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[2]"
+            }
+          ],
+          "items": [
+            {
+              "type": "TABLE",
+              "id": 1,
+              "name": "СписокВалют",
+              "title": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+              },
+              "dataPath": "Валюты",
+              "items": [
+                [
+                  {
+                    "type": "INPUT_FIELD",
+                    "id": 4,
+                    "name": "КодВалюты",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                    },
+                    "dataPath": "Валюты.КодВалютыЦифровой",
+                    "items": []
+                  },
+                  {
+                    "type": "INPUT_FIELD",
+                    "id": 6,
+                    "name": "КраткоеНаименование",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                    },
+                    "dataPath": "Валюты.КодВалютыБуквенный",
+                    "items": []
+                  },
+                  {
+                    "type": "INPUT_FIELD",
+                    "id": 8,
+                    "name": "Наименование",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Наименование валюты"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "Валюты.Наименование",
+                    "items": []
+                  },
+                  {
+                    "type": "INPUT_FIELD",
+                    "id": 10,
+                    "name": "СтраныИТерритории",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Страны и территории"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "Валюты.СтраныИТерритории",
+                    "items": []
+                  },
+                  {
+                    "type": "CHECK_BOX_FIELD",
+                    "id": 15,
+                    "name": "Загружается",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Загружается из Интернета"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "Валюты.Загружается",
+                    "items": []
+                  }
+                ],
+                []
+              ]
+            }
+          ],
+          "attributes": [
+            {
+              "id": 1,
+              "name": "Валюты",
+              "title": {
+                "content": [
+                  {
+                    "default": {
+                      "tag": 2
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                      "langKey": "ru",
+                      "value": "Валюты"
+                    }
+                  }
+                ]
+              },
+              "type": {
+                "types": [
+                  {
+                    "default": {
+                      "tag": 4
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.value.V8ValueType": "VALUE_TABLE"
+                  }
+                ],
+                "composite": false,
+                "qualifiers": []
+              }
+            }
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      }
+    ],
+    []
+  ],
+  "mdoReference": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/owner"
+  },
+  "mdoType": "DATA_PROCESSOR",
+  "moduleTypes": [
+    [
+      "ManagerModule",
+      [
+        "src/test/resources/ext/designer/ssl_3_2/src/cf/DataProcessors/ЗагрузкаКурсовВалют/Ext/ManagerModule.bsl"
+      ]
+    ],
+    [
+      "ObjectModule",
+      [
+        "src/test/resources/ext/designer/ssl_3_2/src/cf/DataProcessors/ЗагрузкаКурсовВалют/Ext/ObjectModule.bsl"
+      ]
+    ]
+  ],
+  "modules": [
+    {
+      "moduleType": "ManagerModule",
+      "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/DataProcessors/ЗагрузкаКурсовВалют/Ext/ManagerModule.bsl",
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/owner"
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "isProtected": false
+    },
+    {
+      "moduleType": "ObjectModule",
+      "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/DataProcessors/ЗагрузкаКурсовВалют/Ext/ObjectModule.bsl",
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/owner"
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "isProtected": false
+    }
+  ],
+  "name": "ЗагрузкаКурсовВалют",
+  "objectBelonging": "OWN",
+  "possibleRights": [
+    {
+      "default": {
+        "tag": 4
+      },
+      "int": 3,
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "EDIT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "USE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "VIEW"
+    }
+  ],
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "content": [
+      {
+        "default": {
+          "tag": 2
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+          "langKey": "ru",
+          "value": "Загрузка курсов валют"
+        }
+      }
+    ]
+  },
+  "tabularSections": [
+    {
+      "uuid": "3068be84-a401-4701-8ac9-411fae130f84",
+      "name": "СписокВалют",
+      "mdoReference": {
+        "type": "TABULAR_SECTION",
+        "mdoRef": "DataProcessor.ЗагрузкаКурсовВалют.TabularSection.СписокВалют",
+        "mdoRefRu": "Обработка.ЗагрузкаКурсовВалют.ТабличнаяЧасть.СписокВалют"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": [
+          {
+            "default": {
+              "tag": 2
+            },
+            "int": 1,
+            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+              "langKey": "ru",
+              "value": "Список валют"
+            }
+          }
+        ]
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/owner"
+      },
+      "attributes": [
+        [
+          {
+            "uuid": "3068be84-a401-4701-8ac9-411fae130f84",
+            "mdoReference": {
+              "type": "STANDARD_ATTRIBUTE",
+              "mdoRef": "DataProcessor.ЗагрузкаКурсовВалют.TabularSection.СписокВалют.StandardAttribute.LineNumber",
+              "mdoRefRu": "Обработка.ЗагрузкаКурсовВалют.ТабличнаяЧасть.СписокВалют.СтандартныйРеквизит.НомерСтроки"
+            },
+            "comment": "",
+            "synonym": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+            },
+            "passwordMode": false,
+            "kind": "STANDARD",
+            "type": {
+              "types": [
+                {
+                  "default": {
+                    "tag": 4
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER"
+                }
+              ],
+              "composite": false,
+              "qualifiers": [
+                {
+                  "default": {
+                    "tag": 4
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                    "precision": 5,
+                    "scale": 0,
+                    "nonNegative": false,
+                    "description": {}
+                  }
+                }
+              ]
+            },
+            "fullName": {
+              "nameRu": "НомерСтроки",
+              "nameEn": "LineNumber"
+            },
+            "format": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+            },
+            "editFormat": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+            },
+            "markNegatives": false,
+            "mask": "",
+            "multiLine": false,
+            "extendedEdit": false,
+            "fillFromFillingValue": false
+          },
+          {
+            "uuid": "957394a7-e5b8-47fc-8680-1e71efe2be7d",
+            "name": "КодВалюты",
+            "mdoReference": {
+              "type": "ATTRIBUTE",
+              "mdoRef": "DataProcessor.ЗагрузкаКурсовВалют.TabularSection.СписокВалют.Attribute.КодВалюты",
+              "mdoRefRu": "Обработка.ЗагрузкаКурсовВалют.ТабличнаяЧасть.СписокВалют.Реквизит.КодВалюты"
+            },
+            "objectBelonging": "OWN",
+            "comment": "",
+            "synonym": {
+              "content": [
+                {
+                  "default": {
+                    "tag": 2
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                    "langKey": "ru",
+                    "value": "Код валюты"
+                  }
+                }
+              ]
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+            },
+            "passwordMode": false,
+            "kind": "CUSTOM",
+            "indexing": "DONT_INDEX",
+            "type": {
+              "types": [
+                {
+                  "default": {
+                    "tag": 4
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+                }
+              ],
+              "composite": false,
+              "qualifiers": [
+                {
+                  "default": {
+                    "tag": 4
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                    "length": 3,
+                    "allowedLength": 0,
+                    "description": {}
+                  }
+                }
+              ]
+            },
+            "format": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+            },
+            "editFormat": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+            },
+            "markNegatives": false,
+            "mask": "",
+            "multiLine": false,
+            "extendedEdit": false,
+            "fillFromFillingValue": false
+          },
+          {
+            "uuid": "ba49a9e4-6ec1-43ff-92cd-9dbf221bbf09",
+            "name": "Валюта",
+            "mdoReference": {
+              "type": "ATTRIBUTE",
+              "mdoRef": "DataProcessor.ЗагрузкаКурсовВалют.TabularSection.СписокВалют.Attribute.Валюта",
+              "mdoRefRu": "Обработка.ЗагрузкаКурсовВалют.ТабличнаяЧасть.СписокВалют.Реквизит.Валюта"
+            },
+            "objectBelonging": "OWN",
+            "comment": "",
+            "synonym": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+            },
+            "passwordMode": false,
+            "kind": "CUSTOM",
+            "indexing": "DONT_INDEX",
+            "type": {
+              "types": [
+                {
+                  "default": {
+                    "tag": 4
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                    "fullName": {
+                      "nameRu": "СправочникСсылка.Валюты",
+                      "nameEn": "CatalogRef.Валюты"
+                    },
+                    "variant": "METADATA",
+                    "kind": "CATALOG"
+                  }
+                }
+              ],
+              "composite": false,
+              "qualifiers": []
+            },
+            "format": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+            },
+            "editFormat": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+            },
+            "markNegatives": false,
+            "mask": "",
+            "multiLine": false,
+            "extendedEdit": false,
+            "fillFromFillingValue": false
+          },
+          {
+            "uuid": "4f25ef45-c8d9-401d-b0e8-2217ac310f04",
+            "name": "ДатаКурса",
+            "mdoReference": {
+              "type": "ATTRIBUTE",
+              "mdoRef": "DataProcessor.ЗагрузкаКурсовВалют.TabularSection.СписокВалют.Attribute.ДатаКурса",
+              "mdoRefRu": "Обработка.ЗагрузкаКурсовВалют.ТабличнаяЧасть.СписокВалют.Реквизит.ДатаКурса"
+            },
+            "objectBelonging": "OWN",
+            "comment": "",
+            "synonym": {
+              "content": [
+                {
+                  "default": {
+                    "tag": 2
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                    "langKey": "ru",
+                    "value": "Дата курса"
+                  }
+                }
+              ]
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+            },
+            "passwordMode": false,
+            "kind": "CUSTOM",
+            "indexing": "DONT_INDEX",
+            "type": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/type"
+            },
+            "format": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+            },
+            "editFormat": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+            },
+            "markNegatives": false,
+            "mask": "",
+            "multiLine": false,
+            "extendedEdit": false,
+            "fillFromFillingValue": false
+          },
+          {
+            "uuid": "504ca240-b5ae-433e-ae5f-d818263eea23",
+            "name": "Курс",
+            "mdoReference": {
+              "type": "ATTRIBUTE",
+              "mdoRef": "DataProcessor.ЗагрузкаКурсовВалют.TabularSection.СписокВалют.Attribute.Курс",
+              "mdoRefRu": "Обработка.ЗагрузкаКурсовВалют.ТабличнаяЧасть.СписокВалют.Реквизит.Курс"
+            },
+            "objectBelonging": "OWN",
+            "comment": "",
+            "synonym": {
+              "content": [
+                {
+                  "default": {
+                    "tag": 2
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                    "langKey": "ru",
+                    "value": "Курс"
+                  }
+                }
+              ]
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+            },
+            "passwordMode": false,
+            "kind": "CUSTOM",
+            "indexing": "DONT_INDEX",
+            "type": {
+              "types": [
+                {
+                  "default": {
+                    "tag": 4
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER"
+                }
+              ],
+              "composite": false,
+              "qualifiers": [
+                {
+                  "default": {
+                    "tag": 4
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                    "precision": 10,
+                    "scale": 4,
+                    "nonNegative": true,
+                    "description": {}
+                  }
+                }
+              ]
+            },
+            "format": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+            },
+            "editFormat": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+            },
+            "markNegatives": false,
+            "mask": "",
+            "multiLine": false,
+            "extendedEdit": false,
+            "fillFromFillingValue": false
+          },
+          {
+            "uuid": "32461819-9437-417d-8d1e-851c9a2dcee2",
+            "name": "Кратность",
+            "mdoReference": {
+              "type": "ATTRIBUTE",
+              "mdoRef": "DataProcessor.ЗагрузкаКурсовВалют.TabularSection.СписокВалют.Attribute.Кратность",
+              "mdoRefRu": "Обработка.ЗагрузкаКурсовВалют.ТабличнаяЧасть.СписокВалют.Реквизит.Кратность"
+            },
+            "objectBelonging": "OWN",
+            "comment": "",
+            "synonym": {
+              "content": [
+                {
+                  "default": {
+                    "tag": 2
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                    "langKey": "ru",
+                    "value": "Кратность"
+                  }
+                }
+              ]
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+            },
+            "passwordMode": false,
+            "kind": "CUSTOM",
+            "indexing": "DONT_INDEX",
+            "type": {
+              "types": [
+                {
+                  "default": {
+                    "tag": 4
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER"
+                }
+              ],
+              "composite": false,
+              "qualifiers": [
+                {
+                  "default": {
+                    "tag": 4
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                    "precision": 10,
+                    "scale": 0,
+                    "nonNegative": true,
+                    "description": {}
+                  }
+                }
+              ]
+            },
+            "format": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+            },
+            "editFormat": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+            },
+            "markNegatives": false,
+            "mask": "",
+            "multiLine": false,
+            "extendedEdit": false,
+            "fillFromFillingValue": false
+          },
+          {
+            "uuid": "74228950-8a4b-4dd6-a053-8650de202521",
+            "name": "Загружать",
+            "mdoReference": {
+              "type": "ATTRIBUTE",
+              "mdoRef": "DataProcessor.ЗагрузкаКурсовВалют.TabularSection.СписокВалют.Attribute.Загружать",
+              "mdoRefRu": "Обработка.ЗагрузкаКурсовВалют.ТабличнаяЧасть.СписокВалют.Реквизит.Загружать"
+            },
+            "objectBelonging": "OWN",
+            "comment": "",
+            "synonym": {
+              "content": [
+                {
+                  "default": {
+                    "tag": 2
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                    "langKey": "ru",
+                    "value": "Загружать"
+                  }
+                }
+              ]
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+            },
+            "passwordMode": false,
+            "kind": "CUSTOM",
+            "indexing": "DONT_INDEX",
+            "type": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[2]/type"
+            },
+            "format": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+            },
+            "editFormat": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+            },
+            "markNegatives": false,
+            "mask": "",
+            "multiLine": false,
+            "extendedEdit": false,
+            "fillFromFillingValue": false
+          },
+          {
+            "uuid": "6b9ce91e-08b9-4972-9878-1724c67b68ec",
+            "name": "Представление",
+            "mdoReference": {
+              "type": "ATTRIBUTE",
+              "mdoRef": "DataProcessor.ЗагрузкаКурсовВалют.TabularSection.СписокВалют.Attribute.Представление",
+              "mdoRefRu": "Обработка.ЗагрузкаКурсовВалют.ТабличнаяЧасть.СписокВалют.Реквизит.Представление"
+            },
+            "objectBelonging": "OWN",
+            "comment": "",
+            "synonym": {
+              "content": [
+                {
+                  "default": {
+                    "tag": 2
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                    "langKey": "ru",
+                    "value": "Представление"
+                  }
+                }
+              ]
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+            },
+            "passwordMode": false,
+            "kind": "CUSTOM",
+            "indexing": "DONT_INDEX",
+            "type": {
+              "types": [
+                {
+                  "default": {
+                    "tag": 4
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+                }
+              ],
+              "composite": false,
+              "qualifiers": [
+                {
+                  "default": {
+                    "tag": 4
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                    "length": 50,
+                    "allowedLength": 0,
+                    "description": {
+                      "value": {
+                        "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                        "nameRu": "КвалификаторыСтроки (50, Переменная)",
+                        "nameEn": "StringQualifiers (50, Variable)"
+                      }
+                    }
+                  }
+                }
+              ]
+            },
+            "format": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+            },
+            "editFormat": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+            },
+            "markNegatives": false,
+            "mask": "",
+            "multiLine": false,
+            "extendedEdit": false,
+            "fillFromFillingValue": false
+          },
+          {
+            "uuid": "640814f2-6082-475e-8006-25fd5b24afdb",
+            "name": "СимвольныйКод",
+            "mdoReference": {
+              "type": "ATTRIBUTE",
+              "mdoRef": "DataProcessor.ЗагрузкаКурсовВалют.TabularSection.СписокВалют.Attribute.СимвольныйКод",
+              "mdoRefRu": "Обработка.ЗагрузкаКурсовВалют.ТабличнаяЧасть.СписокВалют.Реквизит.СимвольныйКод"
+            },
+            "objectBelonging": "OWN",
+            "comment": "",
+            "synonym": {
+              "content": [
+                {
+                  "default": {
+                    "tag": 2
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                    "langKey": "ru",
+                    "value": "Символьный код"
+                  }
+                }
+              ]
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+            },
+            "passwordMode": false,
+            "kind": "CUSTOM",
+            "indexing": "DONT_INDEX",
+            "type": {
+              "types": [
+                {
+                  "default": {
+                    "tag": 4
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+                }
+              ],
+              "composite": false,
+              "qualifiers": [
+                {
+                  "default": {
+                    "tag": 4
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                    "length": 10,
+                    "allowedLength": 0,
+                    "description": {
+                      "value": {
+                        "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                        "nameRu": "КвалификаторыСтроки (10, Переменная)",
+                        "nameEn": "StringQualifiers (10, Variable)"
+                      }
+                    }
+                  }
+                }
+              ]
+            },
+            "format": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+            },
+            "editFormat": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+            },
+            "markNegatives": false,
+            "mask": "",
+            "multiLine": false,
+            "extendedEdit": false,
+            "fillFromFillingValue": false
+          }
+        ],
+        []
+      ]
+    }
+  ],
+  "templates": [
+    {
+      "uuid": "6f2354cd-4a34-4921-96bb-b786486f85cf",
+      "name": "ОбщероссийскийКлассификаторВалют",
+      "mdoReference": {
+        "type": "TEMPLATE",
+        "mdoRef": "DataProcessor.ЗагрузкаКурсовВалют.Template.ОбщероссийскийКлассификаторВалют",
+        "mdoRefRu": "Обработка.ЗагрузкаКурсовВалют.Макет.ОбщероссийскийКлассификаторВалют"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": [
+          {
+            "default": {
+              "tag": 2
+            },
+            "int": 1,
+            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+              "langKey": "ru",
+              "value": "Общероссийский классификатор валют"
+            }
+          }
+        ]
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "modules": [],
+      "templateType": "TEXT_DOCUMENT",
+      "data": {
+        "@class": "com.github._1c_syntax.bsl.mdo.storage.EmptyTemplateData"
+      },
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/owner"
+      }
+    }
+  ],
+  "uuid": "f36150de-33af-4410-8a4c-8c9f4b545793"
+}}

--- a/src/test/resources/fixtures/ssl_3_2/DataProcessors.ЗагрузкаКурсовВалют_edt.json
+++ b/src/test/resources/fixtures/ssl_3_2/DataProcessors.ЗагрузкаКурсовВалют_edt.json
@@ -212,51 +212,9 @@
                 "items": [
                   [
                     {
-                      "type": "USUAL_BUTTON",
-                      "id": 32,
-                      "name": "ФормаЗагрузитьКурсыВалют",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Загрузить и закрыть"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "COMMAND_BAR",
-                      "id": 42,
-                      "name": "КоманднаяПанельЛевая",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Командная панель левая"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
                       "type": "INPUT_FIELD",
-                      "id": 2,
-                      "name": "НачалоПериода",
+                      "id": 106,
+                      "name": "Период",
                       "title": {
                         "content": [
                           {
@@ -266,18 +224,18 @@
                             "int": 1,
                             "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                               "langKey": "ru",
-                              "value": "С"
+                              "value": "Период"
                             }
                           }
                         ]
                       },
-                      "dataPath": "Объект.НачалоПериодаЗагрузки",
+                      "dataPath": "Период",
                       "items": []
                     },
                     {
-                      "type": "INPUT_FIELD",
-                      "id": 3,
-                      "name": "ОкончаниеПериода",
+                      "type": "USUAL_GROUP",
+                      "id": 145,
+                      "name": "КоманднаяПанельПраво",
                       "title": {
                         "content": [
                           {
@@ -287,100 +245,34 @@
                             "int": 1,
                             "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                               "langKey": "ru",
-                              "value": "По"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "Объект.ОкончаниеПериодаЗагрузки",
-                      "items": []
-                    },
-                    {
-                      "type": "COMMAND_BAR",
-                      "id": 44,
-                      "name": "КоманднаяПанельПравая",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Командная панель правая"
+                              "value": "Командная панель право"
                             }
                           }
                         ]
                       },
                       "dataPath": "",
                       "items": [
-                        [
-                          {
-                            "type": "BUTTON",
-                            "id": 35,
-                            "name": "ФормаВыбратьВсеВалюты",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Выбрать все валюты"
-                                  }
+                        {
+                          "type": "ADDITION",
+                          "id": 87,
+                          "name": "СтрокаПоиска",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Поиск"
                                 }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": []
+                              }
+                            ]
                           },
-                          {
-                            "type": "BUTTON",
-                            "id": 36,
-                            "name": "ФормаСнятьВыбор",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Снять выбор"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "ADDITION",
-                            "id": 87,
-                            "name": "СтрокаПоиска",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Поиск"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": []
-                          }
-                        ],
-                        []
+                          "dataPath": "",
+                          "items": []
+                        }
                       ]
                     }
                   ],
@@ -449,16 +341,6 @@
                           "dataPath": "Объект.СписокВалют",
                           "items": [
                             [
-                              {
-                                "type": "CHECK_BOX_FIELD",
-                                "id": 33,
-                                "name": "Загружать",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
-                                },
-                                "dataPath": "Объект.СписокВалют.Загружать",
-                                "items": []
-                              },
                               {
                                 "type": "LABEL_FIELD",
                                 "id": 9,
@@ -550,16 +432,6 @@
                                   "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
                                 },
                                 "dataPath": "Объект.СписокВалют.Кратность",
-                                "items": []
-                              },
-                              {
-                                "type": "INPUT_FIELD",
-                                "id": 84,
-                                "name": "СписокВалютОтступ",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
-                                },
-                                "dataPath": "Объект.СписокВалют.Отступ",
                                 "items": []
                               }
                             ],
@@ -692,6 +564,26 @@
                       },
                       "int": 1,
                       "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "BOOLEAN"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 3,
+                "name": "Период",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "STANDARD_PERIOD"
                     }
                   ],
                   "composite": false,
@@ -905,6 +797,10 @@
             [
               {
                 "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler"
+              },
+              {
+                "event": "BeforeClose",
+                "name": "ПередЗакрытием"
               },
               {
                 "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[2]"
@@ -1559,7 +1455,7 @@
                     "id": 4,
                     "name": "КодВалюты",
                     "title": {
-                      "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                     },
                     "dataPath": "Валюты.КодВалютыЦифровой",
                     "items": []
@@ -1569,7 +1465,7 @@
                     "id": 6,
                     "name": "КраткоеНаименование",
                     "title": {
-                      "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                     },
                     "dataPath": "Валюты.КодВалютыБуквенный",
                     "items": []
@@ -1925,7 +1821,7 @@
             "objectBelonging": "OWN",
             "comment": "",
             "synonym": {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
             },
             "supportVariant": "NOT_EDITABLE",
             "owner": {

--- a/src/test/resources/fixtures/ssl_3_2/DataProcessors.ЗагрузкаКурсовВалют_edt.json
+++ b/src/test/resources/fixtures/ssl_3_2/DataProcessors.ЗагрузкаКурсовВалют_edt.json
@@ -1,0 +1,2389 @@
+{"com.github._1c_syntax.bsl.mdo.DataProcessor": {
+  "attributes": [
+    [
+      {
+        "uuid": "62f97480-7d4a-48f3-9d1d-612909b242c9",
+        "name": "НачалоПериодаЗагрузки",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "DataProcessor.ЗагрузкаКурсовВалют.Attribute.НачалоПериодаЗагрузки",
+          "mdoRefRu": "Обработка.ЗагрузкаКурсовВалют.Реквизит.НачалоПериодаЗагрузки"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Начало периода загрузки"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "type": "DATA_PROCESSOR",
+          "mdoRef": "DataProcessor.ЗагрузкаКурсовВалют",
+          "mdoRefRu": "Обработка.ЗагрузкаКурсовВалют"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "DATE"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.DateQualifiers": {
+                "dateFractions": 1,
+                "description": {
+                  "value": {
+                    "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                    "nameRu": "КвалификаторыДаты (Дата)",
+                    "nameEn": "DateQualifiers (Date)"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "format": {
+          "content": []
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "2b4f6e2f-6cc4-4c7c-98a6-786f3793366b",
+        "name": "ОкончаниеПериодаЗагрузки",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "DataProcessor.ЗагрузкаКурсовВалют.Attribute.ОкончаниеПериодаЗагрузки",
+          "mdoRefRu": "Обработка.ЗагрузкаКурсовВалют.Реквизит.ОкончаниеПериодаЗагрузки"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Окончание периода загрузки"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      }
+    ],
+    []
+  ],
+  "commands": [],
+  "comment": "",
+  "description": "Загрузка курсов валют",
+  "explanation": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+  },
+  "forms": [
+    [
+      {
+        "uuid": "6fcd2a3a-4d66-40e3-bde0-5c274b43783f",
+        "name": "Форма",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "DataProcessor.ЗагрузкаКурсовВалют.Form.Форма",
+          "mdoRefRu": "Обработка.ЗагрузкаКурсовВалют.Форма.Форма"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Форма"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/DataProcessors/ЗагрузкаКурсовВалют/Forms/Форма/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+          },
+          "handlers": [
+            [
+              {
+                "event": "OnOpen",
+                "name": "ПриОткрытии"
+              },
+              {
+                "event": "OnCreateAtServer",
+                "name": "ПриСозданииНаСервере"
+              }
+            ],
+            []
+          ],
+          "items": [
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 43,
+                "name": "КоманднаяПанель",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Командная панель"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "USUAL_BUTTON",
+                      "id": 32,
+                      "name": "ФормаЗагрузитьКурсыВалют",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Загрузить и закрыть"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "COMMAND_BAR",
+                      "id": 42,
+                      "name": "КоманднаяПанельЛевая",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Командная панель левая"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 2,
+                      "name": "НачалоПериода",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "С"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "Объект.НачалоПериодаЗагрузки",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 3,
+                      "name": "ОкончаниеПериода",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "По"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "Объект.ОкончаниеПериодаЗагрузки",
+                      "items": []
+                    },
+                    {
+                      "type": "COMMAND_BAR",
+                      "id": 44,
+                      "name": "КоманднаяПанельПравая",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Командная панель правая"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "BUTTON",
+                            "id": 35,
+                            "name": "ФормаВыбратьВсеВалюты",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Выбрать все валюты"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "BUTTON",
+                            "id": 36,
+                            "name": "ФормаСнятьВыбор",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Снять выбор"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "ADDITION",
+                            "id": 87,
+                            "name": "СтрокаПоиска",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Поиск"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "PAGES",
+                "id": 63,
+                "name": "Страницы",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Страницы"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "PAGE",
+                      "id": 65,
+                      "name": "СтраницаСписокВалют",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Страница список валют"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        {
+                          "type": "TABLE",
+                          "id": 7,
+                          "name": "СписокВалют",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Валют"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "Объект.СписокВалют",
+                          "items": [
+                            [
+                              {
+                                "type": "CHECK_BOX_FIELD",
+                                "id": 33,
+                                "name": "Загружать",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+                                },
+                                "dataPath": "Объект.СписокВалют.Загружать",
+                                "items": []
+                              },
+                              {
+                                "type": "LABEL_FIELD",
+                                "id": 9,
+                                "name": "КодВалюты",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Цифр. код"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "Объект.СписокВалют.КодВалюты",
+                                "items": []
+                              },
+                              {
+                                "type": "LABEL_FIELD",
+                                "id": 40,
+                                "name": "СписокВалютСимвольныйКод",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Симв. код"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "Объект.СписокВалют.СимвольныйКод",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 38,
+                                "name": "СписокВалютПредставление",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Валюта"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "Объект.СписокВалют.Представление",
+                                "items": []
+                              },
+                              {
+                                "type": "LABEL_FIELD",
+                                "id": 11,
+                                "name": "ДатаКурса",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+                                },
+                                "dataPath": "Объект.СписокВалют.ДатаКурса",
+                                "items": []
+                              },
+                              {
+                                "type": "LABEL_FIELD",
+                                "id": 12,
+                                "name": "Курс",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+                                },
+                                "dataPath": "Объект.СписокВалют.Курс",
+                                "items": []
+                              },
+                              {
+                                "type": "LABEL_FIELD",
+                                "id": 13,
+                                "name": "Кратность",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+                                },
+                                "dataPath": "Объект.СписокВалют.Кратность",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 84,
+                                "name": "СписокВалютОтступ",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+                                },
+                                "dataPath": "Объект.СписокВалют.Отступ",
+                                "items": []
+                              }
+                            ],
+                            []
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "PAGE",
+                      "id": 67,
+                      "name": "СтраницаВыполняетсяЗагрузкаКурсов",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Страница выполняется загрузка курсов"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "DECORATION",
+                            "id": 69,
+                            "name": "КартинкаДлительнаяОперация",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Картинка длительная операция"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "LABEL",
+                            "id": 72,
+                            "name": "НадписьВыполняетсяЗагрузкаКурсовВалют",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Выполняется загрузка курсов валют..."
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "Объект",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "ОбработкаОбъект.ЗагрузкаКурсовВалют",
+                          "nameEn": "DataProcessorObject.ЗагрузкаКурсовВалют"
+                        },
+                        "variant": "METADATA",
+                        "kind": "DATA_PROCESSOR"
+                      }
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 0
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 2,
+                "name": "СообщитьЧтоКурсыАктуальны",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "BOOLEAN"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "569047c2-0879-4fba-a814-44812d21043b",
+        "name": "СообщенияОбОшибках",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "DataProcessor.ЗагрузкаКурсовВалют.Form.СообщенияОбОшибках",
+          "mdoRefRu": "Обработка.ЗагрузкаКурсовВалют.Форма.СообщенияОбОшибках"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Сообщения об ошибках"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/DataProcessors/ЗагрузкаКурсовВалют/Forms/СообщенияОбОшибках/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "content": [
+              {
+                "default": {
+                  "tag": 2
+                },
+                "int": 1,
+                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                  "langKey": "ru",
+                  "value": "Подробнее"
+                }
+              }
+            ]
+          },
+          "handlers": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[2]"
+            }
+          ],
+          "items": [
+            {
+              "type": "INPUT_FIELD",
+              "id": 1,
+              "name": "Текст",
+              "title": {
+                "content": [
+                  {
+                    "default": {
+                      "tag": 2
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                      "langKey": "ru",
+                      "value": "Текст"
+                    }
+                  }
+                ]
+              },
+              "dataPath": "Текст",
+              "items": []
+            }
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "Объект",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 2,
+                "name": "Текст",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                        "length": 0,
+                        "allowedLength": 0,
+                        "description": {
+                          "value": {
+                            "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                            "nameRu": "КвалификаторыСтроки (0, Переменная)",
+                            "nameEn": "StringQualifiers (0, Variable)"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "0c3c4494-c037-431e-9eeb-9b6cfd7372c3",
+        "name": "ПараметрыПрописиВалюты_ru",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "DataProcessor.ЗагрузкаКурсовВалют.Form.ПараметрыПрописиВалюты_ru",
+          "mdoRefRu": "Обработка.ЗагрузкаКурсовВалют.Форма.ПараметрыПрописиВалюты_ru"
+        },
+        "objectBelonging": "OWN",
+        "comment": "АПК:58",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Параметры прописи валюты на русском языке"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/DataProcessors/ЗагрузкаКурсовВалют/Forms/ПараметрыПрописиВалюты_ru/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+          },
+          "handlers": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[2]"
+              }
+            ],
+            []
+          ],
+          "items": [
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 9,
+                "name": "СклонениеЦелойЧасти",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Целая часть"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 13,
+                      "name": "ЦелаяЧастьРод",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Род"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "ЦелаяЧастьРод",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 10,
+                      "name": "ЦелаяЧастьОдин",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Один"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "ЦелаяЧастьОдин",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 11,
+                      "name": "ЦелаяЧастьДва",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Два"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "ЦелаяЧастьДва",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 12,
+                      "name": "ПолеПрописи3наРусском",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Пять"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "ЦелаяЧастьПять",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 55,
+                "name": "ГруппаПараметрыДробнойЧасти",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Дробная часть"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 14,
+                      "name": "СклонениеДробнойЧасти",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Склонение дробной части"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 18,
+                            "name": "ДробнаяЧастьРод",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                            },
+                            "dataPath": "ДробнаяЧастьРод",
+                            "items": []
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 17,
+                            "name": "ДробнаяЧастьОдин",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                            },
+                            "dataPath": "ДробнаяЧастьОдин",
+                            "items": []
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 16,
+                            "name": "ДробнаяЧастьДва",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                            },
+                            "dataPath": "ДробнаяЧастьДва",
+                            "items": []
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 15,
+                            "name": "ДробнаяЧастьПять",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                            },
+                            "dataPath": "ДробнаяЧастьПять",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 56,
+                      "name": "ГруппаЧислоРазрядовДробнойЧасти",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Число разрядов дробной части"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        {
+                          "type": "INPUT_FIELD",
+                          "id": 20,
+                          "name": "ДлинаДробнойЧасти",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                          },
+                          "dataPath": "ДлинаДробнойЧасти",
+                          "items": []
+                        }
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 61,
+                "name": "ГруппаПримерПрописи",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Пример прописи суммы"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 59,
+                      "name": "СуммаЧисло",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Сумма"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "СуммаЧисло",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 62,
+                      "name": "СуммаПрописью",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Сумма прописью"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "СуммаПрописью",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 2,
+                "name": "ЦелаяЧастьОдин",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Целая часть один"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                        "length": 25,
+                        "allowedLength": 0,
+                        "description": {}
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 3,
+                "name": "ЦелаяЧастьДва",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Целая часть два"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 4,
+                "name": "ЦелаяЧастьПять",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Целая часть пять"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 5,
+                "name": "ЦелаяЧастьРод",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Целая часть род"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[2]/type"
+                }
+              },
+              {
+                "id": 6,
+                "name": "ДробнаяЧастьОдин",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Дробная часть один"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 7,
+                "name": "ДробнаяЧастьДва",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Дробная часть два"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 8,
+                "name": "ДробнаяЧастьПять",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Дробная часть пять"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 9,
+                "name": "ДробнаяЧастьРод",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Дробная часть род"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 11,
+                "name": "ДлинаДробнойЧасти",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[2]/type"
+                }
+              },
+              {
+                "id": 10,
+                "name": "ЗависимыйКурсВалют",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[2]/type"
+                }
+              },
+              {
+                "id": 12,
+                "name": "СуммаЧисло",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Сумма число"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                        "precision": 10,
+                        "scale": 2,
+                        "nonNegative": true,
+                        "description": {}
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 13,
+                "name": "СуммаПрописью",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[2]/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "80512d95-5458-4934-98ae-a7b58099196b",
+        "name": "ПодборВалютИзКлассификатора",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "DataProcessor.ЗагрузкаКурсовВалют.Form.ПодборВалютИзКлассификатора",
+          "mdoRefRu": "Обработка.ЗагрузкаКурсовВалют.Форма.ПодборВалютИзКлассификатора"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Подбор валют из классификатора"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/DataProcessors/ЗагрузкаКурсовВалют/Forms/ПодборВалютИзКлассификатора/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+          },
+          "handlers": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[2]"
+            }
+          ],
+          "items": [
+            {
+              "type": "TABLE",
+              "id": 1,
+              "name": "СписокВалют",
+              "title": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+              },
+              "dataPath": "Валюты",
+              "items": [
+                [
+                  {
+                    "type": "INPUT_FIELD",
+                    "id": 4,
+                    "name": "КодВалюты",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                    },
+                    "dataPath": "Валюты.КодВалютыЦифровой",
+                    "items": []
+                  },
+                  {
+                    "type": "INPUT_FIELD",
+                    "id": 6,
+                    "name": "КраткоеНаименование",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                    },
+                    "dataPath": "Валюты.КодВалютыБуквенный",
+                    "items": []
+                  },
+                  {
+                    "type": "INPUT_FIELD",
+                    "id": 8,
+                    "name": "Наименование",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Наименование валюты"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "Валюты.Наименование",
+                    "items": []
+                  },
+                  {
+                    "type": "INPUT_FIELD",
+                    "id": 10,
+                    "name": "СтраныИТерритории",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Страны и территории"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "Валюты.СтраныИТерритории",
+                    "items": []
+                  },
+                  {
+                    "type": "CHECK_BOX_FIELD",
+                    "id": 15,
+                    "name": "Загружается",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Загружается из Интернета"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "Валюты.Загружается",
+                    "items": []
+                  }
+                ],
+                []
+              ]
+            }
+          ],
+          "attributes": [
+            {
+              "id": 1,
+              "name": "Валюты",
+              "title": {
+                "content": [
+                  {
+                    "default": {
+                      "tag": 2
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                      "langKey": "ru",
+                      "value": "Валюты"
+                    }
+                  }
+                ]
+              },
+              "type": {
+                "types": [
+                  {
+                    "default": {
+                      "tag": 4
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.value.V8ValueType": "VALUE_TABLE"
+                  }
+                ],
+                "composite": false,
+                "qualifiers": []
+              }
+            }
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      }
+    ],
+    []
+  ],
+  "mdoReference": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/owner"
+  },
+  "mdoType": "DATA_PROCESSOR",
+  "moduleTypes": [
+    [
+      "ManagerModule",
+      [
+        "src/test/resources/ext/edt/ssl_3_2/configuration/src/DataProcessors/ЗагрузкаКурсовВалют/ManagerModule.bsl"
+      ]
+    ],
+    [
+      "ObjectModule",
+      [
+        "src/test/resources/ext/edt/ssl_3_2/configuration/src/DataProcessors/ЗагрузкаКурсовВалют/ObjectModule.bsl"
+      ]
+    ]
+  ],
+  "modules": [
+    {
+      "moduleType": "ManagerModule",
+      "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/DataProcessors/ЗагрузкаКурсовВалют/ManagerModule.bsl",
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/owner"
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "isProtected": false
+    },
+    {
+      "moduleType": "ObjectModule",
+      "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/DataProcessors/ЗагрузкаКурсовВалют/ObjectModule.bsl",
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/owner"
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "isProtected": false
+    }
+  ],
+  "name": "ЗагрузкаКурсовВалют",
+  "objectBelonging": "OWN",
+  "possibleRights": [
+    {
+      "default": {
+        "tag": 4
+      },
+      "int": 3,
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "EDIT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "USE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "VIEW"
+    }
+  ],
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "content": [
+      {
+        "default": {
+          "tag": 2
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+          "langKey": "ru",
+          "value": "Загрузка курсов валют"
+        }
+      }
+    ]
+  },
+  "tabularSections": [
+    {
+      "uuid": "3068be84-a401-4701-8ac9-411fae130f84",
+      "name": "СписокВалют",
+      "mdoReference": {
+        "type": "TABULAR_SECTION",
+        "mdoRef": "DataProcessor.ЗагрузкаКурсовВалют.TabularSection.СписокВалют",
+        "mdoRefRu": "Обработка.ЗагрузкаКурсовВалют.ТабличнаяЧасть.СписокВалют"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": [
+          {
+            "default": {
+              "tag": 2
+            },
+            "int": 1,
+            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+              "langKey": "ru",
+              "value": "Список валют"
+            }
+          }
+        ]
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/owner"
+      },
+      "attributes": [
+        [
+          {
+            "uuid": "3068be84-a401-4701-8ac9-411fae130f84",
+            "mdoReference": {
+              "type": "STANDARD_ATTRIBUTE",
+              "mdoRef": "DataProcessor.ЗагрузкаКурсовВалют.TabularSection.СписокВалют.StandardAttribute.LineNumber",
+              "mdoRefRu": "Обработка.ЗагрузкаКурсовВалют.ТабличнаяЧасть.СписокВалют.СтандартныйРеквизит.НомерСтроки"
+            },
+            "comment": "",
+            "synonym": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+            },
+            "passwordMode": false,
+            "kind": "STANDARD",
+            "type": {
+              "types": [
+                {
+                  "default": {
+                    "tag": 4
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER"
+                }
+              ],
+              "composite": false,
+              "qualifiers": [
+                {
+                  "default": {
+                    "tag": 4
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                    "precision": 5,
+                    "scale": 0,
+                    "nonNegative": false,
+                    "description": {}
+                  }
+                }
+              ]
+            },
+            "fullName": {
+              "nameRu": "НомерСтроки",
+              "nameEn": "LineNumber"
+            },
+            "format": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+            },
+            "editFormat": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+            },
+            "markNegatives": false,
+            "mask": "",
+            "multiLine": false,
+            "extendedEdit": false,
+            "fillFromFillingValue": false
+          },
+          {
+            "uuid": "957394a7-e5b8-47fc-8680-1e71efe2be7d",
+            "name": "КодВалюты",
+            "mdoReference": {
+              "type": "ATTRIBUTE",
+              "mdoRef": "DataProcessor.ЗагрузкаКурсовВалют.TabularSection.СписокВалют.Attribute.КодВалюты",
+              "mdoRefRu": "Обработка.ЗагрузкаКурсовВалют.ТабличнаяЧасть.СписокВалют.Реквизит.КодВалюты"
+            },
+            "objectBelonging": "OWN",
+            "comment": "",
+            "synonym": {
+              "content": [
+                {
+                  "default": {
+                    "tag": 2
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                    "langKey": "ru",
+                    "value": "Код валюты"
+                  }
+                }
+              ]
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+            },
+            "passwordMode": false,
+            "kind": "CUSTOM",
+            "indexing": "DONT_INDEX",
+            "type": {
+              "types": [
+                {
+                  "default": {
+                    "tag": 4
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+                }
+              ],
+              "composite": false,
+              "qualifiers": [
+                {
+                  "default": {
+                    "tag": 4
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                    "length": 3,
+                    "allowedLength": 0,
+                    "description": {}
+                  }
+                }
+              ]
+            },
+            "format": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+            },
+            "editFormat": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+            },
+            "markNegatives": false,
+            "mask": "",
+            "multiLine": false,
+            "extendedEdit": false,
+            "fillFromFillingValue": false
+          },
+          {
+            "uuid": "ba49a9e4-6ec1-43ff-92cd-9dbf221bbf09",
+            "name": "Валюта",
+            "mdoReference": {
+              "type": "ATTRIBUTE",
+              "mdoRef": "DataProcessor.ЗагрузкаКурсовВалют.TabularSection.СписокВалют.Attribute.Валюта",
+              "mdoRefRu": "Обработка.ЗагрузкаКурсовВалют.ТабличнаяЧасть.СписокВалют.Реквизит.Валюта"
+            },
+            "objectBelonging": "OWN",
+            "comment": "",
+            "synonym": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+            },
+            "passwordMode": false,
+            "kind": "CUSTOM",
+            "indexing": "DONT_INDEX",
+            "type": {
+              "types": [
+                {
+                  "default": {
+                    "tag": 4
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                    "fullName": {
+                      "nameRu": "СправочникСсылка.Валюты",
+                      "nameEn": "CatalogRef.Валюты"
+                    },
+                    "variant": "METADATA",
+                    "kind": "CATALOG"
+                  }
+                }
+              ],
+              "composite": false,
+              "qualifiers": []
+            },
+            "format": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+            },
+            "editFormat": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+            },
+            "markNegatives": false,
+            "mask": "",
+            "multiLine": false,
+            "extendedEdit": false,
+            "fillFromFillingValue": false
+          },
+          {
+            "uuid": "4f25ef45-c8d9-401d-b0e8-2217ac310f04",
+            "name": "ДатаКурса",
+            "mdoReference": {
+              "type": "ATTRIBUTE",
+              "mdoRef": "DataProcessor.ЗагрузкаКурсовВалют.TabularSection.СписокВалют.Attribute.ДатаКурса",
+              "mdoRefRu": "Обработка.ЗагрузкаКурсовВалют.ТабличнаяЧасть.СписокВалют.Реквизит.ДатаКурса"
+            },
+            "objectBelonging": "OWN",
+            "comment": "",
+            "synonym": {
+              "content": [
+                {
+                  "default": {
+                    "tag": 2
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                    "langKey": "ru",
+                    "value": "Дата курса"
+                  }
+                }
+              ]
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+            },
+            "passwordMode": false,
+            "kind": "CUSTOM",
+            "indexing": "DONT_INDEX",
+            "type": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/type"
+            },
+            "format": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+            },
+            "editFormat": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+            },
+            "markNegatives": false,
+            "mask": "",
+            "multiLine": false,
+            "extendedEdit": false,
+            "fillFromFillingValue": false
+          },
+          {
+            "uuid": "504ca240-b5ae-433e-ae5f-d818263eea23",
+            "name": "Курс",
+            "mdoReference": {
+              "type": "ATTRIBUTE",
+              "mdoRef": "DataProcessor.ЗагрузкаКурсовВалют.TabularSection.СписокВалют.Attribute.Курс",
+              "mdoRefRu": "Обработка.ЗагрузкаКурсовВалют.ТабличнаяЧасть.СписокВалют.Реквизит.Курс"
+            },
+            "objectBelonging": "OWN",
+            "comment": "",
+            "synonym": {
+              "content": [
+                {
+                  "default": {
+                    "tag": 2
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                    "langKey": "ru",
+                    "value": "Курс"
+                  }
+                }
+              ]
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+            },
+            "passwordMode": false,
+            "kind": "CUSTOM",
+            "indexing": "DONT_INDEX",
+            "type": {
+              "types": [
+                {
+                  "default": {
+                    "tag": 4
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER"
+                }
+              ],
+              "composite": false,
+              "qualifiers": [
+                {
+                  "default": {
+                    "tag": 4
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                    "precision": 10,
+                    "scale": 4,
+                    "nonNegative": true,
+                    "description": {}
+                  }
+                }
+              ]
+            },
+            "format": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+            },
+            "editFormat": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+            },
+            "markNegatives": false,
+            "mask": "",
+            "multiLine": false,
+            "extendedEdit": false,
+            "fillFromFillingValue": false
+          },
+          {
+            "uuid": "32461819-9437-417d-8d1e-851c9a2dcee2",
+            "name": "Кратность",
+            "mdoReference": {
+              "type": "ATTRIBUTE",
+              "mdoRef": "DataProcessor.ЗагрузкаКурсовВалют.TabularSection.СписокВалют.Attribute.Кратность",
+              "mdoRefRu": "Обработка.ЗагрузкаКурсовВалют.ТабличнаяЧасть.СписокВалют.Реквизит.Кратность"
+            },
+            "objectBelonging": "OWN",
+            "comment": "",
+            "synonym": {
+              "content": [
+                {
+                  "default": {
+                    "tag": 2
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                    "langKey": "ru",
+                    "value": "Кратность"
+                  }
+                }
+              ]
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+            },
+            "passwordMode": false,
+            "kind": "CUSTOM",
+            "indexing": "DONT_INDEX",
+            "type": {
+              "types": [
+                {
+                  "default": {
+                    "tag": 4
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER"
+                }
+              ],
+              "composite": false,
+              "qualifiers": [
+                {
+                  "default": {
+                    "tag": 4
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                    "precision": 10,
+                    "scale": 0,
+                    "nonNegative": true,
+                    "description": {}
+                  }
+                }
+              ]
+            },
+            "format": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+            },
+            "editFormat": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+            },
+            "markNegatives": false,
+            "mask": "",
+            "multiLine": false,
+            "extendedEdit": false,
+            "fillFromFillingValue": false
+          },
+          {
+            "uuid": "74228950-8a4b-4dd6-a053-8650de202521",
+            "name": "Загружать",
+            "mdoReference": {
+              "type": "ATTRIBUTE",
+              "mdoRef": "DataProcessor.ЗагрузкаКурсовВалют.TabularSection.СписокВалют.Attribute.Загружать",
+              "mdoRefRu": "Обработка.ЗагрузкаКурсовВалют.ТабличнаяЧасть.СписокВалют.Реквизит.Загружать"
+            },
+            "objectBelonging": "OWN",
+            "comment": "",
+            "synonym": {
+              "content": [
+                {
+                  "default": {
+                    "tag": 2
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                    "langKey": "ru",
+                    "value": "Загружать"
+                  }
+                }
+              ]
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+            },
+            "passwordMode": false,
+            "kind": "CUSTOM",
+            "indexing": "DONT_INDEX",
+            "type": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[2]/type"
+            },
+            "format": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+            },
+            "editFormat": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+            },
+            "markNegatives": false,
+            "mask": "",
+            "multiLine": false,
+            "extendedEdit": false,
+            "fillFromFillingValue": false
+          },
+          {
+            "uuid": "6b9ce91e-08b9-4972-9878-1724c67b68ec",
+            "name": "Представление",
+            "mdoReference": {
+              "type": "ATTRIBUTE",
+              "mdoRef": "DataProcessor.ЗагрузкаКурсовВалют.TabularSection.СписокВалют.Attribute.Представление",
+              "mdoRefRu": "Обработка.ЗагрузкаКурсовВалют.ТабличнаяЧасть.СписокВалют.Реквизит.Представление"
+            },
+            "objectBelonging": "OWN",
+            "comment": "",
+            "synonym": {
+              "content": [
+                {
+                  "default": {
+                    "tag": 2
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                    "langKey": "ru",
+                    "value": "Представление"
+                  }
+                }
+              ]
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+            },
+            "passwordMode": false,
+            "kind": "CUSTOM",
+            "indexing": "DONT_INDEX",
+            "type": {
+              "types": [
+                {
+                  "default": {
+                    "tag": 4
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+                }
+              ],
+              "composite": false,
+              "qualifiers": [
+                {
+                  "default": {
+                    "tag": 4
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                    "length": 50,
+                    "allowedLength": 0,
+                    "description": {
+                      "value": {
+                        "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                        "nameRu": "КвалификаторыСтроки (50, Переменная)",
+                        "nameEn": "StringQualifiers (50, Variable)"
+                      }
+                    }
+                  }
+                }
+              ]
+            },
+            "format": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+            },
+            "editFormat": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+            },
+            "markNegatives": false,
+            "mask": "",
+            "multiLine": false,
+            "extendedEdit": false,
+            "fillFromFillingValue": false
+          },
+          {
+            "uuid": "640814f2-6082-475e-8006-25fd5b24afdb",
+            "name": "СимвольныйКод",
+            "mdoReference": {
+              "type": "ATTRIBUTE",
+              "mdoRef": "DataProcessor.ЗагрузкаКурсовВалют.TabularSection.СписокВалют.Attribute.СимвольныйКод",
+              "mdoRefRu": "Обработка.ЗагрузкаКурсовВалют.ТабличнаяЧасть.СписокВалют.Реквизит.СимвольныйКод"
+            },
+            "objectBelonging": "OWN",
+            "comment": "",
+            "synonym": {
+              "content": [
+                {
+                  "default": {
+                    "tag": 2
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                    "langKey": "ru",
+                    "value": "Символьный код"
+                  }
+                }
+              ]
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+            },
+            "passwordMode": false,
+            "kind": "CUSTOM",
+            "indexing": "DONT_INDEX",
+            "type": {
+              "types": [
+                {
+                  "default": {
+                    "tag": 4
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+                }
+              ],
+              "composite": false,
+              "qualifiers": [
+                {
+                  "default": {
+                    "tag": 4
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                    "length": 10,
+                    "allowedLength": 0,
+                    "description": {
+                      "value": {
+                        "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                        "nameRu": "КвалификаторыСтроки (10, Переменная)",
+                        "nameEn": "StringQualifiers (10, Variable)"
+                      }
+                    }
+                  }
+                }
+              ]
+            },
+            "format": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+            },
+            "editFormat": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/format"
+            },
+            "markNegatives": false,
+            "mask": "",
+            "multiLine": false,
+            "extendedEdit": false,
+            "fillFromFillingValue": false
+          }
+        ],
+        []
+      ]
+    }
+  ],
+  "templates": [
+    {
+      "uuid": "6f2354cd-4a34-4921-96bb-b786486f85cf",
+      "name": "ОбщероссийскийКлассификаторВалют",
+      "mdoReference": {
+        "type": "TEMPLATE",
+        "mdoRef": "DataProcessor.ЗагрузкаКурсовВалют.Template.ОбщероссийскийКлассификаторВалют",
+        "mdoRefRu": "Обработка.ЗагрузкаКурсовВалют.Макет.ОбщероссийскийКлассификаторВалют"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": [
+          {
+            "default": {
+              "tag": 2
+            },
+            "int": 1,
+            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+              "langKey": "ru",
+              "value": "Общероссийский классификатор валют"
+            }
+          }
+        ]
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "modules": [],
+      "templateType": "TEXT_DOCUMENT",
+      "data": {
+        "@class": "com.github._1c_syntax.bsl.mdo.storage.EmptyTemplateData"
+      },
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.DataProcessor/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/owner"
+      }
+    }
+  ],
+  "uuid": "f36150de-33af-4410-8a4c-8c9f4b545793"
+}}

--- a/src/test/resources/fixtures/ssl_3_2/DefinedTypes.ВладелецФайлов.json
+++ b/src/test/resources/fixtures/ssl_3_2/DefinedTypes.ВладелецФайлов.json
@@ -1,0 +1,63 @@
+{"com.github._1c_syntax.bsl.mdo.DefinedType": {
+  "comment": "",
+  "description": "Владелец файлов",
+  "mdoReference": {
+    "type": "DEFINED_TYPE",
+    "mdoRef": "DefinedType.ВладелецФайлов",
+    "mdoRefRu": "ОпределяемыйТип.ВладелецФайлов"
+  },
+  "mdoType": "DEFINED_TYPE",
+  "name": "ВладелецФайлов",
+  "objectBelonging": "OWN",
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "content": [
+      {
+        "default": {
+          "tag": 2
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+          "langKey": "ru",
+          "value": "Владелец файлов"
+        }
+      }
+    ]
+  },
+  "uuid": "ae698468-f42a-4400-aee6-fd849740e634",
+  "valueType": {
+    "types": [
+      {
+        "default": {
+          "tag": 4
+        },
+        "int": 2,
+        "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+          "fullName": {
+            "nameRu": "БизнесПроцессСсылка.Задание",
+            "nameEn": "BusinessProcessRef.Задание"
+          },
+          "variant": "METADATA",
+          "kind": "BUSINESS_PROCESS"
+        },
+        "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+          "fullName": {
+            "nameRu": "СправочникСсылка.ПапкиФайлов",
+            "nameEn": "CatalogRef.ПапкиФайлов"
+          },
+          "variant": "METADATA",
+          "kind": "CATALOG"
+        }
+      }
+    ],
+    "composite": true,
+    "qualifiers": [
+      {
+        "default": {
+          "tag": 4
+        },
+        "int": 0
+      }
+    ]
+  }
+}}

--- a/src/test/resources/fixtures/ssl_3_2/DocumentJournals.Взаимодействия.json
+++ b/src/test/resources/fixtures/ssl_3_2/DocumentJournals.Взаимодействия.json
@@ -1,0 +1,8071 @@
+{"com.github._1c_syntax.bsl.mdo.DocumentJournal": {
+  "columns": [
+    [
+      {
+        "uuid": "b5b94d94-25f7-4cfa-b1e9-6009fb848763",
+        "name": "Автор",
+        "mdoReference": {
+          "type": "COLUMN",
+          "mdoRef": "DocumentJournal.Взаимодействия.Column.Автор",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Колонка.Автор"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Автор"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "type": "DOCUMENT_JOURNAL",
+          "mdoRef": "DocumentJournal.Взаимодействия",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия"
+        },
+        "kind": "CUSTOM",
+        "indexing": "INDEX_WITH_ADDITIONAL_ORDER",
+        "references": [
+          [
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.Встреча.Attribute.Автор",
+              "mdoRefRu": "Документ.Встреча.Реквизит.Автор"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ТелефонныйЗвонок.Attribute.Автор",
+              "mdoRefRu": "Документ.ТелефонныйЗвонок.Реквизит.Автор"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЗапланированноеВзаимодействие.Attribute.Автор",
+              "mdoRefRu": "Документ.ЗапланированноеВзаимодействие.Реквизит.Автор"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЭлектронноеПисьмоИсходящее.Attribute.Автор",
+              "mdoRefRu": "Документ.ЭлектронноеПисьмоИсходящее.Реквизит.Автор"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.СообщениеSMS.Attribute.Автор",
+              "mdoRefRu": "Документ.СообщениеSMS.Реквизит.Автор"
+            }
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "a2accf54-5966-42e8-ab2e-e56e415963ee",
+        "name": "Входящий",
+        "mdoReference": {
+          "type": "COLUMN",
+          "mdoRef": "DocumentJournal.Взаимодействия.Column.Входящий",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Колонка.Входящий"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Входящий"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        },
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "references": [
+          {
+            "type": "ATTRIBUTE",
+            "mdoRef": "Document.ТелефонныйЗвонок.Attribute.Входящий",
+            "mdoRefRu": "Документ.ТелефонныйЗвонок.Реквизит.Входящий"
+          }
+        ]
+      },
+      {
+        "uuid": "d8eb5329-5900-4b5d-b45e-458513dddfef",
+        "name": "Ответственный",
+        "mdoReference": {
+          "type": "COLUMN",
+          "mdoRef": "DocumentJournal.Взаимодействия.Column.Ответственный",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Колонка.Ответственный"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Ответственный"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        },
+        "kind": "CUSTOM",
+        "indexing": "INDEX_WITH_ADDITIONAL_ORDER",
+        "references": [
+          [
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ТелефонныйЗвонок.Attribute.Ответственный",
+              "mdoRefRu": "Документ.ТелефонныйЗвонок.Реквизит.Ответственный"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.Встреча.Attribute.Ответственный",
+              "mdoRefRu": "Документ.Встреча.Реквизит.Ответственный"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЭлектронноеПисьмоВходящее.Attribute.Ответственный",
+              "mdoRefRu": "Документ.ЭлектронноеПисьмоВходящее.Реквизит.Ответственный"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЭлектронноеПисьмоИсходящее.Attribute.Ответственный",
+              "mdoRefRu": "Документ.ЭлектронноеПисьмоИсходящее.Реквизит.Ответственный"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЗапланированноеВзаимодействие.Attribute.Ответственный",
+              "mdoRefRu": "Документ.ЗапланированноеВзаимодействие.Реквизит.Ответственный"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.СообщениеSMS.Attribute.Ответственный",
+              "mdoRefRu": "Документ.СообщениеSMS.Реквизит.Ответственный"
+            }
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "6d521e58-24a3-4f19-b4b0-dff84f7ca86b",
+        "name": "Тема",
+        "mdoReference": {
+          "type": "COLUMN",
+          "mdoRef": "DocumentJournal.Взаимодействия.Column.Тема",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Колонка.Тема"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Тема"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        },
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "references": [
+          [
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЭлектронноеПисьмоВходящее.Attribute.Тема",
+              "mdoRefRu": "Документ.ЭлектронноеПисьмоВходящее.Реквизит.Тема"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЭлектронноеПисьмоИсходящее.Attribute.Тема",
+              "mdoRefRu": "Документ.ЭлектронноеПисьмоИсходящее.Реквизит.Тема"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.Встреча.Attribute.Тема",
+              "mdoRefRu": "Документ.Встреча.Реквизит.Тема"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЗапланированноеВзаимодействие.Attribute.Тема",
+              "mdoRefRu": "Документ.ЗапланированноеВзаимодействие.Реквизит.Тема"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ТелефонныйЗвонок.Attribute.Тема",
+              "mdoRefRu": "Документ.ТелефонныйЗвонок.Реквизит.Тема"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.СообщениеSMS.Attribute.Тема",
+              "mdoRefRu": "Документ.СообщениеSMS.Реквизит.Тема"
+            }
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "8c413fa5-9e24-4b81-aa55-0e78c5e3e20f",
+        "name": "Участники",
+        "mdoReference": {
+          "type": "COLUMN",
+          "mdoRef": "DocumentJournal.Взаимодействия.Column.Участники",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Колонка.Участники"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Участники"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        },
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "references": [
+          [
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.Встреча.Attribute.СписокУчастников",
+              "mdoRefRu": "Документ.Встреча.Реквизит.СписокУчастников"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ТелефонныйЗвонок.Attribute.АбонентПредставление",
+              "mdoRefRu": "Документ.ТелефонныйЗвонок.Реквизит.АбонентПредставление"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЭлектронноеПисьмоИсходящее.Attribute.СписокПолучателейПисьма",
+              "mdoRefRu": "Документ.ЭлектронноеПисьмоИсходящее.Реквизит.СписокПолучателейПисьма"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЭлектронноеПисьмоВходящее.Attribute.ОтправительПредставление",
+              "mdoRefRu": "Документ.ЭлектронноеПисьмоВходящее.Реквизит.ОтправительПредставление"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЗапланированноеВзаимодействие.Attribute.СписокУчастников",
+              "mdoRefRu": "Документ.ЗапланированноеВзаимодействие.Реквизит.СписокУчастников"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.СообщениеSMS.Attribute.СписокУчастников",
+              "mdoRefRu": "Документ.СообщениеSMS.Реквизит.СписокУчастников"
+            }
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "a4322f22-7de0-4018-8e06-9f1aa7cf0c07",
+        "name": "СтатусИсходящегоПисьма",
+        "mdoReference": {
+          "type": "COLUMN",
+          "mdoRef": "DocumentJournal.Взаимодействия.Column.СтатусИсходящегоПисьма",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Колонка.СтатусИсходящегоПисьма"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Статус исходящего письма"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        },
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "references": [
+          [
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЭлектронноеПисьмоИсходящее.Attribute.СтатусПисьма",
+              "mdoRefRu": "Документ.ЭлектронноеПисьмоИсходящее.Реквизит.СтатусПисьма"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.СообщениеSMS.Attribute.Состояние",
+              "mdoRefRu": "Документ.СообщениеSMS.Реквизит.Состояние"
+            }
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "eaaed107-69d4-4963-be83-74519e331715",
+        "name": "УчетнаяЗапись",
+        "mdoReference": {
+          "type": "COLUMN",
+          "mdoRef": "DocumentJournal.Взаимодействия.Column.УчетнаяЗапись",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Колонка.УчетнаяЗапись"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Почта"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        },
+        "kind": "CUSTOM",
+        "indexing": "INDEX_WITH_ADDITIONAL_ORDER",
+        "references": [
+          [
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЭлектронноеПисьмоВходящее.Attribute.УчетнаяЗапись",
+              "mdoRefRu": "Документ.ЭлектронноеПисьмоВходящее.Реквизит.УчетнаяЗапись"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЭлектронноеПисьмоИсходящее.Attribute.УчетнаяЗапись",
+              "mdoRefRu": "Документ.ЭлектронноеПисьмоИсходящее.Реквизит.УчетнаяЗапись"
+            }
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "38cddf96-8703-4396-8c73-47fb22828a48",
+        "name": "ЕстьВложения",
+        "mdoReference": {
+          "type": "COLUMN",
+          "mdoRef": "DocumentJournal.Взаимодействия.Column.ЕстьВложения",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Колонка.ЕстьВложения"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Есть вложения"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        },
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "references": [
+          [
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЭлектронноеПисьмоВходящее.Attribute.ЕстьВложения",
+              "mdoRefRu": "Документ.ЭлектронноеПисьмоВходящее.Реквизит.ЕстьВложения"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЭлектронноеПисьмоИсходящее.Attribute.ЕстьВложения",
+              "mdoRefRu": "Документ.ЭлектронноеПисьмоИсходящее.Реквизит.ЕстьВложения"
+            }
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "2c2cb793-0177-4983-91ca-9c292c5b10f1",
+        "name": "ВзаимодействиеОснование",
+        "mdoReference": {
+          "type": "COLUMN",
+          "mdoRef": "DocumentJournal.Взаимодействия.Column.ВзаимодействиеОснование",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Колонка.ВзаимодействиеОснование"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Взаимодействие основание"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        },
+        "kind": "CUSTOM",
+        "indexing": "INDEX_WITH_ADDITIONAL_ORDER",
+        "references": [
+          [
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.Встреча.Attribute.ВзаимодействиеОснование",
+              "mdoRefRu": "Документ.Встреча.Реквизит.ВзаимодействиеОснование"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЗапланированноеВзаимодействие.Attribute.ВзаимодействиеОснование",
+              "mdoRefRu": "Документ.ЗапланированноеВзаимодействие.Реквизит.ВзаимодействиеОснование"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ТелефонныйЗвонок.Attribute.ВзаимодействиеОснование",
+              "mdoRefRu": "Документ.ТелефонныйЗвонок.Реквизит.ВзаимодействиеОснование"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЭлектронноеПисьмоВходящее.Attribute.ВзаимодействиеОснование",
+              "mdoRefRu": "Документ.ЭлектронноеПисьмоВходящее.Реквизит.ВзаимодействиеОснование"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЭлектронноеПисьмоИсходящее.Attribute.ВзаимодействиеОснование",
+              "mdoRefRu": "Документ.ЭлектронноеПисьмоИсходящее.Реквизит.ВзаимодействиеОснование"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.СообщениеSMS.Attribute.ВзаимодействиеОснование",
+              "mdoRefRu": "Документ.СообщениеSMS.Реквизит.ВзаимодействиеОснование"
+            }
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "2a2e7f51-a4e5-48ec-b969-b1fca18ba9b5",
+        "name": "ПолученоОтправлено",
+        "mdoReference": {
+          "type": "COLUMN",
+          "mdoRef": "DocumentJournal.Взаимодействия.Column.ПолученоОтправлено",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Колонка.ПолученоОтправлено"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Получено отправлено"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        },
+        "kind": "CUSTOM",
+        "indexing": "INDEX_WITH_ADDITIONAL_ORDER",
+        "references": [
+          [
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЭлектронноеПисьмоВходящее.Attribute.ДатаПолучения",
+              "mdoRefRu": "Документ.ЭлектронноеПисьмоВходящее.Реквизит.ДатаПолучения"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЭлектронноеПисьмоИсходящее.Attribute.ДатаОтправления",
+              "mdoRefRu": "Документ.ЭлектронноеПисьмоИсходящее.Реквизит.ДатаОтправления"
+            }
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "221fa473-3327-44e6-a033-6fdfd2be713c",
+        "name": "Размер",
+        "mdoReference": {
+          "type": "COLUMN",
+          "mdoRef": "DocumentJournal.Взаимодействия.Column.Размер",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Колонка.Размер"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Размер"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        },
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "references": [
+          [
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЭлектронноеПисьмоВходящее.Attribute.Размер",
+              "mdoRefRu": "Документ.ЭлектронноеПисьмоВходящее.Реквизит.Размер"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЭлектронноеПисьмоИсходящее.Attribute.Размер",
+              "mdoRefRu": "Документ.ЭлектронноеПисьмоИсходящее.Реквизит.Размер"
+            }
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "7a5973f0-7e29-44af-8e7b-70af71f704a4",
+        "name": "Важность",
+        "mdoReference": {
+          "type": "COLUMN",
+          "mdoRef": "DocumentJournal.Взаимодействия.Column.Важность",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Колонка.Важность"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Важность"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        },
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "references": [
+          [
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.Встреча.Attribute.Важность",
+              "mdoRefRu": "Документ.Встреча.Реквизит.Важность"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЗапланированноеВзаимодействие.Attribute.Важность",
+              "mdoRefRu": "Документ.ЗапланированноеВзаимодействие.Реквизит.Важность"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ТелефонныйЗвонок.Attribute.Важность",
+              "mdoRefRu": "Документ.ТелефонныйЗвонок.Реквизит.Важность"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЭлектронноеПисьмоВходящее.Attribute.Важность",
+              "mdoRefRu": "Документ.ЭлектронноеПисьмоВходящее.Реквизит.Важность"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЭлектронноеПисьмоИсходящее.Attribute.Важность",
+              "mdoRefRu": "Документ.ЭлектронноеПисьмоИсходящее.Реквизит.Важность"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.СообщениеSMS.Attribute.Важность",
+              "mdoRefRu": "Документ.СообщениеSMS.Реквизит.Важность"
+            }
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "2b2bf0f7-0946-4492-bba0-27f007a70e64",
+        "name": "ДатаКогдаОтправить",
+        "mdoReference": {
+          "type": "COLUMN",
+          "mdoRef": "DocumentJournal.Взаимодействия.Column.ДатаКогдаОтправить",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Колонка.ДатаКогдаОтправить"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Дата когда отправить"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        },
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "references": [
+          [
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.СообщениеSMS.Attribute.ДатаКогдаОтправить",
+              "mdoRefRu": "Документ.СообщениеSMS.Реквизит.ДатаКогдаОтправить"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЭлектронноеПисьмоИсходящее.Attribute.ДатаКогдаОтправить",
+              "mdoRefRu": "Документ.ЭлектронноеПисьмоИсходящее.Реквизит.ДатаКогдаОтправить"
+            }
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "22c9a703-5ed3-4156-8fa6-476b1c1452f1",
+        "name": "ДатаАктуальностиОтправки",
+        "mdoReference": {
+          "type": "COLUMN",
+          "mdoRef": "DocumentJournal.Взаимодействия.Column.ДатаАктуальностиОтправки",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Колонка.ДатаАктуальностиОтправки"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Дата актуальности отправки"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        },
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "references": [
+          [
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.СообщениеSMS.Attribute.ДатаАктуальностиОтправки",
+              "mdoRefRu": "Документ.СообщениеSMS.Реквизит.ДатаАктуальностиОтправки"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЭлектронноеПисьмоИсходящее.Attribute.ДатаАктуальностиОтправки",
+              "mdoRefRu": "Документ.ЭлектронноеПисьмоИсходящее.Реквизит.ДатаАктуальностиОтправки"
+            }
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "8be10d88-8c37-4444-9c89-6cbbe9913bda",
+        "name": "ИдентификаторСообщения",
+        "mdoReference": {
+          "type": "COLUMN",
+          "mdoRef": "DocumentJournal.Взаимодействия.Column.ИдентификаторСообщения",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Колонка.ИдентификаторСообщения"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Идентификатор сообщения"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        },
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "references": [
+          [
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЭлектронноеПисьмоВходящее.Attribute.ИдентификаторСообщения",
+              "mdoRefRu": "Документ.ЭлектронноеПисьмоВходящее.Реквизит.ИдентификаторСообщения"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЭлектронноеПисьмоИсходящее.Attribute.ИдентификаторСообщения",
+              "mdoRefRu": "Документ.ЭлектронноеПисьмоИсходящее.Реквизит.ИдентификаторСообщения"
+            }
+          ],
+          []
+        ]
+      }
+    ],
+    []
+  ],
+  "commands": [
+    [
+      {
+        "uuid": "314b0da2-24d3-48cc-8532-d36c45eb3bf8",
+        "name": "ВзаимодействияПоКонтакту",
+        "mdoReference": {
+          "type": "COMMAND",
+          "mdoRef": "DocumentJournal.Взаимодействия.Command.ВзаимодействияПоКонтакту",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Команда.ВзаимодействияПоКонтакту"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Взаимодействия"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "CommandModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/DocumentJournals/Взаимоде_ствия/Commands/Взаимоде_ствияПоКонтакту/Ext/CommandModule.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        }
+      },
+      {
+        "uuid": "2e3ac3fb-9f0e-463f-95c2-9f661ce2e015",
+        "name": "ВзаимодействияПоПредмету",
+        "mdoReference": {
+          "type": "COMMAND",
+          "mdoRef": "DocumentJournal.Взаимодействия.Command.ВзаимодействияПоПредмету",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Команда.ВзаимодействияПоПредмету"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "CommandModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/DocumentJournals/Взаимоде_ствия/Commands/Взаимоде_ствияПоПредмету/Ext/CommandModule.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[2]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        }
+      },
+      {
+        "uuid": "4077e700-ec20-4afa-8155-bf7e516a70cb",
+        "name": "ЗапланироватьВзаимодействиеПоКонтакту",
+        "mdoReference": {
+          "type": "COMMAND",
+          "mdoRef": "DocumentJournal.Взаимодействия.Command.ЗапланироватьВзаимодействиеПоКонтакту",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Команда.ЗапланироватьВзаимодействиеПоКонтакту"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Запланировать взаимодействие"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "CommandModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/DocumentJournals/Взаимоде_ствия/Commands/ЗапланироватьВзаимоде_ствиеПоКонтакту/Ext/CommandModule.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[3]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        }
+      },
+      {
+        "uuid": "5198c6db-2100-4902-82c8-85c8ea555e78",
+        "name": "ЗапланироватьВзаимодействиеПоПредмету",
+        "mdoReference": {
+          "type": "COMMAND",
+          "mdoRef": "DocumentJournal.Взаимодействия.Command.ЗапланироватьВзаимодействиеПоПредмету",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Команда.ЗапланироватьВзаимодействиеПоПредмету"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[3]/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "CommandModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/DocumentJournals/Взаимоде_ствия/Commands/ЗапланироватьВзаимоде_ствиеПоПредмету/Ext/CommandModule.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[4]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        }
+      },
+      {
+        "uuid": "b99f2a63-54e8-490b-a0a4-1941fbc38b3f",
+        "name": "ЗапланироватьВстречуПоКонтакту",
+        "mdoReference": {
+          "type": "COMMAND",
+          "mdoRef": "DocumentJournal.Взаимодействия.Command.ЗапланироватьВстречуПоКонтакту",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Команда.ЗапланироватьВстречуПоКонтакту"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Запланировать встречу"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "CommandModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/DocumentJournals/Взаимоде_ствия/Commands/ЗапланироватьВстречуПоКонтакту/Ext/CommandModule.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[5]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        }
+      },
+      {
+        "uuid": "f0b1e9f4-2e07-44e6-88d2-c11457135781",
+        "name": "ЗапланироватьВстречуПоПредмету",
+        "mdoReference": {
+          "type": "COMMAND",
+          "mdoRef": "DocumentJournal.Взаимодействия.Command.ЗапланироватьВстречуПоПредмету",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Команда.ЗапланироватьВстречуПоПредмету"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[5]/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "CommandModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/DocumentJournals/Взаимоде_ствия/Commands/ЗапланироватьВстречуПоПредмету/Ext/CommandModule.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[6]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        }
+      },
+      {
+        "uuid": "e010c0f9-f770-4fdc-8607-50838c0262ef",
+        "name": "НаписатьSMSПоКонтакту",
+        "mdoReference": {
+          "type": "COMMAND",
+          "mdoRef": "DocumentJournal.Взаимодействия.Command.НаписатьSMSПоКонтакту",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Команда.НаписатьSMSПоКонтакту"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Написать SMS"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "CommandModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/DocumentJournals/Взаимоде_ствия/Commands/НаписатьSMSПоКонтакту/Ext/CommandModule.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[7]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        }
+      },
+      {
+        "uuid": "f935399f-3554-4c08-b0a6-eba13074e1b7",
+        "name": "НаписатьSMSПоПредмету",
+        "mdoReference": {
+          "type": "COMMAND",
+          "mdoRef": "DocumentJournal.Взаимодействия.Command.НаписатьSMSПоПредмету",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Команда.НаписатьSMSПоПредмету"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[7]/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "CommandModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/DocumentJournals/Взаимоде_ствия/Commands/НаписатьSMSПоПредмету/Ext/CommandModule.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[8]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        }
+      },
+      {
+        "uuid": "10008125-3aeb-4912-8ad6-d92d283ea09a",
+        "name": "НаписатьЭлектронноеПисьмоПоКонтакту",
+        "mdoReference": {
+          "type": "COMMAND",
+          "mdoRef": "DocumentJournal.Взаимодействия.Command.НаписатьЭлектронноеПисьмоПоКонтакту",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Команда.НаписатьЭлектронноеПисьмоПоКонтакту"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Написать электронное письмо"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "CommandModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/DocumentJournals/Взаимоде_ствия/Commands/НаписатьЭлектронноеПисьмоПоКонтакту/Ext/CommandModule.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[9]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        }
+      },
+      {
+        "uuid": "765f9584-fefa-4695-b130-dd54c3b0d79d",
+        "name": "НаписатьЭлектронноеПисьмоПоПредмету",
+        "mdoReference": {
+          "type": "COMMAND",
+          "mdoRef": "DocumentJournal.Взаимодействия.Command.НаписатьЭлектронноеПисьмоПоПредмету",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Команда.НаписатьЭлектронноеПисьмоПоПредмету"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[9]/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "CommandModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/DocumentJournals/Взаимоде_ствия/Commands/НаписатьЭлектронноеПисьмоПоПредмету/Ext/CommandModule.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[10]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        }
+      },
+      {
+        "uuid": "dd050ca0-8335-4654-ab5c-7babcb4824ef",
+        "name": "НастройкиРаботыСПочтой",
+        "mdoReference": {
+          "type": "COMMAND",
+          "mdoRef": "DocumentJournal.Взаимодействия.Command.НастройкиРаботыСПочтой",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Команда.НастройкиРаботыСПочтой"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Настройки работы с почтой"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "CommandModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/DocumentJournals/Взаимоде_ствия/Commands/Настро_киРаботыСПочто_/Ext/CommandModule.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[11]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        }
+      },
+      {
+        "uuid": "706cbf55-626d-4cab-b589-a2464368f6c1",
+        "name": "ПечатьЭлектронногоПисьма",
+        "mdoReference": {
+          "type": "COMMAND",
+          "mdoRef": "DocumentJournal.Взаимодействия.Command.ПечатьЭлектронногоПисьма",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Команда.ПечатьЭлектронногоПисьма"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Печать"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "CommandModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/DocumentJournals/Взаимоде_ствия/Commands/ПечатьЭлектронногоПисьма/Ext/CommandModule.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[12]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        }
+      },
+      {
+        "uuid": "d22a0a50-220d-459e-a23a-39730a1e67c4",
+        "name": "ПозвонитьПоКонтакту",
+        "mdoReference": {
+          "type": "COMMAND",
+          "mdoRef": "DocumentJournal.Взаимодействия.Command.ПозвонитьПоКонтакту",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Команда.ПозвонитьПоКонтакту"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Позвонить"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "CommandModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/DocumentJournals/Взаимоде_ствия/Commands/ПозвонитьПоКонтакту/Ext/CommandModule.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[13]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        }
+      },
+      {
+        "uuid": "2c1c9284-ba8b-4282-a89c-429f02ea41f6",
+        "name": "ПозвонитьПоПредмету",
+        "mdoReference": {
+          "type": "COMMAND",
+          "mdoRef": "DocumentJournal.Взаимодействия.Command.ПозвонитьПоПредмету",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Команда.ПозвонитьПоПредмету"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[13]/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "CommandModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/DocumentJournals/Взаимоде_ствия/Commands/ПозвонитьПоПредмету/Ext/CommandModule.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[14]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        }
+      },
+      {
+        "uuid": "8c241467-76f7-4161-a8a1-5da4a6576b75",
+        "name": "СохранитьПисьмо",
+        "mdoReference": {
+          "type": "COMMAND",
+          "mdoRef": "DocumentJournal.Взаимодействия.Command.СохранитьПисьмо",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Команда.СохранитьПисьмо"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Сохранить письмо на компьютер"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "CommandModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/DocumentJournals/Взаимоде_ствия/Commands/СохранитьПисьмо/Ext/CommandModule.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[15]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        }
+      }
+    ],
+    []
+  ],
+  "comment": "",
+  "description": "Взаимодействия",
+  "explanation": {
+    "content": []
+  },
+  "forms": [
+    [
+      {
+        "uuid": "27089e8e-2c75-431c-b808-5d4dcba3cdca",
+        "name": "ФормаСписка",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "DocumentJournal.Взаимодействия.Form.ФормаСписка",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Форма.ФормаСписка"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Форма списка"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/DocumentJournals/Взаимоде_ствия/Forms/ФормаСписка/Ext/Form/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand/synonym"
+          },
+          "handlers": [
+            [
+              {
+                "event": "ChoiceProcessing",
+                "name": "ОбработкаВыбора"
+              },
+              {
+                "event": "NotificationProcessing",
+                "name": "ОбработкаОповещения"
+              },
+              {
+                "event": "OnOpen",
+                "name": "ПриОткрытии"
+              },
+              {
+                "event": "BeforeClose",
+                "name": "ПередЗакрытием"
+              },
+              {
+                "event": "OnLoadDataFromSettingsAtServer",
+                "name": "ПриЗагрузкеДанныхИзНастроекНаСервере"
+              },
+              {
+                "event": "NavigationProcessing",
+                "name": "ОбработкаПерехода"
+              },
+              {
+                "event": "OnCreateAtServer",
+                "name": "ПриСозданииНаСервере"
+              },
+              {
+                "event": "BeforeLoadDataFromSettingsAtServer",
+                "name": "ПередЗагрузкойДанныхИзНастроекНаСервере"
+              }
+            ],
+            []
+          ],
+          "items": [
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 926,
+                "name": "ПредупреждениеОНеотправленныхПисьмах",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Группа предупреждение"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "PICTURE_DECORATION",
+                      "id": 928,
+                      "name": "ПредупреждениеОНеотправленныхПисьмахКартинка",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Картинка предупреждение"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_DECORATION",
+                      "id": 931,
+                      "name": "ПредупреждениеОНеотправленныхПисьмахНадпись",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Регламентное задание <b>Получение</><b> </><b>и</><b> </><b>отправка</><b> </><b>писем</> отключено, доставка писем не выполняется. <link ВключитьПолучениеИОтправкуПисем>Включить</>"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 943,
+                "name": "ПредупреждениеОНеактуальностиИндекса",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Предупреждение о неактуальности индекса"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "PICTURE_DECORATION",
+                      "id": 945,
+                      "name": "ПредупреждениеОНеактуальностиИндексаКартинка",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_DECORATION",
+                      "id": 948,
+                      "name": "ПредупреждениеОНеактуальностиИндексаНадпись",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Результаты поиска могут быть неточными, повторите поиск позднее"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 832,
+                "name": "ГруппаПользовательскихНастроек",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Группа пользовательских настроек"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": []
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 66,
+                "name": "ГруппаФильтры",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Фильтры"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 89,
+                      "name": "СтрокаПоиска",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Найти"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "СтрокаПоиска",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 71,
+                      "name": "ТипВзаимодействия",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Тип"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "ТипВзаимодействия",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 67,
+                      "name": "Статус",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Статус"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "Статус",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 69,
+                      "name": "Пользователь",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn[3]/synonym"
+                      },
+                      "dataPath": "Ответственный",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 826,
+                "name": "ГруппаПанельНавигацииСписок",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Панель навигации список"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "COMMAND_BAR",
+                      "id": 24,
+                      "name": "КоманднаяПанельВариантаНавигации",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Командная панель варианта навигации"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "COMMAND_BAR_BUTTON",
+                            "id": 830,
+                            "name": "ИзменитьОтображениеПанелиНавигации",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Изменить отображение панели навигации"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "POPUP",
+                            "id": 26,
+                            "name": "ВыборВариантаНавигации",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Вариант навигации"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "COMMAND_BAR_BUTTON",
+                                  "id": 27,
+                                  "name": "УстановитьВариантНавигацииПоПредмету",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "По предметам"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "COMMAND_BAR_BUTTON",
+                                  "id": 28,
+                                  "name": "УстановитьВариантНавигацииПоКонтакту",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "По контактам"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "COMMAND_BAR_BUTTON",
+                                  "id": 124,
+                                  "name": "УстановитьВариантНавигацииПоЗакладкам",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "По закладкам"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "COMMAND_BAR_BUTTON",
+                                  "id": 176,
+                                  "name": "УстановитьВариантНавигацииПоПапкам",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "По папкам"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          },
+                          {
+                            "type": "BUTTON_GROUP",
+                            "id": 828,
+                            "name": "ГруппаКоманднаяПанельСписок",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Командная панель список"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "POPUP",
+                                  "id": 43,
+                                  "name": "ГруппаСоздать",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Создать"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "COMMAND_BAR_BUTTON",
+                                        "id": 44,
+                                        "name": "СписокСоздатьВстречу",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Встречу"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "COMMAND_BAR_BUTTON",
+                                        "id": 45,
+                                        "name": "СписокСоздатьЗапланированноеВзаимодействие",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Запланированное взаимодействие"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "COMMAND_BAR_BUTTON",
+                                        "id": 46,
+                                        "name": "СписокСоздатьТелефонныйЗвонок",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Телефонный звонок"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "COMMAND_BAR_BUTTON",
+                                        "id": 415,
+                                        "name": "СписокСоздатьСообщениеSMS",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Сообщение SMS"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "COMMAND_BAR_BUTTON",
+                                        "id": 47,
+                                        "name": "СписокСоздатьЭлектронноеПисьмо",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Электронное письмо"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                },
+                                {
+                                  "type": "COMMAND_BAR_BUTTON",
+                                  "id": 322,
+                                  "name": "СписокСоздатьЭлектронноеПисьмоОтдельнаяКнопка",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Написать"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "BUTTON_GROUP",
+                                  "id": 919,
+                                  "name": "ГруппаОтветитьПереслать",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Ответить переслать"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "COMMAND_BAR_BUTTON",
+                                        "id": 342,
+                                        "name": "СписокОтветить",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Ответить"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "COMMAND_BAR_BUTTON",
+                                        "id": 343,
+                                        "name": "СписокОтветитьВсем",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Ответить всем"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "COMMAND_BAR_BUTTON",
+                                        "id": 344,
+                                        "name": "СписокПереслать",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Переслать"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                },
+                                {
+                                  "type": "COMMAND_BAR_BUTTON",
+                                  "id": 59,
+                                  "name": "СписокОтправитьПолучитьПочту",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Отправить и получить"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "POPUP",
+                                  "id": 917,
+                                  "name": "ПодменюСоздатьНаОсновании",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Создать на основании"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "BUTTON_GROUP",
+                                  "id": 410,
+                                  "name": "ГруппаРассмотрено",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Рассмотрено"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "COMMAND_BAR_BUTTON",
+                                        "id": 40,
+                                        "name": "СписокРассмотрено",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[6]/title"
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "COMMAND_BAR_BUTTON",
+                                        "id": 42,
+                                        "name": "СписокОтложитьРассмотрение",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Отложить рассмотрение..."
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "COMMAND_BAR_BUTTON",
+                                        "id": 191,
+                                        "name": "СписокНеРассмотрено",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Снять признак рассмотрено"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "COMMAND_BAR_BUTTON",
+                                        "id": 39,
+                                        "name": "СписокОтветственный",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Установить ответственного..."
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "COMMAND_BAR_BUTTON",
+                                        "id": 41,
+                                        "name": "СписокПредмет",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Установить предмет взаимодействия..."
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                },
+                                {
+                                  "type": "POPUP",
+                                  "id": 824,
+                                  "name": "СписокТипВзаимодействия",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Показывать"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "POPUP",
+                                  "id": 822,
+                                  "name": "СписокСтатус",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Статус: "
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "BUTTON_GROUP",
+                                  "id": 48,
+                                  "name": "ГруппаКомандыСписка",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Команды списка"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "COMMAND_BAR_BUTTON",
+                                        "id": 49,
+                                        "name": "Изменить",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "COMMAND_BAR_BUTTON",
+                                        "id": 50,
+                                        "name": "Скопировать",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "BUTTON_GROUP",
+                                        "id": 51,
+                                        "name": "ГруппаСписокУстановитьПометкуУдаления",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Список установить пометку удаления"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": [
+                                          {
+                                            "type": "COMMAND_BAR_BUTTON",
+                                            "id": 52,
+                                            "name": "УстановитьПометкуУдаления",
+                                            "title": {
+                                              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                            },
+                                            "dataPath": "",
+                                            "items": []
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "BUTTON_GROUP",
+                                        "id": 55,
+                                        "name": "ГруппаНайти",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                        },
+                                        "dataPath": "",
+                                        "items": [
+                                          [
+                                            {
+                                              "type": "COMMAND_BAR_BUTTON",
+                                              "id": 56,
+                                              "name": "Найти",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                              },
+                                              "dataPath": "",
+                                              "items": []
+                                            },
+                                            {
+                                              "type": "COMMAND_BAR_BUTTON",
+                                              "id": 58,
+                                              "name": "ОтменитьПоиск",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                              },
+                                              "dataPath": "",
+                                              "items": []
+                                            },
+                                            {
+                                              "type": "COMMAND_BAR_BUTTON",
+                                              "id": 54,
+                                              "name": "УстановитьИнтервалДат",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                              },
+                                              "dataPath": "",
+                                              "items": []
+                                            }
+                                          ],
+                                          []
+                                        ]
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                },
+                                {
+                                  "type": "COMMAND_BAR_BUTTON",
+                                  "id": 60,
+                                  "name": "СписокОбновить",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Обновить"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "COMMAND_BAR_BUTTON",
+                                  "id": 61,
+                                  "name": "СписокНастройкаСписка",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "COMMAND_BAR_BUTTON",
+                                  "id": 62,
+                                  "name": "СписокВывестиСписок",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "COMMAND_BAR_BUTTON",
+                                  "id": 64,
+                                  "name": "СписокИзменитьФорму",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "COMMAND_BAR_BUTTON",
+                                  "id": 792,
+                                  "name": "СписокОтображатьОбластьЧтения",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Отображать область чтения"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "COMMAND_BAR_BUTTON",
+                                  "id": 146,
+                                  "name": "ФормаПерсональныеНастройки",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Персональные настройки..."
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          },
+                          {
+                            "type": "BUTTON_GROUP",
+                            "id": 897,
+                            "name": "ГруппаГлобальныеКоманды",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Глобальные команды"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "COMMAND_BAR_BUTTON",
+                            "id": 63,
+                            "name": "СписокСправка",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 5,
+                      "name": "ГруппаОсновное",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Основное"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 6,
+                            "name": "ГруппаПанельНавигации",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Панель навигации"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              {
+                                "type": "PAGES",
+                                "id": 25,
+                                "name": "СтраницыПанелиНавигации",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Страницы панели навигации"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "PAGE",
+                                      "id": 30,
+                                      "name": "СтраницаКонтакт",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Страница контакт"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        [
+                                          {
+                                            "type": "TABLE",
+                                            "id": 31,
+                                            "name": "КонтактыПанелиНавигации",
+                                            "title": {
+                                              "content": [
+                                                {
+                                                  "default": {
+                                                    "tag": 2
+                                                  },
+                                                  "int": 1,
+                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                    "langKey": "ru",
+                                                    "value": "Контакты панели навигации"
+                                                  }
+                                                }
+                                              ]
+                                            },
+                                            "dataPath": "КонтактыПанельНавигации",
+                                            "items": [
+                                              {
+                                                "type": "COLUMN_GROUP",
+                                                "id": 810,
+                                                "name": "КонтактыПанелиНавигацииГруппа",
+                                                "title": {
+                                                  "content": [
+                                                    {
+                                                      "default": {
+                                                        "tag": 2
+                                                      },
+                                                      "int": 1,
+                                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                        "langKey": "ru",
+                                                        "value": "Контакты панели навигации группа"
+                                                      }
+                                                    }
+                                                  ]
+                                                },
+                                                "dataPath": "",
+                                                "items": [
+                                                  [
+                                                    {
+                                                      "type": "LABEL_FIELD",
+                                                      "id": 731,
+                                                      "name": "КонтактыКонтакт",
+                                                      "title": {
+                                                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                                      },
+                                                      "dataPath": "КонтактыПанельНавигации.Контакт",
+                                                      "items": []
+                                                    },
+                                                    {
+                                                      "type": "COLUMN_GROUP",
+                                                      "id": 784,
+                                                      "name": "КонтактыПанелиНавигацииРассмотреноДата",
+                                                      "title": {
+                                                        "content": [
+                                                          {
+                                                            "default": {
+                                                              "tag": 2
+                                                            },
+                                                            "int": 1,
+                                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                              "langKey": "ru",
+                                                              "value": "Контакты панели навигации рассмотрено дата"
+                                                            }
+                                                          }
+                                                        ]
+                                                      },
+                                                      "dataPath": "",
+                                                      "items": [
+                                                        [
+                                                          {
+                                                            "type": "LABEL_FIELD",
+                                                            "id": 728,
+                                                            "name": "НеРассмотрено",
+                                                            "title": {
+                                                              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                                            },
+                                                            "dataPath": "КонтактыПанельНавигации.КоличествоНеРассмотрено",
+                                                            "items": []
+                                                          },
+                                                          {
+                                                            "type": "LABEL_FIELD",
+                                                            "id": 725,
+                                                            "name": "КонтактыДатаПоследнегоВзаимодействия",
+                                                            "title": {
+                                                              "content": [
+                                                                {
+                                                                  "default": {
+                                                                    "tag": 2
+                                                                  },
+                                                                  "int": 1,
+                                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                    "langKey": "ru",
+                                                                    "value": "Последнее взаимодействие"
+                                                                  }
+                                                                }
+                                                              ]
+                                                            },
+                                                            "dataPath": "КонтактыПанельНавигации.ДатаПоследнегоВзаимодействия",
+                                                            "items": []
+                                                          }
+                                                        ],
+                                                        []
+                                                      ]
+                                                    }
+                                                  ],
+                                                  []
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "LABEL_DECORATION",
+                                            "id": 937,
+                                            "name": "ДекорацияТолькоЗначимыеКонтакты",
+                                            "title": {
+                                              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                            },
+                                            "dataPath": "",
+                                            "items": []
+                                          }
+                                        ],
+                                        []
+                                      ]
+                                    },
+                                    {
+                                      "type": "PAGE",
+                                      "id": 73,
+                                      "name": "СтраницаПредмет",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Страница предмет"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        [
+                                          {
+                                            "type": "TABLE",
+                                            "id": 690,
+                                            "name": "ПредметыПанельНавигации",
+                                            "title": {
+                                              "content": [
+                                                {
+                                                  "default": {
+                                                    "tag": 2
+                                                  },
+                                                  "int": 1,
+                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                    "langKey": "ru",
+                                                    "value": "Предметы панель навигации"
+                                                  }
+                                                }
+                                              ]
+                                            },
+                                            "dataPath": "ПредметыПанельНавигации",
+                                            "items": [
+                                              {
+                                                "type": "COLUMN_GROUP",
+                                                "id": 808,
+                                                "name": "ПредметыПанельНавигацииГруппа",
+                                                "title": {
+                                                  "content": [
+                                                    {
+                                                      "default": {
+                                                        "tag": 2
+                                                      },
+                                                      "int": 1,
+                                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                        "langKey": "ru",
+                                                        "value": "Предметы панель навигации группа"
+                                                      }
+                                                    }
+                                                  ]
+                                                },
+                                                "dataPath": "",
+                                                "items": [
+                                                  [
+                                                    {
+                                                      "type": "LABEL_FIELD",
+                                                      "id": 697,
+                                                      "name": "Предмет",
+                                                      "title": {
+                                                        "content": [
+                                                          {
+                                                            "default": {
+                                                              "tag": 2
+                                                            },
+                                                            "int": 1,
+                                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                              "langKey": "ru",
+                                                              "value": "Предмет"
+                                                            }
+                                                          }
+                                                        ]
+                                                      },
+                                                      "dataPath": "ПредметыПанельНавигации.Предмет",
+                                                      "items": []
+                                                    },
+                                                    {
+                                                      "type": "COLUMN_GROUP",
+                                                      "id": 786,
+                                                      "name": "ПредметыПанельНавигацииГруппаРассмотреноДата",
+                                                      "title": {
+                                                        "content": [
+                                                          {
+                                                            "default": {
+                                                              "tag": 2
+                                                            },
+                                                            "int": 1,
+                                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                              "langKey": "ru",
+                                                              "value": "Предметы панель навигации группа рассмотрено дата"
+                                                            }
+                                                          }
+                                                        ]
+                                                      },
+                                                      "dataPath": "",
+                                                      "items": [
+                                                        [
+                                                          {
+                                                            "type": "LABEL_FIELD",
+                                                            "id": 694,
+                                                            "name": "НеРассмотреноПредметы",
+                                                            "title": {
+                                                              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                                            },
+                                                            "dataPath": "ПредметыПанельНавигации.КоличествоНеРассмотрено",
+                                                            "items": []
+                                                          },
+                                                          {
+                                                            "type": "LABEL_FIELD",
+                                                            "id": 700,
+                                                            "name": "ДатаПоследнегоВзаимодействия",
+                                                            "title": {
+                                                              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                                            },
+                                                            "dataPath": "ПредметыПанельНавигации.ДатаПоследнегоВзаимодействия",
+                                                            "items": []
+                                                          }
+                                                        ],
+                                                        []
+                                                      ]
+                                                    }
+                                                  ],
+                                                  []
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "LABEL_DECORATION",
+                                            "id": 934,
+                                            "name": "ДекорацияТолькоЗначимыеПредметы",
+                                            "title": {
+                                              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                            },
+                                            "dataPath": "",
+                                            "items": []
+                                          }
+                                        ],
+                                        []
+                                      ]
+                                    },
+                                    {
+                                      "type": "PAGE",
+                                      "id": 118,
+                                      "name": "СтраницаЗакладки",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Страница закладки"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        {
+                                          "type": "TABLE",
+                                          "id": 119,
+                                          "name": "Закладки",
+                                          "title": {
+                                            "content": [
+                                              {
+                                                "default": {
+                                                  "tag": 2
+                                                },
+                                                "int": 1,
+                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                  "langKey": "ru",
+                                                  "value": "Закладки"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "dataPath": "Закладки",
+                                          "items": [
+                                            [
+                                              {
+                                                "type": "LABEL_FIELD",
+                                                "id": 122,
+                                                "name": "ЗакладкиНаименование",
+                                                "title": {
+                                                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                                },
+                                                "dataPath": "Закладки.Description",
+                                                "items": []
+                                              },
+                                              {
+                                                "type": "INPUT_FIELD",
+                                                "id": 940,
+                                                "name": "ЗакладкиСсылка",
+                                                "title": {
+                                                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                                },
+                                                "dataPath": "Закладки.Ref",
+                                                "items": []
+                                              }
+                                            ],
+                                            []
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "PAGE",
+                                      "id": 129,
+                                      "name": "СтраницаСвойства",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Страница свойства"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        {
+                                          "type": "TABLE",
+                                          "id": 130,
+                                          "name": "Свойства",
+                                          "title": {
+                                            "content": [
+                                              {
+                                                "default": {
+                                                  "tag": 2
+                                                },
+                                                "int": 1,
+                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                  "langKey": "ru",
+                                                  "value": "Свойства"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "dataPath": "Свойства",
+                                          "items": [
+                                            {
+                                              "type": "COLUMN_GROUP",
+                                              "id": 135,
+                                              "name": "СвойстваГруппаКолонок",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Свойства группа колонок"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "",
+                                              "items": [
+                                                [
+                                                  {
+                                                    "type": "INPUT_FIELD",
+                                                    "id": 133,
+                                                    "name": "СвойстваПредставление",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "Представление"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "Свойства.Представление",
+                                                    "items": []
+                                                  },
+                                                  {
+                                                    "type": "PICTURE_FIELD",
+                                                    "id": 136,
+                                                    "name": "СвойстваНомерКартинки",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "Номер картинки"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "Свойства.НомерКартинки",
+                                                    "items": []
+                                                  }
+                                                ],
+                                                []
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "PAGE",
+                                      "id": 177,
+                                      "name": "СтраницаПапки",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Страница папки"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        {
+                                          "type": "TABLE",
+                                          "id": 178,
+                                          "name": "Папки",
+                                          "title": {
+                                            "content": [
+                                              {
+                                                "default": {
+                                                  "tag": 2
+                                                },
+                                                "int": 1,
+                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                  "langKey": "ru",
+                                                  "value": "Папки"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "dataPath": "Папки",
+                                          "items": [
+                                            {
+                                              "type": "COLUMN_GROUP",
+                                              "id": 181,
+                                              "name": "ПапкиГруппаКолонок",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Папки группа колонок"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "",
+                                              "items": [
+                                                [
+                                                  {
+                                                    "type": "PICTURE_FIELD",
+                                                    "id": 182,
+                                                    "name": "ПапкиНомерКартинки",
+                                                    "title": {
+                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                                    },
+                                                    "dataPath": "Папки.НомерКартинки",
+                                                    "items": []
+                                                  },
+                                                  {
+                                                    "type": "INPUT_FIELD",
+                                                    "id": 184,
+                                                    "name": "ПапкиПредставление",
+                                                    "title": {
+                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                                    },
+                                                    "dataPath": "Папки.Представление",
+                                                    "items": []
+                                                  }
+                                                ],
+                                                []
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "PAGE",
+                                      "id": 305,
+                                      "name": "СтраницаКатегории",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Страница категории"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        {
+                                          "type": "TABLE",
+                                          "id": 306,
+                                          "name": "Категории",
+                                          "title": {
+                                            "content": [
+                                              {
+                                                "default": {
+                                                  "tag": 2
+                                                },
+                                                "int": 1,
+                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                  "langKey": "ru",
+                                                  "value": "Категории"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "dataPath": "Категории",
+                                          "items": [
+                                            {
+                                              "type": "COLUMN_GROUP",
+                                              "id": 311,
+                                              "name": "КатегорииГруппаКолонок",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Категории группа колонок"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "",
+                                              "items": [
+                                                [
+                                                  {
+                                                    "type": "PICTURE_FIELD",
+                                                    "id": 312,
+                                                    "name": "КатегорииНомерКартинки",
+                                                    "title": {
+                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                                    },
+                                                    "dataPath": "Категории.НомерКартинки",
+                                                    "items": []
+                                                  },
+                                                  {
+                                                    "type": "INPUT_FIELD",
+                                                    "id": 309,
+                                                    "name": "КатегорииПредставление",
+                                                    "title": {
+                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                                    },
+                                                    "dataPath": "Категории.Представление",
+                                                    "items": []
+                                                  }
+                                                ],
+                                                []
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  []
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 7,
+                            "name": "ГруппаСписок",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Список"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "TABLE",
+                                  "id": 2,
+                                  "name": "Список",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                  },
+                                  "dataPath": "Список",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "COLUMN_GROUP",
+                                        "id": 772,
+                                        "name": "ГруппаФлаги",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Флаги"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": [
+                                          [
+                                            {
+                                              "type": "PICTURE_FIELD",
+                                              "id": 330,
+                                              "name": "НомерКартинки",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Иконка взаимодействия"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "Список.НомерКартинки",
+                                              "items": []
+                                            },
+                                            {
+                                              "type": "PICTURE_FIELD",
+                                              "id": 340,
+                                              "name": "ВажностьНомерКартинки",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Иконка важности"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "Список.ВажностьНомерКартинки",
+                                              "items": []
+                                            }
+                                          ],
+                                          []
+                                        ]
+                                      },
+                                      {
+                                        "type": "COLUMN_GROUP",
+                                        "id": 812,
+                                        "name": "ГруппаСписокОсновное",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Список основное"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": [
+                                          [
+                                            {
+                                              "type": "COLUMN_GROUP",
+                                              "id": 770,
+                                              "name": "ГруппаУчастникиДатаЕстьВложения",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Участники дата есть вложения"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "",
+                                              "items": [
+                                                [
+                                                  {
+                                                    "type": "LABEL_FIELD",
+                                                    "id": 16,
+                                                    "name": "Участники",
+                                                    "title": {
+                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                                    },
+                                                    "dataPath": "Список.Участники",
+                                                    "items": []
+                                                  },
+                                                  {
+                                                    "type": "LABEL_FIELD",
+                                                    "id": 776,
+                                                    "name": "ПолученоОтправлено",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "Дата"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "Список.ПолученоОтправлено",
+                                                    "items": []
+                                                  },
+                                                  {
+                                                    "type": "INPUT_FIELD",
+                                                    "id": 8,
+                                                    "name": "Дата",
+                                                    "title": {
+                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                                    },
+                                                    "dataPath": "Список.Дата",
+                                                    "items": []
+                                                  },
+                                                  {
+                                                    "type": "PICTURE_FIELD",
+                                                    "id": 108,
+                                                    "name": "ЕстьВложения",
+                                                    "title": {
+                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn[8]/synonym"
+                                                    },
+                                                    "dataPath": "Список.ЕстьВложения",
+                                                    "items": []
+                                                  }
+                                                ],
+                                                []
+                                              ]
+                                            },
+                                            {
+                                              "type": "LABEL_FIELD",
+                                              "id": 12,
+                                              "name": "Тема",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                              },
+                                              "dataPath": "Список.Тема",
+                                              "items": []
+                                            }
+                                          ],
+                                          []
+                                        ]
+                                      },
+                                      {
+                                        "type": "LABEL_FIELD",
+                                        "id": 779,
+                                        "name": "Размер",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn[11]/synonym"
+                                        },
+                                        "dataPath": "Список.Размер",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "LABEL_FIELD",
+                                        "id": 744,
+                                        "name": "УчетнаяЗапись",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                        },
+                                        "dataPath": "Список.УчетнаяЗапись",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "LABEL_FIELD",
+                                        "id": 761,
+                                        "name": "Ссылка",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                        },
+                                        "dataPath": "Список.Ссылка",
+                                        "items": []
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                },
+                                {
+                                  "type": "PAGES",
+                                  "id": 147,
+                                  "name": "СтраницыПредпросмотр",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Страницы предпросмотр"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "PAGE",
+                                        "id": 148,
+                                        "name": "СтраницаПредпросмотрОбычныйТекст",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Страница предпросмотр обычный текст"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": [
+                                          {
+                                            "type": "TEXT_DOCUMENT_FIELD",
+                                            "id": 150,
+                                            "name": "ПредпросмотрОбычныйТекст",
+                                            "title": {
+                                              "content": [
+                                                {
+                                                  "default": {
+                                                    "tag": 2
+                                                  },
+                                                  "int": 1,
+                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                    "langKey": "ru",
+                                                    "value": "Предпросмотр"
+                                                  }
+                                                }
+                                              ]
+                                            },
+                                            "dataPath": "Предпросмотр",
+                                            "items": []
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PAGE",
+                                        "id": 149,
+                                        "name": "СтраницаПредпросмотрHTML",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Страница предпросмотр HTML"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": [
+                                          [
+                                            {
+                                              "type": "USUAL_GROUP",
+                                              "id": 912,
+                                              "name": "ПредупреждениеБезопасности",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Предупреждение безопасности"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "",
+                                              "items": [
+                                                [
+                                                  {
+                                                    "type": "PICTURE_DECORATION",
+                                                    "id": 914,
+                                                    "name": "КартинкаПредупреждение",
+                                                    "title": {
+                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": []
+                                                  },
+                                                  {
+                                                    "type": "LABEL_DECORATION",
+                                                    "id": 909,
+                                                    "name": "ПредупреждениеОНебезопасномСодержимом",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "В целях безопасности некоторые элементы письма отключены, письмо может отображаться некорректно. <link ВключитьНебезопасноеСодержимое>Отобразить небезопасное содержимое</>"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": []
+                                                  }
+                                                ],
+                                                []
+                                              ]
+                                            },
+                                            {
+                                              "type": "HTML_DOCUMENT_FIELD",
+                                              "id": 91,
+                                              "name": "ПредпросмотрHTML",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Предпросмотр HTML"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "ПредпросмотрHTML",
+                                              "items": []
+                                            }
+                                          ],
+                                          []
+                                        ]
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                },
+                                {
+                                  "type": "LABEL_FIELD",
+                                  "id": 323,
+                                  "name": "ОписаниеНайденоПолнотекстовымПоиском",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Описание найденного полнотекстовым поиском"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "ОписаниеНайденоПолнотекстовымПоиском",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          }
+                        ],
+                        []
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 2,
+                "name": "Список",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "DYNAMIC_LIST"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 0
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 4,
+                "name": "Статус",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                        "length": 14,
+                        "allowedLength": 0,
+                        "description": {}
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 5,
+                "name": "Ответственный",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn[3]/synonym"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "СправочникСсылка.Пользователи",
+                          "nameEn": "CatalogRef.Пользователи"
+                        },
+                        "variant": "METADATA",
+                        "kind": "CATALOG"
+                      }
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 6,
+                "name": "ТипВзаимодействия",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Тип взаимодействия"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                        "length": 30,
+                        "allowedLength": 0,
+                        "description": {}
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 8,
+                "name": "СтрокаПоиска",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Строка поиска"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                        "length": 0,
+                        "allowedLength": 0,
+                        "description": {
+                          "value": {
+                            "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                            "nameRu": "КвалификаторыСтроки (0, Переменная)",
+                            "nameEn": "StringQualifiers (0, Variable)"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 9,
+                "name": "Предпросмотр",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 7,
+                "name": "Закладки",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 10,
+                "name": "ТаблицаДопРеквизитовСвойств",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "VALUE_TABLE"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 11,
+                "name": "Свойства",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Контакты"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "VALUE_TREE"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 12,
+                "name": "ТекущееСвойствоПанелиНавигации",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "ПланВидовХарактеристикСсылка.ДополнительныеРеквизитыИСведения",
+                          "nameEn": "ChartOfCharacteristicTypesRef.ДополнительныеРеквизитыИСведения"
+                        },
+                        "variant": "METADATA",
+                        "kind": "CHART_OF_CHARACTERISTIC_TYPES"
+                      }
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 13,
+                "name": "ТекущееСвойствоПанелиНавигацииЯвляетсяРеквизитом",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "BOOLEAN"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 14,
+                "name": "СписокВыбораТипаПредмета",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "VALUE_LIST"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 15,
+                "name": "ИмяТекущейПанелиНавигации",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                        "length": 40,
+                        "allowedLength": 0,
+                        "description": {}
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 16,
+                "name": "ПредставлениеТекущегоСвойства",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                        "length": 150,
+                        "allowedLength": 0,
+                        "description": {}
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 17,
+                "name": "ПоказыватьВсеАктивныеПредметы",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 20,
+                "name": "Папки",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[9]/type"
+                }
+              },
+              {
+                "id": 21,
+                "name": "НастройкиДеревьевПанелиНавигации",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[8]/type"
+                }
+              },
+              {
+                "id": 22,
+                "name": "НеОтрабатыватьАктивизациюПанелиНавигации",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 23,
+                "name": "ОтправлятьСообщениеСразу",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 24,
+                "name": "ТаблицаДопРеквизитовСвойствТипаБулево",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[8]/type"
+                }
+              },
+              {
+                "id": 25,
+                "name": "Категории",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[6]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[8]/type"
+                }
+              },
+              {
+                "id": 26,
+                "name": "ТолькоПочта",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 28,
+                "name": "ОписанияНайденоПолнотекстовымПоиском",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[8]/type"
+                }
+              },
+              {
+                "id": 30,
+                "name": "ОписаниеНайденоПолнотекстовымПоиском",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 31,
+                "name": "РасширенныйПоиск",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 29,
+                "name": "ИнформационнаяБазаФайловая",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 32,
+                "name": "ДокументыДоступныеДляСоздания",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[12]/type"
+                }
+              },
+              {
+                "id": 33,
+                "name": "ИспользоватьПризнакРассмотрено",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 34,
+                "name": "ВзаимодействиеДляКоторогоСформированПредпросмотр",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 5,
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "ДокументСсылка.Встреча",
+                          "nameEn": "DocumentRef.Встреча"
+                        },
+                        "variant": "METADATA",
+                        "kind": "DOCUMENT"
+                      },
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "ДокументСсылка.ЗапланированноеВзаимодействие",
+                          "nameEn": "DocumentRef.ЗапланированноеВзаимодействие"
+                        },
+                        "variant": "METADATA",
+                        "kind": "DOCUMENT"
+                      },
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "ДокументСсылка.ТелефонныйЗвонок",
+                          "nameEn": "DocumentRef.ТелефонныйЗвонок"
+                        },
+                        "variant": "METADATA",
+                        "kind": "DOCUMENT"
+                      },
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "ДокументСсылка.ЭлектронноеПисьмоВходящее",
+                          "nameEn": "DocumentRef.ЭлектронноеПисьмоВходящее"
+                        },
+                        "variant": "METADATA",
+                        "kind": "DOCUMENT"
+                      },
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "ДокументСсылка.ЭлектронноеПисьмоИсходящее",
+                          "nameEn": "DocumentRef.ЭлектронноеПисьмоИсходящее"
+                        },
+                        "variant": "METADATA",
+                        "kind": "DOCUMENT"
+                      }
+                    }
+                  ],
+                  "composite": true,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 35,
+                "name": "ПредпросмотрHTML",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 36,
+                "name": "ПредметыПанельНавигации",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 1,
+                "name": "КонтактыПанельНавигации",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Контакты панель навигации"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 3,
+                "name": "ТолькоЗначимыеПредметы",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 18,
+                "name": "ТолькоЗначимыеКонтакты",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 19,
+                "name": "ОтображатьОбластьЧтения",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 38,
+                "name": "ПанельНавигацииСкрыта",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 39,
+                "name": "ЗаголовокПанелиНавигации",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 40,
+                "name": "ЗаголовокПанелиНавигацииПодсказка",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 41,
+                "name": "ТекущееЗначениеПанелиНавигации",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "types": [],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 42,
+                "name": "ВключитьНебезопасноеСодержимое",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 43,
+                "name": "ЕстьНебезопасноеСодержимое",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 44,
+                "name": "ЗапрещеноОтображениеНебезопасногоСодержимогоВПисьмах",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 27,
+                "name": "ПравоПометкиУдаленияПапок",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 37,
+                "name": "ГиперссылкаЦвет",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[39]/type"
+                }
+              },
+              {
+                "id": 45,
+                "name": "ДатаПредыдущегоВыполненияКомандыОтправкиПолученияПочты",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "DATE"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.qualifiers.DateQualifiers": {
+                        "dateFractions": 2,
+                        "description": {
+                          "value": {
+                            "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                            "nameRu": "КвалификаторыДаты (ДатаВремя)",
+                            "nameEn": "DateQualifiers (DateTime)"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 46,
+                "name": "ДатаПредыдущегоПолученияОтправкиПочты",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[45]/type"
+                }
+              },
+              {
+                "id": 47,
+                "name": "ОтправкаПолучениеПисемВыполняется",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 48,
+                "name": "РазделениеВключено",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 49,
+                "name": "ИндексПолнотекстовогоПоискаАктуален",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "9ab3980e-a480-4f90-a8cc-bde99d5ace35",
+        "name": "ФормаСпискаПараметрическая",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "DocumentJournal.Взаимодействия.Form.ФормаСпискаПараметрическая",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Форма.ФормаСпискаПараметрическая"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Форма списка параметрическая"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/DocumentJournals/Взаимоде_ствия/Forms/ФормаСпискаПараметрическая/Ext/Form/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand/synonym"
+          },
+          "handlers": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[2]"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[5]"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[7]"
+              },
+              {
+                "event": "BeforeLoadDataFromSettingsAtServer",
+                "name": "ПриЗагрузкеДанныхИзНастроекНаСервере"
+              }
+            ],
+            []
+          ],
+          "items": [
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 234,
+                "name": "ГруппаПользовательскихНастроек",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                },
+                "dataPath": "",
+                "items": []
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 34,
+                "name": "ГруппаФильтры",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "USUAL_BUTTON",
+                      "id": 102,
+                      "name": "ПереключитьРежимПросмотра",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "В виде дерева / списка"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 136,
+                      "name": "ТипВзаимодействия",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/title"
+                      },
+                      "dataPath": "ТипВзаимодействия",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 50,
+                      "name": "Статус",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                      },
+                      "dataPath": "Статус",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 46,
+                      "name": "Ответственный",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn[3]/synonym"
+                      },
+                      "dataPath": "Ответственный",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "PAGES",
+                "id": 103,
+                "name": "СтраницыСписокДерево",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Страницы список дерево"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "PAGE",
+                      "id": 104,
+                      "name": "СтраницаСписок",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Страница список"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        {
+                          "type": "TABLE",
+                          "id": 1,
+                          "name": "Список",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                          },
+                          "dataPath": "Список",
+                          "items": [
+                            [
+                              {
+                                "type": "COLUMN_GROUP",
+                                "id": 221,
+                                "name": "ГруппаОсновное",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "COLUMN_GROUP",
+                                      "id": 223,
+                                      "name": "ГруппаСостояниеУчастникиДата",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Состояние участники дата"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        [
+                                          {
+                                            "type": "PICTURE_FIELD",
+                                            "id": 225,
+                                            "name": "НомерКартинки",
+                                            "title": {
+                                              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                            },
+                                            "dataPath": "Список.НомерКартинки",
+                                            "items": []
+                                          },
+                                          {
+                                            "type": "INPUT_FIELD",
+                                            "id": 66,
+                                            "name": "Участники",
+                                            "title": {
+                                              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                            },
+                                            "dataPath": "Список.Участники",
+                                            "items": []
+                                          },
+                                          {
+                                            "type": "INPUT_FIELD",
+                                            "id": 68,
+                                            "name": "Дата",
+                                            "title": {
+                                              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                            },
+                                            "dataPath": "Список.Date",
+                                            "items": []
+                                          },
+                                          {
+                                            "type": "PICTURE_FIELD",
+                                            "id": 254,
+                                            "name": "ЕстьВложения",
+                                            "title": {
+                                              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                            },
+                                            "dataPath": "Список.ЕстьВложения",
+                                            "items": []
+                                          }
+                                        ],
+                                        []
+                                      ]
+                                    },
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 20,
+                                      "name": "Тема",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn[4]/synonym"
+                                      },
+                                      "dataPath": "Список.Тема",
+                                      "items": []
+                                    }
+                                  ],
+                                  []
+                                ]
+                              },
+                              {
+                                "type": "LABEL_FIELD",
+                                "id": 216,
+                                "name": "Ссылка",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                },
+                                "dataPath": "Список.Ref",
+                                "items": []
+                              }
+                            ],
+                            []
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "PAGE",
+                      "id": 105,
+                      "name": "СтраницаДерево",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Страница дерево"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        {
+                          "type": "TABLE",
+                          "id": 106,
+                          "name": "ДеревоВзаимодействий",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Дерево взаимодействий"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "ДеревоВзаимодействий",
+                          "items": [
+                            {
+                              "type": "COLUMN_GROUP",
+                              "id": 228,
+                              "name": "ДеревоВзаимодействийГруппаОсновное",
+                              "title": {
+                                "content": [
+                                  {
+                                    "default": {
+                                      "tag": 2
+                                    },
+                                    "int": 1,
+                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                      "langKey": "ru",
+                                      "value": "Дерево взаимодействий группа основное"
+                                    }
+                                  }
+                                ]
+                              },
+                              "dataPath": "",
+                              "items": [
+                                [
+                                  {
+                                    "type": "COLUMN_GROUP",
+                                    "id": 115,
+                                    "name": "УчастникиСостояниеДата",
+                                    "title": {
+                                      "content": [
+                                        {
+                                          "default": {
+                                            "tag": 2
+                                          },
+                                          "int": 1,
+                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                            "langKey": "ru",
+                                            "value": "Участники состояние дата"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    "dataPath": "",
+                                    "items": [
+                                      [
+                                        {
+                                          "type": "PICTURE_FIELD",
+                                          "id": 113,
+                                          "name": "ДеревоВзаимодействийНомерКартинки",
+                                          "title": {
+                                            "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                          },
+                                          "dataPath": "ДеревоВзаимодействий.НомерКартинки",
+                                          "items": []
+                                        },
+                                        {
+                                          "type": "INPUT_FIELD",
+                                          "id": 118,
+                                          "name": "ДеревоВзаимодействийУчастники",
+                                          "title": {
+                                            "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn[5]/synonym"
+                                          },
+                                          "dataPath": "ДеревоВзаимодействий.Участники",
+                                          "items": []
+                                        },
+                                        {
+                                          "type": "INPUT_FIELD",
+                                          "id": 111,
+                                          "name": "ДеревоВзаимодействийДата",
+                                          "title": {
+                                            "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                          },
+                                          "dataPath": "ДеревоВзаимодействий.Дата",
+                                          "items": []
+                                        }
+                                      ],
+                                      []
+                                    ]
+                                  },
+                                  {
+                                    "type": "INPUT_FIELD",
+                                    "id": 116,
+                                    "name": "ДеревоВзаимодействийТема",
+                                    "title": {
+                                      "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn[4]/synonym"
+                                    },
+                                    "dataPath": "ДеревоВзаимодействий.Тема",
+                                    "items": []
+                                  }
+                                ],
+                                []
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "Список",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 2,
+                "name": "Ответственный",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn[3]/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 5,
+                "name": "Статус",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[2]/type"
+                }
+              },
+              {
+                "id": 6,
+                "name": "ОтборПоПредмету",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 8,
+                "name": "Контакт",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "ОпределяемыйТип.КонтактВзаимодействия",
+                          "nameEn": "DefinedType.КонтактВзаимодействия"
+                        },
+                        "variant": "METADATA",
+                        "kind": "DEFINED_TYPE"
+                      }
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 9,
+                "name": "ПредметДляОтбора",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "ОпределяемыйТип.ПредметВзаимодействия",
+                          "nameEn": "DefinedType.ПредметВзаимодействия"
+                        },
+                        "variant": "METADATA",
+                        "kind": "DEFINED_TYPE"
+                      }
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 3,
+                "name": "ВВидеДерева",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 4,
+                "name": "ДеревоВзаимодействий",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[9]/type"
+                }
+              },
+              {
+                "id": 10,
+                "name": "Интервал",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "STANDARD_PERIOD"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 11,
+                "name": "ТипВзаимодействия",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 12,
+                "name": "ТолькоПочта",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 13,
+                "name": "ДокументыДоступныеДляСоздания",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[12]/type"
+                }
+              },
+              {
+                "id": 14,
+                "name": "ИспользоватьПризнакРассмотрено",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "ec928563-6e35-4b84-b477-90d2481cec1c",
+        "name": "ПечатьЭлектронногоПисьма",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "DocumentJournal.Взаимодействия.Form.ПечатьЭлектронногоПисьма",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Форма.ПечатьЭлектронногоПисьма"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Печать электронного письма"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/DocumentJournals/Взаимоде_ствия/Forms/ПечатьЭлектронногоПисьма/Ext/Form/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/synonym"
+          },
+          "handlers": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[7]"
+            }
+          ],
+          "items": [
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 35,
+                "name": "ГруппаПисьмоОснованиеПечать",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Письмо основание печать"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "LABEL_DECORATION",
+                      "id": 32,
+                      "name": "ДекорацияПисьмоОснование",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "USUAL_BUTTON",
+                      "id": 37,
+                      "name": "Печать",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[12]/synonym"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 39,
+                "name": "ПредупреждениеБезопасности",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "PICTURE_DECORATION",
+                      "id": 41,
+                      "name": "КартинкаПредупреждение",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_DECORATION",
+                      "id": 44,
+                      "name": "ПредупреждениеОНебезопасномСодержимом",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "HTML_DOCUMENT_FIELD",
+                "id": 1,
+                "name": "ТекстHTML",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Текст HTML"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "ТекстHTML",
+                "items": []
+              },
+              {
+                "type": "TABLE",
+                "id": 4,
+                "name": "Вложения",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Вложения"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "Вложения",
+                "items": [
+                  {
+                    "type": "COLUMN_GROUP",
+                    "id": 17,
+                    "name": "Группа",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Группа"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "PICTURE_FIELD",
+                          "id": 19,
+                          "name": "ИндексКартинки",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Индекс картинки"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "Вложения.ИндексКартинки",
+                          "items": []
+                        },
+                        {
+                          "type": "INPUT_FIELD",
+                          "id": 22,
+                          "name": "ИмяФайла",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Вложение"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "Вложения.ИмяФайла",
+                          "items": []
+                        },
+                        {
+                          "type": "INPUT_FIELD",
+                          "id": 25,
+                          "name": "ВложенияРазмерПредставление",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Размер представление"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "Вложения.РазмерПредставление",
+                          "items": []
+                        }
+                      ],
+                      []
+                    ]
+                  }
+                ]
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "ТекстHTML",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 2,
+                "name": "ФормаДиалогаПечатиПриОткрытииОткрывалась",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 4,
+                "name": "НеВызыватьКомандуПечати",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 5,
+                "name": "Вложения",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[8]/type"
+                }
+              },
+              {
+                "id": 6,
+                "name": "ИмяПользователяУчетнойЗаписи",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[14]/type"
+                }
+              },
+              {
+                "id": 7,
+                "name": "ВложенияСИдентификаторами",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[8]/type"
+                }
+              },
+              {
+                "id": 8,
+                "name": "ОтображатьВложенияПисьма",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 9,
+                "name": "Письмо",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 5,
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "СправочникСсылка.ЭлектронноеПисьмоВходящееПрисоединенныеФайлы",
+                          "nameEn": "CatalogRef.ЭлектронноеПисьмоВходящееПрисоединенныеФайлы"
+                        },
+                        "variant": "METADATA",
+                        "kind": "CATALOG"
+                      },
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "СправочникСсылка.ЭлектронноеПисьмоИсходящееПрисоединенныеФайлы",
+                          "nameEn": "CatalogRef.ЭлектронноеПисьмоИсходящееПрисоединенныеФайлы"
+                        },
+                        "variant": "METADATA",
+                        "kind": "CATALOG"
+                      },
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[29]/type/types/java.util.CollSer/com.github._1c_syntax.bsl.types.value.CustomValueType[4]"
+                      },
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[29]/type/types/java.util.CollSer/com.github._1c_syntax.bsl.types.value.CustomValueType[5]"
+                      },
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+                    }
+                  ],
+                  "composite": true,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type/qualifiers/java.util.CollSer/com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers"
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 10,
+                "name": "ТемаПисьма",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                        "length": 500,
+                        "allowedLength": 0,
+                        "description": {}
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 11,
+                "name": "ДатаПисьма",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "DATE"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.qualifiers.DateQualifiers": {
+                        "dateFractions": 1,
+                        "description": {
+                          "value": {
+                            "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                            "nameRu": "КвалификаторыДаты (Дата)",
+                            "nameEn": "DateQualifiers (Date)"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 13,
+                "name": "ПисьмоОснование",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 2,
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[29]/type/types/java.util.CollSer/com.github._1c_syntax.bsl.types.value.CustomValueType[4]"
+                      },
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[29]/type/types/java.util.CollSer/com.github._1c_syntax.bsl.types.value.CustomValueType[5]"
+                      }
+                    }
+                  ],
+                  "composite": true,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 14,
+                "name": "ТемаПисьмаОснования",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 15,
+                "name": "ДатаПисьмаОснования",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[10]/type"
+                }
+              },
+              {
+                "id": 16,
+                "name": "ЗапрещенныеРасширения",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[12]/type"
+                }
+              },
+              {
+                "id": 17,
+                "name": "ВключитьНебезопасноеСодержимое",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 18,
+                "name": "ЕстьНебезопасноеСодержимое",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 19,
+                "name": "ИсходныйТекстHTML",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "5d3e9678-20fe-4128-867a-3f7addaa7831",
+        "name": "ПараметрыЭлектронногоПисьма",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "DocumentJournal.Взаимодействия.Form.ПараметрыЭлектронногоПисьма",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Форма.ПараметрыЭлектронногоПисьма"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Параметры электронного письма"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/DocumentJournals/Взаимоде_ствия/Forms/ПараметрыЭлектронногоПисьма/Ext/Form/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "content": [
+              {
+                "default": {
+                  "tag": 2
+                },
+                "int": 1,
+                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                  "langKey": "ru",
+                  "value": "Параметры письма"
+                }
+              }
+            ]
+          },
+          "handlers": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[4]"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[7]"
+              }
+            ],
+            []
+          ],
+          "items": [
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 22,
+                "name": "ГруппаДатыНомер",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Даты номер"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 8,
+                      "name": "ГруппаДаты",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Даты"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 9,
+                            "name": "Создано",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Создано"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "Создано",
+                            "items": []
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 11,
+                            "name": "ОтправленоПолучено",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Отправлено"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "ОтправленоПолучено",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 25,
+                      "name": "ГруппаВключатьВнутреннийНомер",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Включать внутренний номер"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 6,
+                            "name": "ВнутреннийНомер",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Внутренний номер"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "ВнутреннийНомер",
+                            "items": []
+                          },
+                          {
+                            "type": "CHECK_BOX_FIELD",
+                            "id": 23,
+                            "name": "ВключатьТелоИсходногоПисьма",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Включать тело исходного письма"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "ВключатьТелоИсходногоПисьма",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "INPUT_FIELD",
+                "id": 26,
+                "name": "Папка",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Папка"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "Папка",
+                "items": []
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 5,
+                "name": "ГруппаПараметрыОтслеживания",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Параметры отслеживания"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "CHECK_BOX_FIELD",
+                      "id": 1,
+                      "name": "УведомитьОДоставке",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Уведомить о доставке"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "УведомитьОДоставке",
+                      "items": []
+                    },
+                    {
+                      "type": "CHECK_BOX_FIELD",
+                      "id": 3,
+                      "name": "УведомитьОПрочтении",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Уведомить о прочтении"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "УведомитьОПрочтении",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "TEXT_DOCUMENT_FIELD",
+                "id": 17,
+                "name": "Заголовки",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Заголовки Интернета"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "ЗаголовкиИнтернета",
+                "items": []
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "УведомитьОДоставке",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 2,
+                "name": "УведомитьОПрочтении",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 3,
+                "name": "ВнутреннийНомер",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                        "length": 11,
+                        "allowedLength": 0,
+                        "description": {}
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 4,
+                "name": "Создано",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[45]/type"
+                }
+              },
+              {
+                "id": 5,
+                "name": "ОтправленоПолучено",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Отправлено получено"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[45]/type"
+                }
+              },
+              {
+                "id": 7,
+                "name": "ЗаголовкиИнтернета",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "TEXT_DOCUMENT"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 8,
+                "name": "Письмо",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 9,
+                "name": "ТипПисьма",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 6,
+                "name": "ВключатьТелоИсходногоПисьма",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 10,
+                "name": "Папка",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "СправочникСсылка.ПапкиЭлектронныхПисем",
+                          "nameEn": "CatalogRef.ПапкиЭлектронныхПисем"
+                        },
+                        "variant": "METADATA",
+                        "kind": "CATALOG"
+                      }
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 11,
+                "name": "УчетнаяЗапись",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "СправочникСсылка.УчетныеЗаписиЭлектроннойПочты",
+                          "nameEn": "CatalogRef.УчетныеЗаписиЭлектроннойПочты"
+                        },
+                        "variant": "METADATA",
+                        "kind": "CATALOG"
+                      }
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 12,
+                "name": "ТекущаяПапка",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[10]/type"
+                }
+              },
+              {
+                "id": 13,
+                "name": "ВыполненаКомандаЗакрыть",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "bb878f73-8a0f-459a-9076-ce57fe7957dc",
+        "name": "НастройкиРаботыСПочтой",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "DocumentJournal.Взаимодействия.Form.НастройкиРаботыСПочтой",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Форма.НастройкиРаботыСПочтой"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[11]/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/DocumentJournals/Взаимоде_ствия/Forms/Настро_киРаботыСПочто_/Ext/Form/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[5]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[11]/synonym"
+          },
+          "handlers": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[7]"
+            }
+          ],
+          "items": [
+            [
+              {
+                "type": "INPUT_FIELD",
+                "id": 32,
+                "name": "УчетнаяЗаписьЭлектроннойПочты",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "dataPath": "",
+                "items": []
+              },
+              {
+                "type": "PAGES",
+                "id": 16,
+                "name": "СтраницыНастроек",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Страницы настроек"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "PAGE",
+                      "id": 42,
+                      "name": "ПодписьДляНового",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Подпись для нового"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 17,
+                          "name": "ГруппаДляНовыхСообщений",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Подпись для новых сообщений"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "CHECK_BOX_FIELD",
+                                "id": 1,
+                                "name": "ВключатьПодписьДляНовыхСообщений",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Включать подпись для новых сообщений"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "ВключатьПодписьДляНовыхСообщений",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 3,
+                                "name": "ФорматПодписиДляНовыхСообщений",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Формат подписи"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "ФорматПодписиДляНовыхСообщений",
+                                "items": []
+                              },
+                              {
+                                "type": "USUAL_GROUP",
+                                "id": 7,
+                                "name": "ГруппаВключатьФорматНовые",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Для новых сообщений"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": []
+                              },
+                              {
+                                "type": "PAGES",
+                                "id": 8,
+                                "name": "СтраницыПодписьДляНовыхСообщений",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Страницы подпись для новых сообщений"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "PAGE",
+                                      "id": 9,
+                                      "name": "СтраницаНовоеСообщениеПростойТекст",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Страница новое сообщение простой текст"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        {
+                                          "type": "INPUT_FIELD",
+                                          "id": 5,
+                                          "name": "ПодписьДляНовыхСообщенийПростойТекст",
+                                          "title": {
+                                            "content": [
+                                              {
+                                                "default": {
+                                                  "tag": 2
+                                                },
+                                                "int": 1,
+                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                  "langKey": "ru",
+                                                  "value": "Подпись для новых сообщений простой текст"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "dataPath": "ПодписьДляНовыхСообщенийПростойТекст",
+                                          "items": []
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "PAGE",
+                                      "id": 10,
+                                      "name": "СтраницаНовоеСообщениеФорматированныйТекст",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Страница новое сообщение форматированный текст"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        [
+                                          {
+                                            "type": "COMMAND_BAR",
+                                            "id": 15,
+                                            "name": "ГруппаКомандыФорматированныйДокумент",
+                                            "title": {
+                                              "content": [
+                                                {
+                                                  "default": {
+                                                    "tag": 2
+                                                  },
+                                                  "int": 1,
+                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                    "langKey": "ru",
+                                                    "value": "Команды форматированный документ"
+                                                  }
+                                                }
+                                              ]
+                                            },
+                                            "dataPath": "",
+                                            "items": []
+                                          },
+                                          {
+                                            "type": "FORMATTED_DOCUMENT_FIELD",
+                                            "id": 11,
+                                            "name": "НовоеСообщениеФорматированныйДокумент",
+                                            "title": {
+                                              "content": [
+                                                {
+                                                  "default": {
+                                                    "tag": 2
+                                                  },
+                                                  "int": 1,
+                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                    "langKey": "ru",
+                                                    "value": "Новое сообщение форматированный документ"
+                                                  }
+                                                }
+                                              ]
+                                            },
+                                            "dataPath": "НовоеСообщениеФорматированныйДокумент",
+                                            "items": []
+                                          }
+                                        ],
+                                        []
+                                      ]
+                                    }
+                                  ],
+                                  []
+                                ]
+                              }
+                            ],
+                            []
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "PAGE",
+                      "id": 87,
+                      "name": "ПодписьПриОтвете",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Подпись при ответе"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 18,
+                          "name": "ГруппаПриОтветеПересылке",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Подпись при ответе или пересылке"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "CHECK_BOX_FIELD",
+                                "id": 20,
+                                "name": "ВключатьПодписьПриОтветеПересылке",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Включать подпись при ответе или пересылке"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "ВключатьПодписьПриОтветеПересылке",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 22,
+                                "name": "ФорматПодписиПриОтветеПересылке",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[5]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                },
+                                "dataPath": "ФорматПодписиПриОтветеПересылке",
+                                "items": []
+                              },
+                              {
+                                "type": "PAGES",
+                                "id": 24,
+                                "name": "СтраницыПодписьПриОтветеПересылке",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Страницы подпись при ответе пересылке"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "PAGE",
+                                      "id": 25,
+                                      "name": "СтраницаПриОтветеПересылкеПростойТекст",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Страница при ответе пересылке простой текст"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        {
+                                          "type": "INPUT_FIELD",
+                                          "id": 27,
+                                          "name": "ПодписьПриОтветеПересылкеПростойТекст",
+                                          "title": {
+                                            "content": [
+                                              {
+                                                "default": {
+                                                  "tag": 2
+                                                },
+                                                "int": 1,
+                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                  "langKey": "ru",
+                                                  "value": "Подпись при ответе пересылке простой текст"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "dataPath": "ПодписьПриОтветеПересылкеПростойТекст",
+                                          "items": []
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "PAGE",
+                                      "id": 26,
+                                      "name": "СтраницаПриОтветеПересылкеФорматированныйДокумент",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[5]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        [
+                                          {
+                                            "type": "COMMAND_BAR",
+                                            "id": 31,
+                                            "name": "ГруппаКомандыПриОтветеПересылкеФорматированныйДокумент",
+                                            "title": {
+                                              "content": [
+                                                {
+                                                  "default": {
+                                                    "tag": 2
+                                                  },
+                                                  "int": 1,
+                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                    "langKey": "ru",
+                                                    "value": "Команды при ответе пересылке форматированный документ"
+                                                  }
+                                                }
+                                              ]
+                                            },
+                                            "dataPath": "",
+                                            "items": []
+                                          },
+                                          {
+                                            "type": "FORMATTED_DOCUMENT_FIELD",
+                                            "id": 29,
+                                            "name": "ПриОтветеПересылкеФорматированныйДокумент",
+                                            "title": {
+                                              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                            },
+                                            "dataPath": "ПриОтветеПересылкеФорматированныйДокумент",
+                                            "items": []
+                                          }
+                                        ],
+                                        []
+                                      ]
+                                    }
+                                  ],
+                                  []
+                                ]
+                              }
+                            ],
+                            []
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "PAGE",
+                      "id": 34,
+                      "name": "ОтслеживаниеПисем",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Отслеживание писем"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 39,
+                          "name": "ГруппаДляОтправляемыхСообщений",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Для отправляемых сообщений запрашивать:"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "CHECK_BOX_FIELD",
+                                "id": 37,
+                                "name": "ВсегдаЗапрашиватьУведомлениеОПрочтении",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Уведомление о прочтении"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "ВсегдаЗапрашиватьУведомлениеОПрочтении",
+                                "items": []
+                              },
+                              {
+                                "type": "CHECK_BOX_FIELD",
+                                "id": 35,
+                                "name": "ВсегдаЗапрашиватьУведомленияОДоставке",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Уведомление о доставке"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "ВсегдаЗапрашиватьУведомленияОДоставке",
+                                "items": []
+                              },
+                              {
+                                "type": "RADIO_BUTTON_FIELD",
+                                "id": 40,
+                                "name": "ПорядокОтветовНаЗапросыУведомленийОПрочтении",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Порядок ответов на запросы уведомлений о прочтении"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "ПорядокОтветовНаЗапросыУведомленийОПрочтении",
+                                "items": []
+                              }
+                            ],
+                            []
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "PAGE",
+                      "id": 47,
+                      "name": "Прочее",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Прочее"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "CHECK_BOX_FIELD",
+                            "id": 50,
+                            "name": "ОтображатьТелоИсходногоПисьма",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Отображать тело исходного письма  при ответе или пересылке"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "ОтображатьТелоИсходногоПисьма",
+                            "items": []
+                          },
+                          {
+                            "type": "CHECK_BOX_FIELD",
+                            "id": 52,
+                            "name": "ВключатьТелоИсходногоПисьма",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Включать тело исходного письма при ответе пересылке"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "ВключатьТелоИсходногоПисьма",
+                            "items": []
+                          },
+                          {
+                            "type": "CHECK_BOX_FIELD",
+                            "id": 45,
+                            "name": "ОтправлятьСообщенияСразу",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Отправлять сообщения сразу "
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "ОтправлятьСообщенияСразу",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 2,
+                "name": "НовоеСообщениеФорматированныйДокумент",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[5]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "FORMATTED_DOCUMENT"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 3,
+                "name": "ПриОтветеПересылкеФорматированныйДокумент",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[5]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 1,
+                "name": "НастройкиХранилище",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[39]/type"
+                }
+              },
+              {
+                "id": 4,
+                "name": "ФорматПодписиДляНовыхСообщений",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Формат подписи для новых сообщений"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "ПеречислениеСсылка.СпособыРедактированияЭлектронныхПисем",
+                          "nameEn": "EnumRef.СпособыРедактированияЭлектронныхПисем"
+                        },
+                        "variant": "METADATA",
+                        "kind": "ENUM"
+                      }
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 5,
+                "name": "ПодписьДляНовыхСообщенийПростойТекст",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[5]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 6,
+                "name": "ВключатьПодписьПриОтветеПересылке",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[5]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 7,
+                "name": "ВключатьПодписьДляНовыхСообщений",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[5]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 8,
+                "name": "ФорматПодписиПриОтветеПересылке",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Формат подписи при ответе пересылке"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[5]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 9,
+                "name": "ПодписьПриОтветеПересылкеПростойТекст",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[5]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 10,
+                "name": "ВсегдаЗапрашиватьУведомлениеОПрочтении",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Всегда запрашивать уведомление о прочтении"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 11,
+                "name": "ВсегдаЗапрашиватьУведомленияОДоставке",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Всегда запрашивать уведомления о доставке"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 12,
+                "name": "ПорядокОтветовНаЗапросыУведомленийОПрочтении",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[5]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "ПеречислениеСсылка.ПорядокОтветовНаЗапросыУведомленийОПрочтении",
+                          "nameEn": "EnumRef.ПорядокОтветовНаЗапросыУведомленийОПрочтении"
+                        },
+                        "variant": "METADATA",
+                        "kind": "ENUM"
+                      }
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 13,
+                "name": "ОтправлятьСообщенияСразу",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Отправлять сообщения сразу"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 14,
+                "name": "ОтображатьТелоИсходногоПисьма",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[5]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 15,
+                "name": "ВключатьТелоИсходногоПисьма",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[5]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "cb1d4a41-20a9-4d76-8798-d47d8858bff1",
+        "name": "ВыборТипаПредмета",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "DocumentJournal.Взаимодействия.Form.ВыборТипаПредмета",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Форма.ВыборТипаПредмета"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Выбор типа предмета"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/DocumentJournals/Взаимоде_ствия/Forms/ВыборТипаПредмета/Ext/Form/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "content": [
+              {
+                "default": {
+                  "tag": 2
+                },
+                "int": 1,
+                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                  "langKey": "ru",
+                  "value": "Выберите тип предмета"
+                }
+              }
+            ]
+          },
+          "handlers": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[5]"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[7]"
+              }
+            ],
+            []
+          ],
+          "items": [
+            [
+              {
+                "type": "TABLE",
+                "id": 1,
+                "name": "ТаблицаТиповПредметов",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Таблица типов предметов"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "ТаблицаТиповПредметов",
+                "items": [
+                  {
+                    "type": "INPUT_FIELD",
+                    "id": 14,
+                    "name": "ТаблицаТиповПредметовПредставлениеТипа",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Представление типа"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "ТаблицаТиповПредметов.ПредставлениеТипа",
+                    "items": []
+                  }
+                ]
+              },
+              {
+                "type": "CHECK_BOX_FIELD",
+                "id": 23,
+                "name": "НеОтображатьВзаимодействия",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Не отображать взаимодействия"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "НеОтображатьВзаимодействия",
+                "items": []
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "ТаблицаТиповПредметов",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[8]/type"
+                }
+              },
+              {
+                "id": 2,
+                "name": "ТекущийТипПредмета",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 3,
+                "name": "НеОтображатьВзаимодействия",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      }
+    ],
+    []
+  ],
+  "mdoReference": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+  },
+  "mdoType": "DOCUMENT_JOURNAL",
+  "moduleTypes": [
+    [
+      "ManagerModule",
+      [
+        "src/test/resources/ext/designer/ssl_3_2/src/cf/DocumentJournals/Взаимоде_ствия/Ext/ManagerModule.bsl"
+      ]
+    ]
+  ],
+  "modules": [
+    {
+      "moduleType": "ManagerModule",
+      "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/DocumentJournals/Взаимоде_ствия/Ext/ManagerModule.bsl",
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "isProtected": false
+    }
+  ],
+  "name": "Взаимодействия",
+  "objectBelonging": "OWN",
+  "possibleRights": [
+    {
+      "default": {
+        "tag": 4
+      },
+      "int": 2,
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "VIEW"
+    }
+  ],
+  "registeredDocuments": [
+    [
+      {
+        "type": "DOCUMENT",
+        "mdoRef": "Document.Встреча",
+        "mdoRefRu": "Документ.Встреча"
+      },
+      {
+        "type": "DOCUMENT",
+        "mdoRef": "Document.ТелефонныйЗвонок",
+        "mdoRefRu": "Документ.ТелефонныйЗвонок"
+      },
+      {
+        "type": "DOCUMENT",
+        "mdoRef": "Document.ЭлектронноеПисьмоВходящее",
+        "mdoRefRu": "Документ.ЭлектронноеПисьмоВходящее"
+      },
+      {
+        "type": "DOCUMENT",
+        "mdoRef": "Document.ЭлектронноеПисьмоИсходящее",
+        "mdoRefRu": "Документ.ЭлектронноеПисьмоИсходящее"
+      },
+      {
+        "type": "DOCUMENT",
+        "mdoRef": "Document.ЗапланированноеВзаимодействие",
+        "mdoRefRu": "Документ.ЗапланированноеВзаимодействие"
+      },
+      {
+        "type": "DOCUMENT",
+        "mdoRef": "Document.СообщениеSMS",
+        "mdoRefRu": "Документ.СообщениеSMS"
+      }
+    ],
+    []
+  ],
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand/synonym"
+  },
+  "templates": [
+    [
+      {
+        "uuid": "a2b4110b-4d9c-40fd-ab46-bfa08d2eb993",
+        "name": "СхемаОтборВзаимодействия",
+        "mdoReference": {
+          "type": "TEMPLATE",
+          "mdoRef": "DocumentJournal.Взаимодействия.Template.СхемаОтборВзаимодействия",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Макет.СхемаОтборВзаимодействия"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Схема отбор взаимодействия"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [],
+        "templateType": "DATA_COMPOSITION_SCHEME",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.DataCompositionSchema",
+          "dataSets": [
+            {
+              "name": "ОсновнойНаборДанных",
+              "type": "DATA_SET_QUERY",
+              "dataSource": "ИсточникДанных1",
+              "items": [],
+              "querySource": {
+                "line": 154,
+                "column": 10,
+                "textQuery": "ВЫБРАТЬ РАЗРЕШЕННЫЕ\n\tЖурналДокументовВзаимодействия.Ссылка,\n\tЖурналДокументовВзаимодействия.Дата,\n\tЖурналДокументовВзаимодействия.ПометкаУдаления,\n\tЖурналДокументовВзаимодействия.Номер,\n\tЖурналДокументовВзаимодействия.Проведен,\n\tЖурналДокументовВзаимодействия.Автор,\n\tЖурналДокументовВзаимодействия.Входящий,\n\tЖурналДокументовВзаимодействия.Тема,\n\tЖурналДокументовВзаимодействия.Ответственный КАК Ответственный,\n\tЕСТЬNULL(ПредметыВзаимодействий.Рассмотрено, Ложь) КАК Рассмотрено,\n\tЕСТЬNULL(ПредметыВзаимодействий.РассмотретьПосле, ДатаВремя(1,1,1)) КАК РассмотретьПосле,\n\tЖурналДокументовВзаимодействия.Участники,\n\tЖурналДокументовВзаимодействия.Тип,\n\tЖурналДокументовВзаимодействия.СтатусИсходящегоПисьма,\n\tЖурналДокументовВзаимодействия.ЕстьВложения,\n\tЖурналДокументовВзаимодействия.УчетнаяЗапись,\n\tЕСТЬNULL(ПредметыВзаимодействий.Предмет, НЕОПРЕДЕЛЕНО) КАК Предмет,\n\tТИПЗНАЧЕНИЯ(ПредметыВзаимодействий.Предмет) КАК ТипПредмета,\n\tСостоянияПредметовВзаимодействий.Активен КАК ПредметАктивен,\n\tПредметыВзаимодействий.ПапкаЭлектронногоПисьма КАК Папка,\n\tЖурналДокументовВзаимодействия.ПолученоОтправлено,\n\tЖурналДокументовВзаимодействия.Размер,\n\tЖурналДокументовВзаимодействия.Важность,\n\tВЫБОР\n\t\tКОГДА ЖурналДокументовВзаимодействия.Важность = ЗНАЧЕНИЕ(Перечисление.ВариантыВажностиВзаимодействия.Высокая) ТОГДА 2\n\t\tКОГДА ЖурналДокументовВзаимодействия.Важность = ЗНАЧЕНИЕ(Перечисление.ВариантыВажностиВзаимодействия.Низкая) ТОГДА 0\n\t\tИНАЧЕ 1\n\tКОНЕЦ КАК ВажностьНомерКартинки\nИЗ\n\tЖурналДокументов.Взаимодействия КАК ЖурналДокументовВзаимодействия\n\t\t{ЛЕВОЕ СОЕДИНЕНИЕ РегистрСведений.ПредметыПапкиВзаимодействий КАК ПредметыВзаимодействий\n\t\t\tЛЕВОЕ СОЕДИНЕНИЕ РегистрСведений.СостоянияПредметовВзаимодействий КАК СостоянияПредметовВзаимодействий\n\t\t\tПО ПредметыВзаимодействий.Предмет = СостоянияПредметовВзаимодействий.Предмет\n\t\tПО ЖурналДокументовВзаимодействия.Ссылка = ПредметыВзаимодействий.Взаимодействие}\n{ГДЕ\n\t(ЖурналДокументовВзаимодействия.Дата МЕЖДУ &НачалоПериодаОтбора И &КонецПериодаОтбора)}"
+              },
+              "fields": [
+                [
+                  {
+                    "dataPath": "Дата",
+                    "name": "Дата"
+                  },
+                  {
+                    "dataPath": "ПометкаУдаления",
+                    "name": "ПометкаУдаления"
+                  },
+                  {
+                    "dataPath": "Номер",
+                    "name": "Номер"
+                  },
+                  {
+                    "dataPath": "Проведен",
+                    "name": "Проведен"
+                  },
+                  {
+                    "dataPath": "Ссылка",
+                    "name": "Ссылка"
+                  },
+                  {
+                    "dataPath": "Автор",
+                    "name": "Автор"
+                  },
+                  {
+                    "dataPath": "Входящий",
+                    "name": "Входящий"
+                  },
+                  {
+                    "dataPath": "ЕстьВложения",
+                    "name": "ЕстьВложения"
+                  },
+                  {
+                    "dataPath": "Ответственный",
+                    "name": "Ответственный"
+                  },
+                  {
+                    "dataPath": "Предмет",
+                    "name": "Предмет"
+                  },
+                  {
+                    "dataPath": "СтатусИсходящегоПисьма",
+                    "name": "СтатусИсходящегоПисьма"
+                  },
+                  {
+                    "dataPath": "Участники",
+                    "name": "Участники"
+                  },
+                  {
+                    "dataPath": "ТипПредмета",
+                    "name": "ТипПредмета"
+                  },
+                  {
+                    "dataPath": "УчетнаяЗапись",
+                    "name": "УчетнаяЗапись"
+                  },
+                  {
+                    "dataPath": "Рассмотрено",
+                    "name": "Рассмотрено"
+                  },
+                  {
+                    "dataPath": "РассмотретьПосле",
+                    "name": "РассмотретьПосле"
+                  },
+                  {
+                    "dataPath": "Тип",
+                    "name": "Тип"
+                  },
+                  {
+                    "dataPath": "Папка",
+                    "name": "Папка"
+                  },
+                  {
+                    "dataPath": "Тема",
+                    "name": "Тема"
+                  },
+                  {
+                    "dataPath": "ПолученоОтправлено",
+                    "name": "ПолученоОтправлено"
+                  },
+                  {
+                    "dataPath": "Размер",
+                    "name": "Размер"
+                  },
+                  {
+                    "dataPath": "ПредметАктивен",
+                    "name": "ПредметАктивен"
+                  },
+                  {
+                    "dataPath": "Важность",
+                    "name": "Важность"
+                  },
+                  {
+                    "dataPath": "ВажностьНомерКартинки",
+                    "name": "ВажностьНомерКартинки"
+                  }
+                ],
+                []
+              ]
+            }
+          ],
+          "dataPath": "src/test/resources/ext/designer/ssl_3_2/src/cf/DocumentJournals/Взаимодействия/Templates/СхемаОтборВзаимодействия/Ext/Template.xml"
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        }
+      },
+      {
+        "uuid": "4f262b7f-927e-45f2-ad90-9d5e1b3155d1",
+        "name": "ИерархияВзаимодействийПредмет",
+        "mdoReference": {
+          "type": "TEMPLATE",
+          "mdoRef": "DocumentJournal.Взаимодействия.Template.ИерархияВзаимодействийПредмет",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Макет.ИерархияВзаимодействийПредмет"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Иерархия взаимодействий предмет"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [],
+        "templateType": "DATA_COMPOSITION_SCHEME",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.DataCompositionSchema",
+          "dataSets": [
+            {
+              "name": "ИерархияВзаимодействий",
+              "type": "DATA_SET_QUERY",
+              "dataSource": "ИсточникДанных1",
+              "items": [],
+              "querySource": {
+                "line": 90,
+                "column": 10,
+                "textQuery": "ВЫБРАТЬ РАЗРЕШЕННЫЕ\n\tВзаимодействия.Ссылка,\n\tПредметыПапкиВзаимодействий.Предмет,\n\tВзаимодействия.Ответственный КАК Ответственный,\n\tЕСТЬNULL(ПредметыПапкиВзаимодействий.Рассмотрено, Ложь) КАК Рассмотрено,\n\tЕСТЬNULL(ПредметыПапкиВзаимодействий.РассмотретьПосле, ДатаВремя(1,1,1)) КАК РассмотретьПосле,\n\tВзаимодействия.Тип,\n\tВзаимодействия.СтатусИсходящегоПисьма,\n\tВзаимодействия.ПометкаУдаления,\n\tВзаимодействия.Входящий\nПОМЕСТИТЬ ПредОтбор\nИЗ\n\tЖурналДокументов.Взаимодействия КАК Взаимодействия\n\t\tВНУТРЕННЕЕ СОЕДИНЕНИЕ РегистрСведений.ПредметыПапкиВзаимодействий КАК ПредметыПапкиВзаимодействий\n\t\tПО Взаимодействия.Ссылка = ПредметыПапкиВзаимодействий.Взаимодействие\n{ГДЕ\n\t(Взаимодействия.Дата МЕЖДУ &НачалоПериода И &КонецПериода)}\n;\n\n////////////////////////////////////////////////////////////////////////////////\nВЫБРАТЬ РАЗРЕШЕННЫЕ\n\tВЫБОР\n\t\tКОГДА Взаимодействия.Ссылка ССЫЛКА Документ.Встреча\n\t\t\tТОГДА ВЫБОР\n\t\t\t\t\tКОГДА Взаимодействия.ПометкаУдаления\n\t\t\t\t\t\tТОГДА 10\n\t\t\t\t\tИНАЧЕ 0\n\t\t\t\tКОНЕЦ\n\t\tКОГДА Взаимодействия.Ссылка ССЫЛКА Документ.ЗапланированноеВзаимодействие\n\t\t\tТОГДА ВЫБОР\n\t\t\t\t\tКОГДА Взаимодействия.ПометкаУдаления\n\t\t\t\t\t\tТОГДА 11\n\t\t\t\t\tИНАЧЕ 1\n\t\t\t\tКОНЕЦ\n\t\tКОГДА Взаимодействия.Ссылка ССЫЛКА Документ.ТелефонныйЗвонок\n\t\t\tТОГДА ВЫБОР\n\t\t\t\t\tКОГДА Взаимодействия.ПометкаУдаления\n\t\t\t\t\t\tТОГДА 12\n\t\t\t\t\tИНАЧЕ 2\n\t\t\t\tКОНЕЦ\n\t\tКОГДА Взаимодействия.Ссылка ССЫЛКА Документ.ЭлектронноеПисьмоВходящее\n\t\t\tТОГДА ВЫБОР\n\t\t\t\t\tКОГДА Взаимодействия.ПометкаУдаления\n\t\t\t\t\t\tТОГДА 13\n\t\t\t\t\tИНАЧЕ 3\n\t\t\t\tКОНЕЦ\n\t\tКОГДА Взаимодействия.Ссылка ССЫЛКА Документ.ЭлектронноеПисьмоИсходящее\n\t\t\tТОГДА ВЫБОР\n\t\t\t\t\tКОГДА Взаимодействия.ПометкаУдаления\n\t\t\t\t\t\tТОГДА 14\n\t\t\t\t\tИНАЧЕ ВЫБОР\n\t\t\t\t\t\t\tКОГДА Взаимодействия.СтатусИсходящегоПисьма = ЗНАЧЕНИЕ(Перечисление.СтатусыИсходящегоЭлектронногоПисьма.Черновик)\n\t\t\t\t\t\t\t\tТОГДА 15\n\t\t\t\t\t\t\tКОГДА Взаимодействия.СтатусИсходящегоПисьма = ЗНАЧЕНИЕ(Перечисление.СтатусыИсходящегоЭлектронногоПисьма.Исходящее)\n\t\t\t\t\t\t\t\tТОГДА 16\n\t\t\t\t\t\t\tИНАЧЕ 4\n\t\t\t\t\t\tКОНЕЦ\n\t\t\t\tКОНЕЦ\n\t\tКОГДА Взаимодействия.Ссылка ССЫЛКА Документ.СообщениеSMS\n\t\t\tТОГДА ВЫБОР\n\t\t\t\t\tКОГДА Взаимодействия.ПометкаУдаления\n\t\t\t\t\t\tТОГДА 22\n\t\t\t\t\tИНАЧЕ ВЫБОР\n\t\t\t\t\t\t\tКОГДА Взаимодействия.СтатусИсходящегоПисьма = ЗНАЧЕНИЕ(Перечисление.СостоянияДокументаСообщениеSMS.Черновик)\n\t\t\t\t\t\t\t\tТОГДА 17\n\t\t\t\t\t\t\tКОГДА Взаимодействия.СтатусИсходящегоПисьма = ЗНАЧЕНИЕ(Перечисление.СостоянияДокументаСообщениеSMS.Исходящее)\n\t\t\t\t\t\t\t\tТОГДА 18\n\t\t\t\t\t\t\tКОГДА Взаимодействия.СтатусИсходящегоПисьма = ЗНАЧЕНИЕ(Перечисление.СостоянияДокументаСообщениеSMS.Доставляется)\n\t\t\t\t\t\t\t\tТОГДА 19\n\t\t\t\t\t\t\tКОГДА Взаимодействия.СтатусИсходящегоПисьма = ЗНАЧЕНИЕ(Перечисление.СостоянияДокументаСообщениеSMS.ЧастичноДоставлено)\n\t\t\t\t\t\t\t\tТОГДА 21\n\t\t\t\t\t\t\tКОГДА Взаимодействия.СтатусИсходящегоПисьма = ЗНАЧЕНИЕ(Перечисление.СостоянияДокументаСообщениеSMS.НеДоставлено)\n\t\t\t\t\t\t\t\tТОГДА 23\n\t\t\t\t\t\t\tКОГДА Взаимодействия.СтатусИсходящегоПисьма = ЗНАЧЕНИЕ(Перечисление.СостоянияДокументаСообщениеSMS.Доставлено)\n\t\t\t\t\t\t\t\tТОГДА 24\n\t\t\t\t\t\t\tИНАЧЕ 17\n\t\t\t\t\t\tКОНЕЦ\n\t\t\t\tКОНЕЦ\n\tКОНЕЦ КАК НомерКартинки,\n\tВзаимодействия.Ссылка КАК Ссылка,\n\tЕСТЬNULL(ПредОтбор.Ссылка, НЕОПРЕДЕЛЕНО) КАК ВзаимодействиеОснование,\n\tПредметыПапкиВзаимодействий.Предмет,\n\tВзаимодействия.Ответственный КАК Ответственный,\n\tЕСТЬNULL(ПредметыПапкиВзаимодействий.Рассмотрено, Ложь) КАК Рассмотрено,\n\tЕСТЬNULL(ПредметыПапкиВзаимодействий.РассмотретьПосле, ДатаВремя(1,1,1)) КАК РассмотретьПосле,\n\tВзаимодействия.Дата,\n\tВзаимодействия.Тема,\n\tВзаимодействия.Участники,\n\tВзаимодействия.ПометкаУдаления,\n\tВзаимодействия.Тип,\n\tВзаимодействия.СтатусИсходящегоПисьма,\n\tВзаимодействия.Входящий\nИЗ\n\tЖурналДокументов.Взаимодействия КАК Взаимодействия\n\t\tЛЕВОЕ СОЕДИНЕНИЕ ПредОтбор КАК ПредОтбор\n\t\tПО Взаимодействия.ВзаимодействиеОснование = ПредОтбор.Ссылка\n\t\tВНУТРЕННЕЕ СОЕДИНЕНИЕ РегистрСведений.ПредметыПапкиВзаимодействий КАК ПредметыПапкиВзаимодействий\n\t\tПО Взаимодействия.Ссылка = ПредметыПапкиВзаимодействий.Взаимодействие\n{ГДЕ\n\t(Взаимодействия.Дата МЕЖДУ &НачалоПериода И &КонецПериода)}"
+              },
+              "fields": [
+                [
+                  {
+                    "dataPath": "ВзаимодействиеОснование",
+                    "name": "ВзаимодействиеОснование"
+                  },
+                  {
+                    "dataPath": "Ссылка",
+                    "name": "Ссылка"
+                  },
+                  {
+                    "dataPath": "Ответственный",
+                    "name": "Ответственный"
+                  },
+                  {
+                    "dataPath": "Предмет",
+                    "name": "Предмет"
+                  },
+                  {
+                    "dataPath": "Дата",
+                    "name": "Дата"
+                  },
+                  {
+                    "dataPath": "Рассмотрено",
+                    "name": "Рассмотрено"
+                  },
+                  {
+                    "dataPath": "РассмотретьПосле",
+                    "name": "РассмотретьПосле"
+                  },
+                  {
+                    "dataPath": "Тема",
+                    "name": "Тема"
+                  },
+                  {
+                    "dataPath": "Участники",
+                    "name": "Участники"
+                  },
+                  {
+                    "dataPath": "НомерКартинки",
+                    "name": "НомерКартинки"
+                  },
+                  {
+                    "dataPath": "ПометкаУдаления",
+                    "name": "ПометкаУдаления"
+                  },
+                  {
+                    "dataPath": "Тип",
+                    "name": "Тип"
+                  },
+                  {
+                    "dataPath": "СтатусИсходящегоПисьма",
+                    "name": "СтатусИсходящегоПисьма"
+                  },
+                  {
+                    "dataPath": "Входящий",
+                    "name": "Входящий"
+                  }
+                ],
+                []
+              ]
+            }
+          ],
+          "dataPath": "src/test/resources/ext/designer/ssl_3_2/src/cf/DocumentJournals/Взаимодействия/Templates/ИерархияВзаимодействийПредмет/Ext/Template.xml"
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        }
+      },
+      {
+        "uuid": "9f4b8e36-83ff-4694-8540-b5f47b18395f",
+        "name": "ИерархияВзаимодействийКонтакт",
+        "mdoReference": {
+          "type": "TEMPLATE",
+          "mdoRef": "DocumentJournal.Взаимодействия.Template.ИерархияВзаимодействийКонтакт",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Макет.ИерархияВзаимодействийКонтакт"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Иерархия взаимодействий контакт"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [],
+        "templateType": "DATA_COMPOSITION_SCHEME",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.DataCompositionSchema",
+          "dataSets": [
+            {
+              "name": "ИерархияВзаимодействий",
+              "type": "DATA_SET_QUERY",
+              "dataSource": "ИсточникДанных1",
+              "items": [],
+              "querySource": {
+                "line": 120,
+                "column": 10,
+                "textQuery": "ВЫБРАТЬ РАЗРЕШЕННЫЕ РАЗЛИЧНЫЕ\n\tВзаимодействия.Ссылка КАК Ссылка\nПОМЕСТИТЬ ВзаимодействияПоКонтакту\nИЗ\n\tРегистрСведений.КонтактыВзаимодействий КАК КонтактыВзаимодействий\n\t\tВНУТРЕННЕЕ СОЕДИНЕНИЕ ЖурналДокументов.Взаимодействия КАК Взаимодействия\n\t\tПО КонтактыВзаимодействий.Взаимодействие = Взаимодействия.Ссылка\nГДЕ\n\tКонтактыВзаимодействий.Контакт = &Контакт\n{ГДЕ\n\t(Взаимодействия.Дата МЕЖДУ &НачалоПериода И &КонецПериода)}\n;\n\n////////////////////////////////////////////////////////////////////////////////\nВЫБРАТЬ РАЗРЕШЕННЫЕ РАЗЛИЧНЫЕ\n\tВзаимодействия.Ссылка,\n\tВзаимодействия.Ответственный,\n\tЕСТЬNULL(ПредметыПапкиВзаимодействий.Рассмотрено, ЛОЖЬ) КАК Рассмотрено,\n\tЕСТЬNULL(ПредметыПапкиВзаимодействий.РассмотретьПосле, ДАТАВРЕМЯ(1, 1, 1)) КАК РассмотретьПосле,\n\tВзаимодействия.Тип,\n\tВзаимодействия.СтатусИсходящегоПисьма,\n\tВзаимодействия.ПометкаУдаления,\n\tВзаимодействия.Входящий\nПОМЕСТИТЬ ПредОтбор\nИЗ\n\tЖурналДокументов.Взаимодействия КАК Взаимодействия\n\t\tВНУТРЕННЕЕ СОЕДИНЕНИЕ РегистрСведений.ПредметыПапкиВзаимодействий КАК ПредметыПапкиВзаимодействий\n\t\tПО Взаимодействия.Ссылка = ПредметыПапкиВзаимодействий.Взаимодействие\nГДЕ\n\tВзаимодействия.Ссылка В\n\t\t\t(ВЫБРАТЬ\n\t\t\t\tВзаимодействияПоКонтакту.Ссылка\n\t\t\tИЗ\n\t\t\t\tВзаимодействияПоКонтакту КАК ВзаимодействияПоКонтакту)\n;\n\n////////////////////////////////////////////////////////////////////////////////\nВЫБРАТЬ РАЗРЕШЕННЫЕ\n\tВЫБОР\n\t\tКОГДА Взаимодействия.Ссылка ССЫЛКА Документ.Встреча\n\t\t\tТОГДА ВЫБОР\n\t\t\t\t\tКОГДА Взаимодействия.ПометкаУдаления\n\t\t\t\t\t\tТОГДА 10\n\t\t\t\t\tИНАЧЕ 0\n\t\t\t\tКОНЕЦ\n\t\tКОГДА Взаимодействия.Ссылка ССЫЛКА Документ.ЗапланированноеВзаимодействие\n\t\t\tТОГДА ВЫБОР\n\t\t\t\t\tКОГДА Взаимодействия.ПометкаУдаления\n\t\t\t\t\t\tТОГДА 11\n\t\t\t\t\tИНАЧЕ 1\n\t\t\t\tКОНЕЦ\n\t\tКОГДА Взаимодействия.Ссылка ССЫЛКА Документ.ТелефонныйЗвонок\n\t\t\tТОГДА ВЫБОР\n\t\t\t\t\tКОГДА Взаимодействия.ПометкаУдаления\n\t\t\t\t\t\tТОГДА 12\n\t\t\t\t\tИНАЧЕ 2\n\t\t\t\tКОНЕЦ\n\t\tКОГДА Взаимодействия.Ссылка ССЫЛКА Документ.ЭлектронноеПисьмоВходящее\n\t\t\tТОГДА ВЫБОР\n\t\t\t\t\tКОГДА Взаимодействия.ПометкаУдаления\n\t\t\t\t\t\tТОГДА 13\n\t\t\t\t\tИНАЧЕ 3\n\t\t\t\tКОНЕЦ\n\t\tКОГДА Взаимодействия.Ссылка ССЫЛКА Документ.ЭлектронноеПисьмоИсходящее\n\t\t\tТОГДА ВЫБОР\n\t\t\t\t\tКОГДА Взаимодействия.ПометкаУдаления\n\t\t\t\t\t\tТОГДА 14\n\t\t\t\t\tИНАЧЕ ВЫБОР\n\t\t\t\t\t\t\tКОГДА Взаимодействия.СтатусИсходящегоПисьма = ЗНАЧЕНИЕ(Перечисление.СтатусыИсходящегоЭлектронногоПисьма.Черновик)\n\t\t\t\t\t\t\t\tТОГДА 15\n\t\t\t\t\t\t\tКОГДА Взаимодействия.СтатусИсходящегоПисьма = ЗНАЧЕНИЕ(Перечисление.СтатусыИсходящегоЭлектронногоПисьма.Исходящее)\n\t\t\t\t\t\t\t\tТОГДА 16\n\t\t\t\t\t\t\tИНАЧЕ 4\n\t\t\t\t\t\tКОНЕЦ\n\t\t\t\tКОНЕЦ\n\t\tКОГДА Взаимодействия.Ссылка ССЫЛКА Документ.СообщениеSMS\n\t\t\tТОГДА ВЫБОР\n\t\t\t\t\tКОГДА Взаимодействия.ПометкаУдаления\n\t\t\t\t\t\tТОГДА 22\n\t\t\t\t\tИНАЧЕ ВЫБОР\n\t\t\t\t\t\t\tКОГДА Взаимодействия.СтатусИсходящегоПисьма = ЗНАЧЕНИЕ(Перечисление.СостоянияДокументаСообщениеSMS.Черновик)\n\t\t\t\t\t\t\t\tТОГДА 17\n\t\t\t\t\t\t\tКОГДА Взаимодействия.СтатусИсходящегоПисьма = ЗНАЧЕНИЕ(Перечисление.СостоянияДокументаСообщениеSMS.Исходящее)\n\t\t\t\t\t\t\t\tТОГДА 18\n\t\t\t\t\t\t\tКОГДА Взаимодействия.СтатусИсходящегоПисьма = ЗНАЧЕНИЕ(Перечисление.СостоянияДокументаСообщениеSMS.Доставляется)\n\t\t\t\t\t\t\t\tТОГДА 19\n\t\t\t\t\t\t\tКОГДА Взаимодействия.СтатусИсходящегоПисьма = ЗНАЧЕНИЕ(Перечисление.СостоянияДокументаСообщениеSMS.ЧастичноДоставлено)\n\t\t\t\t\t\t\t\tТОГДА 21\n\t\t\t\t\t\t\tКОГДА Взаимодействия.СтатусИсходящегоПисьма = ЗНАЧЕНИЕ(Перечисление.СостоянияДокументаСообщениеSMS.НеДоставлено)\n\t\t\t\t\t\t\t\tТОГДА 23\n\t\t\t\t\t\t\tКОГДА Взаимодействия.СтатусИсходящегоПисьма = ЗНАЧЕНИЕ(Перечисление.СостоянияДокументаСообщениеSMS.Доставлено)\n\t\t\t\t\t\t\t\tТОГДА 24\n\t\t\t\t\t\t\tИНАЧЕ 17\n\t\t\t\t\t\tКОНЕЦ\n\t\t\t\tКОНЕЦ\n\tКОНЕЦ КАК НомерКартинки,\n\tВзаимодействия.Ссылка КАК Ссылка,\n\tВзаимодействия.Ответственный КАК Ответственный,\n\tЕСТЬNULL(ПредОтбор.Ссылка, НЕОПРЕДЕЛЕНО) КАК ВзаимодействиеОснование,\n\tПредметыПапкиВзаимодействий.Предмет,\n\tЕСТЬNULL(ПредметыПапкиВзаимодействий.Рассмотрено, ЛОЖЬ) КАК Рассмотрено,\n\tЕСТЬNULL(ПредметыПапкиВзаимодействий.РассмотретьПосле, ДАТАВРЕМЯ(1, 1, 1)) КАК РассмотретьПосле,\n\tВзаимодействия.Дата,\n\tВзаимодействия.Тема,\n\tВзаимодействия.Участники,\n\tВзаимодействия.ПометкаУдаления,\n\tВзаимодействия.Тип,\n\tВзаимодействия.СтатусИсходящегоПисьма,\n\tВзаимодействия.Входящий\nИЗ\n\tЖурналДокументов.Взаимодействия КАК Взаимодействия\n\t\tЛЕВОЕ СОЕДИНЕНИЕ ПредОтбор КАК ПредОтбор\n\t\tПО Взаимодействия.ВзаимодействиеОснование = ПредОтбор.Ссылка\n\t\tВНУТРЕННЕЕ СОЕДИНЕНИЕ РегистрСведений.ПредметыПапкиВзаимодействий КАК ПредметыПапкиВзаимодействий\n\t\tПО Взаимодействия.Ссылка = ПредметыПапкиВзаимодействий.Взаимодействие\nГДЕ\n\tВзаимодействия.Ссылка В\n\t\t\t(ВЫБРАТЬ\n\t\t\t\tВзаимодействияПоКонтакту.Ссылка\n\t\t\tИЗ\n\t\t\t\tВзаимодействияПоКонтакту КАК ВзаимодействияПоКонтакту)"
+              },
+              "fields": [
+                [
+                  {
+                    "dataPath": "Ссылка",
+                    "name": "Ссылка"
+                  },
+                  {
+                    "dataPath": "Ответственный",
+                    "name": "Ответственный"
+                  },
+                  {
+                    "dataPath": "Рассмотрено",
+                    "name": "Рассмотрено"
+                  },
+                  {
+                    "dataPath": "РассмотретьПосле",
+                    "name": "РассмотретьПосле"
+                  },
+                  {
+                    "dataPath": "Дата",
+                    "name": "Дата"
+                  },
+                  {
+                    "dataPath": "ВзаимодействиеОснование",
+                    "name": "ВзаимодействиеОснование"
+                  },
+                  {
+                    "dataPath": "НомерКартинки",
+                    "name": "НомерКартинки"
+                  },
+                  {
+                    "dataPath": "Тема",
+                    "name": "Тема"
+                  },
+                  {
+                    "dataPath": "Участники",
+                    "name": "Участники"
+                  },
+                  {
+                    "dataPath": "Предмет",
+                    "name": "Предмет"
+                  },
+                  {
+                    "dataPath": "ПометкаУдаления",
+                    "name": "ПометкаУдаления"
+                  },
+                  {
+                    "dataPath": "Тип",
+                    "name": "Тип"
+                  },
+                  {
+                    "dataPath": "СтатусИсходящегоПисьма",
+                    "name": "СтатусИсходящегоПисьма"
+                  },
+                  {
+                    "dataPath": "Входящий",
+                    "name": "Входящий"
+                  }
+                ],
+                []
+              ]
+            }
+          ],
+          "dataPath": "src/test/resources/ext/designer/ssl_3_2/src/cf/DocumentJournals/Взаимодействия/Templates/ИерархияВзаимодействийКонтакт/Ext/Template.xml"
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        }
+      },
+      {
+        "uuid": "b4c026eb-4271-4366-b529-1cdfe2874563",
+        "name": "СхемаОтборВзаимодействияКонтакт",
+        "mdoReference": {
+          "type": "TEMPLATE",
+          "mdoRef": "DocumentJournal.Взаимодействия.Template.СхемаОтборВзаимодействияКонтакт",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Макет.СхемаОтборВзаимодействияКонтакт"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Схема отбор взаимодействия контакт"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [],
+        "templateType": "DATA_COMPOSITION_SCHEME",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.DataCompositionSchema",
+          "dataSets": [
+            {
+              "name": "ОсновнойНаборДанных",
+              "type": "DATA_SET_QUERY",
+              "dataSource": "ИсточникДанных1",
+              "items": [],
+              "querySource": {
+                "line": 158,
+                "column": 10,
+                "textQuery": "ВЫБРАТЬ РАЗРЕШЕННЫЕ\n\tЖурналДокументовВзаимодействия.Ссылка,\n\tЖурналДокументовВзаимодействия.Дата,\n\tЖурналДокументовВзаимодействия.ПометкаУдаления,\n\tЖурналДокументовВзаимодействия.Номер,\n\tЖурналДокументовВзаимодействия.Проведен,\n\tЖурналДокументовВзаимодействия.Автор,\n\tЖурналДокументовВзаимодействия.Входящий,\n\tЖурналДокументовВзаимодействия.Тема,\n\tЖурналДокументовВзаимодействия.Ответственный КАК Ответственный,\n\tЕСТЬNULL(ПредметыВзаимодействий.Рассмотрено, Ложь) КАК Рассмотрено,\n\tЕСТЬNULL(ПредметыВзаимодействий.РассмотретьПосле, ДатаВремя(1,1,1)) КАК РассмотретьПосле,\n\tЖурналДокументовВзаимодействия.Участники,\n\tЖурналДокументовВзаимодействия.Тип,\n\tЖурналДокументовВзаимодействия.СтатусИсходящегоПисьма,\n\tЖурналДокументовВзаимодействия.ЕстьВложения,\n\tЖурналДокументовВзаимодействия.УчетнаяЗапись,\n\tЕСТЬNULL(ПредметыВзаимодействий.Предмет, НЕОПРЕДЕЛЕНО) КАК Предмет,\n\tТИПЗНАЧЕНИЯ(ПредметыВзаимодействий.Предмет) КАК ТипПредмета,\n\tПредметыВзаимодействий.ПапкаЭлектронногоПисьма КАК Папка,\n\tЖурналДокументовВзаимодействия.ПолученоОтправлено,\n\tЖурналДокументовВзаимодействия.Размер,\n\tЖурналДокументовВзаимодействия.Важность,\n\tВЫБОР\n\t\tКОГДА ЖурналДокументовВзаимодействия.Важность = ЗНАЧЕНИЕ(Перечисление.ВариантыВажностиВзаимодействия.Высокая) ТОГДА 2\n\t\tКОГДА ЖурналДокументовВзаимодействия.Важность = ЗНАЧЕНИЕ(Перечисление.ВариантыВажностиВзаимодействия.Низкая) ТОГДА 0\n\t\tИНАЧЕ 1\n\tКОНЕЦ КАК ВажностьНомерКартинки\nИЗ\n\tЖурналДокументов.Взаимодействия КАК ЖурналДокументовВзаимодействия\n\t\t\tВНУТРЕННЕЕ СОЕДИНЕНИЕ РегистрСведений.ПредметыПапкиВзаимодействий КАК ПредметыВзаимодействий\n\t\tПО ЖурналДокументовВзаимодействия.Ссылка = ПредметыВзаимодействий.Взаимодействие\n\t\t{ВНУТРЕННЕЕ СОЕДИНЕНИЕ РегистрСведений.КонтактыВзаимодействий КАК КонтактыВзаимодействий\nПО ЖурналДокументовВзаимодействия.Ссылка = КонтактыВзаимодействий.Взаимодействие}\n{ГДЕ\n\tЖурналДокументовВзаимодействия.Ссылка КАК Поиск\n\t,\nКонтактыВзаимодействий.Контакт}\n{ГДЕ\n\t(ЖурналДокументовВзаимодействия.Дата МЕЖДУ &ДатаНачала И &ДатаОкончания)}"
+              },
+              "fields": [
+                [
+                  {
+                    "dataPath": "Дата",
+                    "name": "Дата"
+                  },
+                  {
+                    "dataPath": "ПометкаУдаления",
+                    "name": "ПометкаУдаления"
+                  },
+                  {
+                    "dataPath": "Номер",
+                    "name": "Номер"
+                  },
+                  {
+                    "dataPath": "Проведен",
+                    "name": "Проведен"
+                  },
+                  {
+                    "dataPath": "Ссылка",
+                    "name": "Ссылка"
+                  },
+                  {
+                    "dataPath": "Автор",
+                    "name": "Автор"
+                  },
+                  {
+                    "dataPath": "Входящий",
+                    "name": "Входящий"
+                  },
+                  {
+                    "dataPath": "ЕстьВложения",
+                    "name": "ЕстьВложения"
+                  },
+                  {
+                    "dataPath": "Ответственный",
+                    "name": "Ответственный"
+                  },
+                  {
+                    "dataPath": "Предмет",
+                    "name": "Предмет"
+                  },
+                  {
+                    "dataPath": "СтатусИсходящегоПисьма",
+                    "name": "СтатусИсходящегоПисьма"
+                  },
+                  {
+                    "dataPath": "Участники",
+                    "name": "Участники"
+                  },
+                  {
+                    "dataPath": "ТипПредмета",
+                    "name": "ТипПредмета"
+                  },
+                  {
+                    "dataPath": "УчетнаяЗапись",
+                    "name": "УчетнаяЗапись"
+                  },
+                  {
+                    "dataPath": "Рассмотрено",
+                    "name": "Рассмотрено"
+                  },
+                  {
+                    "dataPath": "РассмотретьПосле",
+                    "name": "РассмотретьПосле"
+                  },
+                  {
+                    "dataPath": "Тип",
+                    "name": "Тип"
+                  },
+                  {
+                    "dataPath": "Папка",
+                    "name": "Папка"
+                  },
+                  {
+                    "dataPath": "Тема",
+                    "name": "Тема"
+                  },
+                  {
+                    "dataPath": "ПолученоОтправлено",
+                    "name": "ПолученоОтправлено"
+                  },
+                  {
+                    "dataPath": "Размер",
+                    "name": "Размер"
+                  },
+                  {
+                    "dataPath": "Важность",
+                    "name": "Важность"
+                  },
+                  {
+                    "dataPath": "ВажностьНомерКартинки",
+                    "name": "ВажностьНомерКартинки"
+                  },
+                  {
+                    "dataPath": "Контакт",
+                    "name": "Контакт"
+                  },
+                  {
+                    "dataPath": "Поиск",
+                    "name": "Поиск"
+                  }
+                ],
+                []
+              ]
+            }
+          ],
+          "dataPath": "src/test/resources/ext/designer/ssl_3_2/src/cf/DocumentJournals/Взаимодействия/Templates/СхемаОтборВзаимодействияКонтакт/Ext/Template.xml"
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        }
+      }
+    ],
+    []
+  ],
+  "uuid": "7da57c89-af2c-445a-96f7-39250f70306f"
+}}

--- a/src/test/resources/fixtures/ssl_3_2/DocumentJournals.Взаимодействия.json
+++ b/src/test/resources/fixtures/ssl_3_2/DocumentJournals.Взаимодействия.json
@@ -1432,73 +1432,6 @@
             [
               {
                 "type": "USUAL_GROUP",
-                "id": 926,
-                "name": "ПредупреждениеОНеотправленныхПисьмах",
-                "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Группа предупреждение"
-                      }
-                    }
-                  ]
-                },
-                "dataPath": "",
-                "items": [
-                  [
-                    {
-                      "type": "PICTURE_DECORATION",
-                      "id": 928,
-                      "name": "ПредупреждениеОНеотправленныхПисьмахКартинка",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Картинка предупреждение"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "LABEL_DECORATION",
-                      "id": 931,
-                      "name": "ПредупреждениеОНеотправленныхПисьмахНадпись",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Регламентное задание <b>Получение</><b> </><b>и</><b> </><b>отправка</><b> </><b>писем</> отключено, доставка писем не выполняется. <link ВключитьПолучениеИОтправкуПисем>Включить</>"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": []
-                    }
-                  ],
-                  []
-                ]
-              },
-              {
-                "type": "USUAL_GROUP",
                 "id": 943,
                 "name": "ПредупреждениеОНеактуальностиИндекса",
                 "title": {
@@ -1516,42 +1449,7 @@
                   ]
                 },
                 "dataPath": "",
-                "items": [
-                  [
-                    {
-                      "type": "PICTURE_DECORATION",
-                      "id": 945,
-                      "name": "ПредупреждениеОНеактуальностиИндексаКартинка",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "LABEL_DECORATION",
-                      "id": 948,
-                      "name": "ПредупреждениеОНеактуальностиИндексаНадпись",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Результаты поиска могут быть неточными, повторите поиск позднее"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": []
-                    }
-                  ],
-                  []
-                ]
+                "items": []
               },
               {
                 "type": "USUAL_GROUP",
@@ -1674,6 +1572,27 @@
               },
               {
                 "type": "USUAL_GROUP",
+                "id": 1099,
+                "name": "ГруппаСвернутаяНавигация",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Навигация"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": []
+              },
+              {
+                "type": "USUAL_GROUP",
                 "id": 826,
                 "name": "ГруппаПанельНавигацииСписок",
                 "title": {
@@ -1712,853 +1631,7 @@
                         ]
                       },
                       "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "COMMAND_BAR_BUTTON",
-                            "id": 830,
-                            "name": "ИзменитьОтображениеПанелиНавигации",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Изменить отображение панели навигации"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "POPUP",
-                            "id": 26,
-                            "name": "ВыборВариантаНавигации",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Вариант навигации"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": [
-                              [
-                                {
-                                  "type": "COMMAND_BAR_BUTTON",
-                                  "id": 27,
-                                  "name": "УстановитьВариантНавигацииПоПредмету",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "По предметам"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": []
-                                },
-                                {
-                                  "type": "COMMAND_BAR_BUTTON",
-                                  "id": 28,
-                                  "name": "УстановитьВариантНавигацииПоКонтакту",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "По контактам"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": []
-                                },
-                                {
-                                  "type": "COMMAND_BAR_BUTTON",
-                                  "id": 124,
-                                  "name": "УстановитьВариантНавигацииПоЗакладкам",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "По закладкам"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": []
-                                },
-                                {
-                                  "type": "COMMAND_BAR_BUTTON",
-                                  "id": 176,
-                                  "name": "УстановитьВариантНавигацииПоПапкам",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "По папкам"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": []
-                                }
-                              ],
-                              []
-                            ]
-                          },
-                          {
-                            "type": "BUTTON_GROUP",
-                            "id": 828,
-                            "name": "ГруппаКоманднаяПанельСписок",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Командная панель список"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": [
-                              [
-                                {
-                                  "type": "POPUP",
-                                  "id": 43,
-                                  "name": "ГруппаСоздать",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Создать"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": [
-                                    [
-                                      {
-                                        "type": "COMMAND_BAR_BUTTON",
-                                        "id": 44,
-                                        "name": "СписокСоздатьВстречу",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Встречу"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "",
-                                        "items": []
-                                      },
-                                      {
-                                        "type": "COMMAND_BAR_BUTTON",
-                                        "id": 45,
-                                        "name": "СписокСоздатьЗапланированноеВзаимодействие",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Запланированное взаимодействие"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "",
-                                        "items": []
-                                      },
-                                      {
-                                        "type": "COMMAND_BAR_BUTTON",
-                                        "id": 46,
-                                        "name": "СписокСоздатьТелефонныйЗвонок",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Телефонный звонок"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "",
-                                        "items": []
-                                      },
-                                      {
-                                        "type": "COMMAND_BAR_BUTTON",
-                                        "id": 415,
-                                        "name": "СписокСоздатьСообщениеSMS",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Сообщение SMS"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "",
-                                        "items": []
-                                      },
-                                      {
-                                        "type": "COMMAND_BAR_BUTTON",
-                                        "id": 47,
-                                        "name": "СписокСоздатьЭлектронноеПисьмо",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Электронное письмо"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "",
-                                        "items": []
-                                      }
-                                    ],
-                                    []
-                                  ]
-                                },
-                                {
-                                  "type": "COMMAND_BAR_BUTTON",
-                                  "id": 322,
-                                  "name": "СписокСоздатьЭлектронноеПисьмоОтдельнаяКнопка",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Написать"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": []
-                                },
-                                {
-                                  "type": "BUTTON_GROUP",
-                                  "id": 919,
-                                  "name": "ГруппаОтветитьПереслать",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Ответить переслать"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": [
-                                    [
-                                      {
-                                        "type": "COMMAND_BAR_BUTTON",
-                                        "id": 342,
-                                        "name": "СписокОтветить",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Ответить"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "",
-                                        "items": []
-                                      },
-                                      {
-                                        "type": "COMMAND_BAR_BUTTON",
-                                        "id": 343,
-                                        "name": "СписокОтветитьВсем",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Ответить всем"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "",
-                                        "items": []
-                                      },
-                                      {
-                                        "type": "COMMAND_BAR_BUTTON",
-                                        "id": 344,
-                                        "name": "СписокПереслать",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Переслать"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "",
-                                        "items": []
-                                      }
-                                    ],
-                                    []
-                                  ]
-                                },
-                                {
-                                  "type": "COMMAND_BAR_BUTTON",
-                                  "id": 59,
-                                  "name": "СписокОтправитьПолучитьПочту",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Отправить и получить"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": []
-                                },
-                                {
-                                  "type": "POPUP",
-                                  "id": 917,
-                                  "name": "ПодменюСоздатьНаОсновании",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Создать на основании"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": []
-                                },
-                                {
-                                  "type": "BUTTON_GROUP",
-                                  "id": 410,
-                                  "name": "ГруппаРассмотрено",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Рассмотрено"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": [
-                                    [
-                                      {
-                                        "type": "COMMAND_BAR_BUTTON",
-                                        "id": 40,
-                                        "name": "СписокРассмотрено",
-                                        "title": {
-                                          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[6]/title"
-                                        },
-                                        "dataPath": "",
-                                        "items": []
-                                      },
-                                      {
-                                        "type": "COMMAND_BAR_BUTTON",
-                                        "id": 42,
-                                        "name": "СписокОтложитьРассмотрение",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Отложить рассмотрение..."
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "",
-                                        "items": []
-                                      },
-                                      {
-                                        "type": "COMMAND_BAR_BUTTON",
-                                        "id": 191,
-                                        "name": "СписокНеРассмотрено",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Снять признак рассмотрено"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "",
-                                        "items": []
-                                      },
-                                      {
-                                        "type": "COMMAND_BAR_BUTTON",
-                                        "id": 39,
-                                        "name": "СписокОтветственный",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Установить ответственного..."
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "",
-                                        "items": []
-                                      },
-                                      {
-                                        "type": "COMMAND_BAR_BUTTON",
-                                        "id": 41,
-                                        "name": "СписокПредмет",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Установить предмет взаимодействия..."
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "",
-                                        "items": []
-                                      }
-                                    ],
-                                    []
-                                  ]
-                                },
-                                {
-                                  "type": "POPUP",
-                                  "id": 824,
-                                  "name": "СписокТипВзаимодействия",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Показывать"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": []
-                                },
-                                {
-                                  "type": "POPUP",
-                                  "id": 822,
-                                  "name": "СписокСтатус",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Статус: "
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": []
-                                },
-                                {
-                                  "type": "BUTTON_GROUP",
-                                  "id": 48,
-                                  "name": "ГруппаКомандыСписка",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Команды списка"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": [
-                                    [
-                                      {
-                                        "type": "COMMAND_BAR_BUTTON",
-                                        "id": 49,
-                                        "name": "Изменить",
-                                        "title": {
-                                          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
-                                        },
-                                        "dataPath": "",
-                                        "items": []
-                                      },
-                                      {
-                                        "type": "COMMAND_BAR_BUTTON",
-                                        "id": 50,
-                                        "name": "Скопировать",
-                                        "title": {
-                                          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
-                                        },
-                                        "dataPath": "",
-                                        "items": []
-                                      },
-                                      {
-                                        "type": "BUTTON_GROUP",
-                                        "id": 51,
-                                        "name": "ГруппаСписокУстановитьПометкуУдаления",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Список установить пометку удаления"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "",
-                                        "items": [
-                                          {
-                                            "type": "COMMAND_BAR_BUTTON",
-                                            "id": 52,
-                                            "name": "УстановитьПометкуУдаления",
-                                            "title": {
-                                              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
-                                            },
-                                            "dataPath": "",
-                                            "items": []
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "BUTTON_GROUP",
-                                        "id": 55,
-                                        "name": "ГруппаНайти",
-                                        "title": {
-                                          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                        },
-                                        "dataPath": "",
-                                        "items": [
-                                          [
-                                            {
-                                              "type": "COMMAND_BAR_BUTTON",
-                                              "id": 56,
-                                              "name": "Найти",
-                                              "title": {
-                                                "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
-                                              },
-                                              "dataPath": "",
-                                              "items": []
-                                            },
-                                            {
-                                              "type": "COMMAND_BAR_BUTTON",
-                                              "id": 58,
-                                              "name": "ОтменитьПоиск",
-                                              "title": {
-                                                "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
-                                              },
-                                              "dataPath": "",
-                                              "items": []
-                                            },
-                                            {
-                                              "type": "COMMAND_BAR_BUTTON",
-                                              "id": 54,
-                                              "name": "УстановитьИнтервалДат",
-                                              "title": {
-                                                "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
-                                              },
-                                              "dataPath": "",
-                                              "items": []
-                                            }
-                                          ],
-                                          []
-                                        ]
-                                      }
-                                    ],
-                                    []
-                                  ]
-                                },
-                                {
-                                  "type": "COMMAND_BAR_BUTTON",
-                                  "id": 60,
-                                  "name": "СписокОбновить",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Обновить"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": []
-                                },
-                                {
-                                  "type": "COMMAND_BAR_BUTTON",
-                                  "id": 61,
-                                  "name": "СписокНастройкаСписка",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
-                                  },
-                                  "dataPath": "",
-                                  "items": []
-                                },
-                                {
-                                  "type": "COMMAND_BAR_BUTTON",
-                                  "id": 62,
-                                  "name": "СписокВывестиСписок",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
-                                  },
-                                  "dataPath": "",
-                                  "items": []
-                                },
-                                {
-                                  "type": "COMMAND_BAR_BUTTON",
-                                  "id": 64,
-                                  "name": "СписокИзменитьФорму",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
-                                  },
-                                  "dataPath": "",
-                                  "items": []
-                                },
-                                {
-                                  "type": "COMMAND_BAR_BUTTON",
-                                  "id": 792,
-                                  "name": "СписокОтображатьОбластьЧтения",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Отображать область чтения"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": []
-                                },
-                                {
-                                  "type": "COMMAND_BAR_BUTTON",
-                                  "id": 146,
-                                  "name": "ФормаПерсональныеНастройки",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Персональные настройки..."
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": []
-                                }
-                              ],
-                              []
-                            ]
-                          },
-                          {
-                            "type": "BUTTON_GROUP",
-                            "id": 897,
-                            "name": "ГруппаГлобальныеКоманды",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Глобальные команды"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "COMMAND_BAR_BUTTON",
-                            "id": 63,
-                            "name": "СписокСправка",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
-                            },
-                            "dataPath": "",
-                            "items": []
-                          }
-                        ],
-                        []
-                      ]
+                      "items": []
                     },
                     {
                       "type": "USUAL_GROUP",
@@ -2584,7 +1657,7 @@
                           {
                             "type": "USUAL_GROUP",
                             "id": 6,
-                            "name": "ГруппаПанельНавигации",
+                            "name": "ГруппаПанельНавигацииСлева",
                             "title": {
                               "content": [
                                 {
@@ -2602,30 +1675,19 @@
                             "dataPath": "",
                             "items": [
                               {
-                                "type": "PAGES",
-                                "id": 25,
-                                "name": "СтраницыПанелиНавигации",
+                                "type": "USUAL_GROUP",
+                                "id": 1131,
+                                "name": "ГруппаНавигация",
                                 "title": {
-                                  "content": [
-                                    {
-                                      "default": {
-                                        "tag": 2
-                                      },
-                                      "int": 1,
-                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                        "langKey": "ru",
-                                        "value": "Страницы панели навигации"
-                                      }
-                                    }
-                                  ]
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
                                 },
                                 "dataPath": "",
                                 "items": [
                                   [
                                     {
-                                      "type": "PAGE",
-                                      "id": 30,
-                                      "name": "СтраницаКонтакт",
+                                      "type": "COMMAND_BAR",
+                                      "id": 1095,
+                                      "name": "КоманднаяПанельНавигации",
                                       "title": {
                                         "content": [
                                           {
@@ -2635,7 +1697,160 @@
                                             "int": 1,
                                             "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                                               "langKey": "ru",
-                                              "value": "Страница контакт"
+                                              "value": "Командная панель навигации"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        {
+                                          "type": "BUTTON_GROUP",
+                                          "id": 1097,
+                                          "name": "ГруппаКомандыНавигации",
+                                          "title": {
+                                            "content": [
+                                              {
+                                                "default": {
+                                                  "tag": 2
+                                                },
+                                                "int": 1,
+                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                  "langKey": "ru",
+                                                  "value": "Команды навигации"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "dataPath": "",
+                                          "items": [
+                                            {
+                                              "type": "POPUP",
+                                              "id": 26,
+                                              "name": "ВыборВариантаНавигации",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Вариант навигации"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "",
+                                              "items": [
+                                                [
+                                                  {
+                                                    "type": "COMMAND_BAR_BUTTON",
+                                                    "id": 27,
+                                                    "name": "УстановитьВариантНавигацииПоПредмету",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "По предметам"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": []
+                                                  },
+                                                  {
+                                                    "type": "COMMAND_BAR_BUTTON",
+                                                    "id": 28,
+                                                    "name": "УстановитьВариантНавигацииПоКонтакту",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "По контактам"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": []
+                                                  },
+                                                  {
+                                                    "type": "COMMAND_BAR_BUTTON",
+                                                    "id": 124,
+                                                    "name": "УстановитьВариантНавигацииПоЗакладкам",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "По закладкам"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": []
+                                                  },
+                                                  {
+                                                    "type": "COMMAND_BAR_BUTTON",
+                                                    "id": 176,
+                                                    "name": "УстановитьВариантНавигацииПоПапкам",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "По папкам"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": []
+                                                  }
+                                                ],
+                                                []
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "PAGES",
+                                      "id": 25,
+                                      "name": "СтраницыПанелиНавигации",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Страницы панели навигации"
                                             }
                                           }
                                         ]
@@ -2644,9 +1859,9 @@
                                       "items": [
                                         [
                                           {
-                                            "type": "TABLE",
-                                            "id": 31,
-                                            "name": "КонтактыПанелиНавигации",
+                                            "type": "PAGE",
+                                            "id": 30,
+                                            "name": "СтраницаКонтакт",
                                             "title": {
                                               "content": [
                                                 {
@@ -2656,48 +1871,38 @@
                                                   "int": 1,
                                                   "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                                                     "langKey": "ru",
-                                                    "value": "Контакты панели навигации"
+                                                    "value": "Страница контакт"
                                                   }
                                                 }
                                               ]
                                             },
-                                            "dataPath": "КонтактыПанельНавигации",
+                                            "dataPath": "",
                                             "items": [
-                                              {
-                                                "type": "COLUMN_GROUP",
-                                                "id": 810,
-                                                "name": "КонтактыПанелиНавигацииГруппа",
-                                                "title": {
-                                                  "content": [
-                                                    {
-                                                      "default": {
-                                                        "tag": 2
-                                                      },
-                                                      "int": 1,
-                                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                        "langKey": "ru",
-                                                        "value": "Контакты панели навигации группа"
+                                              [
+                                                {
+                                                  "type": "TABLE",
+                                                  "id": 31,
+                                                  "name": "КонтактыПанелиНавигации",
+                                                  "title": {
+                                                    "content": [
+                                                      {
+                                                        "default": {
+                                                          "tag": 2
+                                                        },
+                                                        "int": 1,
+                                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                          "langKey": "ru",
+                                                          "value": "Контакты"
+                                                        }
                                                       }
-                                                    }
-                                                  ]
-                                                },
-                                                "dataPath": "",
-                                                "items": [
-                                                  [
-                                                    {
-                                                      "type": "LABEL_FIELD",
-                                                      "id": 731,
-                                                      "name": "КонтактыКонтакт",
-                                                      "title": {
-                                                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
-                                                      },
-                                                      "dataPath": "КонтактыПанельНавигации.Контакт",
-                                                      "items": []
-                                                    },
+                                                    ]
+                                                  },
+                                                  "dataPath": "КонтактыПанельНавигации",
+                                                  "items": [
                                                     {
                                                       "type": "COLUMN_GROUP",
-                                                      "id": 784,
-                                                      "name": "КонтактыПанелиНавигацииРассмотреноДата",
+                                                      "id": 1033,
+                                                      "name": "КонтактыПанелиНавигацииГруппа",
                                                       "title": {
                                                         "content": [
                                                           {
@@ -2707,7 +1912,7 @@
                                                             "int": 1,
                                                             "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                                                               "langKey": "ru",
-                                                              "value": "Контакты панели навигации рассмотрено дата"
+                                                              "value": "Контакты панели навигации группа"
                                                             }
                                                           }
                                                         ]
@@ -2715,6 +1920,27 @@
                                                       "dataPath": "",
                                                       "items": [
                                                         [
+                                                          {
+                                                            "type": "LABEL_FIELD",
+                                                            "id": 731,
+                                                            "name": "КонтактыКонтакт",
+                                                            "title": {
+                                                              "content": [
+                                                                {
+                                                                  "default": {
+                                                                    "tag": 2
+                                                                  },
+                                                                  "int": 1,
+                                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                    "langKey": "ru",
+                                                                    "value": "Контакт"
+                                                                  }
+                                                                }
+                                                              ]
+                                                            },
+                                                            "dataPath": "КонтактыПанельНавигации.Контакт",
+                                                            "items": []
+                                                          },
                                                           {
                                                             "type": "LABEL_FIELD",
                                                             "id": 728,
@@ -2750,51 +1976,26 @@
                                                         []
                                                       ]
                                                     }
-                                                  ],
-                                                  []
-                                                ]
-                                              }
+                                                  ]
+                                                },
+                                                {
+                                                  "type": "LABEL_DECORATION",
+                                                  "id": 937,
+                                                  "name": "ДекорацияТолькоЗначимыеКонтакты",
+                                                  "title": {
+                                                    "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                                  },
+                                                  "dataPath": "",
+                                                  "items": []
+                                                }
+                                              ],
+                                              []
                                             ]
                                           },
                                           {
-                                            "type": "LABEL_DECORATION",
-                                            "id": 937,
-                                            "name": "ДекорацияТолькоЗначимыеКонтакты",
-                                            "title": {
-                                              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
-                                            },
-                                            "dataPath": "",
-                                            "items": []
-                                          }
-                                        ],
-                                        []
-                                      ]
-                                    },
-                                    {
-                                      "type": "PAGE",
-                                      "id": 73,
-                                      "name": "СтраницаПредмет",
-                                      "title": {
-                                        "content": [
-                                          {
-                                            "default": {
-                                              "tag": 2
-                                            },
-                                            "int": 1,
-                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                              "langKey": "ru",
-                                              "value": "Страница предмет"
-                                            }
-                                          }
-                                        ]
-                                      },
-                                      "dataPath": "",
-                                      "items": [
-                                        [
-                                          {
-                                            "type": "TABLE",
-                                            "id": 690,
-                                            "name": "ПредметыПанельНавигации",
+                                            "type": "PAGE",
+                                            "id": 73,
+                                            "name": "СтраницаПредмет",
                                             "title": {
                                               "content": [
                                                 {
@@ -2804,59 +2005,38 @@
                                                   "int": 1,
                                                   "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                                                     "langKey": "ru",
-                                                    "value": "Предметы панель навигации"
+                                                    "value": "Страница предмет"
                                                   }
                                                 }
                                               ]
                                             },
-                                            "dataPath": "ПредметыПанельНавигации",
+                                            "dataPath": "",
                                             "items": [
-                                              {
-                                                "type": "COLUMN_GROUP",
-                                                "id": 808,
-                                                "name": "ПредметыПанельНавигацииГруппа",
-                                                "title": {
-                                                  "content": [
-                                                    {
-                                                      "default": {
-                                                        "tag": 2
-                                                      },
-                                                      "int": 1,
-                                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                        "langKey": "ru",
-                                                        "value": "Предметы панель навигации группа"
+                                              [
+                                                {
+                                                  "type": "TABLE",
+                                                  "id": 690,
+                                                  "name": "ПредметыПанельНавигации",
+                                                  "title": {
+                                                    "content": [
+                                                      {
+                                                        "default": {
+                                                          "tag": 2
+                                                        },
+                                                        "int": 1,
+                                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                          "langKey": "ru",
+                                                          "value": "Предметы"
+                                                        }
                                                       }
-                                                    }
-                                                  ]
-                                                },
-                                                "dataPath": "",
-                                                "items": [
-                                                  [
-                                                    {
-                                                      "type": "LABEL_FIELD",
-                                                      "id": 697,
-                                                      "name": "Предмет",
-                                                      "title": {
-                                                        "content": [
-                                                          {
-                                                            "default": {
-                                                              "tag": 2
-                                                            },
-                                                            "int": 1,
-                                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                              "langKey": "ru",
-                                                              "value": "Предмет"
-                                                            }
-                                                          }
-                                                        ]
-                                                      },
-                                                      "dataPath": "ПредметыПанельНавигации.Предмет",
-                                                      "items": []
-                                                    },
+                                                    ]
+                                                  },
+                                                  "dataPath": "ПредметыПанельНавигации",
+                                                  "items": [
                                                     {
                                                       "type": "COLUMN_GROUP",
-                                                      "id": 786,
-                                                      "name": "ПредметыПанельНавигацииГруппаРассмотреноДата",
+                                                      "id": 1035,
+                                                      "name": "ПредметыПанельНавигацииГруппа",
                                                       "title": {
                                                         "content": [
                                                           {
@@ -2866,7 +2046,7 @@
                                                             "int": 1,
                                                             "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                                                               "langKey": "ru",
-                                                              "value": "Предметы панель навигации группа рассмотрено дата"
+                                                              "value": "Предметы панель навигации группа"
                                                             }
                                                           }
                                                         ]
@@ -2874,6 +2054,27 @@
                                                       "dataPath": "",
                                                       "items": [
                                                         [
+                                                          {
+                                                            "type": "LABEL_FIELD",
+                                                            "id": 697,
+                                                            "name": "Предмет",
+                                                            "title": {
+                                                              "content": [
+                                                                {
+                                                                  "default": {
+                                                                    "tag": 2
+                                                                  },
+                                                                  "int": 1,
+                                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                    "langKey": "ru",
+                                                                    "value": "Предмет"
+                                                                  }
+                                                                }
+                                                              ]
+                                                            },
+                                                            "dataPath": "ПредметыПанельНавигации.Предмет",
+                                                            "items": []
+                                                          },
                                                           {
                                                             "type": "LABEL_FIELD",
                                                             "id": 694,
@@ -2889,7 +2090,7 @@
                                                             "id": 700,
                                                             "name": "ДатаПоследнегоВзаимодействия",
                                                             "title": {
-                                                              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                                              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
                                                             },
                                                             "dataPath": "ПредметыПанельНавигации.ДатаПоследнегоВзаимодействия",
                                                             "items": []
@@ -2898,6 +2099,94 @@
                                                         []
                                                       ]
                                                     }
+                                                  ]
+                                                },
+                                                {
+                                                  "type": "LABEL_DECORATION",
+                                                  "id": 934,
+                                                  "name": "ДекорацияТолькоЗначимыеПредметы",
+                                                  "title": {
+                                                    "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                                  },
+                                                  "dataPath": "",
+                                                  "items": []
+                                                }
+                                              ],
+                                              []
+                                            ]
+                                          },
+                                          {
+                                            "type": "PAGE",
+                                            "id": 118,
+                                            "name": "СтраницаЗакладки",
+                                            "title": {
+                                              "content": [
+                                                {
+                                                  "default": {
+                                                    "tag": 2
+                                                  },
+                                                  "int": 1,
+                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                    "langKey": "ru",
+                                                    "value": "Страница закладки"
+                                                  }
+                                                }
+                                              ]
+                                            },
+                                            "dataPath": "",
+                                            "items": [
+                                              {
+                                                "type": "TABLE",
+                                                "id": 119,
+                                                "name": "Закладки",
+                                                "title": {
+                                                  "content": [
+                                                    {
+                                                      "default": {
+                                                        "tag": 2
+                                                      },
+                                                      "int": 1,
+                                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                        "langKey": "ru",
+                                                        "value": "Закладки"
+                                                      }
+                                                    }
+                                                  ]
+                                                },
+                                                "dataPath": "Закладки",
+                                                "items": [
+                                                  [
+                                                    {
+                                                      "type": "LABEL_FIELD",
+                                                      "id": 122,
+                                                      "name": "ЗакладкиНаименование",
+                                                      "title": {
+                                                        "content": [
+                                                          {
+                                                            "default": {
+                                                              "tag": 2
+                                                            },
+                                                            "int": 1,
+                                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                              "langKey": "ru",
+                                                              "value": "Закладка"
+                                                            }
+                                                          }
+                                                        ]
+                                                      },
+                                                      "dataPath": "Закладки.Description",
+                                                      "items": []
+                                                    },
+                                                    {
+                                                      "type": "INPUT_FIELD",
+                                                      "id": 940,
+                                                      "name": "ЗакладкиСсылка",
+                                                      "title": {
+                                                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                                      },
+                                                      "dataPath": "Закладки.Ref",
+                                                      "items": []
+                                                    }
                                                   ],
                                                   []
                                                 ]
@@ -2905,374 +2194,318 @@
                                             ]
                                           },
                                           {
-                                            "type": "LABEL_DECORATION",
-                                            "id": 934,
-                                            "name": "ДекорацияТолькоЗначимыеПредметы",
+                                            "type": "PAGE",
+                                            "id": 129,
+                                            "name": "СтраницаСвойства",
                                             "title": {
-                                              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                              "content": [
+                                                {
+                                                  "default": {
+                                                    "tag": 2
+                                                  },
+                                                  "int": 1,
+                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                    "langKey": "ru",
+                                                    "value": "Страница свойства"
+                                                  }
+                                                }
+                                              ]
                                             },
                                             "dataPath": "",
-                                            "items": []
+                                            "items": [
+                                              {
+                                                "type": "TABLE",
+                                                "id": 130,
+                                                "name": "Свойства",
+                                                "title": {
+                                                  "content": [
+                                                    {
+                                                      "default": {
+                                                        "tag": 2
+                                                      },
+                                                      "int": 1,
+                                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                        "langKey": "ru",
+                                                        "value": "Свойство"
+                                                      }
+                                                    }
+                                                  ]
+                                                },
+                                                "dataPath": "Свойства",
+                                                "items": [
+                                                  {
+                                                    "type": "COLUMN_GROUP",
+                                                    "id": 135,
+                                                    "name": "СвойстваГруппаКолонок",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "Свойства группа колонок"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": [
+                                                      [
+                                                        {
+                                                          "type": "PICTURE_FIELD",
+                                                          "id": 136,
+                                                          "name": "СвойстваНомерКартинки",
+                                                          "title": {
+                                                            "content": [
+                                                              {
+                                                                "default": {
+                                                                  "tag": 2
+                                                                },
+                                                                "int": 1,
+                                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                  "langKey": "ru",
+                                                                  "value": "Номер картинки"
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          "dataPath": "Свойства.НомерКартинки",
+                                                          "items": []
+                                                        },
+                                                        {
+                                                          "type": "INPUT_FIELD",
+                                                          "id": 133,
+                                                          "name": "СвойстваПредставление",
+                                                          "title": {
+                                                            "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                                          },
+                                                          "dataPath": "Свойства.Представление",
+                                                          "items": []
+                                                        }
+                                                      ],
+                                                      []
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "PAGE",
+                                            "id": 177,
+                                            "name": "СтраницаПапки",
+                                            "title": {
+                                              "content": [
+                                                {
+                                                  "default": {
+                                                    "tag": 2
+                                                  },
+                                                  "int": 1,
+                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                    "langKey": "ru",
+                                                    "value": "Страница папки"
+                                                  }
+                                                }
+                                              ]
+                                            },
+                                            "dataPath": "",
+                                            "items": [
+                                              {
+                                                "type": "TABLE",
+                                                "id": 178,
+                                                "name": "Папки",
+                                                "title": {
+                                                  "content": [
+                                                    {
+                                                      "default": {
+                                                        "tag": 2
+                                                      },
+                                                      "int": 1,
+                                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                        "langKey": "ru",
+                                                        "value": "Папки"
+                                                      }
+                                                    }
+                                                  ]
+                                                },
+                                                "dataPath": "Папки",
+                                                "items": [
+                                                  {
+                                                    "type": "COLUMN_GROUP",
+                                                    "id": 181,
+                                                    "name": "ПапкиГруппаКолонок",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "Папки группа колонок"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": [
+                                                      [
+                                                        {
+                                                          "type": "PICTURE_FIELD",
+                                                          "id": 182,
+                                                          "name": "ПапкиНомерКартинки",
+                                                          "title": {
+                                                            "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                                          },
+                                                          "dataPath": "Папки.НомерКартинки",
+                                                          "items": []
+                                                        },
+                                                        {
+                                                          "type": "INPUT_FIELD",
+                                                          "id": 184,
+                                                          "name": "ПапкиПредставление",
+                                                          "title": {
+                                                            "content": [
+                                                              {
+                                                                "default": {
+                                                                  "tag": 2
+                                                                },
+                                                                "int": 1,
+                                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                  "langKey": "ru",
+                                                                  "value": "Папка"
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          "dataPath": "Папки.Представление",
+                                                          "items": []
+                                                        }
+                                                      ],
+                                                      []
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "PAGE",
+                                            "id": 305,
+                                            "name": "СтраницаКатегории",
+                                            "title": {
+                                              "content": [
+                                                {
+                                                  "default": {
+                                                    "tag": 2
+                                                  },
+                                                  "int": 1,
+                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                    "langKey": "ru",
+                                                    "value": "Страница категории"
+                                                  }
+                                                }
+                                              ]
+                                            },
+                                            "dataPath": "",
+                                            "items": [
+                                              {
+                                                "type": "TABLE",
+                                                "id": 306,
+                                                "name": "Категории",
+                                                "title": {
+                                                  "content": [
+                                                    {
+                                                      "default": {
+                                                        "tag": 2
+                                                      },
+                                                      "int": 1,
+                                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                        "langKey": "ru",
+                                                        "value": "Категории"
+                                                      }
+                                                    }
+                                                  ]
+                                                },
+                                                "dataPath": "Категории",
+                                                "items": [
+                                                  {
+                                                    "type": "COLUMN_GROUP",
+                                                    "id": 311,
+                                                    "name": "КатегорииГруппаКолонок",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "Категории группа колонок"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": [
+                                                      [
+                                                        {
+                                                          "type": "PICTURE_FIELD",
+                                                          "id": 312,
+                                                          "name": "КатегорииНомерКартинки",
+                                                          "title": {
+                                                            "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                                          },
+                                                          "dataPath": "Категории.НомерКартинки",
+                                                          "items": []
+                                                        },
+                                                        {
+                                                          "type": "INPUT_FIELD",
+                                                          "id": 309,
+                                                          "name": "КатегорииПредставление",
+                                                          "title": {
+                                                            "content": [
+                                                              {
+                                                                "default": {
+                                                                  "tag": 2
+                                                                },
+                                                                "int": 1,
+                                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                  "langKey": "ru",
+                                                                  "value": "Категория"
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          "dataPath": "Категории.Представление",
+                                                          "items": []
+                                                        }
+                                                      ],
+                                                      []
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
                                           }
                                         ],
                                         []
                                       ]
                                     },
                                     {
-                                      "type": "PAGE",
-                                      "id": 118,
-                                      "name": "СтраницаЗакладки",
+                                      "type": "RADIO_BUTTON_FIELD",
+                                      "id": 1127,
+                                      "name": "ПоложениеНавигации",
                                       "title": {
-                                        "content": [
-                                          {
-                                            "default": {
-                                              "tag": 2
-                                            },
-                                            "int": 1,
-                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                              "langKey": "ru",
-                                              "value": "Страница закладки"
-                                            }
-                                          }
-                                        ]
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
                                       },
-                                      "dataPath": "",
-                                      "items": [
-                                        {
-                                          "type": "TABLE",
-                                          "id": 119,
-                                          "name": "Закладки",
-                                          "title": {
-                                            "content": [
-                                              {
-                                                "default": {
-                                                  "tag": 2
-                                                },
-                                                "int": 1,
-                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                  "langKey": "ru",
-                                                  "value": "Закладки"
-                                                }
-                                              }
-                                            ]
-                                          },
-                                          "dataPath": "Закладки",
-                                          "items": [
-                                            [
-                                              {
-                                                "type": "LABEL_FIELD",
-                                                "id": 122,
-                                                "name": "ЗакладкиНаименование",
-                                                "title": {
-                                                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                                },
-                                                "dataPath": "Закладки.Description",
-                                                "items": []
-                                              },
-                                              {
-                                                "type": "INPUT_FIELD",
-                                                "id": 940,
-                                                "name": "ЗакладкиСсылка",
-                                                "title": {
-                                                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
-                                                },
-                                                "dataPath": "Закладки.Ref",
-                                                "items": []
-                                              }
-                                            ],
-                                            []
-                                          ]
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "PAGE",
-                                      "id": 129,
-                                      "name": "СтраницаСвойства",
-                                      "title": {
-                                        "content": [
-                                          {
-                                            "default": {
-                                              "tag": 2
-                                            },
-                                            "int": 1,
-                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                              "langKey": "ru",
-                                              "value": "Страница свойства"
-                                            }
-                                          }
-                                        ]
-                                      },
-                                      "dataPath": "",
-                                      "items": [
-                                        {
-                                          "type": "TABLE",
-                                          "id": 130,
-                                          "name": "Свойства",
-                                          "title": {
-                                            "content": [
-                                              {
-                                                "default": {
-                                                  "tag": 2
-                                                },
-                                                "int": 1,
-                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                  "langKey": "ru",
-                                                  "value": "Свойства"
-                                                }
-                                              }
-                                            ]
-                                          },
-                                          "dataPath": "Свойства",
-                                          "items": [
-                                            {
-                                              "type": "COLUMN_GROUP",
-                                              "id": 135,
-                                              "name": "СвойстваГруппаКолонок",
-                                              "title": {
-                                                "content": [
-                                                  {
-                                                    "default": {
-                                                      "tag": 2
-                                                    },
-                                                    "int": 1,
-                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                      "langKey": "ru",
-                                                      "value": "Свойства группа колонок"
-                                                    }
-                                                  }
-                                                ]
-                                              },
-                                              "dataPath": "",
-                                              "items": [
-                                                [
-                                                  {
-                                                    "type": "INPUT_FIELD",
-                                                    "id": 133,
-                                                    "name": "СвойстваПредставление",
-                                                    "title": {
-                                                      "content": [
-                                                        {
-                                                          "default": {
-                                                            "tag": 2
-                                                          },
-                                                          "int": 1,
-                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                            "langKey": "ru",
-                                                            "value": "Представление"
-                                                          }
-                                                        }
-                                                      ]
-                                                    },
-                                                    "dataPath": "Свойства.Представление",
-                                                    "items": []
-                                                  },
-                                                  {
-                                                    "type": "PICTURE_FIELD",
-                                                    "id": 136,
-                                                    "name": "СвойстваНомерКартинки",
-                                                    "title": {
-                                                      "content": [
-                                                        {
-                                                          "default": {
-                                                            "tag": 2
-                                                          },
-                                                          "int": 1,
-                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                            "langKey": "ru",
-                                                            "value": "Номер картинки"
-                                                          }
-                                                        }
-                                                      ]
-                                                    },
-                                                    "dataPath": "Свойства.НомерКартинки",
-                                                    "items": []
-                                                  }
-                                                ],
-                                                []
-                                              ]
-                                            }
-                                          ]
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "PAGE",
-                                      "id": 177,
-                                      "name": "СтраницаПапки",
-                                      "title": {
-                                        "content": [
-                                          {
-                                            "default": {
-                                              "tag": 2
-                                            },
-                                            "int": 1,
-                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                              "langKey": "ru",
-                                              "value": "Страница папки"
-                                            }
-                                          }
-                                        ]
-                                      },
-                                      "dataPath": "",
-                                      "items": [
-                                        {
-                                          "type": "TABLE",
-                                          "id": 178,
-                                          "name": "Папки",
-                                          "title": {
-                                            "content": [
-                                              {
-                                                "default": {
-                                                  "tag": 2
-                                                },
-                                                "int": 1,
-                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                  "langKey": "ru",
-                                                  "value": "Папки"
-                                                }
-                                              }
-                                            ]
-                                          },
-                                          "dataPath": "Папки",
-                                          "items": [
-                                            {
-                                              "type": "COLUMN_GROUP",
-                                              "id": 181,
-                                              "name": "ПапкиГруппаКолонок",
-                                              "title": {
-                                                "content": [
-                                                  {
-                                                    "default": {
-                                                      "tag": 2
-                                                    },
-                                                    "int": 1,
-                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                      "langKey": "ru",
-                                                      "value": "Папки группа колонок"
-                                                    }
-                                                  }
-                                                ]
-                                              },
-                                              "dataPath": "",
-                                              "items": [
-                                                [
-                                                  {
-                                                    "type": "PICTURE_FIELD",
-                                                    "id": 182,
-                                                    "name": "ПапкиНомерКартинки",
-                                                    "title": {
-                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                                                    },
-                                                    "dataPath": "Папки.НомерКартинки",
-                                                    "items": []
-                                                  },
-                                                  {
-                                                    "type": "INPUT_FIELD",
-                                                    "id": 184,
-                                                    "name": "ПапкиПредставление",
-                                                    "title": {
-                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                                    },
-                                                    "dataPath": "Папки.Представление",
-                                                    "items": []
-                                                  }
-                                                ],
-                                                []
-                                              ]
-                                            }
-                                          ]
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "PAGE",
-                                      "id": 305,
-                                      "name": "СтраницаКатегории",
-                                      "title": {
-                                        "content": [
-                                          {
-                                            "default": {
-                                              "tag": 2
-                                            },
-                                            "int": 1,
-                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                              "langKey": "ru",
-                                              "value": "Страница категории"
-                                            }
-                                          }
-                                        ]
-                                      },
-                                      "dataPath": "",
-                                      "items": [
-                                        {
-                                          "type": "TABLE",
-                                          "id": 306,
-                                          "name": "Категории",
-                                          "title": {
-                                            "content": [
-                                              {
-                                                "default": {
-                                                  "tag": 2
-                                                },
-                                                "int": 1,
-                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                  "langKey": "ru",
-                                                  "value": "Категории"
-                                                }
-                                              }
-                                            ]
-                                          },
-                                          "dataPath": "Категории",
-                                          "items": [
-                                            {
-                                              "type": "COLUMN_GROUP",
-                                              "id": 311,
-                                              "name": "КатегорииГруппаКолонок",
-                                              "title": {
-                                                "content": [
-                                                  {
-                                                    "default": {
-                                                      "tag": 2
-                                                    },
-                                                    "int": 1,
-                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                      "langKey": "ru",
-                                                      "value": "Категории группа колонок"
-                                                    }
-                                                  }
-                                                ]
-                                              },
-                                              "dataPath": "",
-                                              "items": [
-                                                [
-                                                  {
-                                                    "type": "PICTURE_FIELD",
-                                                    "id": 312,
-                                                    "name": "КатегорииНомерКартинки",
-                                                    "title": {
-                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                                                    },
-                                                    "dataPath": "Категории.НомерКартинки",
-                                                    "items": []
-                                                  },
-                                                  {
-                                                    "type": "INPUT_FIELD",
-                                                    "id": 309,
-                                                    "name": "КатегорииПредставление",
-                                                    "title": {
-                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                                    },
-                                                    "dataPath": "Категории.Представление",
-                                                    "items": []
-                                                  }
-                                                ],
-                                                []
-                                              ]
-                                            }
-                                          ]
-                                        }
-                                      ]
+                                      "dataPath": "ПоложениеНавигации",
+                                      "items": []
                                     }
                                   ],
                                   []
@@ -3312,9 +2545,9 @@
                                   "items": [
                                     [
                                       {
-                                        "type": "COLUMN_GROUP",
-                                        "id": 772,
-                                        "name": "ГруппаФлаги",
+                                        "type": "PICTURE_FIELD",
+                                        "id": 340,
+                                        "name": "ВажностьНомерКартинки",
                                         "title": {
                                           "content": [
                                             {
@@ -3324,64 +2557,18 @@
                                               "int": 1,
                                               "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                                                 "langKey": "ru",
-                                                "value": "Флаги"
+                                                "value": "Иконка важности"
                                               }
                                             }
                                           ]
                                         },
-                                        "dataPath": "",
-                                        "items": [
-                                          [
-                                            {
-                                              "type": "PICTURE_FIELD",
-                                              "id": 330,
-                                              "name": "НомерКартинки",
-                                              "title": {
-                                                "content": [
-                                                  {
-                                                    "default": {
-                                                      "tag": 2
-                                                    },
-                                                    "int": 1,
-                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                      "langKey": "ru",
-                                                      "value": "Иконка взаимодействия"
-                                                    }
-                                                  }
-                                                ]
-                                              },
-                                              "dataPath": "Список.НомерКартинки",
-                                              "items": []
-                                            },
-                                            {
-                                              "type": "PICTURE_FIELD",
-                                              "id": 340,
-                                              "name": "ВажностьНомерКартинки",
-                                              "title": {
-                                                "content": [
-                                                  {
-                                                    "default": {
-                                                      "tag": 2
-                                                    },
-                                                    "int": 1,
-                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                      "langKey": "ru",
-                                                      "value": "Иконка важности"
-                                                    }
-                                                  }
-                                                ]
-                                              },
-                                              "dataPath": "Список.ВажностьНомерКартинки",
-                                              "items": []
-                                            }
-                                          ],
-                                          []
-                                        ]
+                                        "dataPath": "Список.ВажностьНомерКартинки",
+                                        "items": []
                                       },
                                       {
-                                        "type": "COLUMN_GROUP",
-                                        "id": 812,
-                                        "name": "ГруппаСписокОсновное",
+                                        "type": "PICTURE_FIELD",
+                                        "id": 330,
+                                        "name": "НомерКартинки",
                                         "title": {
                                           "content": [
                                             {
@@ -3391,103 +2578,74 @@
                                               "int": 1,
                                               "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                                                 "langKey": "ru",
-                                                "value": "Список основное"
+                                                "value": "Иконка взаимодействия"
                                               }
                                             }
                                           ]
                                         },
-                                        "dataPath": "",
-                                        "items": [
-                                          [
+                                        "dataPath": "Список.НомерКартинки",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "LABEL_FIELD",
+                                        "id": 12,
+                                        "name": "Тема",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                        },
+                                        "dataPath": "Список.Тема",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "LABEL_FIELD",
+                                        "id": 16,
+                                        "name": "Участники",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                        },
+                                        "dataPath": "Список.Участники",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "LABEL_FIELD",
+                                        "id": 776,
+                                        "name": "ПолученоОтправлено",
+                                        "title": {
+                                          "content": [
                                             {
-                                              "type": "COLUMN_GROUP",
-                                              "id": 770,
-                                              "name": "ГруппаУчастникиДатаЕстьВложения",
-                                              "title": {
-                                                "content": [
-                                                  {
-                                                    "default": {
-                                                      "tag": 2
-                                                    },
-                                                    "int": 1,
-                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                      "langKey": "ru",
-                                                      "value": "Участники дата есть вложения"
-                                                    }
-                                                  }
-                                                ]
+                                              "default": {
+                                                "tag": 2
                                               },
-                                              "dataPath": "",
-                                              "items": [
-                                                [
-                                                  {
-                                                    "type": "LABEL_FIELD",
-                                                    "id": 16,
-                                                    "name": "Участники",
-                                                    "title": {
-                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
-                                                    },
-                                                    "dataPath": "Список.Участники",
-                                                    "items": []
-                                                  },
-                                                  {
-                                                    "type": "LABEL_FIELD",
-                                                    "id": 776,
-                                                    "name": "ПолученоОтправлено",
-                                                    "title": {
-                                                      "content": [
-                                                        {
-                                                          "default": {
-                                                            "tag": 2
-                                                          },
-                                                          "int": 1,
-                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                            "langKey": "ru",
-                                                            "value": "Дата"
-                                                          }
-                                                        }
-                                                      ]
-                                                    },
-                                                    "dataPath": "Список.ПолученоОтправлено",
-                                                    "items": []
-                                                  },
-                                                  {
-                                                    "type": "INPUT_FIELD",
-                                                    "id": 8,
-                                                    "name": "Дата",
-                                                    "title": {
-                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
-                                                    },
-                                                    "dataPath": "Список.Дата",
-                                                    "items": []
-                                                  },
-                                                  {
-                                                    "type": "PICTURE_FIELD",
-                                                    "id": 108,
-                                                    "name": "ЕстьВложения",
-                                                    "title": {
-                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn[8]/synonym"
-                                                    },
-                                                    "dataPath": "Список.ЕстьВложения",
-                                                    "items": []
-                                                  }
-                                                ],
-                                                []
-                                              ]
-                                            },
-                                            {
-                                              "type": "LABEL_FIELD",
-                                              "id": 12,
-                                              "name": "Тема",
-                                              "title": {
-                                                "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
-                                              },
-                                              "dataPath": "Список.Тема",
-                                              "items": []
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Дата"
+                                              }
                                             }
-                                          ],
-                                          []
-                                        ]
+                                          ]
+                                        },
+                                        "dataPath": "Список.ПолученоОтправлено",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "INPUT_FIELD",
+                                        "id": 8,
+                                        "name": "Дата",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                        },
+                                        "dataPath": "Список.Дата",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "PICTURE_FIELD",
+                                        "id": 108,
+                                        "name": "ЕстьВложения",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn[8]/synonym"
+                                        },
+                                        "dataPath": "Список.ЕстьВложения",
+                                        "items": []
                                       },
                                       {
                                         "type": "LABEL_FIELD",
@@ -3565,7 +2723,7 @@
                                         "dataPath": "",
                                         "items": [
                                           {
-                                            "type": "TEXT_DOCUMENT_FIELD",
+                                            "type": "INPUT_FIELD",
                                             "id": 150,
                                             "name": "ПредпросмотрОбычныйТекст",
                                             "title": {
@@ -3634,7 +2792,18 @@
                                                     "id": 914,
                                                     "name": "КартинкаПредупреждение",
                                                     "title": {
-                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "Картинка предупреждение"
+                                                          }
+                                                        }
+                                                      ]
                                                     },
                                                     "dataPath": "",
                                                     "items": []
@@ -3665,9 +2834,9 @@
                                               ]
                                             },
                                             {
-                                              "type": "HTML_DOCUMENT_FIELD",
-                                              "id": 91,
-                                              "name": "ПредпросмотрHTML",
+                                              "type": "USUAL_GROUP",
+                                              "id": 1031,
+                                              "name": "Группа1",
                                               "title": {
                                                 "content": [
                                                   {
@@ -3677,13 +2846,35 @@
                                                     "int": 1,
                                                     "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                                                       "langKey": "ru",
-                                                      "value": "Предпросмотр HTML"
+                                                      "value": "Группа"
                                                     }
                                                   }
                                                 ]
                                               },
-                                              "dataPath": "ПредпросмотрHTML",
-                                              "items": []
+                                              "dataPath": "",
+                                              "items": [
+                                                {
+                                                  "type": "HTML_DOCUMENT_FIELD",
+                                                  "id": 91,
+                                                  "name": "ПредпросмотрHTML",
+                                                  "title": {
+                                                    "content": [
+                                                      {
+                                                        "default": {
+                                                          "tag": 2
+                                                        },
+                                                        "int": 1,
+                                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                          "langKey": "ru",
+                                                          "value": "Предпросмотр HTML"
+                                                        }
+                                                      }
+                                                    ]
+                                                  },
+                                                  "dataPath": "ПредпросмотрHTML",
+                                                  "items": []
+                                                }
+                                              ]
                                             }
                                           ],
                                           []
@@ -3762,7 +2953,7 @@
                 "id": 4,
                 "name": "Статус",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
                 },
                 "type": {
                   "types": [
@@ -3923,7 +3114,7 @@
                 "id": 7,
                 "name": "Закладки",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
@@ -3953,18 +3144,7 @@
                 "id": 11,
                 "name": "Свойства",
                 "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Контакты"
-                      }
-                    }
-                  ]
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "types": [
@@ -4125,7 +3305,7 @@
                 "id": 20,
                 "name": "Папки",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[9]/type"
@@ -4175,7 +3355,7 @@
                 "id": 25,
                 "name": "Категории",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[6]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[6]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[8]/type"
@@ -4314,7 +3494,7 @@
                 "id": 35,
                 "name": "ПредпросмотрHTML",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
@@ -4324,7 +3504,18 @@
                 "id": 36,
                 "name": "ПредметыПанельНавигации",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Предметы панель навигации"
+                      }
+                    }
+                  ]
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
@@ -4374,16 +3565,6 @@
               {
                 "id": 19,
                 "name": "ОтображатьОбластьЧтения",
-                "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
-                },
-                "type": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
-                }
-              },
-              {
-                "id": 38,
-                "name": "ПанельНавигацииСкрыта",
                 "title": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
                 },
@@ -4470,7 +3651,7 @@
                   "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
                 },
                 "type": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[39]/type"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[38]/type"
                 }
               },
               {
@@ -4517,7 +3698,7 @@
                   "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
                 },
                 "type": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[45]/type"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[44]/type"
                 }
               },
               {
@@ -4543,6 +3724,37 @@
               {
                 "id": 49,
                 "name": "ИндексПолнотекстовогоПоискаАктуален",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 50,
+                "name": "ПоложениеНавигации",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Положение навигации"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 38,
+                "name": "ОтправкаПисемПриостановлена",
                 "title": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
                 },
@@ -4635,7 +3847,7 @@
                 "id": 234,
                 "name": "ГруппаПользовательскихНастроек",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                 },
                 "dataPath": "",
                 "items": []
@@ -4645,7 +3857,7 @@
                 "id": 34,
                 "name": "ГруппаФильтры",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
                 },
                 "dataPath": "",
                 "items": [
@@ -4676,7 +3888,7 @@
                       "id": 136,
                       "name": "ТипВзаимодействия",
                       "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/title"
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                       },
                       "dataPath": "ТипВзаимодействия",
                       "items": []
@@ -4686,7 +3898,7 @@
                       "id": 50,
                       "name": "Статус",
                       "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
                       },
                       "dataPath": "Статус",
                       "items": []
@@ -4757,93 +3969,54 @@
                           "items": [
                             [
                               {
-                                "type": "COLUMN_GROUP",
-                                "id": 221,
-                                "name": "ГруппаОсновное",
+                                "type": "PICTURE_FIELD",
+                                "id": 225,
+                                "name": "НомерКартинки",
                                 "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                                 },
-                                "dataPath": "",
-                                "items": [
-                                  [
-                                    {
-                                      "type": "COLUMN_GROUP",
-                                      "id": 223,
-                                      "name": "ГруппаСостояниеУчастникиДата",
-                                      "title": {
-                                        "content": [
-                                          {
-                                            "default": {
-                                              "tag": 2
-                                            },
-                                            "int": 1,
-                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                              "langKey": "ru",
-                                              "value": "Состояние участники дата"
-                                            }
-                                          }
-                                        ]
-                                      },
-                                      "dataPath": "",
-                                      "items": [
-                                        [
-                                          {
-                                            "type": "PICTURE_FIELD",
-                                            "id": 225,
-                                            "name": "НомерКартинки",
-                                            "title": {
-                                              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                            },
-                                            "dataPath": "Список.НомерКартинки",
-                                            "items": []
-                                          },
-                                          {
-                                            "type": "INPUT_FIELD",
-                                            "id": 66,
-                                            "name": "Участники",
-                                            "title": {
-                                              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
-                                            },
-                                            "dataPath": "Список.Участники",
-                                            "items": []
-                                          },
-                                          {
-                                            "type": "INPUT_FIELD",
-                                            "id": 68,
-                                            "name": "Дата",
-                                            "title": {
-                                              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
-                                            },
-                                            "dataPath": "Список.Date",
-                                            "items": []
-                                          },
-                                          {
-                                            "type": "PICTURE_FIELD",
-                                            "id": 254,
-                                            "name": "ЕстьВложения",
-                                            "title": {
-                                              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
-                                            },
-                                            "dataPath": "Список.ЕстьВложения",
-                                            "items": []
-                                          }
-                                        ],
-                                        []
-                                      ]
-                                    },
-                                    {
-                                      "type": "INPUT_FIELD",
-                                      "id": 20,
-                                      "name": "Тема",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn[4]/synonym"
-                                      },
-                                      "dataPath": "Список.Тема",
-                                      "items": []
-                                    }
-                                  ],
-                                  []
-                                ]
+                                "dataPath": "Список.НомерКартинки",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 20,
+                                "name": "Тема",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn[4]/synonym"
+                                },
+                                "dataPath": "Список.Тема",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 66,
+                                "name": "Участники",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                },
+                                "dataPath": "Список.Участники",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 68,
+                                "name": "Дата",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                },
+                                "dataPath": "Список.Date",
+                                "items": []
+                              },
+                              {
+                                "type": "PICTURE_FIELD",
+                                "id": 254,
+                                "name": "ЕстьВложения",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                },
+                                "dataPath": "Список.ЕстьВложения",
+                                "items": []
                               },
                               {
                                 "type": "LABEL_FIELD",
@@ -4901,96 +4074,49 @@
                           },
                           "dataPath": "ДеревоВзаимодействий",
                           "items": [
-                            {
-                              "type": "COLUMN_GROUP",
-                              "id": 228,
-                              "name": "ДеревоВзаимодействийГруппаОсновное",
-                              "title": {
-                                "content": [
-                                  {
-                                    "default": {
-                                      "tag": 2
-                                    },
-                                    "int": 1,
-                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                      "langKey": "ru",
-                                      "value": "Дерево взаимодействий группа основное"
-                                    }
-                                  }
-                                ]
+                            [
+                              {
+                                "type": "PICTURE_FIELD",
+                                "id": 113,
+                                "name": "ДеревоВзаимодействийНомерКартинки",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                },
+                                "dataPath": "ДеревоВзаимодействий.НомерКартинки",
+                                "items": []
                               },
-                              "dataPath": "",
-                              "items": [
-                                [
-                                  {
-                                    "type": "COLUMN_GROUP",
-                                    "id": 115,
-                                    "name": "УчастникиСостояниеДата",
-                                    "title": {
-                                      "content": [
-                                        {
-                                          "default": {
-                                            "tag": 2
-                                          },
-                                          "int": 1,
-                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                            "langKey": "ru",
-                                            "value": "Участники состояние дата"
-                                          }
-                                        }
-                                      ]
-                                    },
-                                    "dataPath": "",
-                                    "items": [
-                                      [
-                                        {
-                                          "type": "PICTURE_FIELD",
-                                          "id": 113,
-                                          "name": "ДеревоВзаимодействийНомерКартинки",
-                                          "title": {
-                                            "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                                          },
-                                          "dataPath": "ДеревоВзаимодействий.НомерКартинки",
-                                          "items": []
-                                        },
-                                        {
-                                          "type": "INPUT_FIELD",
-                                          "id": 118,
-                                          "name": "ДеревоВзаимодействийУчастники",
-                                          "title": {
-                                            "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn[5]/synonym"
-                                          },
-                                          "dataPath": "ДеревоВзаимодействий.Участники",
-                                          "items": []
-                                        },
-                                        {
-                                          "type": "INPUT_FIELD",
-                                          "id": 111,
-                                          "name": "ДеревоВзаимодействийДата",
-                                          "title": {
-                                            "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                                          },
-                                          "dataPath": "ДеревоВзаимодействий.Дата",
-                                          "items": []
-                                        }
-                                      ],
-                                      []
-                                    ]
-                                  },
-                                  {
-                                    "type": "INPUT_FIELD",
-                                    "id": 116,
-                                    "name": "ДеревоВзаимодействийТема",
-                                    "title": {
-                                      "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn[4]/synonym"
-                                    },
-                                    "dataPath": "ДеревоВзаимодействий.Тема",
-                                    "items": []
-                                  }
-                                ],
-                                []
-                              ]
-                            }
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 116,
+                                "name": "ДеревоВзаимодействийТема",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn[4]/synonym"
+                                },
+                                "dataPath": "ДеревоВзаимодействий.Тема",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 118,
+                                "name": "ДеревоВзаимодействийУчастники",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn[5]/synonym"
+                                },
+                                "dataPath": "ДеревоВзаимодействий.Участники",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 111,
+                                "name": "ДеревоВзаимодействийДата",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/title"
+                                },
+                                "dataPath": "ДеревоВзаимодействий.Дата",
+                                "items": []
+                              }
+                            ],
+                            []
                           ]
                         }
                       ]
@@ -5028,7 +4154,7 @@
                 "id": 5,
                 "name": "Статус",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[2]/type"
@@ -5288,40 +4414,6 @@
                 ]
               },
               {
-                "type": "USUAL_GROUP",
-                "id": 39,
-                "name": "ПредупреждениеБезопасности",
-                "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                },
-                "dataPath": "",
-                "items": [
-                  [
-                    {
-                      "type": "PICTURE_DECORATION",
-                      "id": 41,
-                      "name": "КартинкаПредупреждение",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "LABEL_DECORATION",
-                      "id": 44,
-                      "name": "ПредупреждениеОНебезопасномСодержимом",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    }
-                  ],
-                  []
-                ]
-              },
-              {
                 "type": "HTML_DOCUMENT_FIELD",
                 "id": 1,
                 "name": "ТекстHTML",
@@ -5367,18 +4459,7 @@
                     "id": 17,
                     "name": "Группа",
                     "title": {
-                      "content": [
-                        {
-                          "default": {
-                            "tag": 2
-                          },
-                          "int": 1,
-                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                            "langKey": "ru",
-                            "value": "Группа"
-                          }
-                        }
-                      ]
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                     },
                     "dataPath": "",
                     "items": [
@@ -5461,7 +4542,7 @@
                 "id": 1,
                 "name": "ТекстHTML",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
@@ -5491,7 +4572,7 @@
                 "id": 5,
                 "name": "Вложения",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[8]/type"
@@ -5815,202 +4896,21 @@
           "items": [
             [
               {
-                "type": "USUAL_GROUP",
-                "id": 22,
-                "name": "ГруппаДатыНомер",
-                "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Даты номер"
-                      }
-                    }
-                  ]
-                },
-                "dataPath": "",
-                "items": [
-                  [
-                    {
-                      "type": "USUAL_GROUP",
-                      "id": 8,
-                      "name": "ГруппаДаты",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Даты"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "INPUT_FIELD",
-                            "id": 9,
-                            "name": "Создано",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Создано"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "Создано",
-                            "items": []
-                          },
-                          {
-                            "type": "INPUT_FIELD",
-                            "id": 11,
-                            "name": "ОтправленоПолучено",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Отправлено"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "ОтправленоПолучено",
-                            "items": []
-                          }
-                        ],
-                        []
-                      ]
-                    },
-                    {
-                      "type": "USUAL_GROUP",
-                      "id": 25,
-                      "name": "ГруппаВключатьВнутреннийНомер",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Включать внутренний номер"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "INPUT_FIELD",
-                            "id": 6,
-                            "name": "ВнутреннийНомер",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Внутренний номер"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "ВнутреннийНомер",
-                            "items": []
-                          },
-                          {
-                            "type": "CHECK_BOX_FIELD",
-                            "id": 23,
-                            "name": "ВключатьТелоИсходногоПисьма",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Включать тело исходного письма"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "ВключатьТелоИсходногоПисьма",
-                            "items": []
-                          }
-                        ],
-                        []
-                      ]
-                    }
-                  ],
-                  []
-                ]
-              },
-              {
                 "type": "INPUT_FIELD",
                 "id": 26,
                 "name": "Папка",
                 "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Папка"
-                      }
-                    }
-                  ]
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                 },
                 "dataPath": "Папка",
                 "items": []
               },
               {
                 "type": "USUAL_GROUP",
-                "id": 5,
-                "name": "ГруппаПараметрыОтслеживания",
+                "id": 49,
+                "name": "Группа1",
                 "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Параметры отслеживания"
-                      }
-                    }
-                  ]
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                 },
                 "dataPath": "",
                 "items": [
@@ -6062,6 +4962,162 @@
                 ]
               },
               {
+                "type": "CHECK_BOX_FIELD",
+                "id": 23,
+                "name": "ВключатьТелоИсходногоПисьма",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Включать тело исходного письма"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "ВключатьТелоИсходногоПисьма",
+                "items": []
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 22,
+                "name": "ГруппаДатыНомер",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Даты номер"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 8,
+                      "name": "ГруппаДаты",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Даты"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "LABEL_FIELD",
+                            "id": 9,
+                            "name": "Создано",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Создано"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "Создано",
+                            "items": []
+                          },
+                          {
+                            "type": "LABEL_FIELD",
+                            "id": 11,
+                            "name": "ОтправленоПолучено",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Отправлено"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "ОтправленоПолучено",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 25,
+                      "name": "ГруппаВключатьВнутреннийНомер",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Включать внутренний номер"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        {
+                          "type": "LABEL_FIELD",
+                          "id": 6,
+                          "name": "ВнутреннийНомер",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Внутренний номер"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "ВнутреннийНомер",
+                          "items": []
+                        }
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
                 "type": "TEXT_DOCUMENT_FIELD",
                 "id": 17,
                 "name": "Заголовки",
@@ -6091,7 +5147,7 @@
                 "id": 1,
                 "name": "УведомитьОДоставке",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
@@ -6101,7 +5157,7 @@
                 "id": 2,
                 "name": "УведомитьОПрочтении",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
@@ -6111,7 +5167,7 @@
                 "id": 3,
                 "name": "ВнутреннийНомер",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "types": [
@@ -6143,10 +5199,10 @@
                 "id": 4,
                 "name": "Создано",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[45]/type"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[44]/type"
                 }
               },
               {
@@ -6167,14 +5223,14 @@
                   ]
                 },
                 "type": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[45]/type"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[44]/type"
                 }
               },
               {
                 "id": 7,
                 "name": "ЗаголовкиИнтернета",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/title"
                 },
                 "type": {
                   "types": [
@@ -6214,7 +5270,7 @@
                 "id": 6,
                 "name": "ВключатьТелоИсходногоПисьма",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
@@ -6224,7 +5280,7 @@
                 "id": 10,
                 "name": "Папка",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                 },
                 "type": {
                   "types": [
@@ -7058,7 +6114,7 @@
                   "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
                 },
                 "type": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[39]/type"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[38]/type"
                 }
               },
               {
@@ -7352,29 +6408,18 @@
           "items": [
             [
               {
-                "type": "TABLE",
-                "id": 1,
-                "name": "ТаблицаТиповПредметов",
+                "type": "USUAL_GROUP",
+                "id": 31,
+                "name": "Группа1",
                 "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Таблица типов предметов"
-                      }
-                    }
-                  ]
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                 },
-                "dataPath": "ТаблицаТиповПредметов",
+                "dataPath": "",
                 "items": [
                   {
-                    "type": "INPUT_FIELD",
-                    "id": 14,
-                    "name": "ТаблицаТиповПредметовПредставлениеТипа",
+                    "type": "TABLE",
+                    "id": 1,
+                    "name": "ТаблицаТиповПредметов",
                     "title": {
                       "content": [
                         {
@@ -7384,13 +6429,35 @@
                           "int": 1,
                           "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                             "langKey": "ru",
-                            "value": "Представление типа"
+                            "value": "Таблица типов предметов"
                           }
                         }
                       ]
                     },
-                    "dataPath": "ТаблицаТиповПредметов.ПредставлениеТипа",
-                    "items": []
+                    "dataPath": "ТаблицаТиповПредметов",
+                    "items": [
+                      {
+                        "type": "INPUT_FIELD",
+                        "id": 14,
+                        "name": "ТаблицаТиповПредметовПредставлениеТипа",
+                        "title": {
+                          "content": [
+                            {
+                              "default": {
+                                "tag": 2
+                              },
+                              "int": 1,
+                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                "langKey": "ru",
+                                "value": "Представление типа"
+                              }
+                            }
+                          ]
+                        },
+                        "dataPath": "ТаблицаТиповПредметов.ПредставлениеТипа",
+                        "items": []
+                      }
+                    ]
                   }
                 ]
               },
@@ -7407,7 +6474,7 @@
                       "int": 1,
                       "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                         "langKey": "ru",
-                        "value": "Не отображать взаимодействия"
+                        "value": "Скрыть взаимодействия"
                       }
                     }
                   ]
@@ -7424,7 +6491,7 @@
                 "id": 1,
                 "name": "ТаблицаТиповПредметов",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[8]/type"
@@ -7444,7 +6511,18 @@
                 "id": 3,
                 "name": "НеОтображатьВзаимодействия",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Не отображать взаимодействия"
+                      }
+                    }
+                  ]
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"

--- a/src/test/resources/fixtures/ssl_3_2/DocumentJournals.Взаимодействия_edt.json
+++ b/src/test/resources/fixtures/ssl_3_2/DocumentJournals.Взаимодействия_edt.json
@@ -1,0 +1,8071 @@
+{"com.github._1c_syntax.bsl.mdo.DocumentJournal": {
+  "columns": [
+    [
+      {
+        "uuid": "b5b94d94-25f7-4cfa-b1e9-6009fb848763",
+        "name": "Автор",
+        "mdoReference": {
+          "type": "COLUMN",
+          "mdoRef": "DocumentJournal.Взаимодействия.Column.Автор",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Колонка.Автор"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Автор"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "type": "DOCUMENT_JOURNAL",
+          "mdoRef": "DocumentJournal.Взаимодействия",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия"
+        },
+        "kind": "CUSTOM",
+        "indexing": "INDEX_WITH_ADDITIONAL_ORDER",
+        "references": [
+          [
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.Встреча.Attribute.Автор",
+              "mdoRefRu": "Документ.Встреча.Реквизит.Автор"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ТелефонныйЗвонок.Attribute.Автор",
+              "mdoRefRu": "Документ.ТелефонныйЗвонок.Реквизит.Автор"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЗапланированноеВзаимодействие.Attribute.Автор",
+              "mdoRefRu": "Документ.ЗапланированноеВзаимодействие.Реквизит.Автор"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЭлектронноеПисьмоИсходящее.Attribute.Автор",
+              "mdoRefRu": "Документ.ЭлектронноеПисьмоИсходящее.Реквизит.Автор"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.СообщениеSMS.Attribute.Автор",
+              "mdoRefRu": "Документ.СообщениеSMS.Реквизит.Автор"
+            }
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "a2accf54-5966-42e8-ab2e-e56e415963ee",
+        "name": "Входящий",
+        "mdoReference": {
+          "type": "COLUMN",
+          "mdoRef": "DocumentJournal.Взаимодействия.Column.Входящий",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Колонка.Входящий"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Входящий"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        },
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "references": [
+          {
+            "type": "ATTRIBUTE",
+            "mdoRef": "Document.ТелефонныйЗвонок.Attribute.Входящий",
+            "mdoRefRu": "Документ.ТелефонныйЗвонок.Реквизит.Входящий"
+          }
+        ]
+      },
+      {
+        "uuid": "d8eb5329-5900-4b5d-b45e-458513dddfef",
+        "name": "Ответственный",
+        "mdoReference": {
+          "type": "COLUMN",
+          "mdoRef": "DocumentJournal.Взаимодействия.Column.Ответственный",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Колонка.Ответственный"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Ответственный"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        },
+        "kind": "CUSTOM",
+        "indexing": "INDEX_WITH_ADDITIONAL_ORDER",
+        "references": [
+          [
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ТелефонныйЗвонок.Attribute.Ответственный",
+              "mdoRefRu": "Документ.ТелефонныйЗвонок.Реквизит.Ответственный"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.Встреча.Attribute.Ответственный",
+              "mdoRefRu": "Документ.Встреча.Реквизит.Ответственный"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЭлектронноеПисьмоВходящее.Attribute.Ответственный",
+              "mdoRefRu": "Документ.ЭлектронноеПисьмоВходящее.Реквизит.Ответственный"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЭлектронноеПисьмоИсходящее.Attribute.Ответственный",
+              "mdoRefRu": "Документ.ЭлектронноеПисьмоИсходящее.Реквизит.Ответственный"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЗапланированноеВзаимодействие.Attribute.Ответственный",
+              "mdoRefRu": "Документ.ЗапланированноеВзаимодействие.Реквизит.Ответственный"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.СообщениеSMS.Attribute.Ответственный",
+              "mdoRefRu": "Документ.СообщениеSMS.Реквизит.Ответственный"
+            }
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "6d521e58-24a3-4f19-b4b0-dff84f7ca86b",
+        "name": "Тема",
+        "mdoReference": {
+          "type": "COLUMN",
+          "mdoRef": "DocumentJournal.Взаимодействия.Column.Тема",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Колонка.Тема"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Тема"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        },
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "references": [
+          [
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЭлектронноеПисьмоВходящее.Attribute.Тема",
+              "mdoRefRu": "Документ.ЭлектронноеПисьмоВходящее.Реквизит.Тема"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЭлектронноеПисьмоИсходящее.Attribute.Тема",
+              "mdoRefRu": "Документ.ЭлектронноеПисьмоИсходящее.Реквизит.Тема"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.Встреча.Attribute.Тема",
+              "mdoRefRu": "Документ.Встреча.Реквизит.Тема"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЗапланированноеВзаимодействие.Attribute.Тема",
+              "mdoRefRu": "Документ.ЗапланированноеВзаимодействие.Реквизит.Тема"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ТелефонныйЗвонок.Attribute.Тема",
+              "mdoRefRu": "Документ.ТелефонныйЗвонок.Реквизит.Тема"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.СообщениеSMS.Attribute.Тема",
+              "mdoRefRu": "Документ.СообщениеSMS.Реквизит.Тема"
+            }
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "8c413fa5-9e24-4b81-aa55-0e78c5e3e20f",
+        "name": "Участники",
+        "mdoReference": {
+          "type": "COLUMN",
+          "mdoRef": "DocumentJournal.Взаимодействия.Column.Участники",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Колонка.Участники"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Участники"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        },
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "references": [
+          [
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.Встреча.Attribute.СписокУчастников",
+              "mdoRefRu": "Документ.Встреча.Реквизит.СписокУчастников"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ТелефонныйЗвонок.Attribute.АбонентПредставление",
+              "mdoRefRu": "Документ.ТелефонныйЗвонок.Реквизит.АбонентПредставление"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЭлектронноеПисьмоИсходящее.Attribute.СписокПолучателейПисьма",
+              "mdoRefRu": "Документ.ЭлектронноеПисьмоИсходящее.Реквизит.СписокПолучателейПисьма"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЭлектронноеПисьмоВходящее.Attribute.ОтправительПредставление",
+              "mdoRefRu": "Документ.ЭлектронноеПисьмоВходящее.Реквизит.ОтправительПредставление"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЗапланированноеВзаимодействие.Attribute.СписокУчастников",
+              "mdoRefRu": "Документ.ЗапланированноеВзаимодействие.Реквизит.СписокУчастников"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.СообщениеSMS.Attribute.СписокУчастников",
+              "mdoRefRu": "Документ.СообщениеSMS.Реквизит.СписокУчастников"
+            }
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "a4322f22-7de0-4018-8e06-9f1aa7cf0c07",
+        "name": "СтатусИсходящегоПисьма",
+        "mdoReference": {
+          "type": "COLUMN",
+          "mdoRef": "DocumentJournal.Взаимодействия.Column.СтатусИсходящегоПисьма",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Колонка.СтатусИсходящегоПисьма"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Статус исходящего письма"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        },
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "references": [
+          [
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЭлектронноеПисьмоИсходящее.Attribute.СтатусПисьма",
+              "mdoRefRu": "Документ.ЭлектронноеПисьмоИсходящее.Реквизит.СтатусПисьма"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.СообщениеSMS.Attribute.Состояние",
+              "mdoRefRu": "Документ.СообщениеSMS.Реквизит.Состояние"
+            }
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "eaaed107-69d4-4963-be83-74519e331715",
+        "name": "УчетнаяЗапись",
+        "mdoReference": {
+          "type": "COLUMN",
+          "mdoRef": "DocumentJournal.Взаимодействия.Column.УчетнаяЗапись",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Колонка.УчетнаяЗапись"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Почта"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        },
+        "kind": "CUSTOM",
+        "indexing": "INDEX_WITH_ADDITIONAL_ORDER",
+        "references": [
+          [
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЭлектронноеПисьмоВходящее.Attribute.УчетнаяЗапись",
+              "mdoRefRu": "Документ.ЭлектронноеПисьмоВходящее.Реквизит.УчетнаяЗапись"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЭлектронноеПисьмоИсходящее.Attribute.УчетнаяЗапись",
+              "mdoRefRu": "Документ.ЭлектронноеПисьмоИсходящее.Реквизит.УчетнаяЗапись"
+            }
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "38cddf96-8703-4396-8c73-47fb22828a48",
+        "name": "ЕстьВложения",
+        "mdoReference": {
+          "type": "COLUMN",
+          "mdoRef": "DocumentJournal.Взаимодействия.Column.ЕстьВложения",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Колонка.ЕстьВложения"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Есть вложения"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        },
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "references": [
+          [
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЭлектронноеПисьмоВходящее.Attribute.ЕстьВложения",
+              "mdoRefRu": "Документ.ЭлектронноеПисьмоВходящее.Реквизит.ЕстьВложения"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЭлектронноеПисьмоИсходящее.Attribute.ЕстьВложения",
+              "mdoRefRu": "Документ.ЭлектронноеПисьмоИсходящее.Реквизит.ЕстьВложения"
+            }
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "2c2cb793-0177-4983-91ca-9c292c5b10f1",
+        "name": "ВзаимодействиеОснование",
+        "mdoReference": {
+          "type": "COLUMN",
+          "mdoRef": "DocumentJournal.Взаимодействия.Column.ВзаимодействиеОснование",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Колонка.ВзаимодействиеОснование"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Взаимодействие основание"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        },
+        "kind": "CUSTOM",
+        "indexing": "INDEX_WITH_ADDITIONAL_ORDER",
+        "references": [
+          [
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.Встреча.Attribute.ВзаимодействиеОснование",
+              "mdoRefRu": "Документ.Встреча.Реквизит.ВзаимодействиеОснование"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЗапланированноеВзаимодействие.Attribute.ВзаимодействиеОснование",
+              "mdoRefRu": "Документ.ЗапланированноеВзаимодействие.Реквизит.ВзаимодействиеОснование"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ТелефонныйЗвонок.Attribute.ВзаимодействиеОснование",
+              "mdoRefRu": "Документ.ТелефонныйЗвонок.Реквизит.ВзаимодействиеОснование"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЭлектронноеПисьмоВходящее.Attribute.ВзаимодействиеОснование",
+              "mdoRefRu": "Документ.ЭлектронноеПисьмоВходящее.Реквизит.ВзаимодействиеОснование"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЭлектронноеПисьмоИсходящее.Attribute.ВзаимодействиеОснование",
+              "mdoRefRu": "Документ.ЭлектронноеПисьмоИсходящее.Реквизит.ВзаимодействиеОснование"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.СообщениеSMS.Attribute.ВзаимодействиеОснование",
+              "mdoRefRu": "Документ.СообщениеSMS.Реквизит.ВзаимодействиеОснование"
+            }
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "2a2e7f51-a4e5-48ec-b969-b1fca18ba9b5",
+        "name": "ПолученоОтправлено",
+        "mdoReference": {
+          "type": "COLUMN",
+          "mdoRef": "DocumentJournal.Взаимодействия.Column.ПолученоОтправлено",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Колонка.ПолученоОтправлено"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Получено отправлено"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        },
+        "kind": "CUSTOM",
+        "indexing": "INDEX_WITH_ADDITIONAL_ORDER",
+        "references": [
+          [
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЭлектронноеПисьмоВходящее.Attribute.ДатаПолучения",
+              "mdoRefRu": "Документ.ЭлектронноеПисьмоВходящее.Реквизит.ДатаПолучения"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЭлектронноеПисьмоИсходящее.Attribute.ДатаОтправления",
+              "mdoRefRu": "Документ.ЭлектронноеПисьмоИсходящее.Реквизит.ДатаОтправления"
+            }
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "221fa473-3327-44e6-a033-6fdfd2be713c",
+        "name": "Размер",
+        "mdoReference": {
+          "type": "COLUMN",
+          "mdoRef": "DocumentJournal.Взаимодействия.Column.Размер",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Колонка.Размер"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Размер"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        },
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "references": [
+          [
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЭлектронноеПисьмоВходящее.Attribute.Размер",
+              "mdoRefRu": "Документ.ЭлектронноеПисьмоВходящее.Реквизит.Размер"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЭлектронноеПисьмоИсходящее.Attribute.Размер",
+              "mdoRefRu": "Документ.ЭлектронноеПисьмоИсходящее.Реквизит.Размер"
+            }
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "7a5973f0-7e29-44af-8e7b-70af71f704a4",
+        "name": "Важность",
+        "mdoReference": {
+          "type": "COLUMN",
+          "mdoRef": "DocumentJournal.Взаимодействия.Column.Важность",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Колонка.Важность"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Важность"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        },
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "references": [
+          [
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.Встреча.Attribute.Важность",
+              "mdoRefRu": "Документ.Встреча.Реквизит.Важность"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЗапланированноеВзаимодействие.Attribute.Важность",
+              "mdoRefRu": "Документ.ЗапланированноеВзаимодействие.Реквизит.Важность"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ТелефонныйЗвонок.Attribute.Важность",
+              "mdoRefRu": "Документ.ТелефонныйЗвонок.Реквизит.Важность"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЭлектронноеПисьмоВходящее.Attribute.Важность",
+              "mdoRefRu": "Документ.ЭлектронноеПисьмоВходящее.Реквизит.Важность"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЭлектронноеПисьмоИсходящее.Attribute.Важность",
+              "mdoRefRu": "Документ.ЭлектронноеПисьмоИсходящее.Реквизит.Важность"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.СообщениеSMS.Attribute.Важность",
+              "mdoRefRu": "Документ.СообщениеSMS.Реквизит.Важность"
+            }
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "2b2bf0f7-0946-4492-bba0-27f007a70e64",
+        "name": "ДатаКогдаОтправить",
+        "mdoReference": {
+          "type": "COLUMN",
+          "mdoRef": "DocumentJournal.Взаимодействия.Column.ДатаКогдаОтправить",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Колонка.ДатаКогдаОтправить"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Дата когда отправить"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        },
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "references": [
+          [
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.СообщениеSMS.Attribute.ДатаКогдаОтправить",
+              "mdoRefRu": "Документ.СообщениеSMS.Реквизит.ДатаКогдаОтправить"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЭлектронноеПисьмоИсходящее.Attribute.ДатаКогдаОтправить",
+              "mdoRefRu": "Документ.ЭлектронноеПисьмоИсходящее.Реквизит.ДатаКогдаОтправить"
+            }
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "22c9a703-5ed3-4156-8fa6-476b1c1452f1",
+        "name": "ДатаАктуальностиОтправки",
+        "mdoReference": {
+          "type": "COLUMN",
+          "mdoRef": "DocumentJournal.Взаимодействия.Column.ДатаАктуальностиОтправки",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Колонка.ДатаАктуальностиОтправки"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Дата актуальности отправки"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        },
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "references": [
+          [
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.СообщениеSMS.Attribute.ДатаАктуальностиОтправки",
+              "mdoRefRu": "Документ.СообщениеSMS.Реквизит.ДатаАктуальностиОтправки"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЭлектронноеПисьмоИсходящее.Attribute.ДатаАктуальностиОтправки",
+              "mdoRefRu": "Документ.ЭлектронноеПисьмоИсходящее.Реквизит.ДатаАктуальностиОтправки"
+            }
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "8be10d88-8c37-4444-9c89-6cbbe9913bda",
+        "name": "ИдентификаторСообщения",
+        "mdoReference": {
+          "type": "COLUMN",
+          "mdoRef": "DocumentJournal.Взаимодействия.Column.ИдентификаторСообщения",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Колонка.ИдентификаторСообщения"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Идентификатор сообщения"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        },
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "references": [
+          [
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЭлектронноеПисьмоВходящее.Attribute.ИдентификаторСообщения",
+              "mdoRefRu": "Документ.ЭлектронноеПисьмоВходящее.Реквизит.ИдентификаторСообщения"
+            },
+            {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.ЭлектронноеПисьмоИсходящее.Attribute.ИдентификаторСообщения",
+              "mdoRefRu": "Документ.ЭлектронноеПисьмоИсходящее.Реквизит.ИдентификаторСообщения"
+            }
+          ],
+          []
+        ]
+      }
+    ],
+    []
+  ],
+  "commands": [
+    [
+      {
+        "uuid": "314b0da2-24d3-48cc-8532-d36c45eb3bf8",
+        "name": "ВзаимодействияПоКонтакту",
+        "mdoReference": {
+          "type": "COMMAND",
+          "mdoRef": "DocumentJournal.Взаимодействия.Command.ВзаимодействияПоКонтакту",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Команда.ВзаимодействияПоКонтакту"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Взаимодействия"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "CommandModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/DocumentJournals/Взаимоде_ствия/Commands/Взаимоде_ствияПоКонтакту/CommandModule.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        }
+      },
+      {
+        "uuid": "2e3ac3fb-9f0e-463f-95c2-9f661ce2e015",
+        "name": "ВзаимодействияПоПредмету",
+        "mdoReference": {
+          "type": "COMMAND",
+          "mdoRef": "DocumentJournal.Взаимодействия.Command.ВзаимодействияПоПредмету",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Команда.ВзаимодействияПоПредмету"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "CommandModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/DocumentJournals/Взаимоде_ствия/Commands/Взаимоде_ствияПоПредмету/CommandModule.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[2]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        }
+      },
+      {
+        "uuid": "4077e700-ec20-4afa-8155-bf7e516a70cb",
+        "name": "ЗапланироватьВзаимодействиеПоКонтакту",
+        "mdoReference": {
+          "type": "COMMAND",
+          "mdoRef": "DocumentJournal.Взаимодействия.Command.ЗапланироватьВзаимодействиеПоКонтакту",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Команда.ЗапланироватьВзаимодействиеПоКонтакту"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Запланировать взаимодействие"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "CommandModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/DocumentJournals/Взаимоде_ствия/Commands/ЗапланироватьВзаимоде_ствиеПоКонтакту/CommandModule.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[3]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        }
+      },
+      {
+        "uuid": "5198c6db-2100-4902-82c8-85c8ea555e78",
+        "name": "ЗапланироватьВзаимодействиеПоПредмету",
+        "mdoReference": {
+          "type": "COMMAND",
+          "mdoRef": "DocumentJournal.Взаимодействия.Command.ЗапланироватьВзаимодействиеПоПредмету",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Команда.ЗапланироватьВзаимодействиеПоПредмету"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[3]/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "CommandModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/DocumentJournals/Взаимоде_ствия/Commands/ЗапланироватьВзаимоде_ствиеПоПредмету/CommandModule.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[4]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        }
+      },
+      {
+        "uuid": "b99f2a63-54e8-490b-a0a4-1941fbc38b3f",
+        "name": "ЗапланироватьВстречуПоКонтакту",
+        "mdoReference": {
+          "type": "COMMAND",
+          "mdoRef": "DocumentJournal.Взаимодействия.Command.ЗапланироватьВстречуПоКонтакту",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Команда.ЗапланироватьВстречуПоКонтакту"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Запланировать встречу"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "CommandModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/DocumentJournals/Взаимоде_ствия/Commands/ЗапланироватьВстречуПоКонтакту/CommandModule.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[5]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        }
+      },
+      {
+        "uuid": "f0b1e9f4-2e07-44e6-88d2-c11457135781",
+        "name": "ЗапланироватьВстречуПоПредмету",
+        "mdoReference": {
+          "type": "COMMAND",
+          "mdoRef": "DocumentJournal.Взаимодействия.Command.ЗапланироватьВстречуПоПредмету",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Команда.ЗапланироватьВстречуПоПредмету"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[5]/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "CommandModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/DocumentJournals/Взаимоде_ствия/Commands/ЗапланироватьВстречуПоПредмету/CommandModule.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[6]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        }
+      },
+      {
+        "uuid": "e010c0f9-f770-4fdc-8607-50838c0262ef",
+        "name": "НаписатьSMSПоКонтакту",
+        "mdoReference": {
+          "type": "COMMAND",
+          "mdoRef": "DocumentJournal.Взаимодействия.Command.НаписатьSMSПоКонтакту",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Команда.НаписатьSMSПоКонтакту"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Написать SMS"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "CommandModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/DocumentJournals/Взаимоде_ствия/Commands/НаписатьSMSПоКонтакту/CommandModule.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[7]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        }
+      },
+      {
+        "uuid": "f935399f-3554-4c08-b0a6-eba13074e1b7",
+        "name": "НаписатьSMSПоПредмету",
+        "mdoReference": {
+          "type": "COMMAND",
+          "mdoRef": "DocumentJournal.Взаимодействия.Command.НаписатьSMSПоПредмету",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Команда.НаписатьSMSПоПредмету"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[7]/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "CommandModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/DocumentJournals/Взаимоде_ствия/Commands/НаписатьSMSПоПредмету/CommandModule.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[8]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        }
+      },
+      {
+        "uuid": "10008125-3aeb-4912-8ad6-d92d283ea09a",
+        "name": "НаписатьЭлектронноеПисьмоПоКонтакту",
+        "mdoReference": {
+          "type": "COMMAND",
+          "mdoRef": "DocumentJournal.Взаимодействия.Command.НаписатьЭлектронноеПисьмоПоКонтакту",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Команда.НаписатьЭлектронноеПисьмоПоКонтакту"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Написать электронное письмо"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "CommandModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/DocumentJournals/Взаимоде_ствия/Commands/НаписатьЭлектронноеПисьмоПоКонтакту/CommandModule.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[9]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        }
+      },
+      {
+        "uuid": "765f9584-fefa-4695-b130-dd54c3b0d79d",
+        "name": "НаписатьЭлектронноеПисьмоПоПредмету",
+        "mdoReference": {
+          "type": "COMMAND",
+          "mdoRef": "DocumentJournal.Взаимодействия.Command.НаписатьЭлектронноеПисьмоПоПредмету",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Команда.НаписатьЭлектронноеПисьмоПоПредмету"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[9]/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "CommandModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/DocumentJournals/Взаимоде_ствия/Commands/НаписатьЭлектронноеПисьмоПоПредмету/CommandModule.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[10]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        }
+      },
+      {
+        "uuid": "dd050ca0-8335-4654-ab5c-7babcb4824ef",
+        "name": "НастройкиРаботыСПочтой",
+        "mdoReference": {
+          "type": "COMMAND",
+          "mdoRef": "DocumentJournal.Взаимодействия.Command.НастройкиРаботыСПочтой",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Команда.НастройкиРаботыСПочтой"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Настройки работы с почтой"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "CommandModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/DocumentJournals/Взаимоде_ствия/Commands/Настро_киРаботыСПочто_/CommandModule.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[11]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        }
+      },
+      {
+        "uuid": "706cbf55-626d-4cab-b589-a2464368f6c1",
+        "name": "ПечатьЭлектронногоПисьма",
+        "mdoReference": {
+          "type": "COMMAND",
+          "mdoRef": "DocumentJournal.Взаимодействия.Command.ПечатьЭлектронногоПисьма",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Команда.ПечатьЭлектронногоПисьма"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Печать"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "CommandModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/DocumentJournals/Взаимоде_ствия/Commands/ПечатьЭлектронногоПисьма/CommandModule.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[12]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        }
+      },
+      {
+        "uuid": "d22a0a50-220d-459e-a23a-39730a1e67c4",
+        "name": "ПозвонитьПоКонтакту",
+        "mdoReference": {
+          "type": "COMMAND",
+          "mdoRef": "DocumentJournal.Взаимодействия.Command.ПозвонитьПоКонтакту",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Команда.ПозвонитьПоКонтакту"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Позвонить"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "CommandModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/DocumentJournals/Взаимоде_ствия/Commands/ПозвонитьПоКонтакту/CommandModule.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[13]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        }
+      },
+      {
+        "uuid": "2c1c9284-ba8b-4282-a89c-429f02ea41f6",
+        "name": "ПозвонитьПоПредмету",
+        "mdoReference": {
+          "type": "COMMAND",
+          "mdoRef": "DocumentJournal.Взаимодействия.Command.ПозвонитьПоПредмету",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Команда.ПозвонитьПоПредмету"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[13]/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "CommandModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/DocumentJournals/Взаимоде_ствия/Commands/ПозвонитьПоПредмету/CommandModule.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[14]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        }
+      },
+      {
+        "uuid": "8c241467-76f7-4161-a8a1-5da4a6576b75",
+        "name": "СохранитьПисьмо",
+        "mdoReference": {
+          "type": "COMMAND",
+          "mdoRef": "DocumentJournal.Взаимодействия.Command.СохранитьПисьмо",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Команда.СохранитьПисьмо"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Сохранить письмо на компьютер"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "CommandModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/DocumentJournals/Взаимоде_ствия/Commands/СохранитьПисьмо/CommandModule.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[15]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        }
+      }
+    ],
+    []
+  ],
+  "comment": "",
+  "description": "Взаимодействия",
+  "explanation": {
+    "content": []
+  },
+  "forms": [
+    [
+      {
+        "uuid": "27089e8e-2c75-431c-b808-5d4dcba3cdca",
+        "name": "ФормаСписка",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "DocumentJournal.Взаимодействия.Form.ФормаСписка",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Форма.ФормаСписка"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Форма списка"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/DocumentJournals/Взаимоде_ствия/Forms/ФормаСписка/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand/synonym"
+          },
+          "handlers": [
+            [
+              {
+                "event": "ChoiceProcessing",
+                "name": "ОбработкаВыбора"
+              },
+              {
+                "event": "NotificationProcessing",
+                "name": "ОбработкаОповещения"
+              },
+              {
+                "event": "OnOpen",
+                "name": "ПриОткрытии"
+              },
+              {
+                "event": "BeforeClose",
+                "name": "ПередЗакрытием"
+              },
+              {
+                "event": "OnLoadDataFromSettingsAtServer",
+                "name": "ПриЗагрузкеДанныхИзНастроекНаСервере"
+              },
+              {
+                "event": "NavigationProcessing",
+                "name": "ОбработкаПерехода"
+              },
+              {
+                "event": "OnCreateAtServer",
+                "name": "ПриСозданииНаСервере"
+              },
+              {
+                "event": "BeforeLoadDataFromSettingsAtServer",
+                "name": "ПередЗагрузкойДанныхИзНастроекНаСервере"
+              }
+            ],
+            []
+          ],
+          "items": [
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 926,
+                "name": "ПредупреждениеОНеотправленныхПисьмах",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Группа предупреждение"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "DECORATION",
+                      "id": 928,
+                      "name": "ПредупреждениеОНеотправленныхПисьмахКартинка",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Картинка предупреждение"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL",
+                      "id": 931,
+                      "name": "ПредупреждениеОНеотправленныхПисьмахНадпись",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Регламентное задание <b>Получение</><b> </><b>и</><b> </><b>отправка</><b> </><b>писем</> отключено, доставка писем не выполняется. <link ВключитьПолучениеИОтправкуПисем>Включить</>"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 943,
+                "name": "ПредупреждениеОНеактуальностиИндекса",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Предупреждение о неактуальности индекса"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "DECORATION",
+                      "id": 945,
+                      "name": "ПредупреждениеОНеактуальностиИндексаКартинка",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL",
+                      "id": 948,
+                      "name": "ПредупреждениеОНеактуальностиИндексаНадпись",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Результаты поиска могут быть неточными, повторите поиск позднее"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 832,
+                "name": "ГруппаПользовательскихНастроек",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Группа пользовательских настроек"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": []
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 66,
+                "name": "ГруппаФильтры",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Фильтры"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 89,
+                      "name": "СтрокаПоиска",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Найти"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "СтрокаПоиска",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 71,
+                      "name": "ТипВзаимодействия",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Тип"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "ТипВзаимодействия",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 67,
+                      "name": "Статус",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Статус"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "Статус",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 69,
+                      "name": "Пользователь",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn[3]/synonym"
+                      },
+                      "dataPath": "Ответственный",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 826,
+                "name": "ГруппаПанельНавигацииСписок",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Панель навигации список"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "COMMAND_BAR",
+                      "id": 24,
+                      "name": "КоманднаяПанельВариантаНавигации",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Командная панель варианта навигации"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "BUTTON",
+                            "id": 830,
+                            "name": "ИзменитьОтображениеПанелиНавигации",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Изменить отображение панели навигации"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "POPUP",
+                            "id": 26,
+                            "name": "ВыборВариантаНавигации",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Вариант навигации"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "BUTTON",
+                                  "id": 27,
+                                  "name": "УстановитьВариантНавигацииПоПредмету",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "По предметам"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "BUTTON",
+                                  "id": 28,
+                                  "name": "УстановитьВариантНавигацииПоКонтакту",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "По контактам"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "BUTTON",
+                                  "id": 124,
+                                  "name": "УстановитьВариантНавигацииПоЗакладкам",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "По закладкам"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "BUTTON",
+                                  "id": 176,
+                                  "name": "УстановитьВариантНавигацииПоПапкам",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "По папкам"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          },
+                          {
+                            "type": "FORM_GROUP",
+                            "id": 828,
+                            "name": "ГруппаКоманднаяПанельСписок",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Командная панель список"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "POPUP",
+                                  "id": 43,
+                                  "name": "ГруппаСоздать",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Создать"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "BUTTON",
+                                        "id": 44,
+                                        "name": "СписокСоздатьВстречу",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Встречу"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "BUTTON",
+                                        "id": 45,
+                                        "name": "СписокСоздатьЗапланированноеВзаимодействие",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Запланированное взаимодействие"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "BUTTON",
+                                        "id": 46,
+                                        "name": "СписокСоздатьТелефонныйЗвонок",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Телефонный звонок"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "BUTTON",
+                                        "id": 415,
+                                        "name": "СписокСоздатьСообщениеSMS",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Сообщение SMS"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "BUTTON",
+                                        "id": 47,
+                                        "name": "СписокСоздатьЭлектронноеПисьмо",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Электронное письмо"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                },
+                                {
+                                  "type": "BUTTON",
+                                  "id": 322,
+                                  "name": "СписокСоздатьЭлектронноеПисьмоОтдельнаяКнопка",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Написать"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "FORM_GROUP",
+                                  "id": 919,
+                                  "name": "ГруппаОтветитьПереслать",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Ответить переслать"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "BUTTON",
+                                        "id": 342,
+                                        "name": "СписокОтветить",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Ответить"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "BUTTON",
+                                        "id": 343,
+                                        "name": "СписокОтветитьВсем",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Ответить всем"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "BUTTON",
+                                        "id": 344,
+                                        "name": "СписокПереслать",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Переслать"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                },
+                                {
+                                  "type": "BUTTON",
+                                  "id": 59,
+                                  "name": "СписокОтправитьПолучитьПочту",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Отправить и получить"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "POPUP",
+                                  "id": 917,
+                                  "name": "ПодменюСоздатьНаОсновании",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Создать на основании"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "FORM_GROUP",
+                                  "id": 410,
+                                  "name": "ГруппаРассмотрено",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Рассмотрено"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "BUTTON",
+                                        "id": 40,
+                                        "name": "СписокРассмотрено",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[6]/title"
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "BUTTON",
+                                        "id": 42,
+                                        "name": "СписокОтложитьРассмотрение",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Отложить рассмотрение..."
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "BUTTON",
+                                        "id": 191,
+                                        "name": "СписокНеРассмотрено",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Снять признак рассмотрено"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "BUTTON",
+                                        "id": 39,
+                                        "name": "СписокОтветственный",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Установить ответственного..."
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "BUTTON",
+                                        "id": 41,
+                                        "name": "СписокПредмет",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Установить предмет взаимодействия..."
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                },
+                                {
+                                  "type": "POPUP",
+                                  "id": 824,
+                                  "name": "СписокТипВзаимодействия",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Показывать"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "POPUP",
+                                  "id": 822,
+                                  "name": "СписокСтатус",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Статус: "
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "FORM_GROUP",
+                                  "id": 48,
+                                  "name": "ГруппаКомандыСписка",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Команды списка"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "BUTTON",
+                                        "id": 49,
+                                        "name": "Изменить",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "BUTTON",
+                                        "id": 50,
+                                        "name": "Скопировать",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "FORM_GROUP",
+                                        "id": 51,
+                                        "name": "ГруппаСписокУстановитьПометкуУдаления",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Список установить пометку удаления"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": [
+                                          {
+                                            "type": "BUTTON",
+                                            "id": 52,
+                                            "name": "УстановитьПометкуУдаления",
+                                            "title": {
+                                              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                            },
+                                            "dataPath": "",
+                                            "items": []
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "FORM_GROUP",
+                                        "id": 55,
+                                        "name": "ГруппаНайти",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                        },
+                                        "dataPath": "",
+                                        "items": [
+                                          [
+                                            {
+                                              "type": "BUTTON",
+                                              "id": 56,
+                                              "name": "Найти",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                              },
+                                              "dataPath": "",
+                                              "items": []
+                                            },
+                                            {
+                                              "type": "BUTTON",
+                                              "id": 58,
+                                              "name": "ОтменитьПоиск",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                              },
+                                              "dataPath": "",
+                                              "items": []
+                                            },
+                                            {
+                                              "type": "BUTTON",
+                                              "id": 54,
+                                              "name": "УстановитьИнтервалДат",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                              },
+                                              "dataPath": "",
+                                              "items": []
+                                            }
+                                          ],
+                                          []
+                                        ]
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                },
+                                {
+                                  "type": "BUTTON",
+                                  "id": 60,
+                                  "name": "СписокОбновить",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Обновить"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "BUTTON",
+                                  "id": 61,
+                                  "name": "СписокНастройкаСписка",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "BUTTON",
+                                  "id": 62,
+                                  "name": "СписокВывестиСписок",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "BUTTON",
+                                  "id": 64,
+                                  "name": "СписокИзменитьФорму",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "BUTTON",
+                                  "id": 792,
+                                  "name": "СписокОтображатьОбластьЧтения",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Отображать область чтения"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "BUTTON",
+                                  "id": 146,
+                                  "name": "ФормаПерсональныеНастройки",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Персональные настройки..."
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          },
+                          {
+                            "type": "FORM_GROUP",
+                            "id": 897,
+                            "name": "ГруппаГлобальныеКоманды",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Глобальные команды"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "BUTTON",
+                            "id": 63,
+                            "name": "СписокСправка",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 5,
+                      "name": "ГруппаОсновное",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Основное"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 6,
+                            "name": "ГруппаПанельНавигации",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Панель навигации"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              {
+                                "type": "PAGES",
+                                "id": 25,
+                                "name": "СтраницыПанелиНавигации",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Страницы панели навигации"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "PAGE",
+                                      "id": 30,
+                                      "name": "СтраницаКонтакт",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Страница контакт"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        [
+                                          {
+                                            "type": "TABLE",
+                                            "id": 31,
+                                            "name": "КонтактыПанелиНавигации",
+                                            "title": {
+                                              "content": [
+                                                {
+                                                  "default": {
+                                                    "tag": 2
+                                                  },
+                                                  "int": 1,
+                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                    "langKey": "ru",
+                                                    "value": "Контакты панели навигации"
+                                                  }
+                                                }
+                                              ]
+                                            },
+                                            "dataPath": "КонтактыПанельНавигации",
+                                            "items": [
+                                              {
+                                                "type": "COLUMN_GROUP",
+                                                "id": 810,
+                                                "name": "КонтактыПанелиНавигацииГруппа",
+                                                "title": {
+                                                  "content": [
+                                                    {
+                                                      "default": {
+                                                        "tag": 2
+                                                      },
+                                                      "int": 1,
+                                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                        "langKey": "ru",
+                                                        "value": "Контакты панели навигации группа"
+                                                      }
+                                                    }
+                                                  ]
+                                                },
+                                                "dataPath": "",
+                                                "items": [
+                                                  [
+                                                    {
+                                                      "type": "LABEL_FIELD",
+                                                      "id": 731,
+                                                      "name": "КонтактыКонтакт",
+                                                      "title": {
+                                                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                                      },
+                                                      "dataPath": "КонтактыПанельНавигации.Контакт",
+                                                      "items": []
+                                                    },
+                                                    {
+                                                      "type": "COLUMN_GROUP",
+                                                      "id": 784,
+                                                      "name": "КонтактыПанелиНавигацииРассмотреноДата",
+                                                      "title": {
+                                                        "content": [
+                                                          {
+                                                            "default": {
+                                                              "tag": 2
+                                                            },
+                                                            "int": 1,
+                                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                              "langKey": "ru",
+                                                              "value": "Контакты панели навигации рассмотрено дата"
+                                                            }
+                                                          }
+                                                        ]
+                                                      },
+                                                      "dataPath": "",
+                                                      "items": [
+                                                        [
+                                                          {
+                                                            "type": "LABEL_FIELD",
+                                                            "id": 728,
+                                                            "name": "НеРассмотрено",
+                                                            "title": {
+                                                              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                                            },
+                                                            "dataPath": "КонтактыПанельНавигации.КоличествоНеРассмотрено",
+                                                            "items": []
+                                                          },
+                                                          {
+                                                            "type": "LABEL_FIELD",
+                                                            "id": 725,
+                                                            "name": "КонтактыДатаПоследнегоВзаимодействия",
+                                                            "title": {
+                                                              "content": [
+                                                                {
+                                                                  "default": {
+                                                                    "tag": 2
+                                                                  },
+                                                                  "int": 1,
+                                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                    "langKey": "ru",
+                                                                    "value": "Последнее взаимодействие"
+                                                                  }
+                                                                }
+                                                              ]
+                                                            },
+                                                            "dataPath": "КонтактыПанельНавигации.ДатаПоследнегоВзаимодействия",
+                                                            "items": []
+                                                          }
+                                                        ],
+                                                        []
+                                                      ]
+                                                    }
+                                                  ],
+                                                  []
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "LABEL",
+                                            "id": 937,
+                                            "name": "ДекорацияТолькоЗначимыеКонтакты",
+                                            "title": {
+                                              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                            },
+                                            "dataPath": "",
+                                            "items": []
+                                          }
+                                        ],
+                                        []
+                                      ]
+                                    },
+                                    {
+                                      "type": "PAGE",
+                                      "id": 73,
+                                      "name": "СтраницаПредмет",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Страница предмет"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        [
+                                          {
+                                            "type": "TABLE",
+                                            "id": 690,
+                                            "name": "ПредметыПанельНавигации",
+                                            "title": {
+                                              "content": [
+                                                {
+                                                  "default": {
+                                                    "tag": 2
+                                                  },
+                                                  "int": 1,
+                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                    "langKey": "ru",
+                                                    "value": "Предметы панель навигации"
+                                                  }
+                                                }
+                                              ]
+                                            },
+                                            "dataPath": "ПредметыПанельНавигации",
+                                            "items": [
+                                              {
+                                                "type": "COLUMN_GROUP",
+                                                "id": 808,
+                                                "name": "ПредметыПанельНавигацииГруппа",
+                                                "title": {
+                                                  "content": [
+                                                    {
+                                                      "default": {
+                                                        "tag": 2
+                                                      },
+                                                      "int": 1,
+                                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                        "langKey": "ru",
+                                                        "value": "Предметы панель навигации группа"
+                                                      }
+                                                    }
+                                                  ]
+                                                },
+                                                "dataPath": "",
+                                                "items": [
+                                                  [
+                                                    {
+                                                      "type": "LABEL_FIELD",
+                                                      "id": 697,
+                                                      "name": "Предмет",
+                                                      "title": {
+                                                        "content": [
+                                                          {
+                                                            "default": {
+                                                              "tag": 2
+                                                            },
+                                                            "int": 1,
+                                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                              "langKey": "ru",
+                                                              "value": "Предмет"
+                                                            }
+                                                          }
+                                                        ]
+                                                      },
+                                                      "dataPath": "ПредметыПанельНавигации.Предмет",
+                                                      "items": []
+                                                    },
+                                                    {
+                                                      "type": "COLUMN_GROUP",
+                                                      "id": 786,
+                                                      "name": "ПредметыПанельНавигацииГруппаРассмотреноДата",
+                                                      "title": {
+                                                        "content": [
+                                                          {
+                                                            "default": {
+                                                              "tag": 2
+                                                            },
+                                                            "int": 1,
+                                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                              "langKey": "ru",
+                                                              "value": "Предметы панель навигации группа рассмотрено дата"
+                                                            }
+                                                          }
+                                                        ]
+                                                      },
+                                                      "dataPath": "",
+                                                      "items": [
+                                                        [
+                                                          {
+                                                            "type": "LABEL_FIELD",
+                                                            "id": 694,
+                                                            "name": "НеРассмотреноПредметы",
+                                                            "title": {
+                                                              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                                            },
+                                                            "dataPath": "ПредметыПанельНавигации.КоличествоНеРассмотрено",
+                                                            "items": []
+                                                          },
+                                                          {
+                                                            "type": "LABEL_FIELD",
+                                                            "id": 700,
+                                                            "name": "ДатаПоследнегоВзаимодействия",
+                                                            "title": {
+                                                              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                                            },
+                                                            "dataPath": "ПредметыПанельНавигации.ДатаПоследнегоВзаимодействия",
+                                                            "items": []
+                                                          }
+                                                        ],
+                                                        []
+                                                      ]
+                                                    }
+                                                  ],
+                                                  []
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "LABEL",
+                                            "id": 934,
+                                            "name": "ДекорацияТолькоЗначимыеПредметы",
+                                            "title": {
+                                              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                            },
+                                            "dataPath": "",
+                                            "items": []
+                                          }
+                                        ],
+                                        []
+                                      ]
+                                    },
+                                    {
+                                      "type": "PAGE",
+                                      "id": 118,
+                                      "name": "СтраницаЗакладки",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Страница закладки"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        {
+                                          "type": "TABLE",
+                                          "id": 119,
+                                          "name": "Закладки",
+                                          "title": {
+                                            "content": [
+                                              {
+                                                "default": {
+                                                  "tag": 2
+                                                },
+                                                "int": 1,
+                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                  "langKey": "ru",
+                                                  "value": "Закладки"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "dataPath": "Закладки",
+                                          "items": [
+                                            [
+                                              {
+                                                "type": "LABEL_FIELD",
+                                                "id": 122,
+                                                "name": "ЗакладкиНаименование",
+                                                "title": {
+                                                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                                },
+                                                "dataPath": "Закладки.Description",
+                                                "items": []
+                                              },
+                                              {
+                                                "type": "INPUT_FIELD",
+                                                "id": 940,
+                                                "name": "ЗакладкиСсылка",
+                                                "title": {
+                                                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                                },
+                                                "dataPath": "Закладки.Ref",
+                                                "items": []
+                                              }
+                                            ],
+                                            []
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "PAGE",
+                                      "id": 129,
+                                      "name": "СтраницаСвойства",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Страница свойства"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        {
+                                          "type": "TABLE",
+                                          "id": 130,
+                                          "name": "Свойства",
+                                          "title": {
+                                            "content": [
+                                              {
+                                                "default": {
+                                                  "tag": 2
+                                                },
+                                                "int": 1,
+                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                  "langKey": "ru",
+                                                  "value": "Свойства"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "dataPath": "Свойства",
+                                          "items": [
+                                            {
+                                              "type": "COLUMN_GROUP",
+                                              "id": 135,
+                                              "name": "СвойстваГруппаКолонок",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Свойства группа колонок"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "",
+                                              "items": [
+                                                [
+                                                  {
+                                                    "type": "INPUT_FIELD",
+                                                    "id": 133,
+                                                    "name": "СвойстваПредставление",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "Представление"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "Свойства.Представление",
+                                                    "items": []
+                                                  },
+                                                  {
+                                                    "type": "PICTURE_FIELD",
+                                                    "id": 136,
+                                                    "name": "СвойстваНомерКартинки",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "Номер картинки"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "Свойства.НомерКартинки",
+                                                    "items": []
+                                                  }
+                                                ],
+                                                []
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "PAGE",
+                                      "id": 177,
+                                      "name": "СтраницаПапки",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Страница папки"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        {
+                                          "type": "TABLE",
+                                          "id": 178,
+                                          "name": "Папки",
+                                          "title": {
+                                            "content": [
+                                              {
+                                                "default": {
+                                                  "tag": 2
+                                                },
+                                                "int": 1,
+                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                  "langKey": "ru",
+                                                  "value": "Папки"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "dataPath": "Папки",
+                                          "items": [
+                                            {
+                                              "type": "COLUMN_GROUP",
+                                              "id": 181,
+                                              "name": "ПапкиГруппаКолонок",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Папки группа колонок"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "",
+                                              "items": [
+                                                [
+                                                  {
+                                                    "type": "PICTURE_FIELD",
+                                                    "id": 182,
+                                                    "name": "ПапкиНомерКартинки",
+                                                    "title": {
+                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                                    },
+                                                    "dataPath": "Папки.НомерКартинки",
+                                                    "items": []
+                                                  },
+                                                  {
+                                                    "type": "INPUT_FIELD",
+                                                    "id": 184,
+                                                    "name": "ПапкиПредставление",
+                                                    "title": {
+                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                                    },
+                                                    "dataPath": "Папки.Представление",
+                                                    "items": []
+                                                  }
+                                                ],
+                                                []
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "PAGE",
+                                      "id": 305,
+                                      "name": "СтраницаКатегории",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Страница категории"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        {
+                                          "type": "TABLE",
+                                          "id": 306,
+                                          "name": "Категории",
+                                          "title": {
+                                            "content": [
+                                              {
+                                                "default": {
+                                                  "tag": 2
+                                                },
+                                                "int": 1,
+                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                  "langKey": "ru",
+                                                  "value": "Категории"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "dataPath": "Категории",
+                                          "items": [
+                                            {
+                                              "type": "COLUMN_GROUP",
+                                              "id": 311,
+                                              "name": "КатегорииГруппаКолонок",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Категории группа колонок"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "",
+                                              "items": [
+                                                [
+                                                  {
+                                                    "type": "PICTURE_FIELD",
+                                                    "id": 312,
+                                                    "name": "КатегорииНомерКартинки",
+                                                    "title": {
+                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                                    },
+                                                    "dataPath": "Категории.НомерКартинки",
+                                                    "items": []
+                                                  },
+                                                  {
+                                                    "type": "INPUT_FIELD",
+                                                    "id": 309,
+                                                    "name": "КатегорииПредставление",
+                                                    "title": {
+                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                                    },
+                                                    "dataPath": "Категории.Представление",
+                                                    "items": []
+                                                  }
+                                                ],
+                                                []
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  []
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 7,
+                            "name": "ГруппаСписок",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Список"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "TABLE",
+                                  "id": 2,
+                                  "name": "Список",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                  },
+                                  "dataPath": "Список",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "COLUMN_GROUP",
+                                        "id": 772,
+                                        "name": "ГруппаФлаги",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Флаги"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": [
+                                          [
+                                            {
+                                              "type": "PICTURE_FIELD",
+                                              "id": 330,
+                                              "name": "НомерКартинки",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Иконка взаимодействия"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "Список.НомерКартинки",
+                                              "items": []
+                                            },
+                                            {
+                                              "type": "PICTURE_FIELD",
+                                              "id": 340,
+                                              "name": "ВажностьНомерКартинки",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Иконка важности"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "Список.ВажностьНомерКартинки",
+                                              "items": []
+                                            }
+                                          ],
+                                          []
+                                        ]
+                                      },
+                                      {
+                                        "type": "COLUMN_GROUP",
+                                        "id": 812,
+                                        "name": "ГруппаСписокОсновное",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Список основное"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": [
+                                          [
+                                            {
+                                              "type": "COLUMN_GROUP",
+                                              "id": 770,
+                                              "name": "ГруппаУчастникиДатаЕстьВложения",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Участники дата есть вложения"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "",
+                                              "items": [
+                                                [
+                                                  {
+                                                    "type": "LABEL_FIELD",
+                                                    "id": 16,
+                                                    "name": "Участники",
+                                                    "title": {
+                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                                    },
+                                                    "dataPath": "Список.Участники",
+                                                    "items": []
+                                                  },
+                                                  {
+                                                    "type": "LABEL_FIELD",
+                                                    "id": 776,
+                                                    "name": "ПолученоОтправлено",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "Дата"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "Список.ПолученоОтправлено",
+                                                    "items": []
+                                                  },
+                                                  {
+                                                    "type": "INPUT_FIELD",
+                                                    "id": 8,
+                                                    "name": "Дата",
+                                                    "title": {
+                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                                    },
+                                                    "dataPath": "Список.Дата",
+                                                    "items": []
+                                                  },
+                                                  {
+                                                    "type": "PICTURE_FIELD",
+                                                    "id": 108,
+                                                    "name": "ЕстьВложения",
+                                                    "title": {
+                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn[8]/synonym"
+                                                    },
+                                                    "dataPath": "Список.ЕстьВложения",
+                                                    "items": []
+                                                  }
+                                                ],
+                                                []
+                                              ]
+                                            },
+                                            {
+                                              "type": "LABEL_FIELD",
+                                              "id": 12,
+                                              "name": "Тема",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                              },
+                                              "dataPath": "Список.Тема",
+                                              "items": []
+                                            }
+                                          ],
+                                          []
+                                        ]
+                                      },
+                                      {
+                                        "type": "LABEL_FIELD",
+                                        "id": 779,
+                                        "name": "Размер",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn[11]/synonym"
+                                        },
+                                        "dataPath": "Список.Размер",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "LABEL_FIELD",
+                                        "id": 744,
+                                        "name": "УчетнаяЗапись",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                        },
+                                        "dataPath": "Список.УчетнаяЗапись",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "LABEL_FIELD",
+                                        "id": 761,
+                                        "name": "Ссылка",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                        },
+                                        "dataPath": "Список.Ссылка",
+                                        "items": []
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                },
+                                {
+                                  "type": "PAGES",
+                                  "id": 147,
+                                  "name": "СтраницыПредпросмотр",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Страницы предпросмотр"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "PAGE",
+                                        "id": 148,
+                                        "name": "СтраницаПредпросмотрОбычныйТекст",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Страница предпросмотр обычный текст"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": [
+                                          {
+                                            "type": "TEXT_DOCUMENT_FIELD",
+                                            "id": 150,
+                                            "name": "ПредпросмотрОбычныйТекст",
+                                            "title": {
+                                              "content": [
+                                                {
+                                                  "default": {
+                                                    "tag": 2
+                                                  },
+                                                  "int": 1,
+                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                    "langKey": "ru",
+                                                    "value": "Предпросмотр"
+                                                  }
+                                                }
+                                              ]
+                                            },
+                                            "dataPath": "Предпросмотр",
+                                            "items": []
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PAGE",
+                                        "id": 149,
+                                        "name": "СтраницаПредпросмотрHTML",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Страница предпросмотр HTML"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": [
+                                          [
+                                            {
+                                              "type": "USUAL_GROUP",
+                                              "id": 912,
+                                              "name": "ПредупреждениеБезопасности",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Предупреждение безопасности"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "",
+                                              "items": [
+                                                [
+                                                  {
+                                                    "type": "DECORATION",
+                                                    "id": 914,
+                                                    "name": "КартинкаПредупреждение",
+                                                    "title": {
+                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": []
+                                                  },
+                                                  {
+                                                    "type": "LABEL",
+                                                    "id": 909,
+                                                    "name": "ПредупреждениеОНебезопасномСодержимом",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "В целях безопасности некоторые элементы письма отключены, письмо может отображаться некорректно. <link ВключитьНебезопасноеСодержимое>Отобразить небезопасное содержимое</>"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": []
+                                                  }
+                                                ],
+                                                []
+                                              ]
+                                            },
+                                            {
+                                              "type": "HTML_DOCUMENT_FIELD",
+                                              "id": 91,
+                                              "name": "ПредпросмотрHTML",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Предпросмотр HTML"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "ПредпросмотрHTML",
+                                              "items": []
+                                            }
+                                          ],
+                                          []
+                                        ]
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                },
+                                {
+                                  "type": "LABEL_FIELD",
+                                  "id": 323,
+                                  "name": "ОписаниеНайденоПолнотекстовымПоиском",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Описание найденного полнотекстовым поиском"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "ОписаниеНайденоПолнотекстовымПоиском",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          }
+                        ],
+                        []
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 2,
+                "name": "Список",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "DYNAMIC_LIST"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 0
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 4,
+                "name": "Статус",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                        "length": 14,
+                        "allowedLength": 0,
+                        "description": {}
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 5,
+                "name": "Ответственный",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn[3]/synonym"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "СправочникСсылка.Пользователи",
+                          "nameEn": "CatalogRef.Пользователи"
+                        },
+                        "variant": "METADATA",
+                        "kind": "CATALOG"
+                      }
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 6,
+                "name": "ТипВзаимодействия",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Тип взаимодействия"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                        "length": 30,
+                        "allowedLength": 0,
+                        "description": {}
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 8,
+                "name": "СтрокаПоиска",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Строка поиска"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                        "length": 0,
+                        "allowedLength": 0,
+                        "description": {
+                          "value": {
+                            "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                            "nameRu": "КвалификаторыСтроки (0, Переменная)",
+                            "nameEn": "StringQualifiers (0, Variable)"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 9,
+                "name": "Предпросмотр",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 7,
+                "name": "Закладки",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 10,
+                "name": "ТаблицаДопРеквизитовСвойств",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "VALUE_TABLE"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 11,
+                "name": "Свойства",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Контакты"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "VALUE_TREE"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 12,
+                "name": "ТекущееСвойствоПанелиНавигации",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "ПланВидовХарактеристикСсылка.ДополнительныеРеквизитыИСведения",
+                          "nameEn": "ChartOfCharacteristicTypesRef.ДополнительныеРеквизитыИСведения"
+                        },
+                        "variant": "METADATA",
+                        "kind": "CHART_OF_CHARACTERISTIC_TYPES"
+                      }
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 13,
+                "name": "ТекущееСвойствоПанелиНавигацииЯвляетсяРеквизитом",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "BOOLEAN"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 14,
+                "name": "СписокВыбораТипаПредмета",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "VALUE_LIST"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 15,
+                "name": "ИмяТекущейПанелиНавигации",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                        "length": 40,
+                        "allowedLength": 0,
+                        "description": {}
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 16,
+                "name": "ПредставлениеТекущегоСвойства",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                        "length": 150,
+                        "allowedLength": 0,
+                        "description": {}
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 17,
+                "name": "ПоказыватьВсеАктивныеПредметы",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 20,
+                "name": "Папки",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[9]/type"
+                }
+              },
+              {
+                "id": 21,
+                "name": "НастройкиДеревьевПанелиНавигации",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[8]/type"
+                }
+              },
+              {
+                "id": 22,
+                "name": "НеОтрабатыватьАктивизациюПанелиНавигации",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 23,
+                "name": "ОтправлятьСообщениеСразу",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 24,
+                "name": "ТаблицаДопРеквизитовСвойствТипаБулево",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[8]/type"
+                }
+              },
+              {
+                "id": 25,
+                "name": "Категории",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[6]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[8]/type"
+                }
+              },
+              {
+                "id": 26,
+                "name": "ТолькоПочта",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 28,
+                "name": "ОписанияНайденоПолнотекстовымПоиском",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[8]/type"
+                }
+              },
+              {
+                "id": 30,
+                "name": "ОписаниеНайденоПолнотекстовымПоиском",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 31,
+                "name": "РасширенныйПоиск",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 29,
+                "name": "ИнформационнаяБазаФайловая",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 32,
+                "name": "ДокументыДоступныеДляСоздания",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[12]/type"
+                }
+              },
+              {
+                "id": 33,
+                "name": "ИспользоватьПризнакРассмотрено",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 34,
+                "name": "ВзаимодействиеДляКоторогоСформированПредпросмотр",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 5,
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "ДокументСсылка.Встреча",
+                          "nameEn": "DocumentRef.Встреча"
+                        },
+                        "variant": "METADATA",
+                        "kind": "DOCUMENT"
+                      },
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "ДокументСсылка.ЗапланированноеВзаимодействие",
+                          "nameEn": "DocumentRef.ЗапланированноеВзаимодействие"
+                        },
+                        "variant": "METADATA",
+                        "kind": "DOCUMENT"
+                      },
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "ДокументСсылка.ТелефонныйЗвонок",
+                          "nameEn": "DocumentRef.ТелефонныйЗвонок"
+                        },
+                        "variant": "METADATA",
+                        "kind": "DOCUMENT"
+                      },
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "ДокументСсылка.ЭлектронноеПисьмоВходящее",
+                          "nameEn": "DocumentRef.ЭлектронноеПисьмоВходящее"
+                        },
+                        "variant": "METADATA",
+                        "kind": "DOCUMENT"
+                      },
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "ДокументСсылка.ЭлектронноеПисьмоИсходящее",
+                          "nameEn": "DocumentRef.ЭлектронноеПисьмоИсходящее"
+                        },
+                        "variant": "METADATA",
+                        "kind": "DOCUMENT"
+                      }
+                    }
+                  ],
+                  "composite": true,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 35,
+                "name": "ПредпросмотрHTML",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 36,
+                "name": "ПредметыПанельНавигации",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 1,
+                "name": "КонтактыПанельНавигации",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Контакты панель навигации"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 3,
+                "name": "ТолькоЗначимыеПредметы",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 18,
+                "name": "ТолькоЗначимыеКонтакты",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 19,
+                "name": "ОтображатьОбластьЧтения",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 38,
+                "name": "ПанельНавигацииСкрыта",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 39,
+                "name": "ЗаголовокПанелиНавигации",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 40,
+                "name": "ЗаголовокПанелиНавигацииПодсказка",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 41,
+                "name": "ТекущееЗначениеПанелиНавигации",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "types": [],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 42,
+                "name": "ВключитьНебезопасноеСодержимое",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 43,
+                "name": "ЕстьНебезопасноеСодержимое",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 44,
+                "name": "ЗапрещеноОтображениеНебезопасногоСодержимогоВПисьмах",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 27,
+                "name": "ПравоПометкиУдаленияПапок",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 37,
+                "name": "ГиперссылкаЦвет",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[39]/type"
+                }
+              },
+              {
+                "id": 45,
+                "name": "ДатаПредыдущегоВыполненияКомандыОтправкиПолученияПочты",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "DATE"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.qualifiers.DateQualifiers": {
+                        "dateFractions": 2,
+                        "description": {
+                          "value": {
+                            "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                            "nameRu": "КвалификаторыДаты (ДатаВремя)",
+                            "nameEn": "DateQualifiers (DateTime)"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 46,
+                "name": "ДатаПредыдущегоПолученияОтправкиПочты",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[45]/type"
+                }
+              },
+              {
+                "id": 47,
+                "name": "ОтправкаПолучениеПисемВыполняется",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 48,
+                "name": "РазделениеВключено",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 49,
+                "name": "ИндексПолнотекстовогоПоискаАктуален",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "9ab3980e-a480-4f90-a8cc-bde99d5ace35",
+        "name": "ФормаСпискаПараметрическая",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "DocumentJournal.Взаимодействия.Form.ФормаСпискаПараметрическая",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Форма.ФормаСпискаПараметрическая"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Форма списка параметрическая"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/DocumentJournals/Взаимоде_ствия/Forms/ФормаСпискаПараметрическая/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand/synonym"
+          },
+          "handlers": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[2]"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[5]"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[7]"
+              },
+              {
+                "event": "BeforeLoadDataFromSettingsAtServer",
+                "name": "ПриЗагрузкеДанныхИзНастроекНаСервере"
+              }
+            ],
+            []
+          ],
+          "items": [
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 234,
+                "name": "ГруппаПользовательскихНастроек",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                },
+                "dataPath": "",
+                "items": []
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 34,
+                "name": "ГруппаФильтры",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "USUAL_BUTTON",
+                      "id": 102,
+                      "name": "ПереключитьРежимПросмотра",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "В виде дерева / списка"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 136,
+                      "name": "ТипВзаимодействия",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/title"
+                      },
+                      "dataPath": "ТипВзаимодействия",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 50,
+                      "name": "Статус",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                      },
+                      "dataPath": "Статус",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 46,
+                      "name": "Ответственный",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn[3]/synonym"
+                      },
+                      "dataPath": "Ответственный",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "PAGES",
+                "id": 103,
+                "name": "СтраницыСписокДерево",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Страницы список дерево"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "PAGE",
+                      "id": 104,
+                      "name": "СтраницаСписок",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Страница список"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        {
+                          "type": "TABLE",
+                          "id": 1,
+                          "name": "Список",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                          },
+                          "dataPath": "Список",
+                          "items": [
+                            [
+                              {
+                                "type": "COLUMN_GROUP",
+                                "id": 221,
+                                "name": "ГруппаОсновное",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "COLUMN_GROUP",
+                                      "id": 223,
+                                      "name": "ГруппаСостояниеУчастникиДата",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Состояние участники дата"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        [
+                                          {
+                                            "type": "PICTURE_FIELD",
+                                            "id": 225,
+                                            "name": "НомерКартинки",
+                                            "title": {
+                                              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                            },
+                                            "dataPath": "Список.НомерКартинки",
+                                            "items": []
+                                          },
+                                          {
+                                            "type": "INPUT_FIELD",
+                                            "id": 66,
+                                            "name": "Участники",
+                                            "title": {
+                                              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                            },
+                                            "dataPath": "Список.Участники",
+                                            "items": []
+                                          },
+                                          {
+                                            "type": "INPUT_FIELD",
+                                            "id": 68,
+                                            "name": "Дата",
+                                            "title": {
+                                              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                            },
+                                            "dataPath": "Список.Date",
+                                            "items": []
+                                          },
+                                          {
+                                            "type": "PICTURE_FIELD",
+                                            "id": 254,
+                                            "name": "ЕстьВложения",
+                                            "title": {
+                                              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                            },
+                                            "dataPath": "Список.ЕстьВложения",
+                                            "items": []
+                                          }
+                                        ],
+                                        []
+                                      ]
+                                    },
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 20,
+                                      "name": "Тема",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn[4]/synonym"
+                                      },
+                                      "dataPath": "Список.Тема",
+                                      "items": []
+                                    }
+                                  ],
+                                  []
+                                ]
+                              },
+                              {
+                                "type": "LABEL_FIELD",
+                                "id": 216,
+                                "name": "Ссылка",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                },
+                                "dataPath": "Список.Ref",
+                                "items": []
+                              }
+                            ],
+                            []
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "PAGE",
+                      "id": 105,
+                      "name": "СтраницаДерево",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Страница дерево"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        {
+                          "type": "TABLE",
+                          "id": 106,
+                          "name": "ДеревоВзаимодействий",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Дерево взаимодействий"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "ДеревоВзаимодействий",
+                          "items": [
+                            {
+                              "type": "COLUMN_GROUP",
+                              "id": 228,
+                              "name": "ДеревоВзаимодействийГруппаОсновное",
+                              "title": {
+                                "content": [
+                                  {
+                                    "default": {
+                                      "tag": 2
+                                    },
+                                    "int": 1,
+                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                      "langKey": "ru",
+                                      "value": "Дерево взаимодействий группа основное"
+                                    }
+                                  }
+                                ]
+                              },
+                              "dataPath": "",
+                              "items": [
+                                [
+                                  {
+                                    "type": "COLUMN_GROUP",
+                                    "id": 115,
+                                    "name": "УчастникиСостояниеДата",
+                                    "title": {
+                                      "content": [
+                                        {
+                                          "default": {
+                                            "tag": 2
+                                          },
+                                          "int": 1,
+                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                            "langKey": "ru",
+                                            "value": "Участники состояние дата"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    "dataPath": "",
+                                    "items": [
+                                      [
+                                        {
+                                          "type": "PICTURE_FIELD",
+                                          "id": 113,
+                                          "name": "ДеревоВзаимодействийНомерКартинки",
+                                          "title": {
+                                            "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                          },
+                                          "dataPath": "ДеревоВзаимодействий.НомерКартинки",
+                                          "items": []
+                                        },
+                                        {
+                                          "type": "INPUT_FIELD",
+                                          "id": 118,
+                                          "name": "ДеревоВзаимодействийУчастники",
+                                          "title": {
+                                            "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn[5]/synonym"
+                                          },
+                                          "dataPath": "ДеревоВзаимодействий.Участники",
+                                          "items": []
+                                        },
+                                        {
+                                          "type": "INPUT_FIELD",
+                                          "id": 111,
+                                          "name": "ДеревоВзаимодействийДата",
+                                          "title": {
+                                            "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                          },
+                                          "dataPath": "ДеревоВзаимодействий.Дата",
+                                          "items": []
+                                        }
+                                      ],
+                                      []
+                                    ]
+                                  },
+                                  {
+                                    "type": "INPUT_FIELD",
+                                    "id": 116,
+                                    "name": "ДеревоВзаимодействийТема",
+                                    "title": {
+                                      "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn[4]/synonym"
+                                    },
+                                    "dataPath": "ДеревоВзаимодействий.Тема",
+                                    "items": []
+                                  }
+                                ],
+                                []
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "Список",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 2,
+                "name": "Ответственный",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn[3]/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 5,
+                "name": "Статус",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[2]/type"
+                }
+              },
+              {
+                "id": 6,
+                "name": "ОтборПоПредмету",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 8,
+                "name": "Контакт",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "ОпределяемыйТип.КонтактВзаимодействия",
+                          "nameEn": "DefinedType.КонтактВзаимодействия"
+                        },
+                        "variant": "METADATA",
+                        "kind": "DEFINED_TYPE"
+                      }
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 9,
+                "name": "ПредметДляОтбора",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "ОпределяемыйТип.ПредметВзаимодействия",
+                          "nameEn": "DefinedType.ПредметВзаимодействия"
+                        },
+                        "variant": "METADATA",
+                        "kind": "DEFINED_TYPE"
+                      }
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 3,
+                "name": "ВВидеДерева",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 4,
+                "name": "ДеревоВзаимодействий",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[9]/type"
+                }
+              },
+              {
+                "id": 10,
+                "name": "Интервал",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "STANDARD_PERIOD"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 11,
+                "name": "ТипВзаимодействия",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 12,
+                "name": "ТолькоПочта",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 13,
+                "name": "ДокументыДоступныеДляСоздания",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[12]/type"
+                }
+              },
+              {
+                "id": 14,
+                "name": "ИспользоватьПризнакРассмотрено",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "ec928563-6e35-4b84-b477-90d2481cec1c",
+        "name": "ПечатьЭлектронногоПисьма",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "DocumentJournal.Взаимодействия.Form.ПечатьЭлектронногоПисьма",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Форма.ПечатьЭлектронногоПисьма"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Печать электронного письма"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/DocumentJournals/Взаимоде_ствия/Forms/ПечатьЭлектронногоПисьма/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/synonym"
+          },
+          "handlers": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[7]"
+            }
+          ],
+          "items": [
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 35,
+                "name": "ГруппаПисьмоОснованиеПечать",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Письмо основание печать"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "LABEL",
+                      "id": 32,
+                      "name": "ДекорацияПисьмоОснование",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "USUAL_BUTTON",
+                      "id": 37,
+                      "name": "Печать",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[12]/synonym"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 39,
+                "name": "ПредупреждениеБезопасности",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "DECORATION",
+                      "id": 41,
+                      "name": "КартинкаПредупреждение",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL",
+                      "id": 44,
+                      "name": "ПредупреждениеОНебезопасномСодержимом",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "HTML_DOCUMENT_FIELD",
+                "id": 1,
+                "name": "ТекстHTML",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Текст HTML"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "ТекстHTML",
+                "items": []
+              },
+              {
+                "type": "TABLE",
+                "id": 4,
+                "name": "Вложения",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Вложения"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "Вложения",
+                "items": [
+                  {
+                    "type": "COLUMN_GROUP",
+                    "id": 17,
+                    "name": "Группа",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Группа"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "PICTURE_FIELD",
+                          "id": 19,
+                          "name": "ИндексКартинки",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Индекс картинки"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "Вложения.ИндексКартинки",
+                          "items": []
+                        },
+                        {
+                          "type": "INPUT_FIELD",
+                          "id": 22,
+                          "name": "ИмяФайла",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Вложение"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "Вложения.ИмяФайла",
+                          "items": []
+                        },
+                        {
+                          "type": "INPUT_FIELD",
+                          "id": 25,
+                          "name": "ВложенияРазмерПредставление",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Размер представление"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "Вложения.РазмерПредставление",
+                          "items": []
+                        }
+                      ],
+                      []
+                    ]
+                  }
+                ]
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "ТекстHTML",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 2,
+                "name": "ФормаДиалогаПечатиПриОткрытииОткрывалась",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 4,
+                "name": "НеВызыватьКомандуПечати",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 5,
+                "name": "Вложения",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[8]/type"
+                }
+              },
+              {
+                "id": 6,
+                "name": "ИмяПользователяУчетнойЗаписи",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[14]/type"
+                }
+              },
+              {
+                "id": 7,
+                "name": "ВложенияСИдентификаторами",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[8]/type"
+                }
+              },
+              {
+                "id": 8,
+                "name": "ОтображатьВложенияПисьма",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 9,
+                "name": "Письмо",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 5,
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "СправочникСсылка.ЭлектронноеПисьмоВходящееПрисоединенныеФайлы",
+                          "nameEn": "CatalogRef.ЭлектронноеПисьмоВходящееПрисоединенныеФайлы"
+                        },
+                        "variant": "METADATA",
+                        "kind": "CATALOG"
+                      },
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "СправочникСсылка.ЭлектронноеПисьмоИсходящееПрисоединенныеФайлы",
+                          "nameEn": "CatalogRef.ЭлектронноеПисьмоИсходящееПрисоединенныеФайлы"
+                        },
+                        "variant": "METADATA",
+                        "kind": "CATALOG"
+                      },
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[29]/type/types/java.util.CollSer/com.github._1c_syntax.bsl.types.value.CustomValueType[4]"
+                      },
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[29]/type/types/java.util.CollSer/com.github._1c_syntax.bsl.types.value.CustomValueType[5]"
+                      },
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+                    }
+                  ],
+                  "composite": true,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type/qualifiers/java.util.CollSer/com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers"
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 10,
+                "name": "ТемаПисьма",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                        "length": 500,
+                        "allowedLength": 0,
+                        "description": {}
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 11,
+                "name": "ДатаПисьма",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "DATE"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.qualifiers.DateQualifiers": {
+                        "dateFractions": 1,
+                        "description": {
+                          "value": {
+                            "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                            "nameRu": "КвалификаторыДаты (Дата)",
+                            "nameEn": "DateQualifiers (Date)"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 13,
+                "name": "ПисьмоОснование",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 2,
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[29]/type/types/java.util.CollSer/com.github._1c_syntax.bsl.types.value.CustomValueType[4]"
+                      },
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[29]/type/types/java.util.CollSer/com.github._1c_syntax.bsl.types.value.CustomValueType[5]"
+                      }
+                    }
+                  ],
+                  "composite": true,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 14,
+                "name": "ТемаПисьмаОснования",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 15,
+                "name": "ДатаПисьмаОснования",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[10]/type"
+                }
+              },
+              {
+                "id": 16,
+                "name": "ЗапрещенныеРасширения",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[12]/type"
+                }
+              },
+              {
+                "id": 17,
+                "name": "ВключитьНебезопасноеСодержимое",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 18,
+                "name": "ЕстьНебезопасноеСодержимое",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 19,
+                "name": "ИсходныйТекстHTML",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "5d3e9678-20fe-4128-867a-3f7addaa7831",
+        "name": "ПараметрыЭлектронногоПисьма",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "DocumentJournal.Взаимодействия.Form.ПараметрыЭлектронногоПисьма",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Форма.ПараметрыЭлектронногоПисьма"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Параметры электронного письма"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/DocumentJournals/Взаимоде_ствия/Forms/ПараметрыЭлектронногоПисьма/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "content": [
+              {
+                "default": {
+                  "tag": 2
+                },
+                "int": 1,
+                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                  "langKey": "ru",
+                  "value": "Параметры письма"
+                }
+              }
+            ]
+          },
+          "handlers": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[4]"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[7]"
+              }
+            ],
+            []
+          ],
+          "items": [
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 22,
+                "name": "ГруппаДатыНомер",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Даты номер"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 8,
+                      "name": "ГруппаДаты",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Даты"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 9,
+                            "name": "Создано",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Создано"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "Создано",
+                            "items": []
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 11,
+                            "name": "ОтправленоПолучено",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Отправлено"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "ОтправленоПолучено",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 25,
+                      "name": "ГруппаВключатьВнутреннийНомер",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Включать внутренний номер"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 6,
+                            "name": "ВнутреннийНомер",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Внутренний номер"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "ВнутреннийНомер",
+                            "items": []
+                          },
+                          {
+                            "type": "CHECK_BOX_FIELD",
+                            "id": 23,
+                            "name": "ВключатьТелоИсходногоПисьма",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Включать тело исходного письма"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "ВключатьТелоИсходногоПисьма",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "INPUT_FIELD",
+                "id": 26,
+                "name": "Папка",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Папка"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "Папка",
+                "items": []
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 5,
+                "name": "ГруппаПараметрыОтслеживания",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Параметры отслеживания"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "CHECK_BOX_FIELD",
+                      "id": 1,
+                      "name": "УведомитьОДоставке",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Уведомить о доставке"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "УведомитьОДоставке",
+                      "items": []
+                    },
+                    {
+                      "type": "CHECK_BOX_FIELD",
+                      "id": 3,
+                      "name": "УведомитьОПрочтении",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Уведомить о прочтении"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "УведомитьОПрочтении",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "TEXT_DOCUMENT_FIELD",
+                "id": 17,
+                "name": "Заголовки",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Заголовки Интернета"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "ЗаголовкиИнтернета",
+                "items": []
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "УведомитьОДоставке",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 2,
+                "name": "УведомитьОПрочтении",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 3,
+                "name": "ВнутреннийНомер",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                        "length": 11,
+                        "allowedLength": 0,
+                        "description": {}
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 4,
+                "name": "Создано",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[45]/type"
+                }
+              },
+              {
+                "id": 5,
+                "name": "ОтправленоПолучено",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Отправлено получено"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[45]/type"
+                }
+              },
+              {
+                "id": 7,
+                "name": "ЗаголовкиИнтернета",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "TEXT_DOCUMENT"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 8,
+                "name": "Письмо",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 9,
+                "name": "ТипПисьма",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 6,
+                "name": "ВключатьТелоИсходногоПисьма",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 10,
+                "name": "Папка",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "СправочникСсылка.ПапкиЭлектронныхПисем",
+                          "nameEn": "CatalogRef.ПапкиЭлектронныхПисем"
+                        },
+                        "variant": "METADATA",
+                        "kind": "CATALOG"
+                      }
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 11,
+                "name": "УчетнаяЗапись",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "СправочникСсылка.УчетныеЗаписиЭлектроннойПочты",
+                          "nameEn": "CatalogRef.УчетныеЗаписиЭлектроннойПочты"
+                        },
+                        "variant": "METADATA",
+                        "kind": "CATALOG"
+                      }
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 12,
+                "name": "ТекущаяПапка",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[10]/type"
+                }
+              },
+              {
+                "id": 13,
+                "name": "ВыполненаКомандаЗакрыть",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "bb878f73-8a0f-459a-9076-ce57fe7957dc",
+        "name": "НастройкиРаботыСПочтой",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "DocumentJournal.Взаимодействия.Form.НастройкиРаботыСПочтой",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Форма.НастройкиРаботыСПочтой"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[11]/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/DocumentJournals/Взаимоде_ствия/Forms/Настро_киРаботыСПочто_/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[5]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[11]/synonym"
+          },
+          "handlers": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[7]"
+            }
+          ],
+          "items": [
+            [
+              {
+                "type": "INPUT_FIELD",
+                "id": 32,
+                "name": "УчетнаяЗаписьЭлектроннойПочты",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "dataPath": "",
+                "items": []
+              },
+              {
+                "type": "PAGES",
+                "id": 16,
+                "name": "СтраницыНастроек",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Страницы настроек"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "PAGE",
+                      "id": 42,
+                      "name": "ПодписьДляНового",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Подпись для нового"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 17,
+                          "name": "ГруппаДляНовыхСообщений",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Подпись для новых сообщений"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "CHECK_BOX_FIELD",
+                                "id": 1,
+                                "name": "ВключатьПодписьДляНовыхСообщений",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Включать подпись для новых сообщений"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "ВключатьПодписьДляНовыхСообщений",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 3,
+                                "name": "ФорматПодписиДляНовыхСообщений",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Формат подписи"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "ФорматПодписиДляНовыхСообщений",
+                                "items": []
+                              },
+                              {
+                                "type": "USUAL_GROUP",
+                                "id": 7,
+                                "name": "ГруппаВключатьФорматНовые",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Для новых сообщений"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": []
+                              },
+                              {
+                                "type": "PAGES",
+                                "id": 8,
+                                "name": "СтраницыПодписьДляНовыхСообщений",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Страницы подпись для новых сообщений"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "PAGE",
+                                      "id": 9,
+                                      "name": "СтраницаНовоеСообщениеПростойТекст",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Страница новое сообщение простой текст"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        {
+                                          "type": "INPUT_FIELD",
+                                          "id": 5,
+                                          "name": "ПодписьДляНовыхСообщенийПростойТекст",
+                                          "title": {
+                                            "content": [
+                                              {
+                                                "default": {
+                                                  "tag": 2
+                                                },
+                                                "int": 1,
+                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                  "langKey": "ru",
+                                                  "value": "Подпись для новых сообщений простой текст"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "dataPath": "ПодписьДляНовыхСообщенийПростойТекст",
+                                          "items": []
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "PAGE",
+                                      "id": 10,
+                                      "name": "СтраницаНовоеСообщениеФорматированныйТекст",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Страница новое сообщение форматированный текст"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        [
+                                          {
+                                            "type": "COMMAND_BAR",
+                                            "id": 15,
+                                            "name": "ГруппаКомандыФорматированныйДокумент",
+                                            "title": {
+                                              "content": [
+                                                {
+                                                  "default": {
+                                                    "tag": 2
+                                                  },
+                                                  "int": 1,
+                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                    "langKey": "ru",
+                                                    "value": "Команды форматированный документ"
+                                                  }
+                                                }
+                                              ]
+                                            },
+                                            "dataPath": "",
+                                            "items": []
+                                          },
+                                          {
+                                            "type": "FORMATTED_DOCUMENT_FIELD",
+                                            "id": 11,
+                                            "name": "НовоеСообщениеФорматированныйДокумент",
+                                            "title": {
+                                              "content": [
+                                                {
+                                                  "default": {
+                                                    "tag": 2
+                                                  },
+                                                  "int": 1,
+                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                    "langKey": "ru",
+                                                    "value": "Новое сообщение форматированный документ"
+                                                  }
+                                                }
+                                              ]
+                                            },
+                                            "dataPath": "НовоеСообщениеФорматированныйДокумент",
+                                            "items": []
+                                          }
+                                        ],
+                                        []
+                                      ]
+                                    }
+                                  ],
+                                  []
+                                ]
+                              }
+                            ],
+                            []
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "PAGE",
+                      "id": 87,
+                      "name": "ПодписьПриОтвете",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Подпись при ответе"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 18,
+                          "name": "ГруппаПриОтветеПересылке",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Подпись при ответе или пересылке"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "CHECK_BOX_FIELD",
+                                "id": 20,
+                                "name": "ВключатьПодписьПриОтветеПересылке",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Включать подпись при ответе или пересылке"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "ВключатьПодписьПриОтветеПересылке",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 22,
+                                "name": "ФорматПодписиПриОтветеПересылке",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[5]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                },
+                                "dataPath": "ФорматПодписиПриОтветеПересылке",
+                                "items": []
+                              },
+                              {
+                                "type": "PAGES",
+                                "id": 24,
+                                "name": "СтраницыПодписьПриОтветеПересылке",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Страницы подпись при ответе пересылке"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "PAGE",
+                                      "id": 25,
+                                      "name": "СтраницаПриОтветеПересылкеПростойТекст",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Страница при ответе пересылке простой текст"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        {
+                                          "type": "INPUT_FIELD",
+                                          "id": 27,
+                                          "name": "ПодписьПриОтветеПересылкеПростойТекст",
+                                          "title": {
+                                            "content": [
+                                              {
+                                                "default": {
+                                                  "tag": 2
+                                                },
+                                                "int": 1,
+                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                  "langKey": "ru",
+                                                  "value": "Подпись при ответе пересылке простой текст"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "dataPath": "ПодписьПриОтветеПересылкеПростойТекст",
+                                          "items": []
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "PAGE",
+                                      "id": 26,
+                                      "name": "СтраницаПриОтветеПересылкеФорматированныйДокумент",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[5]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        [
+                                          {
+                                            "type": "COMMAND_BAR",
+                                            "id": 31,
+                                            "name": "ГруппаКомандыПриОтветеПересылкеФорматированныйДокумент",
+                                            "title": {
+                                              "content": [
+                                                {
+                                                  "default": {
+                                                    "tag": 2
+                                                  },
+                                                  "int": 1,
+                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                    "langKey": "ru",
+                                                    "value": "Команды при ответе пересылке форматированный документ"
+                                                  }
+                                                }
+                                              ]
+                                            },
+                                            "dataPath": "",
+                                            "items": []
+                                          },
+                                          {
+                                            "type": "FORMATTED_DOCUMENT_FIELD",
+                                            "id": 29,
+                                            "name": "ПриОтветеПересылкеФорматированныйДокумент",
+                                            "title": {
+                                              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                            },
+                                            "dataPath": "ПриОтветеПересылкеФорматированныйДокумент",
+                                            "items": []
+                                          }
+                                        ],
+                                        []
+                                      ]
+                                    }
+                                  ],
+                                  []
+                                ]
+                              }
+                            ],
+                            []
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "PAGE",
+                      "id": 34,
+                      "name": "ОтслеживаниеПисем",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Отслеживание писем"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 39,
+                          "name": "ГруппаДляОтправляемыхСообщений",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Для отправляемых сообщений запрашивать:"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "CHECK_BOX_FIELD",
+                                "id": 37,
+                                "name": "ВсегдаЗапрашиватьУведомлениеОПрочтении",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Уведомление о прочтении"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "ВсегдаЗапрашиватьУведомлениеОПрочтении",
+                                "items": []
+                              },
+                              {
+                                "type": "CHECK_BOX_FIELD",
+                                "id": 35,
+                                "name": "ВсегдаЗапрашиватьУведомленияОДоставке",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Уведомление о доставке"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "ВсегдаЗапрашиватьУведомленияОДоставке",
+                                "items": []
+                              },
+                              {
+                                "type": "RADIO_BUTTON_FIELD",
+                                "id": 40,
+                                "name": "ПорядокОтветовНаЗапросыУведомленийОПрочтении",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Порядок ответов на запросы уведомлений о прочтении"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "ПорядокОтветовНаЗапросыУведомленийОПрочтении",
+                                "items": []
+                              }
+                            ],
+                            []
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "PAGE",
+                      "id": 47,
+                      "name": "Прочее",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Прочее"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "CHECK_BOX_FIELD",
+                            "id": 50,
+                            "name": "ОтображатьТелоИсходногоПисьма",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Отображать тело исходного письма  при ответе или пересылке"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "ОтображатьТелоИсходногоПисьма",
+                            "items": []
+                          },
+                          {
+                            "type": "CHECK_BOX_FIELD",
+                            "id": 52,
+                            "name": "ВключатьТелоИсходногоПисьма",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Включать тело исходного письма при ответе пересылке"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "ВключатьТелоИсходногоПисьма",
+                            "items": []
+                          },
+                          {
+                            "type": "CHECK_BOX_FIELD",
+                            "id": 45,
+                            "name": "ОтправлятьСообщенияСразу",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Отправлять сообщения сразу "
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "ОтправлятьСообщенияСразу",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 2,
+                "name": "НовоеСообщениеФорматированныйДокумент",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[5]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "FORMATTED_DOCUMENT"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 3,
+                "name": "ПриОтветеПересылкеФорматированныйДокумент",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[5]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 1,
+                "name": "НастройкиХранилище",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[39]/type"
+                }
+              },
+              {
+                "id": 4,
+                "name": "ФорматПодписиДляНовыхСообщений",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Формат подписи для новых сообщений"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "ПеречислениеСсылка.СпособыРедактированияЭлектронныхПисем",
+                          "nameEn": "EnumRef.СпособыРедактированияЭлектронныхПисем"
+                        },
+                        "variant": "METADATA",
+                        "kind": "ENUM"
+                      }
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 5,
+                "name": "ПодписьДляНовыхСообщенийПростойТекст",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[5]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 6,
+                "name": "ВключатьПодписьПриОтветеПересылке",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[5]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 7,
+                "name": "ВключатьПодписьДляНовыхСообщений",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[5]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 8,
+                "name": "ФорматПодписиПриОтветеПересылке",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Формат подписи при ответе пересылке"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[5]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 9,
+                "name": "ПодписьПриОтветеПересылкеПростойТекст",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[5]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 10,
+                "name": "ВсегдаЗапрашиватьУведомлениеОПрочтении",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Всегда запрашивать уведомление о прочтении"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 11,
+                "name": "ВсегдаЗапрашиватьУведомленияОДоставке",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Всегда запрашивать уведомления о доставке"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 12,
+                "name": "ПорядокОтветовНаЗапросыУведомленийОПрочтении",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[5]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "ПеречислениеСсылка.ПорядокОтветовНаЗапросыУведомленийОПрочтении",
+                          "nameEn": "EnumRef.ПорядокОтветовНаЗапросыУведомленийОПрочтении"
+                        },
+                        "variant": "METADATA",
+                        "kind": "ENUM"
+                      }
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 13,
+                "name": "ОтправлятьСообщенияСразу",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Отправлять сообщения сразу"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 14,
+                "name": "ОтображатьТелоИсходногоПисьма",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[5]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 15,
+                "name": "ВключатьТелоИсходногоПисьма",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[5]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "cb1d4a41-20a9-4d76-8798-d47d8858bff1",
+        "name": "ВыборТипаПредмета",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "DocumentJournal.Взаимодействия.Form.ВыборТипаПредмета",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Форма.ВыборТипаПредмета"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Выбор типа предмета"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/DocumentJournals/Взаимоде_ствия/Forms/ВыборТипаПредмета/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "content": [
+              {
+                "default": {
+                  "tag": 2
+                },
+                "int": 1,
+                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                  "langKey": "ru",
+                  "value": "Выберите тип предмета"
+                }
+              }
+            ]
+          },
+          "handlers": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[5]"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[7]"
+              }
+            ],
+            []
+          ],
+          "items": [
+            [
+              {
+                "type": "TABLE",
+                "id": 1,
+                "name": "ТаблицаТиповПредметов",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Таблица типов предметов"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "ТаблицаТиповПредметов",
+                "items": [
+                  {
+                    "type": "INPUT_FIELD",
+                    "id": 14,
+                    "name": "ТаблицаТиповПредметовПредставлениеТипа",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Представление типа"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "ТаблицаТиповПредметов.ПредставлениеТипа",
+                    "items": []
+                  }
+                ]
+              },
+              {
+                "type": "CHECK_BOX_FIELD",
+                "id": 23,
+                "name": "НеОтображатьВзаимодействия",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Не отображать взаимодействия"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "НеОтображатьВзаимодействия",
+                "items": []
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "ТаблицаТиповПредметов",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[8]/type"
+                }
+              },
+              {
+                "id": 2,
+                "name": "ТекущийТипПредмета",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 3,
+                "name": "НеОтображатьВзаимодействия",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      }
+    ],
+    []
+  ],
+  "mdoReference": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+  },
+  "mdoType": "DOCUMENT_JOURNAL",
+  "moduleTypes": [
+    [
+      "ManagerModule",
+      [
+        "src/test/resources/ext/edt/ssl_3_2/configuration/src/DocumentJournals/Взаимоде_ствия/ManagerModule.bsl"
+      ]
+    ]
+  ],
+  "modules": [
+    {
+      "moduleType": "ManagerModule",
+      "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/DocumentJournals/Взаимоде_ствия/ManagerModule.bsl",
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "isProtected": false
+    }
+  ],
+  "name": "Взаимодействия",
+  "objectBelonging": "OWN",
+  "possibleRights": [
+    {
+      "default": {
+        "tag": 4
+      },
+      "int": 2,
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "VIEW"
+    }
+  ],
+  "registeredDocuments": [
+    [
+      {
+        "type": "DOCUMENT",
+        "mdoRef": "Document.Встреча",
+        "mdoRefRu": "Документ.Встреча"
+      },
+      {
+        "type": "DOCUMENT",
+        "mdoRef": "Document.ТелефонныйЗвонок",
+        "mdoRefRu": "Документ.ТелефонныйЗвонок"
+      },
+      {
+        "type": "DOCUMENT",
+        "mdoRef": "Document.ЭлектронноеПисьмоВходящее",
+        "mdoRefRu": "Документ.ЭлектронноеПисьмоВходящее"
+      },
+      {
+        "type": "DOCUMENT",
+        "mdoRef": "Document.ЭлектронноеПисьмоИсходящее",
+        "mdoRefRu": "Документ.ЭлектронноеПисьмоИсходящее"
+      },
+      {
+        "type": "DOCUMENT",
+        "mdoRef": "Document.ЗапланированноеВзаимодействие",
+        "mdoRefRu": "Документ.ЗапланированноеВзаимодействие"
+      },
+      {
+        "type": "DOCUMENT",
+        "mdoRef": "Document.СообщениеSMS",
+        "mdoRefRu": "Документ.СообщениеSMS"
+      }
+    ],
+    []
+  ],
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand/synonym"
+  },
+  "templates": [
+    [
+      {
+        "uuid": "a2b4110b-4d9c-40fd-ab46-bfa08d2eb993",
+        "name": "СхемаОтборВзаимодействия",
+        "mdoReference": {
+          "type": "TEMPLATE",
+          "mdoRef": "DocumentJournal.Взаимодействия.Template.СхемаОтборВзаимодействия",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Макет.СхемаОтборВзаимодействия"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Схема отбор взаимодействия"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [],
+        "templateType": "DATA_COMPOSITION_SCHEME",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.DataCompositionSchema",
+          "dataSets": [
+            {
+              "name": "ОсновнойНаборДанных",
+              "type": "DATA_SET_QUERY",
+              "dataSource": "ИсточникДанных1",
+              "items": [],
+              "querySource": {
+                "line": 154,
+                "column": 10,
+                "textQuery": "ВЫБРАТЬ РАЗРЕШЕННЫЕ\n\tЖурналДокументовВзаимодействия.Ссылка,\n\tЖурналДокументовВзаимодействия.Дата,\n\tЖурналДокументовВзаимодействия.ПометкаУдаления,\n\tЖурналДокументовВзаимодействия.Номер,\n\tЖурналДокументовВзаимодействия.Проведен,\n\tЖурналДокументовВзаимодействия.Автор,\n\tЖурналДокументовВзаимодействия.Входящий,\n\tЖурналДокументовВзаимодействия.Тема,\n\tЖурналДокументовВзаимодействия.Ответственный КАК Ответственный,\n\tЕСТЬNULL(ПредметыВзаимодействий.Рассмотрено, Ложь) КАК Рассмотрено,\n\tЕСТЬNULL(ПредметыВзаимодействий.РассмотретьПосле, ДатаВремя(1,1,1)) КАК РассмотретьПосле,\n\tЖурналДокументовВзаимодействия.Участники,\n\tЖурналДокументовВзаимодействия.Тип,\n\tЖурналДокументовВзаимодействия.СтатусИсходящегоПисьма,\n\tЖурналДокументовВзаимодействия.ЕстьВложения,\n\tЖурналДокументовВзаимодействия.УчетнаяЗапись,\n\tЕСТЬNULL(ПредметыВзаимодействий.Предмет, НЕОПРЕДЕЛЕНО) КАК Предмет,\n\tТИПЗНАЧЕНИЯ(ПредметыВзаимодействий.Предмет) КАК ТипПредмета,\n\tСостоянияПредметовВзаимодействий.Активен КАК ПредметАктивен,\n\tПредметыВзаимодействий.ПапкаЭлектронногоПисьма КАК Папка,\n\tЖурналДокументовВзаимодействия.ПолученоОтправлено,\n\tЖурналДокументовВзаимодействия.Размер,\n\tЖурналДокументовВзаимодействия.Важность,\n\tВЫБОР\n\t\tКОГДА ЖурналДокументовВзаимодействия.Важность = ЗНАЧЕНИЕ(Перечисление.ВариантыВажностиВзаимодействия.Высокая) ТОГДА 2\n\t\tКОГДА ЖурналДокументовВзаимодействия.Важность = ЗНАЧЕНИЕ(Перечисление.ВариантыВажностиВзаимодействия.Низкая) ТОГДА 0\n\t\tИНАЧЕ 1\n\tКОНЕЦ КАК ВажностьНомерКартинки\nИЗ\n\tЖурналДокументов.Взаимодействия КАК ЖурналДокументовВзаимодействия\n\t\t{ЛЕВОЕ СОЕДИНЕНИЕ РегистрСведений.ПредметыПапкиВзаимодействий КАК ПредметыВзаимодействий\n\t\t\tЛЕВОЕ СОЕДИНЕНИЕ РегистрСведений.СостоянияПредметовВзаимодействий КАК СостоянияПредметовВзаимодействий\n\t\t\tПО ПредметыВзаимодействий.Предмет = СостоянияПредметовВзаимодействий.Предмет\n\t\tПО ЖурналДокументовВзаимодействия.Ссылка = ПредметыВзаимодействий.Взаимодействие}\n{ГДЕ\n\t(ЖурналДокументовВзаимодействия.Дата МЕЖДУ &НачалоПериодаОтбора И &КонецПериодаОтбора)}"
+              },
+              "fields": [
+                [
+                  {
+                    "dataPath": "Дата",
+                    "name": "Дата"
+                  },
+                  {
+                    "dataPath": "ПометкаУдаления",
+                    "name": "ПометкаУдаления"
+                  },
+                  {
+                    "dataPath": "Номер",
+                    "name": "Номер"
+                  },
+                  {
+                    "dataPath": "Проведен",
+                    "name": "Проведен"
+                  },
+                  {
+                    "dataPath": "Ссылка",
+                    "name": "Ссылка"
+                  },
+                  {
+                    "dataPath": "Автор",
+                    "name": "Автор"
+                  },
+                  {
+                    "dataPath": "Входящий",
+                    "name": "Входящий"
+                  },
+                  {
+                    "dataPath": "ЕстьВложения",
+                    "name": "ЕстьВложения"
+                  },
+                  {
+                    "dataPath": "Ответственный",
+                    "name": "Ответственный"
+                  },
+                  {
+                    "dataPath": "Предмет",
+                    "name": "Предмет"
+                  },
+                  {
+                    "dataPath": "СтатусИсходящегоПисьма",
+                    "name": "СтатусИсходящегоПисьма"
+                  },
+                  {
+                    "dataPath": "Участники",
+                    "name": "Участники"
+                  },
+                  {
+                    "dataPath": "ТипПредмета",
+                    "name": "ТипПредмета"
+                  },
+                  {
+                    "dataPath": "УчетнаяЗапись",
+                    "name": "УчетнаяЗапись"
+                  },
+                  {
+                    "dataPath": "Рассмотрено",
+                    "name": "Рассмотрено"
+                  },
+                  {
+                    "dataPath": "РассмотретьПосле",
+                    "name": "РассмотретьПосле"
+                  },
+                  {
+                    "dataPath": "Тип",
+                    "name": "Тип"
+                  },
+                  {
+                    "dataPath": "Папка",
+                    "name": "Папка"
+                  },
+                  {
+                    "dataPath": "Тема",
+                    "name": "Тема"
+                  },
+                  {
+                    "dataPath": "ПолученоОтправлено",
+                    "name": "ПолученоОтправлено"
+                  },
+                  {
+                    "dataPath": "Размер",
+                    "name": "Размер"
+                  },
+                  {
+                    "dataPath": "ПредметАктивен",
+                    "name": "ПредметАктивен"
+                  },
+                  {
+                    "dataPath": "Важность",
+                    "name": "Важность"
+                  },
+                  {
+                    "dataPath": "ВажностьНомерКартинки",
+                    "name": "ВажностьНомерКартинки"
+                  }
+                ],
+                []
+              ]
+            }
+          ],
+          "dataPath": "src/test/resources/ext/edt/ssl_3_2/configuration/src/DocumentJournals/Взаимодействия/Templates/СхемаОтборВзаимодействия/Template.dcs"
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        }
+      },
+      {
+        "uuid": "4f262b7f-927e-45f2-ad90-9d5e1b3155d1",
+        "name": "ИерархияВзаимодействийПредмет",
+        "mdoReference": {
+          "type": "TEMPLATE",
+          "mdoRef": "DocumentJournal.Взаимодействия.Template.ИерархияВзаимодействийПредмет",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Макет.ИерархияВзаимодействийПредмет"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Иерархия взаимодействий предмет"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [],
+        "templateType": "DATA_COMPOSITION_SCHEME",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.DataCompositionSchema",
+          "dataSets": [
+            {
+              "name": "ИерархияВзаимодействий",
+              "type": "DATA_SET_QUERY",
+              "dataSource": "ИсточникДанных1",
+              "items": [],
+              "querySource": {
+                "line": 90,
+                "column": 10,
+                "textQuery": "ВЫБРАТЬ РАЗРЕШЕННЫЕ\n\tВзаимодействия.Ссылка,\n\tПредметыПапкиВзаимодействий.Предмет,\n\tВзаимодействия.Ответственный КАК Ответственный,\n\tЕСТЬNULL(ПредметыПапкиВзаимодействий.Рассмотрено, Ложь) КАК Рассмотрено,\n\tЕСТЬNULL(ПредметыПапкиВзаимодействий.РассмотретьПосле, ДатаВремя(1,1,1)) КАК РассмотретьПосле,\n\tВзаимодействия.Тип,\n\tВзаимодействия.СтатусИсходящегоПисьма,\n\tВзаимодействия.ПометкаУдаления,\n\tВзаимодействия.Входящий\nПОМЕСТИТЬ ПредОтбор\nИЗ\n\tЖурналДокументов.Взаимодействия КАК Взаимодействия\n\t\tВНУТРЕННЕЕ СОЕДИНЕНИЕ РегистрСведений.ПредметыПапкиВзаимодействий КАК ПредметыПапкиВзаимодействий\n\t\tПО Взаимодействия.Ссылка = ПредметыПапкиВзаимодействий.Взаимодействие\n{ГДЕ\n\t(Взаимодействия.Дата МЕЖДУ &НачалоПериода И &КонецПериода)}\n;\n\n////////////////////////////////////////////////////////////////////////////////\nВЫБРАТЬ РАЗРЕШЕННЫЕ\n\tВЫБОР\n\t\tКОГДА Взаимодействия.Ссылка ССЫЛКА Документ.Встреча\n\t\t\tТОГДА ВЫБОР\n\t\t\t\t\tКОГДА Взаимодействия.ПометкаУдаления\n\t\t\t\t\t\tТОГДА 10\n\t\t\t\t\tИНАЧЕ 0\n\t\t\t\tКОНЕЦ\n\t\tКОГДА Взаимодействия.Ссылка ССЫЛКА Документ.ЗапланированноеВзаимодействие\n\t\t\tТОГДА ВЫБОР\n\t\t\t\t\tКОГДА Взаимодействия.ПометкаУдаления\n\t\t\t\t\t\tТОГДА 11\n\t\t\t\t\tИНАЧЕ 1\n\t\t\t\tКОНЕЦ\n\t\tКОГДА Взаимодействия.Ссылка ССЫЛКА Документ.ТелефонныйЗвонок\n\t\t\tТОГДА ВЫБОР\n\t\t\t\t\tКОГДА Взаимодействия.ПометкаУдаления\n\t\t\t\t\t\tТОГДА 12\n\t\t\t\t\tИНАЧЕ 2\n\t\t\t\tКОНЕЦ\n\t\tКОГДА Взаимодействия.Ссылка ССЫЛКА Документ.ЭлектронноеПисьмоВходящее\n\t\t\tТОГДА ВЫБОР\n\t\t\t\t\tКОГДА Взаимодействия.ПометкаУдаления\n\t\t\t\t\t\tТОГДА 13\n\t\t\t\t\tИНАЧЕ 3\n\t\t\t\tКОНЕЦ\n\t\tКОГДА Взаимодействия.Ссылка ССЫЛКА Документ.ЭлектронноеПисьмоИсходящее\n\t\t\tТОГДА ВЫБОР\n\t\t\t\t\tКОГДА Взаимодействия.ПометкаУдаления\n\t\t\t\t\t\tТОГДА 14\n\t\t\t\t\tИНАЧЕ ВЫБОР\n\t\t\t\t\t\t\tКОГДА Взаимодействия.СтатусИсходящегоПисьма = ЗНАЧЕНИЕ(Перечисление.СтатусыИсходящегоЭлектронногоПисьма.Черновик)\n\t\t\t\t\t\t\t\tТОГДА 15\n\t\t\t\t\t\t\tКОГДА Взаимодействия.СтатусИсходящегоПисьма = ЗНАЧЕНИЕ(Перечисление.СтатусыИсходящегоЭлектронногоПисьма.Исходящее)\n\t\t\t\t\t\t\t\tТОГДА 16\n\t\t\t\t\t\t\tИНАЧЕ 4\n\t\t\t\t\t\tКОНЕЦ\n\t\t\t\tКОНЕЦ\n\t\tКОГДА Взаимодействия.Ссылка ССЫЛКА Документ.СообщениеSMS\n\t\t\tТОГДА ВЫБОР\n\t\t\t\t\tКОГДА Взаимодействия.ПометкаУдаления\n\t\t\t\t\t\tТОГДА 22\n\t\t\t\t\tИНАЧЕ ВЫБОР\n\t\t\t\t\t\t\tКОГДА Взаимодействия.СтатусИсходящегоПисьма = ЗНАЧЕНИЕ(Перечисление.СостоянияДокументаСообщениеSMS.Черновик)\n\t\t\t\t\t\t\t\tТОГДА 17\n\t\t\t\t\t\t\tКОГДА Взаимодействия.СтатусИсходящегоПисьма = ЗНАЧЕНИЕ(Перечисление.СостоянияДокументаСообщениеSMS.Исходящее)\n\t\t\t\t\t\t\t\tТОГДА 18\n\t\t\t\t\t\t\tКОГДА Взаимодействия.СтатусИсходящегоПисьма = ЗНАЧЕНИЕ(Перечисление.СостоянияДокументаСообщениеSMS.Доставляется)\n\t\t\t\t\t\t\t\tТОГДА 19\n\t\t\t\t\t\t\tКОГДА Взаимодействия.СтатусИсходящегоПисьма = ЗНАЧЕНИЕ(Перечисление.СостоянияДокументаСообщениеSMS.ЧастичноДоставлено)\n\t\t\t\t\t\t\t\tТОГДА 21\n\t\t\t\t\t\t\tКОГДА Взаимодействия.СтатусИсходящегоПисьма = ЗНАЧЕНИЕ(Перечисление.СостоянияДокументаСообщениеSMS.НеДоставлено)\n\t\t\t\t\t\t\t\tТОГДА 23\n\t\t\t\t\t\t\tКОГДА Взаимодействия.СтатусИсходящегоПисьма = ЗНАЧЕНИЕ(Перечисление.СостоянияДокументаСообщениеSMS.Доставлено)\n\t\t\t\t\t\t\t\tТОГДА 24\n\t\t\t\t\t\t\tИНАЧЕ 17\n\t\t\t\t\t\tКОНЕЦ\n\t\t\t\tКОНЕЦ\n\tКОНЕЦ КАК НомерКартинки,\n\tВзаимодействия.Ссылка КАК Ссылка,\n\tЕСТЬNULL(ПредОтбор.Ссылка, НЕОПРЕДЕЛЕНО) КАК ВзаимодействиеОснование,\n\tПредметыПапкиВзаимодействий.Предмет,\n\tВзаимодействия.Ответственный КАК Ответственный,\n\tЕСТЬNULL(ПредметыПапкиВзаимодействий.Рассмотрено, Ложь) КАК Рассмотрено,\n\tЕСТЬNULL(ПредметыПапкиВзаимодействий.РассмотретьПосле, ДатаВремя(1,1,1)) КАК РассмотретьПосле,\n\tВзаимодействия.Дата,\n\tВзаимодействия.Тема,\n\tВзаимодействия.Участники,\n\tВзаимодействия.ПометкаУдаления,\n\tВзаимодействия.Тип,\n\tВзаимодействия.СтатусИсходящегоПисьма,\n\tВзаимодействия.Входящий\nИЗ\n\tЖурналДокументов.Взаимодействия КАК Взаимодействия\n\t\tЛЕВОЕ СОЕДИНЕНИЕ ПредОтбор КАК ПредОтбор\n\t\tПО Взаимодействия.ВзаимодействиеОснование = ПредОтбор.Ссылка\n\t\tВНУТРЕННЕЕ СОЕДИНЕНИЕ РегистрСведений.ПредметыПапкиВзаимодействий КАК ПредметыПапкиВзаимодействий\n\t\tПО Взаимодействия.Ссылка = ПредметыПапкиВзаимодействий.Взаимодействие\n{ГДЕ\n\t(Взаимодействия.Дата МЕЖДУ &НачалоПериода И &КонецПериода)}"
+              },
+              "fields": [
+                [
+                  {
+                    "dataPath": "ВзаимодействиеОснование",
+                    "name": "ВзаимодействиеОснование"
+                  },
+                  {
+                    "dataPath": "Ссылка",
+                    "name": "Ссылка"
+                  },
+                  {
+                    "dataPath": "Ответственный",
+                    "name": "Ответственный"
+                  },
+                  {
+                    "dataPath": "Предмет",
+                    "name": "Предмет"
+                  },
+                  {
+                    "dataPath": "Дата",
+                    "name": "Дата"
+                  },
+                  {
+                    "dataPath": "Рассмотрено",
+                    "name": "Рассмотрено"
+                  },
+                  {
+                    "dataPath": "РассмотретьПосле",
+                    "name": "РассмотретьПосле"
+                  },
+                  {
+                    "dataPath": "Тема",
+                    "name": "Тема"
+                  },
+                  {
+                    "dataPath": "Участники",
+                    "name": "Участники"
+                  },
+                  {
+                    "dataPath": "НомерКартинки",
+                    "name": "НомерКартинки"
+                  },
+                  {
+                    "dataPath": "ПометкаУдаления",
+                    "name": "ПометкаУдаления"
+                  },
+                  {
+                    "dataPath": "Тип",
+                    "name": "Тип"
+                  },
+                  {
+                    "dataPath": "СтатусИсходящегоПисьма",
+                    "name": "СтатусИсходящегоПисьма"
+                  },
+                  {
+                    "dataPath": "Входящий",
+                    "name": "Входящий"
+                  }
+                ],
+                []
+              ]
+            }
+          ],
+          "dataPath": "src/test/resources/ext/edt/ssl_3_2/configuration/src/DocumentJournals/Взаимодействия/Templates/ИерархияВзаимодействийПредмет/Template.dcs"
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        }
+      },
+      {
+        "uuid": "9f4b8e36-83ff-4694-8540-b5f47b18395f",
+        "name": "ИерархияВзаимодействийКонтакт",
+        "mdoReference": {
+          "type": "TEMPLATE",
+          "mdoRef": "DocumentJournal.Взаимодействия.Template.ИерархияВзаимодействийКонтакт",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Макет.ИерархияВзаимодействийКонтакт"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Иерархия взаимодействий контакт"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [],
+        "templateType": "DATA_COMPOSITION_SCHEME",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.DataCompositionSchema",
+          "dataSets": [
+            {
+              "name": "ИерархияВзаимодействий",
+              "type": "DATA_SET_QUERY",
+              "dataSource": "ИсточникДанных1",
+              "items": [],
+              "querySource": {
+                "line": 120,
+                "column": 10,
+                "textQuery": "ВЫБРАТЬ РАЗРЕШЕННЫЕ РАЗЛИЧНЫЕ\n\tВзаимодействия.Ссылка КАК Ссылка\nПОМЕСТИТЬ ВзаимодействияПоКонтакту\nИЗ\n\tРегистрСведений.КонтактыВзаимодействий КАК КонтактыВзаимодействий\n\t\tВНУТРЕННЕЕ СОЕДИНЕНИЕ ЖурналДокументов.Взаимодействия КАК Взаимодействия\n\t\tПО КонтактыВзаимодействий.Взаимодействие = Взаимодействия.Ссылка\nГДЕ\n\tКонтактыВзаимодействий.Контакт = &Контакт\n{ГДЕ\n\t(Взаимодействия.Дата МЕЖДУ &НачалоПериода И &КонецПериода)}\n;\n\n////////////////////////////////////////////////////////////////////////////////\nВЫБРАТЬ РАЗРЕШЕННЫЕ РАЗЛИЧНЫЕ\n\tВзаимодействия.Ссылка,\n\tВзаимодействия.Ответственный,\n\tЕСТЬNULL(ПредметыПапкиВзаимодействий.Рассмотрено, ЛОЖЬ) КАК Рассмотрено,\n\tЕСТЬNULL(ПредметыПапкиВзаимодействий.РассмотретьПосле, ДАТАВРЕМЯ(1, 1, 1)) КАК РассмотретьПосле,\n\tВзаимодействия.Тип,\n\tВзаимодействия.СтатусИсходящегоПисьма,\n\tВзаимодействия.ПометкаУдаления,\n\tВзаимодействия.Входящий\nПОМЕСТИТЬ ПредОтбор\nИЗ\n\tЖурналДокументов.Взаимодействия КАК Взаимодействия\n\t\tВНУТРЕННЕЕ СОЕДИНЕНИЕ РегистрСведений.ПредметыПапкиВзаимодействий КАК ПредметыПапкиВзаимодействий\n\t\tПО Взаимодействия.Ссылка = ПредметыПапкиВзаимодействий.Взаимодействие\nГДЕ\n\tВзаимодействия.Ссылка В\n\t\t\t(ВЫБРАТЬ\n\t\t\t\tВзаимодействияПоКонтакту.Ссылка\n\t\t\tИЗ\n\t\t\t\tВзаимодействияПоКонтакту КАК ВзаимодействияПоКонтакту)\n;\n\n////////////////////////////////////////////////////////////////////////////////\nВЫБРАТЬ РАЗРЕШЕННЫЕ\n\tВЫБОР\n\t\tКОГДА Взаимодействия.Ссылка ССЫЛКА Документ.Встреча\n\t\t\tТОГДА ВЫБОР\n\t\t\t\t\tКОГДА Взаимодействия.ПометкаУдаления\n\t\t\t\t\t\tТОГДА 10\n\t\t\t\t\tИНАЧЕ 0\n\t\t\t\tКОНЕЦ\n\t\tКОГДА Взаимодействия.Ссылка ССЫЛКА Документ.ЗапланированноеВзаимодействие\n\t\t\tТОГДА ВЫБОР\n\t\t\t\t\tКОГДА Взаимодействия.ПометкаУдаления\n\t\t\t\t\t\tТОГДА 11\n\t\t\t\t\tИНАЧЕ 1\n\t\t\t\tКОНЕЦ\n\t\tКОГДА Взаимодействия.Ссылка ССЫЛКА Документ.ТелефонныйЗвонок\n\t\t\tТОГДА ВЫБОР\n\t\t\t\t\tКОГДА Взаимодействия.ПометкаУдаления\n\t\t\t\t\t\tТОГДА 12\n\t\t\t\t\tИНАЧЕ 2\n\t\t\t\tКОНЕЦ\n\t\tКОГДА Взаимодействия.Ссылка ССЫЛКА Документ.ЭлектронноеПисьмоВходящее\n\t\t\tТОГДА ВЫБОР\n\t\t\t\t\tКОГДА Взаимодействия.ПометкаУдаления\n\t\t\t\t\t\tТОГДА 13\n\t\t\t\t\tИНАЧЕ 3\n\t\t\t\tКОНЕЦ\n\t\tКОГДА Взаимодействия.Ссылка ССЫЛКА Документ.ЭлектронноеПисьмоИсходящее\n\t\t\tТОГДА ВЫБОР\n\t\t\t\t\tКОГДА Взаимодействия.ПометкаУдаления\n\t\t\t\t\t\tТОГДА 14\n\t\t\t\t\tИНАЧЕ ВЫБОР\n\t\t\t\t\t\t\tКОГДА Взаимодействия.СтатусИсходящегоПисьма = ЗНАЧЕНИЕ(Перечисление.СтатусыИсходящегоЭлектронногоПисьма.Черновик)\n\t\t\t\t\t\t\t\tТОГДА 15\n\t\t\t\t\t\t\tКОГДА Взаимодействия.СтатусИсходящегоПисьма = ЗНАЧЕНИЕ(Перечисление.СтатусыИсходящегоЭлектронногоПисьма.Исходящее)\n\t\t\t\t\t\t\t\tТОГДА 16\n\t\t\t\t\t\t\tИНАЧЕ 4\n\t\t\t\t\t\tКОНЕЦ\n\t\t\t\tКОНЕЦ\n\t\tКОГДА Взаимодействия.Ссылка ССЫЛКА Документ.СообщениеSMS\n\t\t\tТОГДА ВЫБОР\n\t\t\t\t\tКОГДА Взаимодействия.ПометкаУдаления\n\t\t\t\t\t\tТОГДА 22\n\t\t\t\t\tИНАЧЕ ВЫБОР\n\t\t\t\t\t\t\tКОГДА Взаимодействия.СтатусИсходящегоПисьма = ЗНАЧЕНИЕ(Перечисление.СостоянияДокументаСообщениеSMS.Черновик)\n\t\t\t\t\t\t\t\tТОГДА 17\n\t\t\t\t\t\t\tКОГДА Взаимодействия.СтатусИсходящегоПисьма = ЗНАЧЕНИЕ(Перечисление.СостоянияДокументаСообщениеSMS.Исходящее)\n\t\t\t\t\t\t\t\tТОГДА 18\n\t\t\t\t\t\t\tКОГДА Взаимодействия.СтатусИсходящегоПисьма = ЗНАЧЕНИЕ(Перечисление.СостоянияДокументаСообщениеSMS.Доставляется)\n\t\t\t\t\t\t\t\tТОГДА 19\n\t\t\t\t\t\t\tКОГДА Взаимодействия.СтатусИсходящегоПисьма = ЗНАЧЕНИЕ(Перечисление.СостоянияДокументаСообщениеSMS.ЧастичноДоставлено)\n\t\t\t\t\t\t\t\tТОГДА 21\n\t\t\t\t\t\t\tКОГДА Взаимодействия.СтатусИсходящегоПисьма = ЗНАЧЕНИЕ(Перечисление.СостоянияДокументаСообщениеSMS.НеДоставлено)\n\t\t\t\t\t\t\t\tТОГДА 23\n\t\t\t\t\t\t\tКОГДА Взаимодействия.СтатусИсходящегоПисьма = ЗНАЧЕНИЕ(Перечисление.СостоянияДокументаСообщениеSMS.Доставлено)\n\t\t\t\t\t\t\t\tТОГДА 24\n\t\t\t\t\t\t\tИНАЧЕ 17\n\t\t\t\t\t\tКОНЕЦ\n\t\t\t\tКОНЕЦ\n\tКОНЕЦ КАК НомерКартинки,\n\tВзаимодействия.Ссылка КАК Ссылка,\n\tВзаимодействия.Ответственный КАК Ответственный,\n\tЕСТЬNULL(ПредОтбор.Ссылка, НЕОПРЕДЕЛЕНО) КАК ВзаимодействиеОснование,\n\tПредметыПапкиВзаимодействий.Предмет,\n\tЕСТЬNULL(ПредметыПапкиВзаимодействий.Рассмотрено, ЛОЖЬ) КАК Рассмотрено,\n\tЕСТЬNULL(ПредметыПапкиВзаимодействий.РассмотретьПосле, ДАТАВРЕМЯ(1, 1, 1)) КАК РассмотретьПосле,\n\tВзаимодействия.Дата,\n\tВзаимодействия.Тема,\n\tВзаимодействия.Участники,\n\tВзаимодействия.ПометкаУдаления,\n\tВзаимодействия.Тип,\n\tВзаимодействия.СтатусИсходящегоПисьма,\n\tВзаимодействия.Входящий\nИЗ\n\tЖурналДокументов.Взаимодействия КАК Взаимодействия\n\t\tЛЕВОЕ СОЕДИНЕНИЕ ПредОтбор КАК ПредОтбор\n\t\tПО Взаимодействия.ВзаимодействиеОснование = ПредОтбор.Ссылка\n\t\tВНУТРЕННЕЕ СОЕДИНЕНИЕ РегистрСведений.ПредметыПапкиВзаимодействий КАК ПредметыПапкиВзаимодействий\n\t\tПО Взаимодействия.Ссылка = ПредметыПапкиВзаимодействий.Взаимодействие\nГДЕ\n\tВзаимодействия.Ссылка В\n\t\t\t(ВЫБРАТЬ\n\t\t\t\tВзаимодействияПоКонтакту.Ссылка\n\t\t\tИЗ\n\t\t\t\tВзаимодействияПоКонтакту КАК ВзаимодействияПоКонтакту)"
+              },
+              "fields": [
+                [
+                  {
+                    "dataPath": "Ссылка",
+                    "name": "Ссылка"
+                  },
+                  {
+                    "dataPath": "Ответственный",
+                    "name": "Ответственный"
+                  },
+                  {
+                    "dataPath": "Рассмотрено",
+                    "name": "Рассмотрено"
+                  },
+                  {
+                    "dataPath": "РассмотретьПосле",
+                    "name": "РассмотретьПосле"
+                  },
+                  {
+                    "dataPath": "Дата",
+                    "name": "Дата"
+                  },
+                  {
+                    "dataPath": "ВзаимодействиеОснование",
+                    "name": "ВзаимодействиеОснование"
+                  },
+                  {
+                    "dataPath": "НомерКартинки",
+                    "name": "НомерКартинки"
+                  },
+                  {
+                    "dataPath": "Тема",
+                    "name": "Тема"
+                  },
+                  {
+                    "dataPath": "Участники",
+                    "name": "Участники"
+                  },
+                  {
+                    "dataPath": "Предмет",
+                    "name": "Предмет"
+                  },
+                  {
+                    "dataPath": "ПометкаУдаления",
+                    "name": "ПометкаУдаления"
+                  },
+                  {
+                    "dataPath": "Тип",
+                    "name": "Тип"
+                  },
+                  {
+                    "dataPath": "СтатусИсходящегоПисьма",
+                    "name": "СтатусИсходящегоПисьма"
+                  },
+                  {
+                    "dataPath": "Входящий",
+                    "name": "Входящий"
+                  }
+                ],
+                []
+              ]
+            }
+          ],
+          "dataPath": "src/test/resources/ext/edt/ssl_3_2/configuration/src/DocumentJournals/Взаимодействия/Templates/ИерархияВзаимодействийКонтакт/Template.dcs"
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        }
+      },
+      {
+        "uuid": "b4c026eb-4271-4366-b529-1cdfe2874563",
+        "name": "СхемаОтборВзаимодействияКонтакт",
+        "mdoReference": {
+          "type": "TEMPLATE",
+          "mdoRef": "DocumentJournal.Взаимодействия.Template.СхемаОтборВзаимодействияКонтакт",
+          "mdoRefRu": "ЖурналДокументов.Взаимодействия.Макет.СхемаОтборВзаимодействияКонтакт"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Схема отбор взаимодействия контакт"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [],
+        "templateType": "DATA_COMPOSITION_SCHEME",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.DataCompositionSchema",
+          "dataSets": [
+            {
+              "name": "ОсновнойНаборДанных",
+              "type": "DATA_SET_QUERY",
+              "dataSource": "ИсточникДанных1",
+              "items": [],
+              "querySource": {
+                "line": 158,
+                "column": 10,
+                "textQuery": "ВЫБРАТЬ РАЗРЕШЕННЫЕ\n\tЖурналДокументовВзаимодействия.Ссылка,\n\tЖурналДокументовВзаимодействия.Дата,\n\tЖурналДокументовВзаимодействия.ПометкаУдаления,\n\tЖурналДокументовВзаимодействия.Номер,\n\tЖурналДокументовВзаимодействия.Проведен,\n\tЖурналДокументовВзаимодействия.Автор,\n\tЖурналДокументовВзаимодействия.Входящий,\n\tЖурналДокументовВзаимодействия.Тема,\n\tЖурналДокументовВзаимодействия.Ответственный КАК Ответственный,\n\tЕСТЬNULL(ПредметыВзаимодействий.Рассмотрено, Ложь) КАК Рассмотрено,\n\tЕСТЬNULL(ПредметыВзаимодействий.РассмотретьПосле, ДатаВремя(1,1,1)) КАК РассмотретьПосле,\n\tЖурналДокументовВзаимодействия.Участники,\n\tЖурналДокументовВзаимодействия.Тип,\n\tЖурналДокументовВзаимодействия.СтатусИсходящегоПисьма,\n\tЖурналДокументовВзаимодействия.ЕстьВложения,\n\tЖурналДокументовВзаимодействия.УчетнаяЗапись,\n\tЕСТЬNULL(ПредметыВзаимодействий.Предмет, НЕОПРЕДЕЛЕНО) КАК Предмет,\n\tТИПЗНАЧЕНИЯ(ПредметыВзаимодействий.Предмет) КАК ТипПредмета,\n\tПредметыВзаимодействий.ПапкаЭлектронногоПисьма КАК Папка,\n\tЖурналДокументовВзаимодействия.ПолученоОтправлено,\n\tЖурналДокументовВзаимодействия.Размер,\n\tЖурналДокументовВзаимодействия.Важность,\n\tВЫБОР\n\t\tКОГДА ЖурналДокументовВзаимодействия.Важность = ЗНАЧЕНИЕ(Перечисление.ВариантыВажностиВзаимодействия.Высокая) ТОГДА 2\n\t\tКОГДА ЖурналДокументовВзаимодействия.Важность = ЗНАЧЕНИЕ(Перечисление.ВариантыВажностиВзаимодействия.Низкая) ТОГДА 0\n\t\tИНАЧЕ 1\n\tКОНЕЦ КАК ВажностьНомерКартинки\nИЗ\n\tЖурналДокументов.Взаимодействия КАК ЖурналДокументовВзаимодействия\n\t\t\tВНУТРЕННЕЕ СОЕДИНЕНИЕ РегистрСведений.ПредметыПапкиВзаимодействий КАК ПредметыВзаимодействий\n\t\tПО ЖурналДокументовВзаимодействия.Ссылка = ПредметыВзаимодействий.Взаимодействие\n\t\t{ВНУТРЕННЕЕ СОЕДИНЕНИЕ РегистрСведений.КонтактыВзаимодействий КАК КонтактыВзаимодействий\nПО ЖурналДокументовВзаимодействия.Ссылка = КонтактыВзаимодействий.Взаимодействие}\n{ГДЕ\n\tЖурналДокументовВзаимодействия.Ссылка КАК Поиск\n\t,\nКонтактыВзаимодействий.Контакт}\n{ГДЕ\n\t(ЖурналДокументовВзаимодействия.Дата МЕЖДУ &ДатаНачала И &ДатаОкончания)}"
+              },
+              "fields": [
+                [
+                  {
+                    "dataPath": "Дата",
+                    "name": "Дата"
+                  },
+                  {
+                    "dataPath": "ПометкаУдаления",
+                    "name": "ПометкаУдаления"
+                  },
+                  {
+                    "dataPath": "Номер",
+                    "name": "Номер"
+                  },
+                  {
+                    "dataPath": "Проведен",
+                    "name": "Проведен"
+                  },
+                  {
+                    "dataPath": "Ссылка",
+                    "name": "Ссылка"
+                  },
+                  {
+                    "dataPath": "Автор",
+                    "name": "Автор"
+                  },
+                  {
+                    "dataPath": "Входящий",
+                    "name": "Входящий"
+                  },
+                  {
+                    "dataPath": "ЕстьВложения",
+                    "name": "ЕстьВложения"
+                  },
+                  {
+                    "dataPath": "Ответственный",
+                    "name": "Ответственный"
+                  },
+                  {
+                    "dataPath": "Предмет",
+                    "name": "Предмет"
+                  },
+                  {
+                    "dataPath": "СтатусИсходящегоПисьма",
+                    "name": "СтатусИсходящегоПисьма"
+                  },
+                  {
+                    "dataPath": "Участники",
+                    "name": "Участники"
+                  },
+                  {
+                    "dataPath": "ТипПредмета",
+                    "name": "ТипПредмета"
+                  },
+                  {
+                    "dataPath": "УчетнаяЗапись",
+                    "name": "УчетнаяЗапись"
+                  },
+                  {
+                    "dataPath": "Рассмотрено",
+                    "name": "Рассмотрено"
+                  },
+                  {
+                    "dataPath": "РассмотретьПосле",
+                    "name": "РассмотретьПосле"
+                  },
+                  {
+                    "dataPath": "Тип",
+                    "name": "Тип"
+                  },
+                  {
+                    "dataPath": "Папка",
+                    "name": "Папка"
+                  },
+                  {
+                    "dataPath": "Тема",
+                    "name": "Тема"
+                  },
+                  {
+                    "dataPath": "ПолученоОтправлено",
+                    "name": "ПолученоОтправлено"
+                  },
+                  {
+                    "dataPath": "Размер",
+                    "name": "Размер"
+                  },
+                  {
+                    "dataPath": "Важность",
+                    "name": "Важность"
+                  },
+                  {
+                    "dataPath": "ВажностьНомерКартинки",
+                    "name": "ВажностьНомерКартинки"
+                  },
+                  {
+                    "dataPath": "Контакт",
+                    "name": "Контакт"
+                  },
+                  {
+                    "dataPath": "Поиск",
+                    "name": "Поиск"
+                  }
+                ],
+                []
+              ]
+            }
+          ],
+          "dataPath": "src/test/resources/ext/edt/ssl_3_2/configuration/src/DocumentJournals/Взаимодействия/Templates/СхемаОтборВзаимодействияКонтакт/Template.dcs"
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn/owner"
+        }
+      }
+    ],
+    []
+  ],
+  "uuid": "7da57c89-af2c-445a-96f7-39250f70306f"
+}}

--- a/src/test/resources/fixtures/ssl_3_2/DocumentJournals.Взаимодействия_edt.json
+++ b/src/test/resources/fixtures/ssl_3_2/DocumentJournals.Взаимодействия_edt.json
@@ -1432,73 +1432,6 @@
             [
               {
                 "type": "USUAL_GROUP",
-                "id": 926,
-                "name": "ПредупреждениеОНеотправленныхПисьмах",
-                "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Группа предупреждение"
-                      }
-                    }
-                  ]
-                },
-                "dataPath": "",
-                "items": [
-                  [
-                    {
-                      "type": "DECORATION",
-                      "id": 928,
-                      "name": "ПредупреждениеОНеотправленныхПисьмахКартинка",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Картинка предупреждение"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "LABEL",
-                      "id": 931,
-                      "name": "ПредупреждениеОНеотправленныхПисьмахНадпись",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Регламентное задание <b>Получение</><b> </><b>и</><b> </><b>отправка</><b> </><b>писем</> отключено, доставка писем не выполняется. <link ВключитьПолучениеИОтправкуПисем>Включить</>"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": []
-                    }
-                  ],
-                  []
-                ]
-              },
-              {
-                "type": "USUAL_GROUP",
                 "id": 943,
                 "name": "ПредупреждениеОНеактуальностиИндекса",
                 "title": {
@@ -1516,42 +1449,7 @@
                   ]
                 },
                 "dataPath": "",
-                "items": [
-                  [
-                    {
-                      "type": "DECORATION",
-                      "id": 945,
-                      "name": "ПредупреждениеОНеактуальностиИндексаКартинка",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "LABEL",
-                      "id": 948,
-                      "name": "ПредупреждениеОНеактуальностиИндексаНадпись",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Результаты поиска могут быть неточными, повторите поиск позднее"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": []
-                    }
-                  ],
-                  []
-                ]
+                "items": []
               },
               {
                 "type": "USUAL_GROUP",
@@ -1674,6 +1572,27 @@
               },
               {
                 "type": "USUAL_GROUP",
+                "id": 1099,
+                "name": "ГруппаСвернутаяНавигация",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Навигация"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": []
+              },
+              {
+                "type": "USUAL_GROUP",
                 "id": 826,
                 "name": "ГруппаПанельНавигацииСписок",
                 "title": {
@@ -1712,853 +1631,7 @@
                         ]
                       },
                       "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "BUTTON",
-                            "id": 830,
-                            "name": "ИзменитьОтображениеПанелиНавигации",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Изменить отображение панели навигации"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "POPUP",
-                            "id": 26,
-                            "name": "ВыборВариантаНавигации",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Вариант навигации"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": [
-                              [
-                                {
-                                  "type": "BUTTON",
-                                  "id": 27,
-                                  "name": "УстановитьВариантНавигацииПоПредмету",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "По предметам"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": []
-                                },
-                                {
-                                  "type": "BUTTON",
-                                  "id": 28,
-                                  "name": "УстановитьВариантНавигацииПоКонтакту",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "По контактам"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": []
-                                },
-                                {
-                                  "type": "BUTTON",
-                                  "id": 124,
-                                  "name": "УстановитьВариантНавигацииПоЗакладкам",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "По закладкам"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": []
-                                },
-                                {
-                                  "type": "BUTTON",
-                                  "id": 176,
-                                  "name": "УстановитьВариантНавигацииПоПапкам",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "По папкам"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": []
-                                }
-                              ],
-                              []
-                            ]
-                          },
-                          {
-                            "type": "FORM_GROUP",
-                            "id": 828,
-                            "name": "ГруппаКоманднаяПанельСписок",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Командная панель список"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": [
-                              [
-                                {
-                                  "type": "POPUP",
-                                  "id": 43,
-                                  "name": "ГруппаСоздать",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Создать"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": [
-                                    [
-                                      {
-                                        "type": "BUTTON",
-                                        "id": 44,
-                                        "name": "СписокСоздатьВстречу",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Встречу"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "",
-                                        "items": []
-                                      },
-                                      {
-                                        "type": "BUTTON",
-                                        "id": 45,
-                                        "name": "СписокСоздатьЗапланированноеВзаимодействие",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Запланированное взаимодействие"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "",
-                                        "items": []
-                                      },
-                                      {
-                                        "type": "BUTTON",
-                                        "id": 46,
-                                        "name": "СписокСоздатьТелефонныйЗвонок",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Телефонный звонок"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "",
-                                        "items": []
-                                      },
-                                      {
-                                        "type": "BUTTON",
-                                        "id": 415,
-                                        "name": "СписокСоздатьСообщениеSMS",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Сообщение SMS"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "",
-                                        "items": []
-                                      },
-                                      {
-                                        "type": "BUTTON",
-                                        "id": 47,
-                                        "name": "СписокСоздатьЭлектронноеПисьмо",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Электронное письмо"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "",
-                                        "items": []
-                                      }
-                                    ],
-                                    []
-                                  ]
-                                },
-                                {
-                                  "type": "BUTTON",
-                                  "id": 322,
-                                  "name": "СписокСоздатьЭлектронноеПисьмоОтдельнаяКнопка",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Написать"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": []
-                                },
-                                {
-                                  "type": "FORM_GROUP",
-                                  "id": 919,
-                                  "name": "ГруппаОтветитьПереслать",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Ответить переслать"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": [
-                                    [
-                                      {
-                                        "type": "BUTTON",
-                                        "id": 342,
-                                        "name": "СписокОтветить",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Ответить"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "",
-                                        "items": []
-                                      },
-                                      {
-                                        "type": "BUTTON",
-                                        "id": 343,
-                                        "name": "СписокОтветитьВсем",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Ответить всем"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "",
-                                        "items": []
-                                      },
-                                      {
-                                        "type": "BUTTON",
-                                        "id": 344,
-                                        "name": "СписокПереслать",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Переслать"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "",
-                                        "items": []
-                                      }
-                                    ],
-                                    []
-                                  ]
-                                },
-                                {
-                                  "type": "BUTTON",
-                                  "id": 59,
-                                  "name": "СписокОтправитьПолучитьПочту",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Отправить и получить"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": []
-                                },
-                                {
-                                  "type": "POPUP",
-                                  "id": 917,
-                                  "name": "ПодменюСоздатьНаОсновании",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Создать на основании"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": []
-                                },
-                                {
-                                  "type": "FORM_GROUP",
-                                  "id": 410,
-                                  "name": "ГруппаРассмотрено",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Рассмотрено"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": [
-                                    [
-                                      {
-                                        "type": "BUTTON",
-                                        "id": 40,
-                                        "name": "СписокРассмотрено",
-                                        "title": {
-                                          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[6]/title"
-                                        },
-                                        "dataPath": "",
-                                        "items": []
-                                      },
-                                      {
-                                        "type": "BUTTON",
-                                        "id": 42,
-                                        "name": "СписокОтложитьРассмотрение",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Отложить рассмотрение..."
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "",
-                                        "items": []
-                                      },
-                                      {
-                                        "type": "BUTTON",
-                                        "id": 191,
-                                        "name": "СписокНеРассмотрено",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Снять признак рассмотрено"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "",
-                                        "items": []
-                                      },
-                                      {
-                                        "type": "BUTTON",
-                                        "id": 39,
-                                        "name": "СписокОтветственный",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Установить ответственного..."
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "",
-                                        "items": []
-                                      },
-                                      {
-                                        "type": "BUTTON",
-                                        "id": 41,
-                                        "name": "СписокПредмет",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Установить предмет взаимодействия..."
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "",
-                                        "items": []
-                                      }
-                                    ],
-                                    []
-                                  ]
-                                },
-                                {
-                                  "type": "POPUP",
-                                  "id": 824,
-                                  "name": "СписокТипВзаимодействия",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Показывать"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": []
-                                },
-                                {
-                                  "type": "POPUP",
-                                  "id": 822,
-                                  "name": "СписокСтатус",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Статус: "
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": []
-                                },
-                                {
-                                  "type": "FORM_GROUP",
-                                  "id": 48,
-                                  "name": "ГруппаКомандыСписка",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Команды списка"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": [
-                                    [
-                                      {
-                                        "type": "BUTTON",
-                                        "id": 49,
-                                        "name": "Изменить",
-                                        "title": {
-                                          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
-                                        },
-                                        "dataPath": "",
-                                        "items": []
-                                      },
-                                      {
-                                        "type": "BUTTON",
-                                        "id": 50,
-                                        "name": "Скопировать",
-                                        "title": {
-                                          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
-                                        },
-                                        "dataPath": "",
-                                        "items": []
-                                      },
-                                      {
-                                        "type": "FORM_GROUP",
-                                        "id": 51,
-                                        "name": "ГруппаСписокУстановитьПометкуУдаления",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Список установить пометку удаления"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "",
-                                        "items": [
-                                          {
-                                            "type": "BUTTON",
-                                            "id": 52,
-                                            "name": "УстановитьПометкуУдаления",
-                                            "title": {
-                                              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
-                                            },
-                                            "dataPath": "",
-                                            "items": []
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "FORM_GROUP",
-                                        "id": 55,
-                                        "name": "ГруппаНайти",
-                                        "title": {
-                                          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                        },
-                                        "dataPath": "",
-                                        "items": [
-                                          [
-                                            {
-                                              "type": "BUTTON",
-                                              "id": 56,
-                                              "name": "Найти",
-                                              "title": {
-                                                "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
-                                              },
-                                              "dataPath": "",
-                                              "items": []
-                                            },
-                                            {
-                                              "type": "BUTTON",
-                                              "id": 58,
-                                              "name": "ОтменитьПоиск",
-                                              "title": {
-                                                "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
-                                              },
-                                              "dataPath": "",
-                                              "items": []
-                                            },
-                                            {
-                                              "type": "BUTTON",
-                                              "id": 54,
-                                              "name": "УстановитьИнтервалДат",
-                                              "title": {
-                                                "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
-                                              },
-                                              "dataPath": "",
-                                              "items": []
-                                            }
-                                          ],
-                                          []
-                                        ]
-                                      }
-                                    ],
-                                    []
-                                  ]
-                                },
-                                {
-                                  "type": "BUTTON",
-                                  "id": 60,
-                                  "name": "СписокОбновить",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Обновить"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": []
-                                },
-                                {
-                                  "type": "BUTTON",
-                                  "id": 61,
-                                  "name": "СписокНастройкаСписка",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
-                                  },
-                                  "dataPath": "",
-                                  "items": []
-                                },
-                                {
-                                  "type": "BUTTON",
-                                  "id": 62,
-                                  "name": "СписокВывестиСписок",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
-                                  },
-                                  "dataPath": "",
-                                  "items": []
-                                },
-                                {
-                                  "type": "BUTTON",
-                                  "id": 64,
-                                  "name": "СписокИзменитьФорму",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
-                                  },
-                                  "dataPath": "",
-                                  "items": []
-                                },
-                                {
-                                  "type": "BUTTON",
-                                  "id": 792,
-                                  "name": "СписокОтображатьОбластьЧтения",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Отображать область чтения"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": []
-                                },
-                                {
-                                  "type": "BUTTON",
-                                  "id": 146,
-                                  "name": "ФормаПерсональныеНастройки",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Персональные настройки..."
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": []
-                                }
-                              ],
-                              []
-                            ]
-                          },
-                          {
-                            "type": "FORM_GROUP",
-                            "id": 897,
-                            "name": "ГруппаГлобальныеКоманды",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Глобальные команды"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "BUTTON",
-                            "id": 63,
-                            "name": "СписокСправка",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
-                            },
-                            "dataPath": "",
-                            "items": []
-                          }
-                        ],
-                        []
-                      ]
+                      "items": []
                     },
                     {
                       "type": "USUAL_GROUP",
@@ -2584,7 +1657,7 @@
                           {
                             "type": "USUAL_GROUP",
                             "id": 6,
-                            "name": "ГруппаПанельНавигации",
+                            "name": "ГруппаПанельНавигацииСлева",
                             "title": {
                               "content": [
                                 {
@@ -2602,30 +1675,19 @@
                             "dataPath": "",
                             "items": [
                               {
-                                "type": "PAGES",
-                                "id": 25,
-                                "name": "СтраницыПанелиНавигации",
+                                "type": "USUAL_GROUP",
+                                "id": 1131,
+                                "name": "ГруппаНавигация",
                                 "title": {
-                                  "content": [
-                                    {
-                                      "default": {
-                                        "tag": 2
-                                      },
-                                      "int": 1,
-                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                        "langKey": "ru",
-                                        "value": "Страницы панели навигации"
-                                      }
-                                    }
-                                  ]
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
                                 },
                                 "dataPath": "",
                                 "items": [
                                   [
                                     {
-                                      "type": "PAGE",
-                                      "id": 30,
-                                      "name": "СтраницаКонтакт",
+                                      "type": "COMMAND_BAR",
+                                      "id": 1095,
+                                      "name": "КоманднаяПанельНавигации",
                                       "title": {
                                         "content": [
                                           {
@@ -2635,7 +1697,160 @@
                                             "int": 1,
                                             "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                                               "langKey": "ru",
-                                              "value": "Страница контакт"
+                                              "value": "Командная панель навигации"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        {
+                                          "type": "FORM_GROUP",
+                                          "id": 1097,
+                                          "name": "ГруппаКомандыНавигации",
+                                          "title": {
+                                            "content": [
+                                              {
+                                                "default": {
+                                                  "tag": 2
+                                                },
+                                                "int": 1,
+                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                  "langKey": "ru",
+                                                  "value": "Команды навигации"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "dataPath": "",
+                                          "items": [
+                                            {
+                                              "type": "POPUP",
+                                              "id": 26,
+                                              "name": "ВыборВариантаНавигации",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Вариант навигации"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "",
+                                              "items": [
+                                                [
+                                                  {
+                                                    "type": "BUTTON",
+                                                    "id": 27,
+                                                    "name": "УстановитьВариантНавигацииПоПредмету",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "По предметам"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": []
+                                                  },
+                                                  {
+                                                    "type": "BUTTON",
+                                                    "id": 28,
+                                                    "name": "УстановитьВариантНавигацииПоКонтакту",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "По контактам"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": []
+                                                  },
+                                                  {
+                                                    "type": "BUTTON",
+                                                    "id": 124,
+                                                    "name": "УстановитьВариантНавигацииПоЗакладкам",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "По закладкам"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": []
+                                                  },
+                                                  {
+                                                    "type": "BUTTON",
+                                                    "id": 176,
+                                                    "name": "УстановитьВариантНавигацииПоПапкам",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "По папкам"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": []
+                                                  }
+                                                ],
+                                                []
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "PAGES",
+                                      "id": 25,
+                                      "name": "СтраницыПанелиНавигации",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Страницы панели навигации"
                                             }
                                           }
                                         ]
@@ -2644,9 +1859,9 @@
                                       "items": [
                                         [
                                           {
-                                            "type": "TABLE",
-                                            "id": 31,
-                                            "name": "КонтактыПанелиНавигации",
+                                            "type": "PAGE",
+                                            "id": 30,
+                                            "name": "СтраницаКонтакт",
                                             "title": {
                                               "content": [
                                                 {
@@ -2656,48 +1871,38 @@
                                                   "int": 1,
                                                   "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                                                     "langKey": "ru",
-                                                    "value": "Контакты панели навигации"
+                                                    "value": "Страница контакт"
                                                   }
                                                 }
                                               ]
                                             },
-                                            "dataPath": "КонтактыПанельНавигации",
+                                            "dataPath": "",
                                             "items": [
-                                              {
-                                                "type": "COLUMN_GROUP",
-                                                "id": 810,
-                                                "name": "КонтактыПанелиНавигацииГруппа",
-                                                "title": {
-                                                  "content": [
-                                                    {
-                                                      "default": {
-                                                        "tag": 2
-                                                      },
-                                                      "int": 1,
-                                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                        "langKey": "ru",
-                                                        "value": "Контакты панели навигации группа"
+                                              [
+                                                {
+                                                  "type": "TABLE",
+                                                  "id": 31,
+                                                  "name": "КонтактыПанелиНавигации",
+                                                  "title": {
+                                                    "content": [
+                                                      {
+                                                        "default": {
+                                                          "tag": 2
+                                                        },
+                                                        "int": 1,
+                                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                          "langKey": "ru",
+                                                          "value": "Контакты"
+                                                        }
                                                       }
-                                                    }
-                                                  ]
-                                                },
-                                                "dataPath": "",
-                                                "items": [
-                                                  [
-                                                    {
-                                                      "type": "LABEL_FIELD",
-                                                      "id": 731,
-                                                      "name": "КонтактыКонтакт",
-                                                      "title": {
-                                                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
-                                                      },
-                                                      "dataPath": "КонтактыПанельНавигации.Контакт",
-                                                      "items": []
-                                                    },
+                                                    ]
+                                                  },
+                                                  "dataPath": "КонтактыПанельНавигации",
+                                                  "items": [
                                                     {
                                                       "type": "COLUMN_GROUP",
-                                                      "id": 784,
-                                                      "name": "КонтактыПанелиНавигацииРассмотреноДата",
+                                                      "id": 1033,
+                                                      "name": "КонтактыПанелиНавигацииГруппа",
                                                       "title": {
                                                         "content": [
                                                           {
@@ -2707,7 +1912,7 @@
                                                             "int": 1,
                                                             "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                                                               "langKey": "ru",
-                                                              "value": "Контакты панели навигации рассмотрено дата"
+                                                              "value": "Контакты панели навигации группа"
                                                             }
                                                           }
                                                         ]
@@ -2715,6 +1920,27 @@
                                                       "dataPath": "",
                                                       "items": [
                                                         [
+                                                          {
+                                                            "type": "LABEL_FIELD",
+                                                            "id": 731,
+                                                            "name": "КонтактыКонтакт",
+                                                            "title": {
+                                                              "content": [
+                                                                {
+                                                                  "default": {
+                                                                    "tag": 2
+                                                                  },
+                                                                  "int": 1,
+                                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                    "langKey": "ru",
+                                                                    "value": "Контакт"
+                                                                  }
+                                                                }
+                                                              ]
+                                                            },
+                                                            "dataPath": "КонтактыПанельНавигации.Контакт",
+                                                            "items": []
+                                                          },
                                                           {
                                                             "type": "LABEL_FIELD",
                                                             "id": 728,
@@ -2750,51 +1976,26 @@
                                                         []
                                                       ]
                                                     }
-                                                  ],
-                                                  []
-                                                ]
-                                              }
+                                                  ]
+                                                },
+                                                {
+                                                  "type": "LABEL",
+                                                  "id": 937,
+                                                  "name": "ДекорацияТолькоЗначимыеКонтакты",
+                                                  "title": {
+                                                    "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                                  },
+                                                  "dataPath": "",
+                                                  "items": []
+                                                }
+                                              ],
+                                              []
                                             ]
                                           },
                                           {
-                                            "type": "LABEL",
-                                            "id": 937,
-                                            "name": "ДекорацияТолькоЗначимыеКонтакты",
-                                            "title": {
-                                              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
-                                            },
-                                            "dataPath": "",
-                                            "items": []
-                                          }
-                                        ],
-                                        []
-                                      ]
-                                    },
-                                    {
-                                      "type": "PAGE",
-                                      "id": 73,
-                                      "name": "СтраницаПредмет",
-                                      "title": {
-                                        "content": [
-                                          {
-                                            "default": {
-                                              "tag": 2
-                                            },
-                                            "int": 1,
-                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                              "langKey": "ru",
-                                              "value": "Страница предмет"
-                                            }
-                                          }
-                                        ]
-                                      },
-                                      "dataPath": "",
-                                      "items": [
-                                        [
-                                          {
-                                            "type": "TABLE",
-                                            "id": 690,
-                                            "name": "ПредметыПанельНавигации",
+                                            "type": "PAGE",
+                                            "id": 73,
+                                            "name": "СтраницаПредмет",
                                             "title": {
                                               "content": [
                                                 {
@@ -2804,59 +2005,38 @@
                                                   "int": 1,
                                                   "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                                                     "langKey": "ru",
-                                                    "value": "Предметы панель навигации"
+                                                    "value": "Страница предмет"
                                                   }
                                                 }
                                               ]
                                             },
-                                            "dataPath": "ПредметыПанельНавигации",
+                                            "dataPath": "",
                                             "items": [
-                                              {
-                                                "type": "COLUMN_GROUP",
-                                                "id": 808,
-                                                "name": "ПредметыПанельНавигацииГруппа",
-                                                "title": {
-                                                  "content": [
-                                                    {
-                                                      "default": {
-                                                        "tag": 2
-                                                      },
-                                                      "int": 1,
-                                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                        "langKey": "ru",
-                                                        "value": "Предметы панель навигации группа"
+                                              [
+                                                {
+                                                  "type": "TABLE",
+                                                  "id": 690,
+                                                  "name": "ПредметыПанельНавигации",
+                                                  "title": {
+                                                    "content": [
+                                                      {
+                                                        "default": {
+                                                          "tag": 2
+                                                        },
+                                                        "int": 1,
+                                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                          "langKey": "ru",
+                                                          "value": "Предметы"
+                                                        }
                                                       }
-                                                    }
-                                                  ]
-                                                },
-                                                "dataPath": "",
-                                                "items": [
-                                                  [
-                                                    {
-                                                      "type": "LABEL_FIELD",
-                                                      "id": 697,
-                                                      "name": "Предмет",
-                                                      "title": {
-                                                        "content": [
-                                                          {
-                                                            "default": {
-                                                              "tag": 2
-                                                            },
-                                                            "int": 1,
-                                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                              "langKey": "ru",
-                                                              "value": "Предмет"
-                                                            }
-                                                          }
-                                                        ]
-                                                      },
-                                                      "dataPath": "ПредметыПанельНавигации.Предмет",
-                                                      "items": []
-                                                    },
+                                                    ]
+                                                  },
+                                                  "dataPath": "ПредметыПанельНавигации",
+                                                  "items": [
                                                     {
                                                       "type": "COLUMN_GROUP",
-                                                      "id": 786,
-                                                      "name": "ПредметыПанельНавигацииГруппаРассмотреноДата",
+                                                      "id": 1035,
+                                                      "name": "ПредметыПанельНавигацииГруппа",
                                                       "title": {
                                                         "content": [
                                                           {
@@ -2866,7 +2046,7 @@
                                                             "int": 1,
                                                             "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                                                               "langKey": "ru",
-                                                              "value": "Предметы панель навигации группа рассмотрено дата"
+                                                              "value": "Предметы панель навигации группа"
                                                             }
                                                           }
                                                         ]
@@ -2874,6 +2054,27 @@
                                                       "dataPath": "",
                                                       "items": [
                                                         [
+                                                          {
+                                                            "type": "LABEL_FIELD",
+                                                            "id": 697,
+                                                            "name": "Предмет",
+                                                            "title": {
+                                                              "content": [
+                                                                {
+                                                                  "default": {
+                                                                    "tag": 2
+                                                                  },
+                                                                  "int": 1,
+                                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                    "langKey": "ru",
+                                                                    "value": "Предмет"
+                                                                  }
+                                                                }
+                                                              ]
+                                                            },
+                                                            "dataPath": "ПредметыПанельНавигации.Предмет",
+                                                            "items": []
+                                                          },
                                                           {
                                                             "type": "LABEL_FIELD",
                                                             "id": 694,
@@ -2889,7 +2090,7 @@
                                                             "id": 700,
                                                             "name": "ДатаПоследнегоВзаимодействия",
                                                             "title": {
-                                                              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                                              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
                                                             },
                                                             "dataPath": "ПредметыПанельНавигации.ДатаПоследнегоВзаимодействия",
                                                             "items": []
@@ -2898,6 +2099,94 @@
                                                         []
                                                       ]
                                                     }
+                                                  ]
+                                                },
+                                                {
+                                                  "type": "LABEL",
+                                                  "id": 934,
+                                                  "name": "ДекорацияТолькоЗначимыеПредметы",
+                                                  "title": {
+                                                    "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                                  },
+                                                  "dataPath": "",
+                                                  "items": []
+                                                }
+                                              ],
+                                              []
+                                            ]
+                                          },
+                                          {
+                                            "type": "PAGE",
+                                            "id": 118,
+                                            "name": "СтраницаЗакладки",
+                                            "title": {
+                                              "content": [
+                                                {
+                                                  "default": {
+                                                    "tag": 2
+                                                  },
+                                                  "int": 1,
+                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                    "langKey": "ru",
+                                                    "value": "Страница закладки"
+                                                  }
+                                                }
+                                              ]
+                                            },
+                                            "dataPath": "",
+                                            "items": [
+                                              {
+                                                "type": "TABLE",
+                                                "id": 119,
+                                                "name": "Закладки",
+                                                "title": {
+                                                  "content": [
+                                                    {
+                                                      "default": {
+                                                        "tag": 2
+                                                      },
+                                                      "int": 1,
+                                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                        "langKey": "ru",
+                                                        "value": "Закладки"
+                                                      }
+                                                    }
+                                                  ]
+                                                },
+                                                "dataPath": "Закладки",
+                                                "items": [
+                                                  [
+                                                    {
+                                                      "type": "LABEL_FIELD",
+                                                      "id": 122,
+                                                      "name": "ЗакладкиНаименование",
+                                                      "title": {
+                                                        "content": [
+                                                          {
+                                                            "default": {
+                                                              "tag": 2
+                                                            },
+                                                            "int": 1,
+                                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                              "langKey": "ru",
+                                                              "value": "Закладка"
+                                                            }
+                                                          }
+                                                        ]
+                                                      },
+                                                      "dataPath": "Закладки.Description",
+                                                      "items": []
+                                                    },
+                                                    {
+                                                      "type": "INPUT_FIELD",
+                                                      "id": 940,
+                                                      "name": "ЗакладкиСсылка",
+                                                      "title": {
+                                                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                                      },
+                                                      "dataPath": "Закладки.Ref",
+                                                      "items": []
+                                                    }
                                                   ],
                                                   []
                                                 ]
@@ -2905,374 +2194,318 @@
                                             ]
                                           },
                                           {
-                                            "type": "LABEL",
-                                            "id": 934,
-                                            "name": "ДекорацияТолькоЗначимыеПредметы",
+                                            "type": "PAGE",
+                                            "id": 129,
+                                            "name": "СтраницаСвойства",
                                             "title": {
-                                              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                              "content": [
+                                                {
+                                                  "default": {
+                                                    "tag": 2
+                                                  },
+                                                  "int": 1,
+                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                    "langKey": "ru",
+                                                    "value": "Страница свойства"
+                                                  }
+                                                }
+                                              ]
                                             },
                                             "dataPath": "",
-                                            "items": []
+                                            "items": [
+                                              {
+                                                "type": "TABLE",
+                                                "id": 130,
+                                                "name": "Свойства",
+                                                "title": {
+                                                  "content": [
+                                                    {
+                                                      "default": {
+                                                        "tag": 2
+                                                      },
+                                                      "int": 1,
+                                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                        "langKey": "ru",
+                                                        "value": "Свойство"
+                                                      }
+                                                    }
+                                                  ]
+                                                },
+                                                "dataPath": "Свойства",
+                                                "items": [
+                                                  {
+                                                    "type": "COLUMN_GROUP",
+                                                    "id": 135,
+                                                    "name": "СвойстваГруппаКолонок",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "Свойства группа колонок"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": [
+                                                      [
+                                                        {
+                                                          "type": "PICTURE_FIELD",
+                                                          "id": 136,
+                                                          "name": "СвойстваНомерКартинки",
+                                                          "title": {
+                                                            "content": [
+                                                              {
+                                                                "default": {
+                                                                  "tag": 2
+                                                                },
+                                                                "int": 1,
+                                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                  "langKey": "ru",
+                                                                  "value": "Номер картинки"
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          "dataPath": "Свойства.НомерКартинки",
+                                                          "items": []
+                                                        },
+                                                        {
+                                                          "type": "INPUT_FIELD",
+                                                          "id": 133,
+                                                          "name": "СвойстваПредставление",
+                                                          "title": {
+                                                            "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                                          },
+                                                          "dataPath": "Свойства.Представление",
+                                                          "items": []
+                                                        }
+                                                      ],
+                                                      []
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "PAGE",
+                                            "id": 177,
+                                            "name": "СтраницаПапки",
+                                            "title": {
+                                              "content": [
+                                                {
+                                                  "default": {
+                                                    "tag": 2
+                                                  },
+                                                  "int": 1,
+                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                    "langKey": "ru",
+                                                    "value": "Страница папки"
+                                                  }
+                                                }
+                                              ]
+                                            },
+                                            "dataPath": "",
+                                            "items": [
+                                              {
+                                                "type": "TABLE",
+                                                "id": 178,
+                                                "name": "Папки",
+                                                "title": {
+                                                  "content": [
+                                                    {
+                                                      "default": {
+                                                        "tag": 2
+                                                      },
+                                                      "int": 1,
+                                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                        "langKey": "ru",
+                                                        "value": "Папки"
+                                                      }
+                                                    }
+                                                  ]
+                                                },
+                                                "dataPath": "Папки",
+                                                "items": [
+                                                  {
+                                                    "type": "COLUMN_GROUP",
+                                                    "id": 181,
+                                                    "name": "ПапкиГруппаКолонок",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "Папки группа колонок"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": [
+                                                      [
+                                                        {
+                                                          "type": "PICTURE_FIELD",
+                                                          "id": 182,
+                                                          "name": "ПапкиНомерКартинки",
+                                                          "title": {
+                                                            "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                                          },
+                                                          "dataPath": "Папки.НомерКартинки",
+                                                          "items": []
+                                                        },
+                                                        {
+                                                          "type": "INPUT_FIELD",
+                                                          "id": 184,
+                                                          "name": "ПапкиПредставление",
+                                                          "title": {
+                                                            "content": [
+                                                              {
+                                                                "default": {
+                                                                  "tag": 2
+                                                                },
+                                                                "int": 1,
+                                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                  "langKey": "ru",
+                                                                  "value": "Папка"
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          "dataPath": "Папки.Представление",
+                                                          "items": []
+                                                        }
+                                                      ],
+                                                      []
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "PAGE",
+                                            "id": 305,
+                                            "name": "СтраницаКатегории",
+                                            "title": {
+                                              "content": [
+                                                {
+                                                  "default": {
+                                                    "tag": 2
+                                                  },
+                                                  "int": 1,
+                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                    "langKey": "ru",
+                                                    "value": "Страница категории"
+                                                  }
+                                                }
+                                              ]
+                                            },
+                                            "dataPath": "",
+                                            "items": [
+                                              {
+                                                "type": "TABLE",
+                                                "id": 306,
+                                                "name": "Категории",
+                                                "title": {
+                                                  "content": [
+                                                    {
+                                                      "default": {
+                                                        "tag": 2
+                                                      },
+                                                      "int": 1,
+                                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                        "langKey": "ru",
+                                                        "value": "Категории"
+                                                      }
+                                                    }
+                                                  ]
+                                                },
+                                                "dataPath": "Категории",
+                                                "items": [
+                                                  {
+                                                    "type": "COLUMN_GROUP",
+                                                    "id": 311,
+                                                    "name": "КатегорииГруппаКолонок",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "Категории группа колонок"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": [
+                                                      [
+                                                        {
+                                                          "type": "PICTURE_FIELD",
+                                                          "id": 312,
+                                                          "name": "КатегорииНомерКартинки",
+                                                          "title": {
+                                                            "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                                          },
+                                                          "dataPath": "Категории.НомерКартинки",
+                                                          "items": []
+                                                        },
+                                                        {
+                                                          "type": "INPUT_FIELD",
+                                                          "id": 309,
+                                                          "name": "КатегорииПредставление",
+                                                          "title": {
+                                                            "content": [
+                                                              {
+                                                                "default": {
+                                                                  "tag": 2
+                                                                },
+                                                                "int": 1,
+                                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                  "langKey": "ru",
+                                                                  "value": "Категория"
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          "dataPath": "Категории.Представление",
+                                                          "items": []
+                                                        }
+                                                      ],
+                                                      []
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
                                           }
                                         ],
                                         []
                                       ]
                                     },
                                     {
-                                      "type": "PAGE",
-                                      "id": 118,
-                                      "name": "СтраницаЗакладки",
+                                      "type": "RADIO_BUTTON_FIELD",
+                                      "id": 1127,
+                                      "name": "ПоложениеНавигации",
                                       "title": {
-                                        "content": [
-                                          {
-                                            "default": {
-                                              "tag": 2
-                                            },
-                                            "int": 1,
-                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                              "langKey": "ru",
-                                              "value": "Страница закладки"
-                                            }
-                                          }
-                                        ]
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
                                       },
-                                      "dataPath": "",
-                                      "items": [
-                                        {
-                                          "type": "TABLE",
-                                          "id": 119,
-                                          "name": "Закладки",
-                                          "title": {
-                                            "content": [
-                                              {
-                                                "default": {
-                                                  "tag": 2
-                                                },
-                                                "int": 1,
-                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                  "langKey": "ru",
-                                                  "value": "Закладки"
-                                                }
-                                              }
-                                            ]
-                                          },
-                                          "dataPath": "Закладки",
-                                          "items": [
-                                            [
-                                              {
-                                                "type": "LABEL_FIELD",
-                                                "id": 122,
-                                                "name": "ЗакладкиНаименование",
-                                                "title": {
-                                                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                                },
-                                                "dataPath": "Закладки.Description",
-                                                "items": []
-                                              },
-                                              {
-                                                "type": "INPUT_FIELD",
-                                                "id": 940,
-                                                "name": "ЗакладкиСсылка",
-                                                "title": {
-                                                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
-                                                },
-                                                "dataPath": "Закладки.Ref",
-                                                "items": []
-                                              }
-                                            ],
-                                            []
-                                          ]
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "PAGE",
-                                      "id": 129,
-                                      "name": "СтраницаСвойства",
-                                      "title": {
-                                        "content": [
-                                          {
-                                            "default": {
-                                              "tag": 2
-                                            },
-                                            "int": 1,
-                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                              "langKey": "ru",
-                                              "value": "Страница свойства"
-                                            }
-                                          }
-                                        ]
-                                      },
-                                      "dataPath": "",
-                                      "items": [
-                                        {
-                                          "type": "TABLE",
-                                          "id": 130,
-                                          "name": "Свойства",
-                                          "title": {
-                                            "content": [
-                                              {
-                                                "default": {
-                                                  "tag": 2
-                                                },
-                                                "int": 1,
-                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                  "langKey": "ru",
-                                                  "value": "Свойства"
-                                                }
-                                              }
-                                            ]
-                                          },
-                                          "dataPath": "Свойства",
-                                          "items": [
-                                            {
-                                              "type": "COLUMN_GROUP",
-                                              "id": 135,
-                                              "name": "СвойстваГруппаКолонок",
-                                              "title": {
-                                                "content": [
-                                                  {
-                                                    "default": {
-                                                      "tag": 2
-                                                    },
-                                                    "int": 1,
-                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                      "langKey": "ru",
-                                                      "value": "Свойства группа колонок"
-                                                    }
-                                                  }
-                                                ]
-                                              },
-                                              "dataPath": "",
-                                              "items": [
-                                                [
-                                                  {
-                                                    "type": "INPUT_FIELD",
-                                                    "id": 133,
-                                                    "name": "СвойстваПредставление",
-                                                    "title": {
-                                                      "content": [
-                                                        {
-                                                          "default": {
-                                                            "tag": 2
-                                                          },
-                                                          "int": 1,
-                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                            "langKey": "ru",
-                                                            "value": "Представление"
-                                                          }
-                                                        }
-                                                      ]
-                                                    },
-                                                    "dataPath": "Свойства.Представление",
-                                                    "items": []
-                                                  },
-                                                  {
-                                                    "type": "PICTURE_FIELD",
-                                                    "id": 136,
-                                                    "name": "СвойстваНомерКартинки",
-                                                    "title": {
-                                                      "content": [
-                                                        {
-                                                          "default": {
-                                                            "tag": 2
-                                                          },
-                                                          "int": 1,
-                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                            "langKey": "ru",
-                                                            "value": "Номер картинки"
-                                                          }
-                                                        }
-                                                      ]
-                                                    },
-                                                    "dataPath": "Свойства.НомерКартинки",
-                                                    "items": []
-                                                  }
-                                                ],
-                                                []
-                                              ]
-                                            }
-                                          ]
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "PAGE",
-                                      "id": 177,
-                                      "name": "СтраницаПапки",
-                                      "title": {
-                                        "content": [
-                                          {
-                                            "default": {
-                                              "tag": 2
-                                            },
-                                            "int": 1,
-                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                              "langKey": "ru",
-                                              "value": "Страница папки"
-                                            }
-                                          }
-                                        ]
-                                      },
-                                      "dataPath": "",
-                                      "items": [
-                                        {
-                                          "type": "TABLE",
-                                          "id": 178,
-                                          "name": "Папки",
-                                          "title": {
-                                            "content": [
-                                              {
-                                                "default": {
-                                                  "tag": 2
-                                                },
-                                                "int": 1,
-                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                  "langKey": "ru",
-                                                  "value": "Папки"
-                                                }
-                                              }
-                                            ]
-                                          },
-                                          "dataPath": "Папки",
-                                          "items": [
-                                            {
-                                              "type": "COLUMN_GROUP",
-                                              "id": 181,
-                                              "name": "ПапкиГруппаКолонок",
-                                              "title": {
-                                                "content": [
-                                                  {
-                                                    "default": {
-                                                      "tag": 2
-                                                    },
-                                                    "int": 1,
-                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                      "langKey": "ru",
-                                                      "value": "Папки группа колонок"
-                                                    }
-                                                  }
-                                                ]
-                                              },
-                                              "dataPath": "",
-                                              "items": [
-                                                [
-                                                  {
-                                                    "type": "PICTURE_FIELD",
-                                                    "id": 182,
-                                                    "name": "ПапкиНомерКартинки",
-                                                    "title": {
-                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                                                    },
-                                                    "dataPath": "Папки.НомерКартинки",
-                                                    "items": []
-                                                  },
-                                                  {
-                                                    "type": "INPUT_FIELD",
-                                                    "id": 184,
-                                                    "name": "ПапкиПредставление",
-                                                    "title": {
-                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                                    },
-                                                    "dataPath": "Папки.Представление",
-                                                    "items": []
-                                                  }
-                                                ],
-                                                []
-                                              ]
-                                            }
-                                          ]
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "PAGE",
-                                      "id": 305,
-                                      "name": "СтраницаКатегории",
-                                      "title": {
-                                        "content": [
-                                          {
-                                            "default": {
-                                              "tag": 2
-                                            },
-                                            "int": 1,
-                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                              "langKey": "ru",
-                                              "value": "Страница категории"
-                                            }
-                                          }
-                                        ]
-                                      },
-                                      "dataPath": "",
-                                      "items": [
-                                        {
-                                          "type": "TABLE",
-                                          "id": 306,
-                                          "name": "Категории",
-                                          "title": {
-                                            "content": [
-                                              {
-                                                "default": {
-                                                  "tag": 2
-                                                },
-                                                "int": 1,
-                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                  "langKey": "ru",
-                                                  "value": "Категории"
-                                                }
-                                              }
-                                            ]
-                                          },
-                                          "dataPath": "Категории",
-                                          "items": [
-                                            {
-                                              "type": "COLUMN_GROUP",
-                                              "id": 311,
-                                              "name": "КатегорииГруппаКолонок",
-                                              "title": {
-                                                "content": [
-                                                  {
-                                                    "default": {
-                                                      "tag": 2
-                                                    },
-                                                    "int": 1,
-                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                      "langKey": "ru",
-                                                      "value": "Категории группа колонок"
-                                                    }
-                                                  }
-                                                ]
-                                              },
-                                              "dataPath": "",
-                                              "items": [
-                                                [
-                                                  {
-                                                    "type": "PICTURE_FIELD",
-                                                    "id": 312,
-                                                    "name": "КатегорииНомерКартинки",
-                                                    "title": {
-                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                                                    },
-                                                    "dataPath": "Категории.НомерКартинки",
-                                                    "items": []
-                                                  },
-                                                  {
-                                                    "type": "INPUT_FIELD",
-                                                    "id": 309,
-                                                    "name": "КатегорииПредставление",
-                                                    "title": {
-                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                                    },
-                                                    "dataPath": "Категории.Представление",
-                                                    "items": []
-                                                  }
-                                                ],
-                                                []
-                                              ]
-                                            }
-                                          ]
-                                        }
-                                      ]
+                                      "dataPath": "ПоложениеНавигации",
+                                      "items": []
                                     }
                                   ],
                                   []
@@ -3312,9 +2545,9 @@
                                   "items": [
                                     [
                                       {
-                                        "type": "COLUMN_GROUP",
-                                        "id": 772,
-                                        "name": "ГруппаФлаги",
+                                        "type": "PICTURE_FIELD",
+                                        "id": 340,
+                                        "name": "ВажностьНомерКартинки",
                                         "title": {
                                           "content": [
                                             {
@@ -3324,64 +2557,18 @@
                                               "int": 1,
                                               "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                                                 "langKey": "ru",
-                                                "value": "Флаги"
+                                                "value": "Иконка важности"
                                               }
                                             }
                                           ]
                                         },
-                                        "dataPath": "",
-                                        "items": [
-                                          [
-                                            {
-                                              "type": "PICTURE_FIELD",
-                                              "id": 330,
-                                              "name": "НомерКартинки",
-                                              "title": {
-                                                "content": [
-                                                  {
-                                                    "default": {
-                                                      "tag": 2
-                                                    },
-                                                    "int": 1,
-                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                      "langKey": "ru",
-                                                      "value": "Иконка взаимодействия"
-                                                    }
-                                                  }
-                                                ]
-                                              },
-                                              "dataPath": "Список.НомерКартинки",
-                                              "items": []
-                                            },
-                                            {
-                                              "type": "PICTURE_FIELD",
-                                              "id": 340,
-                                              "name": "ВажностьНомерКартинки",
-                                              "title": {
-                                                "content": [
-                                                  {
-                                                    "default": {
-                                                      "tag": 2
-                                                    },
-                                                    "int": 1,
-                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                      "langKey": "ru",
-                                                      "value": "Иконка важности"
-                                                    }
-                                                  }
-                                                ]
-                                              },
-                                              "dataPath": "Список.ВажностьНомерКартинки",
-                                              "items": []
-                                            }
-                                          ],
-                                          []
-                                        ]
+                                        "dataPath": "Список.ВажностьНомерКартинки",
+                                        "items": []
                                       },
                                       {
-                                        "type": "COLUMN_GROUP",
-                                        "id": 812,
-                                        "name": "ГруппаСписокОсновное",
+                                        "type": "PICTURE_FIELD",
+                                        "id": 330,
+                                        "name": "НомерКартинки",
                                         "title": {
                                           "content": [
                                             {
@@ -3391,103 +2578,74 @@
                                               "int": 1,
                                               "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                                                 "langKey": "ru",
-                                                "value": "Список основное"
+                                                "value": "Иконка взаимодействия"
                                               }
                                             }
                                           ]
                                         },
-                                        "dataPath": "",
-                                        "items": [
-                                          [
+                                        "dataPath": "Список.НомерКартинки",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "LABEL_FIELD",
+                                        "id": 12,
+                                        "name": "Тема",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                        },
+                                        "dataPath": "Список.Тема",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "LABEL_FIELD",
+                                        "id": 16,
+                                        "name": "Участники",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                        },
+                                        "dataPath": "Список.Участники",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "LABEL_FIELD",
+                                        "id": 776,
+                                        "name": "ПолученоОтправлено",
+                                        "title": {
+                                          "content": [
                                             {
-                                              "type": "COLUMN_GROUP",
-                                              "id": 770,
-                                              "name": "ГруппаУчастникиДатаЕстьВложения",
-                                              "title": {
-                                                "content": [
-                                                  {
-                                                    "default": {
-                                                      "tag": 2
-                                                    },
-                                                    "int": 1,
-                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                      "langKey": "ru",
-                                                      "value": "Участники дата есть вложения"
-                                                    }
-                                                  }
-                                                ]
+                                              "default": {
+                                                "tag": 2
                                               },
-                                              "dataPath": "",
-                                              "items": [
-                                                [
-                                                  {
-                                                    "type": "LABEL_FIELD",
-                                                    "id": 16,
-                                                    "name": "Участники",
-                                                    "title": {
-                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
-                                                    },
-                                                    "dataPath": "Список.Участники",
-                                                    "items": []
-                                                  },
-                                                  {
-                                                    "type": "LABEL_FIELD",
-                                                    "id": 776,
-                                                    "name": "ПолученоОтправлено",
-                                                    "title": {
-                                                      "content": [
-                                                        {
-                                                          "default": {
-                                                            "tag": 2
-                                                          },
-                                                          "int": 1,
-                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                            "langKey": "ru",
-                                                            "value": "Дата"
-                                                          }
-                                                        }
-                                                      ]
-                                                    },
-                                                    "dataPath": "Список.ПолученоОтправлено",
-                                                    "items": []
-                                                  },
-                                                  {
-                                                    "type": "INPUT_FIELD",
-                                                    "id": 8,
-                                                    "name": "Дата",
-                                                    "title": {
-                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
-                                                    },
-                                                    "dataPath": "Список.Дата",
-                                                    "items": []
-                                                  },
-                                                  {
-                                                    "type": "PICTURE_FIELD",
-                                                    "id": 108,
-                                                    "name": "ЕстьВложения",
-                                                    "title": {
-                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn[8]/synonym"
-                                                    },
-                                                    "dataPath": "Список.ЕстьВложения",
-                                                    "items": []
-                                                  }
-                                                ],
-                                                []
-                                              ]
-                                            },
-                                            {
-                                              "type": "LABEL_FIELD",
-                                              "id": 12,
-                                              "name": "Тема",
-                                              "title": {
-                                                "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
-                                              },
-                                              "dataPath": "Список.Тема",
-                                              "items": []
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Дата"
+                                              }
                                             }
-                                          ],
-                                          []
-                                        ]
+                                          ]
+                                        },
+                                        "dataPath": "Список.ПолученоОтправлено",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "INPUT_FIELD",
+                                        "id": 8,
+                                        "name": "Дата",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                        },
+                                        "dataPath": "Список.Дата",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "PICTURE_FIELD",
+                                        "id": 108,
+                                        "name": "ЕстьВложения",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn[8]/synonym"
+                                        },
+                                        "dataPath": "Список.ЕстьВложения",
+                                        "items": []
                                       },
                                       {
                                         "type": "LABEL_FIELD",
@@ -3565,7 +2723,7 @@
                                         "dataPath": "",
                                         "items": [
                                           {
-                                            "type": "TEXT_DOCUMENT_FIELD",
+                                            "type": "INPUT_FIELD",
                                             "id": 150,
                                             "name": "ПредпросмотрОбычныйТекст",
                                             "title": {
@@ -3634,7 +2792,18 @@
                                                     "id": 914,
                                                     "name": "КартинкаПредупреждение",
                                                     "title": {
-                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "Картинка предупреждение"
+                                                          }
+                                                        }
+                                                      ]
                                                     },
                                                     "dataPath": "",
                                                     "items": []
@@ -3665,9 +2834,9 @@
                                               ]
                                             },
                                             {
-                                              "type": "HTML_DOCUMENT_FIELD",
-                                              "id": 91,
-                                              "name": "ПредпросмотрHTML",
+                                              "type": "USUAL_GROUP",
+                                              "id": 1031,
+                                              "name": "Группа1",
                                               "title": {
                                                 "content": [
                                                   {
@@ -3677,13 +2846,35 @@
                                                     "int": 1,
                                                     "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                                                       "langKey": "ru",
-                                                      "value": "Предпросмотр HTML"
+                                                      "value": "Группа"
                                                     }
                                                   }
                                                 ]
                                               },
-                                              "dataPath": "ПредпросмотрHTML",
-                                              "items": []
+                                              "dataPath": "",
+                                              "items": [
+                                                {
+                                                  "type": "HTML_DOCUMENT_FIELD",
+                                                  "id": 91,
+                                                  "name": "ПредпросмотрHTML",
+                                                  "title": {
+                                                    "content": [
+                                                      {
+                                                        "default": {
+                                                          "tag": 2
+                                                        },
+                                                        "int": 1,
+                                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                          "langKey": "ru",
+                                                          "value": "Предпросмотр HTML"
+                                                        }
+                                                      }
+                                                    ]
+                                                  },
+                                                  "dataPath": "ПредпросмотрHTML",
+                                                  "items": []
+                                                }
+                                              ]
                                             }
                                           ],
                                           []
@@ -3762,7 +2953,7 @@
                 "id": 4,
                 "name": "Статус",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
                 },
                 "type": {
                   "types": [
@@ -3923,7 +3114,7 @@
                 "id": 7,
                 "name": "Закладки",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
@@ -3953,18 +3144,7 @@
                 "id": 11,
                 "name": "Свойства",
                 "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Контакты"
-                      }
-                    }
-                  ]
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "types": [
@@ -4125,7 +3305,7 @@
                 "id": 20,
                 "name": "Папки",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[9]/type"
@@ -4175,7 +3355,7 @@
                 "id": 25,
                 "name": "Категории",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[6]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[6]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[8]/type"
@@ -4314,7 +3494,7 @@
                 "id": 35,
                 "name": "ПредпросмотрHTML",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
@@ -4324,7 +3504,18 @@
                 "id": 36,
                 "name": "ПредметыПанельНавигации",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Предметы панель навигации"
+                      }
+                    }
+                  ]
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
@@ -4374,16 +3565,6 @@
               {
                 "id": 19,
                 "name": "ОтображатьОбластьЧтения",
-                "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
-                },
-                "type": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
-                }
-              },
-              {
-                "id": 38,
-                "name": "ПанельНавигацииСкрыта",
                 "title": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
                 },
@@ -4470,7 +3651,7 @@
                   "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
                 },
                 "type": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[39]/type"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[38]/type"
                 }
               },
               {
@@ -4517,7 +3698,7 @@
                   "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
                 },
                 "type": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[45]/type"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[44]/type"
                 }
               },
               {
@@ -4543,6 +3724,37 @@
               {
                 "id": 49,
                 "name": "ИндексПолнотекстовогоПоискаАктуален",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
+                }
+              },
+              {
+                "id": 50,
+                "name": "ПоложениеНавигации",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Положение навигации"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 38,
+                "name": "ОтправкаПисемПриостановлена",
                 "title": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
                 },
@@ -4635,7 +3847,7 @@
                 "id": 234,
                 "name": "ГруппаПользовательскихНастроек",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                 },
                 "dataPath": "",
                 "items": []
@@ -4645,7 +3857,7 @@
                 "id": 34,
                 "name": "ГруппаФильтры",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
                 },
                 "dataPath": "",
                 "items": [
@@ -4676,7 +3888,7 @@
                       "id": 136,
                       "name": "ТипВзаимодействия",
                       "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/title"
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                       },
                       "dataPath": "ТипВзаимодействия",
                       "items": []
@@ -4686,7 +3898,7 @@
                       "id": 50,
                       "name": "Статус",
                       "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
                       },
                       "dataPath": "Статус",
                       "items": []
@@ -4757,93 +3969,54 @@
                           "items": [
                             [
                               {
-                                "type": "COLUMN_GROUP",
-                                "id": 221,
-                                "name": "ГруппаОсновное",
+                                "type": "PICTURE_FIELD",
+                                "id": 225,
+                                "name": "НомерКартинки",
                                 "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                                 },
-                                "dataPath": "",
-                                "items": [
-                                  [
-                                    {
-                                      "type": "COLUMN_GROUP",
-                                      "id": 223,
-                                      "name": "ГруппаСостояниеУчастникиДата",
-                                      "title": {
-                                        "content": [
-                                          {
-                                            "default": {
-                                              "tag": 2
-                                            },
-                                            "int": 1,
-                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                              "langKey": "ru",
-                                              "value": "Состояние участники дата"
-                                            }
-                                          }
-                                        ]
-                                      },
-                                      "dataPath": "",
-                                      "items": [
-                                        [
-                                          {
-                                            "type": "PICTURE_FIELD",
-                                            "id": 225,
-                                            "name": "НомерКартинки",
-                                            "title": {
-                                              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                            },
-                                            "dataPath": "Список.НомерКартинки",
-                                            "items": []
-                                          },
-                                          {
-                                            "type": "INPUT_FIELD",
-                                            "id": 66,
-                                            "name": "Участники",
-                                            "title": {
-                                              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
-                                            },
-                                            "dataPath": "Список.Участники",
-                                            "items": []
-                                          },
-                                          {
-                                            "type": "INPUT_FIELD",
-                                            "id": 68,
-                                            "name": "Дата",
-                                            "title": {
-                                              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
-                                            },
-                                            "dataPath": "Список.Date",
-                                            "items": []
-                                          },
-                                          {
-                                            "type": "PICTURE_FIELD",
-                                            "id": 254,
-                                            "name": "ЕстьВложения",
-                                            "title": {
-                                              "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
-                                            },
-                                            "dataPath": "Список.ЕстьВложения",
-                                            "items": []
-                                          }
-                                        ],
-                                        []
-                                      ]
-                                    },
-                                    {
-                                      "type": "INPUT_FIELD",
-                                      "id": 20,
-                                      "name": "Тема",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn[4]/synonym"
-                                      },
-                                      "dataPath": "Список.Тема",
-                                      "items": []
-                                    }
-                                  ],
-                                  []
-                                ]
+                                "dataPath": "Список.НомерКартинки",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 20,
+                                "name": "Тема",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn[4]/synonym"
+                                },
+                                "dataPath": "Список.Тема",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 66,
+                                "name": "Участники",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                },
+                                "dataPath": "Список.Участники",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 68,
+                                "name": "Дата",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                },
+                                "dataPath": "Список.Date",
+                                "items": []
+                              },
+                              {
+                                "type": "PICTURE_FIELD",
+                                "id": 254,
+                                "name": "ЕстьВложения",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
+                                },
+                                "dataPath": "Список.ЕстьВложения",
+                                "items": []
                               },
                               {
                                 "type": "LABEL_FIELD",
@@ -4901,96 +4074,49 @@
                           },
                           "dataPath": "ДеревоВзаимодействий",
                           "items": [
-                            {
-                              "type": "COLUMN_GROUP",
-                              "id": 228,
-                              "name": "ДеревоВзаимодействийГруппаОсновное",
-                              "title": {
-                                "content": [
-                                  {
-                                    "default": {
-                                      "tag": 2
-                                    },
-                                    "int": 1,
-                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                      "langKey": "ru",
-                                      "value": "Дерево взаимодействий группа основное"
-                                    }
-                                  }
-                                ]
+                            [
+                              {
+                                "type": "PICTURE_FIELD",
+                                "id": 113,
+                                "name": "ДеревоВзаимодействийНомерКартинки",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                },
+                                "dataPath": "ДеревоВзаимодействий.НомерКартинки",
+                                "items": []
                               },
-                              "dataPath": "",
-                              "items": [
-                                [
-                                  {
-                                    "type": "COLUMN_GROUP",
-                                    "id": 115,
-                                    "name": "УчастникиСостояниеДата",
-                                    "title": {
-                                      "content": [
-                                        {
-                                          "default": {
-                                            "tag": 2
-                                          },
-                                          "int": 1,
-                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                            "langKey": "ru",
-                                            "value": "Участники состояние дата"
-                                          }
-                                        }
-                                      ]
-                                    },
-                                    "dataPath": "",
-                                    "items": [
-                                      [
-                                        {
-                                          "type": "PICTURE_FIELD",
-                                          "id": 113,
-                                          "name": "ДеревоВзаимодействийНомерКартинки",
-                                          "title": {
-                                            "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                                          },
-                                          "dataPath": "ДеревоВзаимодействий.НомерКартинки",
-                                          "items": []
-                                        },
-                                        {
-                                          "type": "INPUT_FIELD",
-                                          "id": 118,
-                                          "name": "ДеревоВзаимодействийУчастники",
-                                          "title": {
-                                            "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn[5]/synonym"
-                                          },
-                                          "dataPath": "ДеревоВзаимодействий.Участники",
-                                          "items": []
-                                        },
-                                        {
-                                          "type": "INPUT_FIELD",
-                                          "id": 111,
-                                          "name": "ДеревоВзаимодействийДата",
-                                          "title": {
-                                            "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                                          },
-                                          "dataPath": "ДеревоВзаимодействий.Дата",
-                                          "items": []
-                                        }
-                                      ],
-                                      []
-                                    ]
-                                  },
-                                  {
-                                    "type": "INPUT_FIELD",
-                                    "id": 116,
-                                    "name": "ДеревоВзаимодействийТема",
-                                    "title": {
-                                      "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn[4]/synonym"
-                                    },
-                                    "dataPath": "ДеревоВзаимодействий.Тема",
-                                    "items": []
-                                  }
-                                ],
-                                []
-                              ]
-                            }
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 116,
+                                "name": "ДеревоВзаимодействийТема",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn[4]/synonym"
+                                },
+                                "dataPath": "ДеревоВзаимодействий.Тема",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 118,
+                                "name": "ДеревоВзаимодействийУчастники",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/columns/c/com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn[5]/synonym"
+                                },
+                                "dataPath": "ДеревоВзаимодействий.Участники",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 111,
+                                "name": "ДеревоВзаимодействийДата",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/title"
+                                },
+                                "dataPath": "ДеревоВзаимодействий.Дата",
+                                "items": []
+                              }
+                            ],
+                            []
                           ]
                         }
                       ]
@@ -5028,7 +4154,7 @@
                 "id": 5,
                 "name": "Статус",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[2]/type"
@@ -5288,40 +4414,6 @@
                 ]
               },
               {
-                "type": "USUAL_GROUP",
-                "id": 39,
-                "name": "ПредупреждениеБезопасности",
-                "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                },
-                "dataPath": "",
-                "items": [
-                  [
-                    {
-                      "type": "DECORATION",
-                      "id": 41,
-                      "name": "КартинкаПредупреждение",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "LABEL",
-                      "id": 44,
-                      "name": "ПредупреждениеОНебезопасномСодержимом",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    }
-                  ],
-                  []
-                ]
-              },
-              {
                 "type": "HTML_DOCUMENT_FIELD",
                 "id": 1,
                 "name": "ТекстHTML",
@@ -5367,18 +4459,7 @@
                     "id": 17,
                     "name": "Группа",
                     "title": {
-                      "content": [
-                        {
-                          "default": {
-                            "tag": 2
-                          },
-                          "int": 1,
-                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                            "langKey": "ru",
-                            "value": "Группа"
-                          }
-                        }
-                      ]
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                     },
                     "dataPath": "",
                     "items": [
@@ -5461,7 +4542,7 @@
                 "id": 1,
                 "name": "ТекстHTML",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
@@ -5491,7 +4572,7 @@
                 "id": 5,
                 "name": "Вложения",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[8]/type"
@@ -5815,202 +4896,21 @@
           "items": [
             [
               {
-                "type": "USUAL_GROUP",
-                "id": 22,
-                "name": "ГруппаДатыНомер",
-                "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Даты номер"
-                      }
-                    }
-                  ]
-                },
-                "dataPath": "",
-                "items": [
-                  [
-                    {
-                      "type": "USUAL_GROUP",
-                      "id": 8,
-                      "name": "ГруппаДаты",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Даты"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "INPUT_FIELD",
-                            "id": 9,
-                            "name": "Создано",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Создано"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "Создано",
-                            "items": []
-                          },
-                          {
-                            "type": "INPUT_FIELD",
-                            "id": 11,
-                            "name": "ОтправленоПолучено",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Отправлено"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "ОтправленоПолучено",
-                            "items": []
-                          }
-                        ],
-                        []
-                      ]
-                    },
-                    {
-                      "type": "USUAL_GROUP",
-                      "id": 25,
-                      "name": "ГруппаВключатьВнутреннийНомер",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Включать внутренний номер"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "INPUT_FIELD",
-                            "id": 6,
-                            "name": "ВнутреннийНомер",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Внутренний номер"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "ВнутреннийНомер",
-                            "items": []
-                          },
-                          {
-                            "type": "CHECK_BOX_FIELD",
-                            "id": 23,
-                            "name": "ВключатьТелоИсходногоПисьма",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Включать тело исходного письма"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "ВключатьТелоИсходногоПисьма",
-                            "items": []
-                          }
-                        ],
-                        []
-                      ]
-                    }
-                  ],
-                  []
-                ]
-              },
-              {
                 "type": "INPUT_FIELD",
                 "id": 26,
                 "name": "Папка",
                 "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Папка"
-                      }
-                    }
-                  ]
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                 },
                 "dataPath": "Папка",
                 "items": []
               },
               {
                 "type": "USUAL_GROUP",
-                "id": 5,
-                "name": "ГруппаПараметрыОтслеживания",
+                "id": 49,
+                "name": "Группа1",
                 "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Параметры отслеживания"
-                      }
-                    }
-                  ]
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                 },
                 "dataPath": "",
                 "items": [
@@ -6062,6 +4962,162 @@
                 ]
               },
               {
+                "type": "CHECK_BOX_FIELD",
+                "id": 23,
+                "name": "ВключатьТелоИсходногоПисьма",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Включать тело исходного письма"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "ВключатьТелоИсходногоПисьма",
+                "items": []
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 22,
+                "name": "ГруппаДатыНомер",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Даты номер"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 8,
+                      "name": "ГруппаДаты",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Даты"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "LABEL_FIELD",
+                            "id": 9,
+                            "name": "Создано",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Создано"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "Создано",
+                            "items": []
+                          },
+                          {
+                            "type": "LABEL_FIELD",
+                            "id": 11,
+                            "name": "ОтправленоПолучено",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Отправлено"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "ОтправленоПолучено",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 25,
+                      "name": "ГруппаВключатьВнутреннийНомер",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Включать внутренний номер"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        {
+                          "type": "LABEL_FIELD",
+                          "id": 6,
+                          "name": "ВнутреннийНомер",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Внутренний номер"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "ВнутреннийНомер",
+                          "items": []
+                        }
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
                 "type": "TEXT_DOCUMENT_FIELD",
                 "id": 17,
                 "name": "Заголовки",
@@ -6091,7 +5147,7 @@
                 "id": 1,
                 "name": "УведомитьОДоставке",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
@@ -6101,7 +5157,7 @@
                 "id": 2,
                 "name": "УведомитьОПрочтении",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
@@ -6111,7 +5167,7 @@
                 "id": 3,
                 "name": "ВнутреннийНомер",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "types": [
@@ -6143,10 +5199,10 @@
                 "id": 4,
                 "name": "Создано",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[45]/type"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[44]/type"
                 }
               },
               {
@@ -6167,14 +5223,14 @@
                   ]
                 },
                 "type": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[45]/type"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[44]/type"
                 }
               },
               {
                 "id": 7,
                 "name": "ЗаголовкиИнтернета",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/title"
                 },
                 "type": {
                   "types": [
@@ -6214,7 +5270,7 @@
                 "id": 6,
                 "name": "ВключатьТелоИсходногоПисьма",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"
@@ -6224,7 +5280,7 @@
                 "id": 10,
                 "name": "Папка",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                 },
                 "type": {
                   "types": [
@@ -7058,7 +6114,7 @@
                   "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/explanation"
                 },
                 "type": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[39]/type"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[38]/type"
                 }
               },
               {
@@ -7352,29 +6408,18 @@
           "items": [
             [
               {
-                "type": "TABLE",
-                "id": 1,
-                "name": "ТаблицаТиповПредметов",
+                "type": "USUAL_GROUP",
+                "id": 31,
+                "name": "Группа1",
                 "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Таблица типов предметов"
-                      }
-                    }
-                  ]
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                 },
-                "dataPath": "ТаблицаТиповПредметов",
+                "dataPath": "",
                 "items": [
                   {
-                    "type": "INPUT_FIELD",
-                    "id": 14,
-                    "name": "ТаблицаТиповПредметовПредставлениеТипа",
+                    "type": "TABLE",
+                    "id": 1,
+                    "name": "ТаблицаТиповПредметов",
                     "title": {
                       "content": [
                         {
@@ -7384,13 +6429,35 @@
                           "int": 1,
                           "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                             "langKey": "ru",
-                            "value": "Представление типа"
+                            "value": "Таблица типов предметов"
                           }
                         }
                       ]
                     },
-                    "dataPath": "ТаблицаТиповПредметов.ПредставлениеТипа",
-                    "items": []
+                    "dataPath": "ТаблицаТиповПредметов",
+                    "items": [
+                      {
+                        "type": "INPUT_FIELD",
+                        "id": 14,
+                        "name": "ТаблицаТиповПредметовПредставлениеТипа",
+                        "title": {
+                          "content": [
+                            {
+                              "default": {
+                                "tag": 2
+                              },
+                              "int": 1,
+                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                "langKey": "ru",
+                                "value": "Представление типа"
+                              }
+                            }
+                          ]
+                        },
+                        "dataPath": "ТаблицаТиповПредметов.ПредставлениеТипа",
+                        "items": []
+                      }
+                    ]
                   }
                 ]
               },
@@ -7407,7 +6474,7 @@
                       "int": 1,
                       "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                         "langKey": "ru",
-                        "value": "Не отображать взаимодействия"
+                        "value": "Скрыть взаимодействия"
                       }
                     }
                   ]
@@ -7424,7 +6491,7 @@
                 "id": 1,
                 "name": "ТаблицаТиповПредметов",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[8]/type"
@@ -7444,7 +6511,18 @@
                 "id": 3,
                 "name": "НеОтображатьВзаимодействия",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Не отображать взаимодействия"
+                      }
+                    }
+                  ]
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.DocumentJournal/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[11]/type"

--- a/src/test/resources/fixtures/ssl_3_2/Documents.Анкета.json
+++ b/src/test/resources/fixtures/ssl_3_2/Documents.Анкета.json
@@ -1,0 +1,2811 @@
+{"com.github._1c_syntax.bsl.mdo.Document": {
+  "attributes": [
+    [
+      {
+        "uuid": "73eff626-a363-4a5a-879e-61ef6ce0726f",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Document.Анкета.StandardAttribute.Posted",
+          "mdoRefRu": "Документ.Анкета.СтандартныйРеквизит.Проведен"
+        },
+        "comment": "",
+        "synonym": {
+          "content": []
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "type": "DOCUMENT",
+          "mdoRef": "Document.Анкета",
+          "mdoRefRu": "Документ.Анкета"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "BOOLEAN"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 0
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "Проведен",
+          "nameEn": "Posted"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "73eff626-a363-4a5a-879e-61ef6ce0726f",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Document.Анкета.StandardAttribute.Ref",
+          "mdoRefRu": "Документ.Анкета.СтандартныйРеквизит.Ссылка"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "ДокументСсылка.Анкета",
+                  "nameEn": "DocumentRef.Анкета"
+                },
+                "variant": "METADATA",
+                "kind": "DOCUMENT"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "fullName": {
+          "nameRu": "Ссылка",
+          "nameEn": "Ref"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "73eff626-a363-4a5a-879e-61ef6ce0726f",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Document.Анкета.StandardAttribute.DeletionMark",
+          "mdoRefRu": "Документ.Анкета.СтандартныйРеквизит.ПометкаУдаления"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+        },
+        "fullName": {
+          "nameRu": "ПометкаУдаления",
+          "nameEn": "DeletionMark"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "73eff626-a363-4a5a-879e-61ef6ce0726f",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Document.Анкета.StandardAttribute.Date",
+          "mdoRefRu": "Документ.Анкета.СтандартныйРеквизит.Дата"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "DATE"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.DateQualifiers": {
+                "dateFractions": 2,
+                "description": {
+                  "value": {
+                    "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                    "nameRu": "КвалификаторыДаты (ДатаВремя)",
+                    "nameEn": "DateQualifiers (DateTime)"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "Дата",
+          "nameEn": "Date"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "73eff626-a363-4a5a-879e-61ef6ce0726f",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Document.Анкета.StandardAttribute.Number",
+          "mdoRefRu": "Документ.Анкета.СтандартныйРеквизит.Номер"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                "length": 11,
+                "allowedLength": 0,
+                "description": {}
+              }
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "Номер",
+          "nameEn": "Number"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "acf15b79-a6c4-4c46-8013-50d3b223baf6",
+        "name": "Опрос",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Document.Анкета.Attribute.Опрос",
+          "mdoRefRu": "Документ.Анкета.Реквизит.Опрос"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Опрос"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "ДокументСсылка.НазначениеОпросов",
+                  "nameEn": "DocumentRef.НазначениеОпросов"
+                },
+                "variant": "METADATA",
+                "kind": "DOCUMENT"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "f6a29b80-e4c3-4c4f-8e2c-d4dda851d813",
+        "name": "Респондент",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Document.Анкета.Attribute.Респондент",
+          "mdoRefRu": "Документ.Анкета.Реквизит.Респондент"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Респондент"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "ОпределяемыйТип.Респондент",
+                  "nameEn": "DefinedType.Респондент"
+                },
+                "variant": "METADATA",
+                "kind": "DEFINED_TYPE"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "2d8d5d74-2bc0-4282-af66-e4a37694c147",
+        "name": "ДатаРедактирования",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Document.Анкета.Attribute.ДатаРедактирования",
+          "mdoRefRu": "Документ.Анкета.Реквизит.ДатаРедактирования"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Дата редактирования"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[4]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "cfd31341-287b-4684-9ac0-b28b4e066f15",
+        "name": "РедактируемыйРаздел",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Document.Анкета.Attribute.РедактируемыйРаздел",
+          "mdoRefRu": "Документ.Анкета.Реквизит.РедактируемыйРаздел"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Редактируемый раздел"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 2,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "СправочникСсылка.ВопросыШаблонаАнкеты",
+                  "nameEn": "CatalogRef.ВопросыШаблонаАнкеты"
+                },
+                "variant": "METADATA",
+                "kind": "CATALOG"
+              },
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+            }
+          ],
+          "composite": true,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                "length": 10,
+                "allowedLength": 0,
+                "description": {
+                  "value": {
+                    "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                    "nameRu": "КвалификаторыСтроки (10, Переменная)",
+                    "nameEn": "StringQualifiers (10, Variable)"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "81de1b0b-7f2d-4098-ae99-061c6a90dc29",
+        "name": "Комментарий",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Document.Анкета.Attribute.Комментарий",
+          "mdoRefRu": "Документ.Анкета.Реквизит.Комментарий"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Комментарий"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                "length": 0,
+                "allowedLength": 0,
+                "description": {
+                  "value": {
+                    "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                    "nameRu": "КвалификаторыСтроки (0, Переменная)",
+                    "nameEn": "StringQualifiers (0, Variable)"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": true,
+        "extendedEdit": true,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "77c8a065-a8aa-4f39-93b6-c88f4c38ec66",
+        "name": "Интервьюер",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Document.Анкета.Attribute.Интервьюер",
+          "mdoRefRu": "Документ.Анкета.Реквизит.Интервьюер"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Интервьюер"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "ОпределяемыйТип.Интервьюер",
+                  "nameEn": "DefinedType.Интервьюер"
+                },
+                "variant": "METADATA",
+                "kind": "DEFINED_TYPE"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "366fa6da-d3bf-4bb0-9a55-a307f9edee6a",
+        "name": "ШаблонАнкеты",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Document.Анкета.Attribute.ШаблонАнкеты",
+          "mdoRefRu": "Документ.Анкета.Реквизит.ШаблонАнкеты"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Шаблон анкеты"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "СправочникСсылка.ШаблоныАнкет",
+                  "nameEn": "CatalogRef.ШаблоныАнкет"
+                },
+                "variant": "METADATA",
+                "kind": "CATALOG"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "dd0610c8-cd87-4fe2-8a1f-70157132785b",
+        "name": "РежимАнкетирования",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Document.Анкета.Attribute.РежимАнкетирования",
+          "mdoRefRu": "Документ.Анкета.Реквизит.РежимАнкетирования"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Режим анкетирования"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "ПеречислениеСсылка.РежимыАнкетирования",
+                  "nameEn": "EnumRef.РежимыАнкетирования"
+                },
+                "variant": "METADATA",
+                "kind": "ENUM"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      }
+    ],
+    []
+  ],
+  "commands": [],
+  "comment": "",
+  "description": "Анкета",
+  "explanation": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+  },
+  "forms": [
+    [
+      {
+        "uuid": "f829e2a9-5bdb-4171-8b32-8d10d5968813",
+        "name": "ФормаДокумента",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "Document.Анкета.Form.ФормаДокумента",
+          "mdoRefRu": "Документ.Анкета.Форма.ФормаДокумента"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Форма документа"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/Documents/Анкета/Forms/ФормаДокумента/Ext/Form/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+          },
+          "handlers": [
+            [
+              {
+                "event": "AfterWrite",
+                "name": "ПослеЗаписи"
+              },
+              {
+                "event": "AfterWriteAtServer",
+                "name": "ПослеЗаписиНаСервере"
+              },
+              {
+                "event": "OnReadAtServer",
+                "name": "ПриЧтенииНаСервере"
+              },
+              {
+                "event": "OnOpen",
+                "name": "ПриОткрытии"
+              },
+              {
+                "event": "BeforeClose",
+                "name": "ПередЗакрытием"
+              },
+              {
+                "event": "BeforeWriteAtServer",
+                "name": "ПередЗаписьюНаСервере"
+              },
+              {
+                "event": "OnCreateAtServer",
+                "name": "ПриСозданииНаСервере"
+              }
+            ],
+            []
+          ],
+          "items": [
+            [
+              {
+                "type": "COMMAND_BAR",
+                "id": 182,
+                "name": "КоманднаяПанельШапка",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Командная панель шапка"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "BUTTON_GROUP",
+                      "id": 190,
+                      "name": "ФормаГруппаКомандыФормы",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Форма группа команды формы"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "COMMAND_BAR_BUTTON",
+                            "id": 92,
+                            "name": "ФормаЗаполненияЗавершитьИЗакрыть",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Завершить и закрыть"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "COMMAND_BAR_BUTTON",
+                            "id": 91,
+                            "name": "ФормаЗаполненияЗаписать",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Сохранить анкету"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "COMMAND_BAR_BUTTON",
+                      "id": 86,
+                      "name": "ФормаКоманднаяПанельПровестиИЗакрыть",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "COMMAND_BAR_BUTTON",
+                      "id": 192,
+                      "name": "Провести",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "COMMAND_BAR_BUTTON",
+                      "id": 87,
+                      "name": "ФормаКоманднаяПанельЗаписать",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "COMMAND_BAR_BUTTON",
+                      "id": 156,
+                      "name": "СкрытьПоказатьДеревоРазделов",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Показать разделы"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "BUTTON_GROUP",
+                      "id": 223,
+                      "name": "ГруппаНавигация",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Навигация"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "COMMAND_BAR_BUTTON",
+                            "id": 163,
+                            "name": "ПредыдущийРаздел",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Назад"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "COMMAND_BAR_BUTTON",
+                            "id": 165,
+                            "name": "СледующийРаздел",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Далее"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "COMMAND_BAR_BUTTON",
+                      "id": 215,
+                      "name": "ФормаПеречитать",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "COMMAND_BAR_BUTTON",
+                      "id": 219,
+                      "name": "ФормаОтменаПроведения",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "COMMAND_BAR_BUTTON",
+                      "id": 217,
+                      "name": "ФормаУстановитьПометкуУдаления",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "BUTTON_GROUP",
+                      "id": 186,
+                      "name": "ФормаГлобальныеКоманды",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Форма глобальные команды"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "POPUP",
+                      "id": 188,
+                      "name": "ПодменюПечать",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Печать"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "BUTTON_GROUP",
+                      "id": 204,
+                      "name": "ПодменюАнкетирование",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Подменю анкетирование"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "COMMAND_BAR_BUTTON",
+                      "id": 194,
+                      "name": "ПоказатьВСпискеАнкета",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "COMMAND_BAR_BUTTON",
+                      "id": 93,
+                      "name": "Справка",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 15,
+                "name": "ГруппаОсновныеРеквизиты",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Основные реквизиты"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 184,
+                      "name": "ГруппаШапкаЛево",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Шапка лево"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 2,
+                            "name": "ГруппаНомерДата",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Номер дата"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 3,
+                                  "name": "Номер",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                  },
+                                  "dataPath": "Объект.Number",
+                                  "items": []
+                                },
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 5,
+                                  "name": "Дата",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                  },
+                                  "dataPath": "Объект.Date",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 212,
+                            "name": "РежимАнкетирования",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                            },
+                            "dataPath": "Объект.РежимАнкетирования",
+                            "items": []
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 10,
+                            "name": "Опрос",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                            },
+                            "dataPath": "Объект.Опрос",
+                            "items": []
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 206,
+                            "name": "ШаблонАнкеты",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                            },
+                            "dataPath": "Объект.ШаблонАнкеты",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 37,
+                      "name": "ГруппаШапкаПраво",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Шапка право"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 66,
+                            "name": "ДатаРедактирования",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                            },
+                            "dataPath": "Объект.ДатаРедактирования",
+                            "items": []
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 12,
+                            "name": "Респондент",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                            },
+                            "dataPath": "Объект.Респондент",
+                            "items": []
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 209,
+                            "name": "Интервьюер",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                            },
+                            "dataPath": "Объект.Интервьюер",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 158,
+                "name": "ГруппаЗаполнение",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Заполнение"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": []
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 68,
+                "name": "ГруппаДеревоРазделовФормаЗаполнения",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Дерево разделов форма заполнения"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 77,
+                      "name": "ГруппаДеревоРазделов",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Дерево разделов"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        {
+                          "type": "TABLE",
+                          "id": 69,
+                          "name": "ДеревоРазделов",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.Document/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                          },
+                          "dataPath": "ДеревоРазделов",
+                          "items": [
+                            {
+                              "type": "LABEL_FIELD",
+                              "id": 72,
+                              "name": "ДеревоРазделовФормулировка",
+                              "title": {
+                                "content": [
+                                  {
+                                    "default": {
+                                      "tag": 2
+                                    },
+                                    "int": 1,
+                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                      "langKey": "ru",
+                                      "value": "Раздел"
+                                    }
+                                  }
+                                ]
+                              },
+                              "dataPath": "ДеревоРазделов.Формулировка",
+                              "items": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 43,
+                      "name": "ГруппаТелоАнкеты",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Тело анкеты"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        {
+                          "type": "LABEL_DECORATION",
+                          "id": 78,
+                          "name": "НадписьВступление",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                          },
+                          "dataPath": "",
+                          "items": []
+                        }
+                      ]
+                    },
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 95,
+                      "name": "ГруппаОжидание",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Ожидание"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 103,
+                          "name": "ГруппаОжиданиеЭлементы",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Ожидание элементы"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "PICTURE_DECORATION",
+                                "id": 96,
+                                "name": "ДекорацияОжиданиеЭлементы",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Декорация ожидание элементы"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": []
+                              },
+                              {
+                                "type": "PICTURE_DECORATION",
+                                "id": 98,
+                                "name": "КартинкаДлительныйПроцесс",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Подождите пожалуйста…\nОткрывается раздел анкеты"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": []
+                              },
+                              {
+                                "type": "LABEL_DECORATION",
+                                "id": 100,
+                                "name": "НадписьПодождите",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Подождите пожалуйста…    Открывается раздел анкеты\n"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": []
+                              }
+                            ],
+                            []
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 229,
+                "name": "ГруппаКоманднаяПанель",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Командная панель"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  {
+                    "type": "COMMAND_BAR",
+                    "id": 176,
+                    "name": "КоманднаяПанельПодвал",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Командная панель подвал"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "COMMAND_BAR_BUTTON",
+                          "id": 227,
+                          "name": "СкрытьПоказатьДеревоРазделовПодвал",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.Document/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/title"
+                          },
+                          "dataPath": "",
+                          "items": []
+                        },
+                        {
+                          "type": "BUTTON_GROUP",
+                          "id": 225,
+                          "name": "ГруппаНавигацияПодвал",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Навигация подвал"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "COMMAND_BAR_BUTTON",
+                                "id": 107,
+                                "name": "ПредыдущийРазделПодвал",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "< Назад"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": []
+                              },
+                              {
+                                "type": "COMMAND_BAR_BUTTON",
+                                "id": 108,
+                                "name": "СледующийРазделПодвал",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[6]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                },
+                                "dataPath": "",
+                                "items": []
+                              }
+                            ],
+                            []
+                          ]
+                        }
+                      ],
+                      []
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 221,
+                "name": "ГруппаПодвал",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Подвал"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  {
+                    "type": "INPUT_FIELD",
+                    "id": 111,
+                    "name": "Комментарий",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                    },
+                    "dataPath": "Объект.Комментарий",
+                    "items": []
+                  }
+                ]
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "Объект",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "ДокументОбъект.Анкета",
+                          "nameEn": "DocumentObject.Анкета"
+                        },
+                        "variant": "METADATA",
+                        "kind": "DOCUMENT"
+                      }
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 4,
+                "name": "ОтборРеспондентов",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "VALUE_LIST"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 5,
+                "name": "ИмяМетаданныхРеспондент",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[5]/type"
+                }
+              },
+              {
+                "id": 2,
+                "name": "ВозможностьПредварительногоСохранения",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              },
+              {
+                "id": 6,
+                "name": "ШаблонАнкеты",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[7]/type"
+                }
+              },
+              {
+                "id": 7,
+                "name": "ВопросыПредставлениеТипы",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "VALUE_TABLE"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 8,
+                "name": "ТаблицаВопросовРаздела",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[6]/type"
+                }
+              },
+              {
+                "id": 9,
+                "name": "ВариантыОтветовНаВопросы",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[6]/type"
+                }
+              },
+              {
+                "id": 10,
+                "name": "ПодчиненныеВопросы",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[6]/type"
+                }
+              },
+              {
+                "id": 12,
+                "name": "ДеревоРазделов",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "VALUE_TREE"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 13,
+                "name": "ДобавленныеДинамическиРеквизиты",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[2]/type"
+                }
+              },
+              {
+                "id": 3,
+                "name": "Вступление",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[5]/type"
+                }
+              },
+              {
+                "id": 14,
+                "name": "Заключение",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[5]/type"
+                }
+              },
+              {
+                "id": 15,
+                "name": "НомерТекущегоРаздела",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                        "precision": 10,
+                        "scale": 0,
+                        "nonNegative": true,
+                        "description": {}
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 11,
+                "name": "ПредыдущийРазделБезВопросов",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              },
+              {
+                "id": 16,
+                "name": "ИмяЭлементаДляПозиционирования",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                        "length": 200,
+                        "allowedLength": 0,
+                        "description": {}
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 17,
+                "name": "ЭтоСеансОбычногоПользователя",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              },
+              {
+                "id": 20,
+                "name": "ПараметрыПодключаемыхКоманд",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "types": [],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "647ba8f8-57f7-4c19-af59-525517c1e392",
+        "name": "ФормаСписка",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "Document.Анкета.Form.ФормаСписка",
+          "mdoRefRu": "Документ.Анкета.Форма.ФормаСписка"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Форма списка"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/Documents/Анкета/Forms/ФормаСписка/Ext/Form/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+          },
+          "handlers": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[7]"
+            }
+          ],
+          "items": [
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 23,
+                "name": "ГруппаПользовательскихНастроек",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Группа пользовательских настроек"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": []
+              },
+              {
+                "type": "TABLE",
+                "id": 1,
+                "name": "Список",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Список"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "Список",
+                "items": [
+                  [
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 6,
+                      "name": "Номер",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.Номер",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 4,
+                      "name": "Дата",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.Дата",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 34,
+                      "name": "РежимАнкетирования",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Режим"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "Список.РежимАнкетирования",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 37,
+                      "name": "ШаблонАнкеты",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Шаблон"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "Список.ШаблонАнкеты",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 8,
+                      "name": "Опрос",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.Опрос",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 10,
+                      "name": "Респондент",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.Респондент",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 12,
+                      "name": "ДатаРедактирования",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.ДатаРедактирования",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 20,
+                      "name": "Ссылка",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.Ссылка",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            {
+              "id": 1,
+              "name": "Список",
+              "title": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "type": {
+                "types": [
+                  {
+                    "default": {
+                      "tag": 4
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.value.V8ValueType": "DYNAMIC_LIST"
+                  }
+                ],
+                "composite": false,
+                "qualifiers": []
+              }
+            }
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      }
+    ],
+    []
+  ],
+  "mdoReference": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+  },
+  "mdoType": "DOCUMENT",
+  "moduleTypes": [
+    [
+      "ManagerModule",
+      [
+        "src/test/resources/ext/designer/ssl_3_2/src/cf/Documents/Анкета/Ext/ManagerModule.bsl"
+      ]
+    ],
+    [
+      "ObjectModule",
+      [
+        "src/test/resources/ext/designer/ssl_3_2/src/cf/Documents/Анкета/Ext/ObjectModule.bsl"
+      ]
+    ]
+  ],
+  "modules": [
+    {
+      "moduleType": "ManagerModule",
+      "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/Documents/Анкета/Ext/ManagerModule.bsl",
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "isProtected": false
+    },
+    {
+      "moduleType": "ObjectModule",
+      "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/Documents/Анкета/Ext/ObjectModule.bsl",
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "isProtected": false
+    }
+  ],
+  "name": "Анкета",
+  "objectBelonging": "OWN",
+  "possibleRights": [
+    {
+      "default": {
+        "tag": 4
+      },
+      "int": 27,
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INSERT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "DELETE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "VIEW",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "EDIT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INPUT_BY_STRING",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "POSTING",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UNDO_POSTING",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_DELETE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_INSERT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_SET_DELETION_MARK",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_CLEAR_DELETION_MARK",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_DELETE_MARKED",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_POSTING",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_POSTING_REGULAR",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_UNDO_POSTING",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_CHANGE_OF_POSTED",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "VIEW_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ_DATA_HISTORY_OF_MISSING_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_OF_MISSING_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_SETTINGS",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_VERSION_COMMENT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "EDIT_DATA_HISTORY_VERSION_COMMENT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "SWITCH_TO_DATA_HISTORY_VERSION"
+    }
+  ],
+  "registerRecords": [
+    {
+      "type": "INFORMATION_REGISTER",
+      "mdoRef": "InformationRegister.ОтветыНаВопросыАнкет",
+      "mdoRefRu": "РегистрСведений.ОтветыНаВопросыАнкет"
+    }
+  ],
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "content": [
+      {
+        "default": {
+          "tag": 2
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+          "langKey": "ru",
+          "value": "Анкета"
+        }
+      }
+    ]
+  },
+  "tabularSections": [
+    {
+      "uuid": "39062cb3-4ae8-4c0d-889b-038a55179946",
+      "name": "Состав",
+      "mdoReference": {
+        "type": "TABULAR_SECTION",
+        "mdoRef": "Document.Анкета.TabularSection.Состав",
+        "mdoRefRu": "Документ.Анкета.ТабличнаяЧасть.Состав"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": [
+          {
+            "default": {
+              "tag": 2
+            },
+            "int": 1,
+            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+              "langKey": "ru",
+              "value": "Состав"
+            }
+          }
+        ]
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+      },
+      "attributes": [
+        [
+          {
+            "uuid": "39062cb3-4ae8-4c0d-889b-038a55179946",
+            "mdoReference": {
+              "type": "STANDARD_ATTRIBUTE",
+              "mdoRef": "Document.Анкета.TabularSection.Состав.StandardAttribute.LineNumber",
+              "mdoRefRu": "Документ.Анкета.ТабличнаяЧасть.Состав.СтандартныйРеквизит.НомерСтроки"
+            },
+            "comment": "",
+            "synonym": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+            },
+            "passwordMode": false,
+            "kind": "STANDARD",
+            "type": {
+              "types": [
+                {
+                  "default": {
+                    "tag": 4
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER"
+                }
+              ],
+              "composite": false,
+              "qualifiers": [
+                {
+                  "default": {
+                    "tag": 4
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                    "precision": 5,
+                    "scale": 0,
+                    "nonNegative": false,
+                    "description": {}
+                  }
+                }
+              ]
+            },
+            "fullName": {
+              "nameRu": "НомерСтроки",
+              "nameEn": "LineNumber"
+            },
+            "format": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "editFormat": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "markNegatives": false,
+            "mask": "",
+            "multiLine": false,
+            "extendedEdit": false,
+            "fillFromFillingValue": false
+          },
+          {
+            "uuid": "c62d4212-36ca-4afb-bac9-269b6f64ca51",
+            "name": "Вопрос",
+            "mdoReference": {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.Анкета.TabularSection.Состав.Attribute.Вопрос",
+              "mdoRefRu": "Документ.Анкета.ТабличнаяЧасть.Состав.Реквизит.Вопрос"
+            },
+            "objectBelonging": "OWN",
+            "comment": "",
+            "synonym": {
+              "content": [
+                {
+                  "default": {
+                    "tag": 2
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                    "langKey": "ru",
+                    "value": "Вопрос"
+                  }
+                }
+              ]
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+            },
+            "passwordMode": false,
+            "kind": "CUSTOM",
+            "indexing": "DONT_INDEX",
+            "type": {
+              "types": [
+                {
+                  "default": {
+                    "tag": 4
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                    "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[4]/type/types/java.util.CollSer/com.github._1c_syntax.bsl.types.value.CustomValueType"
+                  }
+                }
+              ],
+              "composite": false,
+              "qualifiers": []
+            },
+            "format": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "editFormat": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "markNegatives": false,
+            "mask": "",
+            "multiLine": false,
+            "extendedEdit": false,
+            "fillFromFillingValue": false
+          },
+          {
+            "uuid": "5cec5e16-46ad-4f8c-b869-f5b1cc487884",
+            "name": "ЭлементарныйВопрос",
+            "mdoReference": {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.Анкета.TabularSection.Состав.Attribute.ЭлементарныйВопрос",
+              "mdoRefRu": "Документ.Анкета.ТабличнаяЧасть.Состав.Реквизит.ЭлементарныйВопрос"
+            },
+            "objectBelonging": "OWN",
+            "comment": "",
+            "synonym": {
+              "content": [
+                {
+                  "default": {
+                    "tag": 2
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                    "langKey": "ru",
+                    "value": "Элементарный вопрос"
+                  }
+                }
+              ]
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+            },
+            "passwordMode": false,
+            "kind": "CUSTOM",
+            "indexing": "DONT_INDEX",
+            "type": {
+              "types": [
+                {
+                  "default": {
+                    "tag": 4
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                    "fullName": {
+                      "nameRu": "ПланВидовХарактеристикСсылка.ВопросыДляАнкетирования",
+                      "nameEn": "ChartOfCharacteristicTypesRef.ВопросыДляАнкетирования"
+                    },
+                    "variant": "METADATA",
+                    "kind": "CHART_OF_CHARACTERISTIC_TYPES"
+                  }
+                }
+              ],
+              "composite": false,
+              "qualifiers": []
+            },
+            "format": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "editFormat": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "markNegatives": false,
+            "mask": "",
+            "multiLine": false,
+            "extendedEdit": false,
+            "fillFromFillingValue": false
+          },
+          {
+            "uuid": "ca0363bb-81c2-4fce-b2f0-e8f42d118a74",
+            "name": "НомерЯчейки",
+            "mdoReference": {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.Анкета.TabularSection.Состав.Attribute.НомерЯчейки",
+              "mdoRefRu": "Документ.Анкета.ТабличнаяЧасть.Состав.Реквизит.НомерЯчейки"
+            },
+            "objectBelonging": "OWN",
+            "comment": "",
+            "synonym": {
+              "content": [
+                {
+                  "default": {
+                    "tag": 2
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                    "langKey": "ru",
+                    "value": "Номер ячейки"
+                  }
+                }
+              ]
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+            },
+            "passwordMode": false,
+            "kind": "CUSTOM",
+            "indexing": "DONT_INDEX",
+            "type": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[14]/type"
+            },
+            "format": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "editFormat": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "markNegatives": false,
+            "mask": "",
+            "multiLine": false,
+            "extendedEdit": false,
+            "fillFromFillingValue": false
+          },
+          {
+            "uuid": "7aacdf81-49fd-47a3-a36a-c483f1b05872",
+            "name": "Ответ",
+            "mdoReference": {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.Анкета.TabularSection.Состав.Attribute.Ответ",
+              "mdoRefRu": "Документ.Анкета.ТабличнаяЧасть.Состав.Реквизит.Ответ"
+            },
+            "objectBelonging": "OWN",
+            "comment": "",
+            "synonym": {
+              "content": [
+                {
+                  "default": {
+                    "tag": 2
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                    "langKey": "ru",
+                    "value": "Ответ"
+                  }
+                }
+              ]
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+            },
+            "passwordMode": false,
+            "kind": "CUSTOM",
+            "indexing": "DONT_INDEX",
+            "type": {
+              "types": [
+                {
+                  "default": {
+                    "tag": 4
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                    "fullName": {
+                      "nameRu": "Характеристика.ВопросыДляАнкетирования",
+                      "nameEn": "Characteristic.ВопросыДляАнкетирования"
+                    },
+                    "variant": "METADATA",
+                    "kind": "CHART_OF_CHARACTERISTIC_TYPES"
+                  }
+                }
+              ],
+              "composite": false,
+              "qualifiers": []
+            },
+            "format": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "editFormat": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "markNegatives": false,
+            "mask": "",
+            "multiLine": false,
+            "extendedEdit": false,
+            "fillFromFillingValue": false
+          },
+          {
+            "uuid": "857015e2-afb2-403d-bfb7-7acb5080797b",
+            "name": "ОткрытыйОтвет",
+            "mdoReference": {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.Анкета.TabularSection.Состав.Attribute.ОткрытыйОтвет",
+              "mdoRefRu": "Документ.Анкета.ТабличнаяЧасть.Состав.Реквизит.ОткрытыйОтвет"
+            },
+            "objectBelonging": "OWN",
+            "comment": "",
+            "synonym": {
+              "content": [
+                {
+                  "default": {
+                    "tag": 2
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                    "langKey": "ru",
+                    "value": "Открытый ответ"
+                  }
+                }
+              ]
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+            },
+            "passwordMode": false,
+            "kind": "CUSTOM",
+            "indexing": "DONT_INDEX",
+            "type": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[5]/type"
+            },
+            "format": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "editFormat": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "markNegatives": false,
+            "mask": "",
+            "multiLine": false,
+            "extendedEdit": false,
+            "fillFromFillingValue": false
+          },
+          {
+            "uuid": "100ec1d0-3719-4feb-8a66-02f2c89fcd36",
+            "name": "БезОтвета",
+            "mdoReference": {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.Анкета.TabularSection.Состав.Attribute.БезОтвета",
+              "mdoRefRu": "Документ.Анкета.ТабличнаяЧасть.Состав.Реквизит.БезОтвета"
+            },
+            "objectBelonging": "OWN",
+            "comment": "",
+            "synonym": {
+              "content": [
+                {
+                  "default": {
+                    "tag": 2
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                    "langKey": "ru",
+                    "value": "Без ответа"
+                  }
+                }
+              ]
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+            },
+            "passwordMode": false,
+            "kind": "CUSTOM",
+            "indexing": "DONT_INDEX",
+            "type": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+            },
+            "format": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "editFormat": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "markNegatives": false,
+            "mask": "",
+            "multiLine": false,
+            "extendedEdit": false,
+            "fillFromFillingValue": false
+          }
+        ],
+        []
+      ]
+    }
+  ],
+  "templates": [],
+  "uuid": "73eff626-a363-4a5a-879e-61ef6ce0726f"
+}}

--- a/src/test/resources/fixtures/ssl_3_2/Documents.Анкета.json
+++ b/src/test/resources/fixtures/ssl_3_2/Documents.Анкета.json
@@ -872,9 +872,9 @@
           "items": [
             [
               {
-                "type": "COMMAND_BAR",
-                "id": 182,
-                "name": "КоманднаяПанельШапка",
+                "type": "PAGES",
+                "id": 257,
+                "name": "Страницы",
                 "title": {
                   "content": [
                     {
@@ -884,7 +884,7 @@
                       "int": 1,
                       "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                         "langKey": "ru",
-                        "value": "Командная панель шапка"
+                        "value": "Страницы"
                       }
                     }
                   ]
@@ -893,9 +893,9 @@
                 "items": [
                   [
                     {
-                      "type": "BUTTON_GROUP",
-                      "id": 190,
-                      "name": "ФормаГруппаКомандыФормы",
+                      "type": "PAGE",
+                      "id": 259,
+                      "name": "СтраницаГлавное",
                       "title": {
                         "content": [
                           {
@@ -905,617 +905,7 @@
                             "int": 1,
                             "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                               "langKey": "ru",
-                              "value": "Форма группа команды формы"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "COMMAND_BAR_BUTTON",
-                            "id": 92,
-                            "name": "ФормаЗаполненияЗавершитьИЗакрыть",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Завершить и закрыть"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "COMMAND_BAR_BUTTON",
-                            "id": 91,
-                            "name": "ФормаЗаполненияЗаписать",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Сохранить анкету"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": []
-                          }
-                        ],
-                        []
-                      ]
-                    },
-                    {
-                      "type": "COMMAND_BAR_BUTTON",
-                      "id": 86,
-                      "name": "ФормаКоманднаяПанельПровестиИЗакрыть",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "COMMAND_BAR_BUTTON",
-                      "id": 192,
-                      "name": "Провести",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "COMMAND_BAR_BUTTON",
-                      "id": 87,
-                      "name": "ФормаКоманднаяПанельЗаписать",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "COMMAND_BAR_BUTTON",
-                      "id": 156,
-                      "name": "СкрытьПоказатьДеревоРазделов",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Показать разделы"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "BUTTON_GROUP",
-                      "id": 223,
-                      "name": "ГруппаНавигация",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Навигация"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "COMMAND_BAR_BUTTON",
-                            "id": 163,
-                            "name": "ПредыдущийРаздел",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Назад"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "COMMAND_BAR_BUTTON",
-                            "id": 165,
-                            "name": "СледующийРаздел",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Далее"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": []
-                          }
-                        ],
-                        []
-                      ]
-                    },
-                    {
-                      "type": "COMMAND_BAR_BUTTON",
-                      "id": 215,
-                      "name": "ФормаПеречитать",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "COMMAND_BAR_BUTTON",
-                      "id": 219,
-                      "name": "ФормаОтменаПроведения",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "COMMAND_BAR_BUTTON",
-                      "id": 217,
-                      "name": "ФормаУстановитьПометкуУдаления",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "BUTTON_GROUP",
-                      "id": 186,
-                      "name": "ФормаГлобальныеКоманды",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Форма глобальные команды"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "POPUP",
-                      "id": 188,
-                      "name": "ПодменюПечать",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Печать"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "BUTTON_GROUP",
-                      "id": 204,
-                      "name": "ПодменюАнкетирование",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Подменю анкетирование"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "COMMAND_BAR_BUTTON",
-                      "id": 194,
-                      "name": "ПоказатьВСпискеАнкета",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "COMMAND_BAR_BUTTON",
-                      "id": 93,
-                      "name": "Справка",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    }
-                  ],
-                  []
-                ]
-              },
-              {
-                "type": "USUAL_GROUP",
-                "id": 15,
-                "name": "ГруппаОсновныеРеквизиты",
-                "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Основные реквизиты"
-                      }
-                    }
-                  ]
-                },
-                "dataPath": "",
-                "items": [
-                  [
-                    {
-                      "type": "USUAL_GROUP",
-                      "id": 184,
-                      "name": "ГруппаШапкаЛево",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Шапка лево"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "USUAL_GROUP",
-                            "id": 2,
-                            "name": "ГруппаНомерДата",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Номер дата"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": [
-                              [
-                                {
-                                  "type": "INPUT_FIELD",
-                                  "id": 3,
-                                  "name": "Номер",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                  },
-                                  "dataPath": "Объект.Number",
-                                  "items": []
-                                },
-                                {
-                                  "type": "INPUT_FIELD",
-                                  "id": 5,
-                                  "name": "Дата",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                  },
-                                  "dataPath": "Объект.Date",
-                                  "items": []
-                                }
-                              ],
-                              []
-                            ]
-                          },
-                          {
-                            "type": "INPUT_FIELD",
-                            "id": 212,
-                            "name": "РежимАнкетирования",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                            },
-                            "dataPath": "Объект.РежимАнкетирования",
-                            "items": []
-                          },
-                          {
-                            "type": "INPUT_FIELD",
-                            "id": 10,
-                            "name": "Опрос",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                            },
-                            "dataPath": "Объект.Опрос",
-                            "items": []
-                          },
-                          {
-                            "type": "INPUT_FIELD",
-                            "id": 206,
-                            "name": "ШаблонАнкеты",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                            },
-                            "dataPath": "Объект.ШаблонАнкеты",
-                            "items": []
-                          }
-                        ],
-                        []
-                      ]
-                    },
-                    {
-                      "type": "USUAL_GROUP",
-                      "id": 37,
-                      "name": "ГруппаШапкаПраво",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Шапка право"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "INPUT_FIELD",
-                            "id": 66,
-                            "name": "ДатаРедактирования",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                            },
-                            "dataPath": "Объект.ДатаРедактирования",
-                            "items": []
-                          },
-                          {
-                            "type": "INPUT_FIELD",
-                            "id": 12,
-                            "name": "Респондент",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                            },
-                            "dataPath": "Объект.Респондент",
-                            "items": []
-                          },
-                          {
-                            "type": "INPUT_FIELD",
-                            "id": 209,
-                            "name": "Интервьюер",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                            },
-                            "dataPath": "Объект.Интервьюер",
-                            "items": []
-                          }
-                        ],
-                        []
-                      ]
-                    }
-                  ],
-                  []
-                ]
-              },
-              {
-                "type": "USUAL_GROUP",
-                "id": 158,
-                "name": "ГруппаЗаполнение",
-                "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Заполнение"
-                      }
-                    }
-                  ]
-                },
-                "dataPath": "",
-                "items": []
-              },
-              {
-                "type": "USUAL_GROUP",
-                "id": 68,
-                "name": "ГруппаДеревоРазделовФормаЗаполнения",
-                "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Дерево разделов форма заполнения"
-                      }
-                    }
-                  ]
-                },
-                "dataPath": "",
-                "items": [
-                  [
-                    {
-                      "type": "USUAL_GROUP",
-                      "id": 77,
-                      "name": "ГруппаДеревоРазделов",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Дерево разделов"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
-                        {
-                          "type": "TABLE",
-                          "id": 69,
-                          "name": "ДеревоРазделов",
-                          "title": {
-                            "@reference": "/com.github._1c_syntax.bsl.mdo.Document/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                          },
-                          "dataPath": "ДеревоРазделов",
-                          "items": [
-                            {
-                              "type": "LABEL_FIELD",
-                              "id": 72,
-                              "name": "ДеревоРазделовФормулировка",
-                              "title": {
-                                "content": [
-                                  {
-                                    "default": {
-                                      "tag": 2
-                                    },
-                                    "int": 1,
-                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                      "langKey": "ru",
-                                      "value": "Раздел"
-                                    }
-                                  }
-                                ]
-                              },
-                              "dataPath": "ДеревоРазделов.Формулировка",
-                              "items": []
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "type": "USUAL_GROUP",
-                      "id": 43,
-                      "name": "ГруппаТелоАнкеты",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Тело анкеты"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
-                        {
-                          "type": "LABEL_DECORATION",
-                          "id": 78,
-                          "name": "НадписьВступление",
-                          "title": {
-                            "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                          },
-                          "dataPath": "",
-                          "items": []
-                        }
-                      ]
-                    },
-                    {
-                      "type": "USUAL_GROUP",
-                      "id": 95,
-                      "name": "ГруппаОжидание",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Ожидание"
+                              "value": "Главное"
                             }
                           }
                         ]
@@ -1524,8 +914,8 @@
                       "items": [
                         {
                           "type": "USUAL_GROUP",
-                          "id": 103,
-                          "name": "ГруппаОжиданиеЭлементы",
+                          "id": 15,
+                          "name": "ГруппаОсновныеРеквизиты",
                           "title": {
                             "content": [
                               {
@@ -1535,7 +925,7 @@
                                 "int": 1,
                                 "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                                   "langKey": "ru",
-                                  "value": "Ожидание элементы"
+                                  "value": "Основные реквизиты"
                                 }
                               }
                             ]
@@ -1544,9 +934,9 @@
                           "items": [
                             [
                               {
-                                "type": "PICTURE_DECORATION",
-                                "id": 96,
-                                "name": "ДекорацияОжиданиеЭлементы",
+                                "type": "USUAL_GROUP",
+                                "id": 2,
+                                "name": "ГруппаНомерДата",
                                 "title": {
                                   "content": [
                                     {
@@ -1556,18 +946,42 @@
                                       "int": 1,
                                       "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                                         "langKey": "ru",
-                                        "value": "Декорация ожидание элементы"
+                                        "value": "Номер дата"
                                       }
                                     }
                                   ]
                                 },
                                 "dataPath": "",
-                                "items": []
+                                "items": [
+                                  [
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 5,
+                                      "name": "Дата",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                      },
+                                      "dataPath": "Объект.Date",
+                                      "items": []
+                                    },
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 3,
+                                      "name": "Номер",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                      },
+                                      "dataPath": "Объект.Number",
+                                      "items": []
+                                    }
+                                  ],
+                                  []
+                                ]
                               },
                               {
-                                "type": "PICTURE_DECORATION",
-                                "id": 98,
-                                "name": "КартинкаДлительныйПроцесс",
+                                "type": "USUAL_GROUP",
+                                "id": 244,
+                                "name": "ГруппаКолонки",
                                 "title": {
                                   "content": [
                                     {
@@ -1577,156 +991,540 @@
                                       "int": 1,
                                       "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                                         "langKey": "ru",
-                                        "value": "Подождите пожалуйста…\nОткрывается раздел анкеты"
+                                        "value": "Колонки"
                                       }
                                     }
                                   ]
                                 },
                                 "dataPath": "",
-                                "items": []
+                                "items": [
+                                  [
+                                    {
+                                      "type": "USUAL_GROUP",
+                                      "id": 184,
+                                      "name": "ГруппаШапкаЛево",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Шапка лево"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        [
+                                          {
+                                            "type": "INPUT_FIELD",
+                                            "id": 12,
+                                            "name": "Респондент",
+                                            "title": {
+                                              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                            },
+                                            "dataPath": "Объект.Респондент",
+                                            "items": []
+                                          },
+                                          {
+                                            "type": "INPUT_FIELD",
+                                            "id": 212,
+                                            "name": "РежимАнкетирования",
+                                            "title": {
+                                              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                            },
+                                            "dataPath": "Объект.РежимАнкетирования",
+                                            "items": []
+                                          },
+                                          {
+                                            "type": "INPUT_FIELD",
+                                            "id": 209,
+                                            "name": "Интервьюер",
+                                            "title": {
+                                              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                            },
+                                            "dataPath": "Объект.Интервьюер",
+                                            "items": []
+                                          }
+                                        ],
+                                        []
+                                      ]
+                                    },
+                                    {
+                                      "type": "USUAL_GROUP",
+                                      "id": 37,
+                                      "name": "ГруппаШапкаПраво",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Шапка право"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        [
+                                          {
+                                            "type": "INPUT_FIELD",
+                                            "id": 206,
+                                            "name": "ШаблонАнкеты",
+                                            "title": {
+                                              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                            },
+                                            "dataPath": "Объект.ШаблонАнкеты",
+                                            "items": []
+                                          },
+                                          {
+                                            "type": "INPUT_FIELD",
+                                            "id": 10,
+                                            "name": "Опрос",
+                                            "title": {
+                                              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                            },
+                                            "dataPath": "Объект.Опрос",
+                                            "items": []
+                                          },
+                                          {
+                                            "type": "INPUT_FIELD",
+                                            "id": 66,
+                                            "name": "ДатаРедактирования",
+                                            "title": {
+                                              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                            },
+                                            "dataPath": "Объект.ДатаРедактирования",
+                                            "items": []
+                                          }
+                                        ],
+                                        []
+                                      ]
+                                    }
+                                  ],
+                                  []
+                                ]
                               },
                               {
-                                "type": "LABEL_DECORATION",
-                                "id": 100,
-                                "name": "НадписьПодождите",
+                                "type": "INPUT_FIELD",
+                                "id": 111,
+                                "name": "Комментарий",
                                 "title": {
-                                  "content": [
-                                    {
-                                      "default": {
-                                        "tag": 2
-                                      },
-                                      "int": 1,
-                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                        "langKey": "ru",
-                                        "value": "Подождите пожалуйста…    Открывается раздел анкеты\n"
-                                      }
-                                    }
-                                  ]
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
                                 },
-                                "dataPath": "",
+                                "dataPath": "Объект.Комментарий",
                                 "items": []
                               }
                             ],
                             []
                           ]
                         }
+                      ]
+                    },
+                    {
+                      "type": "PAGE",
+                      "id": 274,
+                      "name": "СтраницаАнкета",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Анкета"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "COMMAND_BAR",
+                            "id": 266,
+                            "name": "КоманднаяПанельШапка",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Командная панель шапка"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "COMMAND_BAR_BUTTON",
+                                  "id": 227,
+                                  "name": "СкрытьПоказатьДеревоРазделовШапка",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Показать разделы"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "BUTTON_GROUP",
+                                  "id": 272,
+                                  "name": "ГруппаКомандНавигации",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Команд навигации"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "COMMAND_BAR_BUTTON",
+                                        "id": 268,
+                                        "name": "ПредыдущийРаздел",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Назад"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "COMMAND_BAR_BUTTON",
+                                        "id": 270,
+                                        "name": "СледующийРаздел",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Далее"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                }
+                              ],
+                              []
+                            ]
+                          },
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 281,
+                            "name": "ГруппаАнкета",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                            },
+                            "dataPath": "",
+                            "items": [
+                              {
+                                "type": "USUAL_GROUP",
+                                "id": 249,
+                                "name": "ГруппаКолонкиАнкеты",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Колонки анкеты"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "USUAL_GROUP",
+                                      "id": 77,
+                                      "name": "ГруппаДеревоРазделов",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Дерево разделов"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        {
+                                          "type": "TABLE",
+                                          "id": 69,
+                                          "name": "ДеревоРазделов",
+                                          "title": {
+                                            "@reference": "/com.github._1c_syntax.bsl.mdo.Document/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                          },
+                                          "dataPath": "ДеревоРазделов",
+                                          "items": [
+                                            {
+                                              "type": "LABEL_FIELD",
+                                              "id": 72,
+                                              "name": "ДеревоРазделовФормулировка",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Раздел"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "ДеревоРазделов.Формулировка",
+                                              "items": []
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "USUAL_GROUP",
+                                      "id": 95,
+                                      "name": "ГруппаОжидание",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Ожидание"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        {
+                                          "type": "USUAL_GROUP",
+                                          "id": 103,
+                                          "name": "ГруппаОжиданиеЭлементы",
+                                          "title": {
+                                            "content": [
+                                              {
+                                                "default": {
+                                                  "tag": 2
+                                                },
+                                                "int": 1,
+                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                  "langKey": "ru",
+                                                  "value": "Ожидание элементы"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "dataPath": "",
+                                          "items": [
+                                            [
+                                              {
+                                                "type": "PICTURE_DECORATION",
+                                                "id": 98,
+                                                "name": "КартинкаДлительныйПроцесс",
+                                                "title": {
+                                                  "content": [
+                                                    {
+                                                      "default": {
+                                                        "tag": 2
+                                                      },
+                                                      "int": 1,
+                                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                        "langKey": "ru",
+                                                        "value": "Подождите пожалуйста…\nОткрывается раздел анкеты"
+                                                      }
+                                                    }
+                                                  ]
+                                                },
+                                                "dataPath": "",
+                                                "items": []
+                                              },
+                                              {
+                                                "type": "LABEL_DECORATION",
+                                                "id": 100,
+                                                "name": "НадписьПодождите",
+                                                "title": {
+                                                  "content": [
+                                                    {
+                                                      "default": {
+                                                        "tag": 2
+                                                      },
+                                                      "int": 1,
+                                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                        "langKey": "ru",
+                                                        "value": "Подождите пожалуйста…\nОткрывается раздел анкеты\n"
+                                                      }
+                                                    }
+                                                  ]
+                                                },
+                                                "dataPath": "",
+                                                "items": []
+                                              }
+                                            ],
+                                            []
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "USUAL_GROUP",
+                                      "id": 43,
+                                      "name": "ГруппаТелоАнкеты",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Тело анкеты"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        {
+                                          "type": "LABEL_DECORATION",
+                                          "id": 78,
+                                          "name": "НадписьВступление",
+                                          "title": {
+                                            "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                          },
+                                          "dataPath": "",
+                                          "items": []
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  []
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "COMMAND_BAR",
+                            "id": 176,
+                            "name": "КоманднаяПанельПодвал",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Командная панель подвал"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "COMMAND_BAR_BUTTON",
+                                  "id": 107,
+                                  "name": "ПредыдущийРазделПодвал",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Document/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "COMMAND_BAR_BUTTON",
+                                  "id": 108,
+                                  "name": "СледующийРазделПодвал",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Document/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          }
+                        ],
+                        []
                       ]
                     }
                   ],
                   []
-                ]
-              },
-              {
-                "type": "USUAL_GROUP",
-                "id": 229,
-                "name": "ГруппаКоманднаяПанель",
-                "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Командная панель"
-                      }
-                    }
-                  ]
-                },
-                "dataPath": "",
-                "items": [
-                  {
-                    "type": "COMMAND_BAR",
-                    "id": 176,
-                    "name": "КоманднаяПанельПодвал",
-                    "title": {
-                      "content": [
-                        {
-                          "default": {
-                            "tag": 2
-                          },
-                          "int": 1,
-                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                            "langKey": "ru",
-                            "value": "Командная панель подвал"
-                          }
-                        }
-                      ]
-                    },
-                    "dataPath": "",
-                    "items": [
-                      [
-                        {
-                          "type": "COMMAND_BAR_BUTTON",
-                          "id": 227,
-                          "name": "СкрытьПоказатьДеревоРазделовПодвал",
-                          "title": {
-                            "@reference": "/com.github._1c_syntax.bsl.mdo.Document/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/title"
-                          },
-                          "dataPath": "",
-                          "items": []
-                        },
-                        {
-                          "type": "BUTTON_GROUP",
-                          "id": 225,
-                          "name": "ГруппаНавигацияПодвал",
-                          "title": {
-                            "content": [
-                              {
-                                "default": {
-                                  "tag": 2
-                                },
-                                "int": 1,
-                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                  "langKey": "ru",
-                                  "value": "Навигация подвал"
-                                }
-                              }
-                            ]
-                          },
-                          "dataPath": "",
-                          "items": [
-                            [
-                              {
-                                "type": "COMMAND_BAR_BUTTON",
-                                "id": 107,
-                                "name": "ПредыдущийРазделПодвал",
-                                "title": {
-                                  "content": [
-                                    {
-                                      "default": {
-                                        "tag": 2
-                                      },
-                                      "int": 1,
-                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                        "langKey": "ru",
-                                        "value": "< Назад"
-                                      }
-                                    }
-                                  ]
-                                },
-                                "dataPath": "",
-                                "items": []
-                              },
-                              {
-                                "type": "COMMAND_BAR_BUTTON",
-                                "id": 108,
-                                "name": "СледующийРазделПодвал",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[6]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                                },
-                                "dataPath": "",
-                                "items": []
-                              }
-                            ],
-                            []
-                          ]
-                        }
-                      ],
-                      []
-                    ]
-                  }
                 ]
               },
               {
@@ -1748,18 +1546,7 @@
                   ]
                 },
                 "dataPath": "",
-                "items": [
-                  {
-                    "type": "INPUT_FIELD",
-                    "id": 111,
-                    "name": "Комментарий",
-                    "title": {
-                      "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                    },
-                    "dataPath": "Объект.Комментарий",
-                    "items": []
-                  }
-                ]
+                "items": []
               }
             ],
             []
@@ -1897,7 +1684,7 @@
                 "id": 12,
                 "name": "ДеревоРазделов",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "types": [
@@ -2376,18 +2163,7 @@
   ],
   "supportVariant": "NOT_EDITABLE",
   "synonym": {
-    "content": [
-      {
-        "default": {
-          "tag": 2
-        },
-        "int": 1,
-        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-          "langKey": "ru",
-          "value": "Анкета"
-        }
-      }
-    ]
+    "@reference": "/com.github._1c_syntax.bsl.mdo.Document/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
   },
   "tabularSections": [
     {

--- a/src/test/resources/fixtures/ssl_3_2/Documents.Анкета_edt.json
+++ b/src/test/resources/fixtures/ssl_3_2/Documents.Анкета_edt.json
@@ -856,9 +856,9 @@
           "items": [
             [
               {
-                "type": "COMMAND_BAR",
-                "id": 182,
-                "name": "КоманднаяПанельШапка",
+                "type": "PAGES",
+                "id": 257,
+                "name": "Страницы",
                 "title": {
                   "content": [
                     {
@@ -868,7 +868,7 @@
                       "int": 1,
                       "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                         "langKey": "ru",
-                        "value": "Командная панель шапка"
+                        "value": "Страницы"
                       }
                     }
                   ]
@@ -877,9 +877,9 @@
                 "items": [
                   [
                     {
-                      "type": "FORM_GROUP",
-                      "id": 190,
-                      "name": "ФормаГруппаКомандыФормы",
+                      "type": "PAGE",
+                      "id": 259,
+                      "name": "СтраницаГлавное",
                       "title": {
                         "content": [
                           {
@@ -889,617 +889,7 @@
                             "int": 1,
                             "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                               "langKey": "ru",
-                              "value": "Форма группа команды формы"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "BUTTON",
-                            "id": 92,
-                            "name": "ФормаЗаполненияЗавершитьИЗакрыть",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Завершить и закрыть"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "BUTTON",
-                            "id": 91,
-                            "name": "ФормаЗаполненияЗаписать",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Сохранить анкету"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": []
-                          }
-                        ],
-                        []
-                      ]
-                    },
-                    {
-                      "type": "BUTTON",
-                      "id": 86,
-                      "name": "ФормаКоманднаяПанельПровестиИЗакрыть",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "BUTTON",
-                      "id": 192,
-                      "name": "Провести",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "BUTTON",
-                      "id": 87,
-                      "name": "ФормаКоманднаяПанельЗаписать",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "BUTTON",
-                      "id": 156,
-                      "name": "СкрытьПоказатьДеревоРазделов",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Показать разделы"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "FORM_GROUP",
-                      "id": 223,
-                      "name": "ГруппаНавигация",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Навигация"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "BUTTON",
-                            "id": 163,
-                            "name": "ПредыдущийРаздел",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Назад"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "BUTTON",
-                            "id": 165,
-                            "name": "СледующийРаздел",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Далее"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": []
-                          }
-                        ],
-                        []
-                      ]
-                    },
-                    {
-                      "type": "BUTTON",
-                      "id": 215,
-                      "name": "ФормаПеречитать",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "BUTTON",
-                      "id": 219,
-                      "name": "ФормаОтменаПроведения",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "BUTTON",
-                      "id": 217,
-                      "name": "ФормаУстановитьПометкуУдаления",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "FORM_GROUP",
-                      "id": 186,
-                      "name": "ФормаГлобальныеКоманды",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Форма глобальные команды"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "POPUP",
-                      "id": 188,
-                      "name": "ПодменюПечать",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Печать"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "FORM_GROUP",
-                      "id": 204,
-                      "name": "ПодменюАнкетирование",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Подменю анкетирование"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "BUTTON",
-                      "id": 194,
-                      "name": "ПоказатьВСпискеАнкета",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "BUTTON",
-                      "id": 93,
-                      "name": "Справка",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    }
-                  ],
-                  []
-                ]
-              },
-              {
-                "type": "USUAL_GROUP",
-                "id": 15,
-                "name": "ГруппаОсновныеРеквизиты",
-                "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Основные реквизиты"
-                      }
-                    }
-                  ]
-                },
-                "dataPath": "",
-                "items": [
-                  [
-                    {
-                      "type": "USUAL_GROUP",
-                      "id": 184,
-                      "name": "ГруппаШапкаЛево",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Шапка лево"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "USUAL_GROUP",
-                            "id": 2,
-                            "name": "ГруппаНомерДата",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Номер дата"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": [
-                              [
-                                {
-                                  "type": "INPUT_FIELD",
-                                  "id": 3,
-                                  "name": "Номер",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                  },
-                                  "dataPath": "Объект.Number",
-                                  "items": []
-                                },
-                                {
-                                  "type": "INPUT_FIELD",
-                                  "id": 5,
-                                  "name": "Дата",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                                  },
-                                  "dataPath": "Объект.Date",
-                                  "items": []
-                                }
-                              ],
-                              []
-                            ]
-                          },
-                          {
-                            "type": "INPUT_FIELD",
-                            "id": 212,
-                            "name": "РежимАнкетирования",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                            },
-                            "dataPath": "Объект.РежимАнкетирования",
-                            "items": []
-                          },
-                          {
-                            "type": "INPUT_FIELD",
-                            "id": 10,
-                            "name": "Опрос",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                            },
-                            "dataPath": "Объект.Опрос",
-                            "items": []
-                          },
-                          {
-                            "type": "INPUT_FIELD",
-                            "id": 206,
-                            "name": "ШаблонАнкеты",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                            },
-                            "dataPath": "Объект.ШаблонАнкеты",
-                            "items": []
-                          }
-                        ],
-                        []
-                      ]
-                    },
-                    {
-                      "type": "USUAL_GROUP",
-                      "id": 37,
-                      "name": "ГруппаШапкаПраво",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Шапка право"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "INPUT_FIELD",
-                            "id": 66,
-                            "name": "ДатаРедактирования",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                            },
-                            "dataPath": "Объект.ДатаРедактирования",
-                            "items": []
-                          },
-                          {
-                            "type": "INPUT_FIELD",
-                            "id": 12,
-                            "name": "Респондент",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                            },
-                            "dataPath": "Объект.Респондент",
-                            "items": []
-                          },
-                          {
-                            "type": "INPUT_FIELD",
-                            "id": 209,
-                            "name": "Интервьюер",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                            },
-                            "dataPath": "Объект.Интервьюер",
-                            "items": []
-                          }
-                        ],
-                        []
-                      ]
-                    }
-                  ],
-                  []
-                ]
-              },
-              {
-                "type": "USUAL_GROUP",
-                "id": 158,
-                "name": "ГруппаЗаполнение",
-                "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Заполнение"
-                      }
-                    }
-                  ]
-                },
-                "dataPath": "",
-                "items": []
-              },
-              {
-                "type": "USUAL_GROUP",
-                "id": 68,
-                "name": "ГруппаДеревоРазделовФормаЗаполнения",
-                "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Дерево разделов форма заполнения"
-                      }
-                    }
-                  ]
-                },
-                "dataPath": "",
-                "items": [
-                  [
-                    {
-                      "type": "USUAL_GROUP",
-                      "id": 77,
-                      "name": "ГруппаДеревоРазделов",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Дерево разделов"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
-                        {
-                          "type": "TABLE",
-                          "id": 69,
-                          "name": "ДеревоРазделов",
-                          "title": {
-                            "@reference": "/com.github._1c_syntax.bsl.mdo.Document/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                          },
-                          "dataPath": "ДеревоРазделов",
-                          "items": [
-                            {
-                              "type": "LABEL_FIELD",
-                              "id": 72,
-                              "name": "ДеревоРазделовФормулировка",
-                              "title": {
-                                "content": [
-                                  {
-                                    "default": {
-                                      "tag": 2
-                                    },
-                                    "int": 1,
-                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                      "langKey": "ru",
-                                      "value": "Раздел"
-                                    }
-                                  }
-                                ]
-                              },
-                              "dataPath": "ДеревоРазделов.Формулировка",
-                              "items": []
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "type": "USUAL_GROUP",
-                      "id": 43,
-                      "name": "ГруппаТелоАнкеты",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Тело анкеты"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
-                        {
-                          "type": "LABEL",
-                          "id": 78,
-                          "name": "НадписьВступление",
-                          "title": {
-                            "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                          },
-                          "dataPath": "",
-                          "items": []
-                        }
-                      ]
-                    },
-                    {
-                      "type": "USUAL_GROUP",
-                      "id": 95,
-                      "name": "ГруппаОжидание",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Ожидание"
+                              "value": "Главное"
                             }
                           }
                         ]
@@ -1508,8 +898,8 @@
                       "items": [
                         {
                           "type": "USUAL_GROUP",
-                          "id": 103,
-                          "name": "ГруппаОжиданиеЭлементы",
+                          "id": 15,
+                          "name": "ГруппаОсновныеРеквизиты",
                           "title": {
                             "content": [
                               {
@@ -1519,7 +909,7 @@
                                 "int": 1,
                                 "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                                   "langKey": "ru",
-                                  "value": "Ожидание элементы"
+                                  "value": "Основные реквизиты"
                                 }
                               }
                             ]
@@ -1528,9 +918,9 @@
                           "items": [
                             [
                               {
-                                "type": "DECORATION",
-                                "id": 96,
-                                "name": "ДекорацияОжиданиеЭлементы",
+                                "type": "USUAL_GROUP",
+                                "id": 2,
+                                "name": "ГруппаНомерДата",
                                 "title": {
                                   "content": [
                                     {
@@ -1540,18 +930,42 @@
                                       "int": 1,
                                       "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                                         "langKey": "ru",
-                                        "value": "Декорация ожидание элементы"
+                                        "value": "Номер дата"
                                       }
                                     }
                                   ]
                                 },
                                 "dataPath": "",
-                                "items": []
+                                "items": [
+                                  [
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 5,
+                                      "name": "Дата",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                      },
+                                      "dataPath": "Объект.Date",
+                                      "items": []
+                                    },
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 3,
+                                      "name": "Номер",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                      },
+                                      "dataPath": "Объект.Number",
+                                      "items": []
+                                    }
+                                  ],
+                                  []
+                                ]
                               },
                               {
-                                "type": "DECORATION",
-                                "id": 98,
-                                "name": "КартинкаДлительныйПроцесс",
+                                "type": "USUAL_GROUP",
+                                "id": 244,
+                                "name": "ГруппаКолонки",
                                 "title": {
                                   "content": [
                                     {
@@ -1561,156 +975,540 @@
                                       "int": 1,
                                       "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                                         "langKey": "ru",
-                                        "value": "Подождите пожалуйста…\nОткрывается раздел анкеты"
+                                        "value": "Колонки"
                                       }
                                     }
                                   ]
                                 },
                                 "dataPath": "",
-                                "items": []
+                                "items": [
+                                  [
+                                    {
+                                      "type": "USUAL_GROUP",
+                                      "id": 184,
+                                      "name": "ГруппаШапкаЛево",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Шапка лево"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        [
+                                          {
+                                            "type": "INPUT_FIELD",
+                                            "id": 12,
+                                            "name": "Респондент",
+                                            "title": {
+                                              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                            },
+                                            "dataPath": "Объект.Респондент",
+                                            "items": []
+                                          },
+                                          {
+                                            "type": "INPUT_FIELD",
+                                            "id": 212,
+                                            "name": "РежимАнкетирования",
+                                            "title": {
+                                              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                            },
+                                            "dataPath": "Объект.РежимАнкетирования",
+                                            "items": []
+                                          },
+                                          {
+                                            "type": "INPUT_FIELD",
+                                            "id": 209,
+                                            "name": "Интервьюер",
+                                            "title": {
+                                              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                            },
+                                            "dataPath": "Объект.Интервьюер",
+                                            "items": []
+                                          }
+                                        ],
+                                        []
+                                      ]
+                                    },
+                                    {
+                                      "type": "USUAL_GROUP",
+                                      "id": 37,
+                                      "name": "ГруппаШапкаПраво",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Шапка право"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        [
+                                          {
+                                            "type": "INPUT_FIELD",
+                                            "id": 206,
+                                            "name": "ШаблонАнкеты",
+                                            "title": {
+                                              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                            },
+                                            "dataPath": "Объект.ШаблонАнкеты",
+                                            "items": []
+                                          },
+                                          {
+                                            "type": "INPUT_FIELD",
+                                            "id": 10,
+                                            "name": "Опрос",
+                                            "title": {
+                                              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                            },
+                                            "dataPath": "Объект.Опрос",
+                                            "items": []
+                                          },
+                                          {
+                                            "type": "INPUT_FIELD",
+                                            "id": 66,
+                                            "name": "ДатаРедактирования",
+                                            "title": {
+                                              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                            },
+                                            "dataPath": "Объект.ДатаРедактирования",
+                                            "items": []
+                                          }
+                                        ],
+                                        []
+                                      ]
+                                    }
+                                  ],
+                                  []
+                                ]
                               },
                               {
-                                "type": "LABEL",
-                                "id": 100,
-                                "name": "НадписьПодождите",
+                                "type": "INPUT_FIELD",
+                                "id": 111,
+                                "name": "Комментарий",
                                 "title": {
-                                  "content": [
-                                    {
-                                      "default": {
-                                        "tag": 2
-                                      },
-                                      "int": 1,
-                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                        "langKey": "ru",
-                                        "value": "Подождите пожалуйста…    Открывается раздел анкеты\n"
-                                      }
-                                    }
-                                  ]
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
                                 },
-                                "dataPath": "",
+                                "dataPath": "Объект.Комментарий",
                                 "items": []
                               }
                             ],
                             []
                           ]
                         }
+                      ]
+                    },
+                    {
+                      "type": "PAGE",
+                      "id": 274,
+                      "name": "СтраницаАнкета",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Анкета"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "COMMAND_BAR",
+                            "id": 266,
+                            "name": "КоманднаяПанельШапка",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Командная панель шапка"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "BUTTON",
+                                  "id": 227,
+                                  "name": "СкрытьПоказатьДеревоРазделовШапка",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Показать разделы"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "FORM_GROUP",
+                                  "id": 272,
+                                  "name": "ГруппаКомандНавигации",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Команд навигации"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "BUTTON",
+                                        "id": 268,
+                                        "name": "ПредыдущийРаздел",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Назад"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "BUTTON",
+                                        "id": 270,
+                                        "name": "СледующийРаздел",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Далее"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                }
+                              ],
+                              []
+                            ]
+                          },
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 281,
+                            "name": "ГруппаАнкета",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                            },
+                            "dataPath": "",
+                            "items": [
+                              {
+                                "type": "USUAL_GROUP",
+                                "id": 249,
+                                "name": "ГруппаКолонкиАнкеты",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Колонки анкеты"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "USUAL_GROUP",
+                                      "id": 77,
+                                      "name": "ГруппаДеревоРазделов",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Дерево разделов"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        {
+                                          "type": "TABLE",
+                                          "id": 69,
+                                          "name": "ДеревоРазделов",
+                                          "title": {
+                                            "@reference": "/com.github._1c_syntax.bsl.mdo.Document/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                          },
+                                          "dataPath": "ДеревоРазделов",
+                                          "items": [
+                                            {
+                                              "type": "LABEL_FIELD",
+                                              "id": 72,
+                                              "name": "ДеревоРазделовФормулировка",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Раздел"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "ДеревоРазделов.Формулировка",
+                                              "items": []
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "USUAL_GROUP",
+                                      "id": 95,
+                                      "name": "ГруппаОжидание",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Ожидание"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        {
+                                          "type": "USUAL_GROUP",
+                                          "id": 103,
+                                          "name": "ГруппаОжиданиеЭлементы",
+                                          "title": {
+                                            "content": [
+                                              {
+                                                "default": {
+                                                  "tag": 2
+                                                },
+                                                "int": 1,
+                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                  "langKey": "ru",
+                                                  "value": "Ожидание элементы"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "dataPath": "",
+                                          "items": [
+                                            [
+                                              {
+                                                "type": "DECORATION",
+                                                "id": 98,
+                                                "name": "КартинкаДлительныйПроцесс",
+                                                "title": {
+                                                  "content": [
+                                                    {
+                                                      "default": {
+                                                        "tag": 2
+                                                      },
+                                                      "int": 1,
+                                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                        "langKey": "ru",
+                                                        "value": "Подождите пожалуйста…\nОткрывается раздел анкеты"
+                                                      }
+                                                    }
+                                                  ]
+                                                },
+                                                "dataPath": "",
+                                                "items": []
+                                              },
+                                              {
+                                                "type": "LABEL",
+                                                "id": 100,
+                                                "name": "НадписьПодождите",
+                                                "title": {
+                                                  "content": [
+                                                    {
+                                                      "default": {
+                                                        "tag": 2
+                                                      },
+                                                      "int": 1,
+                                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                        "langKey": "ru",
+                                                        "value": "Подождите пожалуйста…\nОткрывается раздел анкеты\n"
+                                                      }
+                                                    }
+                                                  ]
+                                                },
+                                                "dataPath": "",
+                                                "items": []
+                                              }
+                                            ],
+                                            []
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "USUAL_GROUP",
+                                      "id": 43,
+                                      "name": "ГруппаТелоАнкеты",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Тело анкеты"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        {
+                                          "type": "LABEL",
+                                          "id": 78,
+                                          "name": "НадписьВступление",
+                                          "title": {
+                                            "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                          },
+                                          "dataPath": "",
+                                          "items": []
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  []
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "COMMAND_BAR",
+                            "id": 176,
+                            "name": "КоманднаяПанельПодвал",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Командная панель подвал"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "BUTTON",
+                                  "id": 107,
+                                  "name": "ПредыдущийРазделПодвал",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Document/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "BUTTON",
+                                  "id": 108,
+                                  "name": "СледующийРазделПодвал",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Document/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          }
+                        ],
+                        []
                       ]
                     }
                   ],
                   []
-                ]
-              },
-              {
-                "type": "USUAL_GROUP",
-                "id": 229,
-                "name": "ГруппаКоманднаяПанель",
-                "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Командная панель"
-                      }
-                    }
-                  ]
-                },
-                "dataPath": "",
-                "items": [
-                  {
-                    "type": "COMMAND_BAR",
-                    "id": 176,
-                    "name": "КоманднаяПанельПодвал",
-                    "title": {
-                      "content": [
-                        {
-                          "default": {
-                            "tag": 2
-                          },
-                          "int": 1,
-                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                            "langKey": "ru",
-                            "value": "Командная панель подвал"
-                          }
-                        }
-                      ]
-                    },
-                    "dataPath": "",
-                    "items": [
-                      [
-                        {
-                          "type": "BUTTON",
-                          "id": 227,
-                          "name": "СкрытьПоказатьДеревоРазделовПодвал",
-                          "title": {
-                            "@reference": "/com.github._1c_syntax.bsl.mdo.Document/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/title"
-                          },
-                          "dataPath": "",
-                          "items": []
-                        },
-                        {
-                          "type": "FORM_GROUP",
-                          "id": 225,
-                          "name": "ГруппаНавигацияПодвал",
-                          "title": {
-                            "content": [
-                              {
-                                "default": {
-                                  "tag": 2
-                                },
-                                "int": 1,
-                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                  "langKey": "ru",
-                                  "value": "Навигация подвал"
-                                }
-                              }
-                            ]
-                          },
-                          "dataPath": "",
-                          "items": [
-                            [
-                              {
-                                "type": "BUTTON",
-                                "id": 107,
-                                "name": "ПредыдущийРазделПодвал",
-                                "title": {
-                                  "content": [
-                                    {
-                                      "default": {
-                                        "tag": 2
-                                      },
-                                      "int": 1,
-                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                        "langKey": "ru",
-                                        "value": "< Назад"
-                                      }
-                                    }
-                                  ]
-                                },
-                                "dataPath": "",
-                                "items": []
-                              },
-                              {
-                                "type": "BUTTON",
-                                "id": 108,
-                                "name": "СледующийРазделПодвал",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[6]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                                },
-                                "dataPath": "",
-                                "items": []
-                              }
-                            ],
-                            []
-                          ]
-                        }
-                      ],
-                      []
-                    ]
-                  }
                 ]
               },
               {
@@ -1732,18 +1530,7 @@
                   ]
                 },
                 "dataPath": "",
-                "items": [
-                  {
-                    "type": "INPUT_FIELD",
-                    "id": 111,
-                    "name": "Комментарий",
-                    "title": {
-                      "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                    },
-                    "dataPath": "Объект.Комментарий",
-                    "items": []
-                  }
-                ]
+                "items": []
               }
             ],
             []
@@ -1881,7 +1668,7 @@
                 "id": 12,
                 "name": "ДеревоРазделов",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "types": [
@@ -2360,18 +2147,7 @@
   ],
   "supportVariant": "NOT_EDITABLE",
   "synonym": {
-    "content": [
-      {
-        "default": {
-          "tag": 2
-        },
-        "int": 1,
-        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-          "langKey": "ru",
-          "value": "Анкета"
-        }
-      }
-    ]
+    "@reference": "/com.github._1c_syntax.bsl.mdo.Document/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
   },
   "tabularSections": [
     {

--- a/src/test/resources/fixtures/ssl_3_2/Documents.Анкета_edt.json
+++ b/src/test/resources/fixtures/ssl_3_2/Documents.Анкета_edt.json
@@ -1,0 +1,2795 @@
+{"com.github._1c_syntax.bsl.mdo.Document": {
+  "attributes": [
+    [
+      {
+        "uuid": "73eff626-a363-4a5a-879e-61ef6ce0726f",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Document.Анкета.StandardAttribute.Posted",
+          "mdoRefRu": "Документ.Анкета.СтандартныйРеквизит.Проведен"
+        },
+        "comment": "",
+        "synonym": {
+          "content": []
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "type": "DOCUMENT",
+          "mdoRef": "Document.Анкета",
+          "mdoRefRu": "Документ.Анкета"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "BOOLEAN"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 0
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "Проведен",
+          "nameEn": "Posted"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "73eff626-a363-4a5a-879e-61ef6ce0726f",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Document.Анкета.StandardAttribute.Ref",
+          "mdoRefRu": "Документ.Анкета.СтандартныйРеквизит.Ссылка"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "ДокументСсылка.Анкета",
+                  "nameEn": "DocumentRef.Анкета"
+                },
+                "variant": "METADATA",
+                "kind": "DOCUMENT"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "fullName": {
+          "nameRu": "Ссылка",
+          "nameEn": "Ref"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "73eff626-a363-4a5a-879e-61ef6ce0726f",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Document.Анкета.StandardAttribute.DeletionMark",
+          "mdoRefRu": "Документ.Анкета.СтандартныйРеквизит.ПометкаУдаления"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+        },
+        "fullName": {
+          "nameRu": "ПометкаУдаления",
+          "nameEn": "DeletionMark"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "73eff626-a363-4a5a-879e-61ef6ce0726f",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Document.Анкета.StandardAttribute.Date",
+          "mdoRefRu": "Документ.Анкета.СтандартныйРеквизит.Дата"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "DATE"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.DateQualifiers": {
+                "dateFractions": 2,
+                "description": {
+                  "value": {
+                    "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                    "nameRu": "КвалификаторыДаты (ДатаВремя)",
+                    "nameEn": "DateQualifiers (DateTime)"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "Дата",
+          "nameEn": "Date"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "73eff626-a363-4a5a-879e-61ef6ce0726f",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Document.Анкета.StandardAttribute.Number",
+          "mdoRefRu": "Документ.Анкета.СтандартныйРеквизит.Номер"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                "length": 11,
+                "allowedLength": 0,
+                "description": {}
+              }
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "Номер",
+          "nameEn": "Number"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "acf15b79-a6c4-4c46-8013-50d3b223baf6",
+        "name": "Опрос",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Document.Анкета.Attribute.Опрос",
+          "mdoRefRu": "Документ.Анкета.Реквизит.Опрос"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Опрос"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "ДокументСсылка.НазначениеОпросов",
+                  "nameEn": "DocumentRef.НазначениеОпросов"
+                },
+                "variant": "METADATA",
+                "kind": "DOCUMENT"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "f6a29b80-e4c3-4c4f-8e2c-d4dda851d813",
+        "name": "Респондент",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Document.Анкета.Attribute.Респондент",
+          "mdoRefRu": "Документ.Анкета.Реквизит.Респондент"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Респондент"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "ОпределяемыйТип.Респондент",
+                  "nameEn": "DefinedType.Респондент"
+                },
+                "variant": "METADATA",
+                "kind": "DEFINED_TYPE"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "2d8d5d74-2bc0-4282-af66-e4a37694c147",
+        "name": "ДатаРедактирования",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Document.Анкета.Attribute.ДатаРедактирования",
+          "mdoRefRu": "Документ.Анкета.Реквизит.ДатаРедактирования"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Дата редактирования"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[4]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "cfd31341-287b-4684-9ac0-b28b4e066f15",
+        "name": "РедактируемыйРаздел",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Document.Анкета.Attribute.РедактируемыйРаздел",
+          "mdoRefRu": "Документ.Анкета.Реквизит.РедактируемыйРаздел"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Редактируемый раздел"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 2,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "СправочникСсылка.ВопросыШаблонаАнкеты",
+                  "nameEn": "CatalogRef.ВопросыШаблонаАнкеты"
+                },
+                "variant": "METADATA",
+                "kind": "CATALOG"
+              },
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+            }
+          ],
+          "composite": true,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                "length": 10,
+                "allowedLength": 0,
+                "description": {
+                  "value": {
+                    "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                    "nameRu": "КвалификаторыСтроки (10, Переменная)",
+                    "nameEn": "StringQualifiers (10, Variable)"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "81de1b0b-7f2d-4098-ae99-061c6a90dc29",
+        "name": "Комментарий",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Document.Анкета.Attribute.Комментарий",
+          "mdoRefRu": "Документ.Анкета.Реквизит.Комментарий"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Комментарий"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                "length": 0,
+                "allowedLength": 0,
+                "description": {
+                  "value": {
+                    "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                    "nameRu": "КвалификаторыСтроки (0, Переменная)",
+                    "nameEn": "StringQualifiers (0, Variable)"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": true,
+        "extendedEdit": true,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "77c8a065-a8aa-4f39-93b6-c88f4c38ec66",
+        "name": "Интервьюер",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Document.Анкета.Attribute.Интервьюер",
+          "mdoRefRu": "Документ.Анкета.Реквизит.Интервьюер"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Интервьюер"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "ОпределяемыйТип.Интервьюер",
+                  "nameEn": "DefinedType.Интервьюер"
+                },
+                "variant": "METADATA",
+                "kind": "DEFINED_TYPE"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "366fa6da-d3bf-4bb0-9a55-a307f9edee6a",
+        "name": "ШаблонАнкеты",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Document.Анкета.Attribute.ШаблонАнкеты",
+          "mdoRefRu": "Документ.Анкета.Реквизит.ШаблонАнкеты"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Шаблон анкеты"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "СправочникСсылка.ШаблоныАнкет",
+                  "nameEn": "CatalogRef.ШаблоныАнкет"
+                },
+                "variant": "METADATA",
+                "kind": "CATALOG"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "dd0610c8-cd87-4fe2-8a1f-70157132785b",
+        "name": "РежимАнкетирования",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Document.Анкета.Attribute.РежимАнкетирования",
+          "mdoRefRu": "Документ.Анкета.Реквизит.РежимАнкетирования"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Режим анкетирования"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "ПеречислениеСсылка.РежимыАнкетирования",
+                  "nameEn": "EnumRef.РежимыАнкетирования"
+                },
+                "variant": "METADATA",
+                "kind": "ENUM"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      }
+    ],
+    []
+  ],
+  "commands": [],
+  "comment": "",
+  "description": "Анкета",
+  "explanation": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+  },
+  "forms": [
+    [
+      {
+        "uuid": "f829e2a9-5bdb-4171-8b32-8d10d5968813",
+        "name": "ФормаДокумента",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "Document.Анкета.Form.ФормаДокумента",
+          "mdoRefRu": "Документ.Анкета.Форма.ФормаДокумента"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Форма документа"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/Documents/Анкета/Forms/ФормаДокумента/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+          },
+          "handlers": [
+            [
+              {
+                "event": "OnOpen",
+                "name": "ПриОткрытии"
+              },
+              {
+                "event": "BeforeClose",
+                "name": "ПередЗакрытием"
+              },
+              {
+                "event": "OnCreateAtServer",
+                "name": "ПриСозданииНаСервере"
+              }
+            ],
+            []
+          ],
+          "items": [
+            [
+              {
+                "type": "COMMAND_BAR",
+                "id": 182,
+                "name": "КоманднаяПанельШапка",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Командная панель шапка"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "FORM_GROUP",
+                      "id": 190,
+                      "name": "ФормаГруппаКомандыФормы",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Форма группа команды формы"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "BUTTON",
+                            "id": 92,
+                            "name": "ФормаЗаполненияЗавершитьИЗакрыть",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Завершить и закрыть"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "BUTTON",
+                            "id": 91,
+                            "name": "ФормаЗаполненияЗаписать",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Сохранить анкету"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "BUTTON",
+                      "id": 86,
+                      "name": "ФормаКоманднаяПанельПровестиИЗакрыть",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "BUTTON",
+                      "id": 192,
+                      "name": "Провести",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "BUTTON",
+                      "id": 87,
+                      "name": "ФормаКоманднаяПанельЗаписать",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "BUTTON",
+                      "id": 156,
+                      "name": "СкрытьПоказатьДеревоРазделов",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Показать разделы"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "FORM_GROUP",
+                      "id": 223,
+                      "name": "ГруппаНавигация",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Навигация"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "BUTTON",
+                            "id": 163,
+                            "name": "ПредыдущийРаздел",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Назад"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "BUTTON",
+                            "id": 165,
+                            "name": "СледующийРаздел",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Далее"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "BUTTON",
+                      "id": 215,
+                      "name": "ФормаПеречитать",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "BUTTON",
+                      "id": 219,
+                      "name": "ФормаОтменаПроведения",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "BUTTON",
+                      "id": 217,
+                      "name": "ФормаУстановитьПометкуУдаления",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "FORM_GROUP",
+                      "id": 186,
+                      "name": "ФормаГлобальныеКоманды",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Форма глобальные команды"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "POPUP",
+                      "id": 188,
+                      "name": "ПодменюПечать",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Печать"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "FORM_GROUP",
+                      "id": 204,
+                      "name": "ПодменюАнкетирование",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Подменю анкетирование"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "BUTTON",
+                      "id": 194,
+                      "name": "ПоказатьВСпискеАнкета",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "BUTTON",
+                      "id": 93,
+                      "name": "Справка",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 15,
+                "name": "ГруппаОсновныеРеквизиты",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Основные реквизиты"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 184,
+                      "name": "ГруппаШапкаЛево",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Шапка лево"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 2,
+                            "name": "ГруппаНомерДата",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Номер дата"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 3,
+                                  "name": "Номер",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                  },
+                                  "dataPath": "Объект.Number",
+                                  "items": []
+                                },
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 5,
+                                  "name": "Дата",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                                  },
+                                  "dataPath": "Объект.Date",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 212,
+                            "name": "РежимАнкетирования",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                            },
+                            "dataPath": "Объект.РежимАнкетирования",
+                            "items": []
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 10,
+                            "name": "Опрос",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                            },
+                            "dataPath": "Объект.Опрос",
+                            "items": []
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 206,
+                            "name": "ШаблонАнкеты",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                            },
+                            "dataPath": "Объект.ШаблонАнкеты",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 37,
+                      "name": "ГруппаШапкаПраво",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Шапка право"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 66,
+                            "name": "ДатаРедактирования",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                            },
+                            "dataPath": "Объект.ДатаРедактирования",
+                            "items": []
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 12,
+                            "name": "Респондент",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                            },
+                            "dataPath": "Объект.Респондент",
+                            "items": []
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 209,
+                            "name": "Интервьюер",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                            },
+                            "dataPath": "Объект.Интервьюер",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 158,
+                "name": "ГруппаЗаполнение",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Заполнение"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": []
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 68,
+                "name": "ГруппаДеревоРазделовФормаЗаполнения",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Дерево разделов форма заполнения"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 77,
+                      "name": "ГруппаДеревоРазделов",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Дерево разделов"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        {
+                          "type": "TABLE",
+                          "id": 69,
+                          "name": "ДеревоРазделов",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.Document/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                          },
+                          "dataPath": "ДеревоРазделов",
+                          "items": [
+                            {
+                              "type": "LABEL_FIELD",
+                              "id": 72,
+                              "name": "ДеревоРазделовФормулировка",
+                              "title": {
+                                "content": [
+                                  {
+                                    "default": {
+                                      "tag": 2
+                                    },
+                                    "int": 1,
+                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                      "langKey": "ru",
+                                      "value": "Раздел"
+                                    }
+                                  }
+                                ]
+                              },
+                              "dataPath": "ДеревоРазделов.Формулировка",
+                              "items": []
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 43,
+                      "name": "ГруппаТелоАнкеты",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Тело анкеты"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        {
+                          "type": "LABEL",
+                          "id": 78,
+                          "name": "НадписьВступление",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                          },
+                          "dataPath": "",
+                          "items": []
+                        }
+                      ]
+                    },
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 95,
+                      "name": "ГруппаОжидание",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Ожидание"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 103,
+                          "name": "ГруппаОжиданиеЭлементы",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Ожидание элементы"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "DECORATION",
+                                "id": 96,
+                                "name": "ДекорацияОжиданиеЭлементы",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Декорация ожидание элементы"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": []
+                              },
+                              {
+                                "type": "DECORATION",
+                                "id": 98,
+                                "name": "КартинкаДлительныйПроцесс",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Подождите пожалуйста…\nОткрывается раздел анкеты"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": []
+                              },
+                              {
+                                "type": "LABEL",
+                                "id": 100,
+                                "name": "НадписьПодождите",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Подождите пожалуйста…    Открывается раздел анкеты\n"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": []
+                              }
+                            ],
+                            []
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 229,
+                "name": "ГруппаКоманднаяПанель",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Командная панель"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  {
+                    "type": "COMMAND_BAR",
+                    "id": 176,
+                    "name": "КоманднаяПанельПодвал",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Командная панель подвал"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "BUTTON",
+                          "id": 227,
+                          "name": "СкрытьПоказатьДеревоРазделовПодвал",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.Document/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/title"
+                          },
+                          "dataPath": "",
+                          "items": []
+                        },
+                        {
+                          "type": "FORM_GROUP",
+                          "id": 225,
+                          "name": "ГруппаНавигацияПодвал",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Навигация подвал"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "BUTTON",
+                                "id": 107,
+                                "name": "ПредыдущийРазделПодвал",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "< Назад"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": []
+                              },
+                              {
+                                "type": "BUTTON",
+                                "id": 108,
+                                "name": "СледующийРазделПодвал",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[6]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                },
+                                "dataPath": "",
+                                "items": []
+                              }
+                            ],
+                            []
+                          ]
+                        }
+                      ],
+                      []
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 221,
+                "name": "ГруппаПодвал",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Подвал"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  {
+                    "type": "INPUT_FIELD",
+                    "id": 111,
+                    "name": "Комментарий",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                    },
+                    "dataPath": "Объект.Комментарий",
+                    "items": []
+                  }
+                ]
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "Объект",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "ДокументОбъект.Анкета",
+                          "nameEn": "DocumentObject.Анкета"
+                        },
+                        "variant": "METADATA",
+                        "kind": "DOCUMENT"
+                      }
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 4,
+                "name": "ОтборРеспондентов",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "VALUE_LIST"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 5,
+                "name": "ИмяМетаданныхРеспондент",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[5]/type"
+                }
+              },
+              {
+                "id": 2,
+                "name": "ВозможностьПредварительногоСохранения",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              },
+              {
+                "id": 6,
+                "name": "ШаблонАнкеты",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[7]/type"
+                }
+              },
+              {
+                "id": 7,
+                "name": "ВопросыПредставлениеТипы",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "VALUE_TABLE"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 8,
+                "name": "ТаблицаВопросовРаздела",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[6]/type"
+                }
+              },
+              {
+                "id": 9,
+                "name": "ВариантыОтветовНаВопросы",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[6]/type"
+                }
+              },
+              {
+                "id": 10,
+                "name": "ПодчиненныеВопросы",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[6]/type"
+                }
+              },
+              {
+                "id": 12,
+                "name": "ДеревоРазделов",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "VALUE_TREE"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 13,
+                "name": "ДобавленныеДинамическиРеквизиты",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[2]/type"
+                }
+              },
+              {
+                "id": 3,
+                "name": "Вступление",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[5]/type"
+                }
+              },
+              {
+                "id": 14,
+                "name": "Заключение",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[5]/type"
+                }
+              },
+              {
+                "id": 15,
+                "name": "НомерТекущегоРаздела",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                        "precision": 10,
+                        "scale": 0,
+                        "nonNegative": true,
+                        "description": {}
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 11,
+                "name": "ПредыдущийРазделБезВопросов",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              },
+              {
+                "id": 16,
+                "name": "ИмяЭлементаДляПозиционирования",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                        "length": 200,
+                        "allowedLength": 0,
+                        "description": {}
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 17,
+                "name": "ЭтоСеансОбычногоПользователя",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              },
+              {
+                "id": 20,
+                "name": "ПараметрыПодключаемыхКоманд",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                },
+                "type": {
+                  "types": [],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "647ba8f8-57f7-4c19-af59-525517c1e392",
+        "name": "ФормаСписка",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "Document.Анкета.Form.ФормаСписка",
+          "mdoRefRu": "Документ.Анкета.Форма.ФормаСписка"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Форма списка"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/Documents/Анкета/Forms/ФормаСписка/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+          },
+          "handlers": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[3]"
+            }
+          ],
+          "items": [
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 23,
+                "name": "ГруппаПользовательскихНастроек",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Группа пользовательских настроек"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": []
+              },
+              {
+                "type": "TABLE",
+                "id": 1,
+                "name": "Список",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Список"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "Список",
+                "items": [
+                  [
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 6,
+                      "name": "Номер",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.Номер",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 4,
+                      "name": "Дата",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.Дата",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 34,
+                      "name": "РежимАнкетирования",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Режим"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "Список.РежимАнкетирования",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 37,
+                      "name": "ШаблонАнкеты",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Шаблон"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "Список.ШаблонАнкеты",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 8,
+                      "name": "Опрос",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.Опрос",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 10,
+                      "name": "Респондент",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.Респондент",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 12,
+                      "name": "ДатаРедактирования",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.ДатаРедактирования",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 20,
+                      "name": "Ссылка",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "Список.Ссылка",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            {
+              "id": 1,
+              "name": "Список",
+              "title": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "type": {
+                "types": [
+                  {
+                    "default": {
+                      "tag": 4
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.value.V8ValueType": "DYNAMIC_LIST"
+                  }
+                ],
+                "composite": false,
+                "qualifiers": []
+              }
+            }
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      }
+    ],
+    []
+  ],
+  "mdoReference": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+  },
+  "mdoType": "DOCUMENT",
+  "moduleTypes": [
+    [
+      "ManagerModule",
+      [
+        "src/test/resources/ext/edt/ssl_3_2/configuration/src/Documents/Анкета/ManagerModule.bsl"
+      ]
+    ],
+    [
+      "ObjectModule",
+      [
+        "src/test/resources/ext/edt/ssl_3_2/configuration/src/Documents/Анкета/ObjectModule.bsl"
+      ]
+    ]
+  ],
+  "modules": [
+    {
+      "moduleType": "ManagerModule",
+      "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/Documents/Анкета/ManagerModule.bsl",
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "isProtected": false
+    },
+    {
+      "moduleType": "ObjectModule",
+      "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/Documents/Анкета/ObjectModule.bsl",
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "isProtected": false
+    }
+  ],
+  "name": "Анкета",
+  "objectBelonging": "OWN",
+  "possibleRights": [
+    {
+      "default": {
+        "tag": 4
+      },
+      "int": 27,
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INSERT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "DELETE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "VIEW",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "EDIT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INPUT_BY_STRING",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "POSTING",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UNDO_POSTING",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_DELETE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_INSERT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_SET_DELETION_MARK",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_CLEAR_DELETION_MARK",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_DELETE_MARKED",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_POSTING",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_POSTING_REGULAR",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_UNDO_POSTING",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_CHANGE_OF_POSTED",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "VIEW_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ_DATA_HISTORY_OF_MISSING_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_OF_MISSING_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_SETTINGS",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_VERSION_COMMENT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "EDIT_DATA_HISTORY_VERSION_COMMENT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "SWITCH_TO_DATA_HISTORY_VERSION"
+    }
+  ],
+  "registerRecords": [
+    {
+      "type": "INFORMATION_REGISTER",
+      "mdoRef": "InformationRegister.ОтветыНаВопросыАнкет",
+      "mdoRefRu": "РегистрСведений.ОтветыНаВопросыАнкет"
+    }
+  ],
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "content": [
+      {
+        "default": {
+          "tag": 2
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+          "langKey": "ru",
+          "value": "Анкета"
+        }
+      }
+    ]
+  },
+  "tabularSections": [
+    {
+      "uuid": "39062cb3-4ae8-4c0d-889b-038a55179946",
+      "name": "Состав",
+      "mdoReference": {
+        "type": "TABULAR_SECTION",
+        "mdoRef": "Document.Анкета.TabularSection.Состав",
+        "mdoRefRu": "Документ.Анкета.ТабличнаяЧасть.Состав"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": [
+          {
+            "default": {
+              "tag": 2
+            },
+            "int": 1,
+            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+              "langKey": "ru",
+              "value": "Состав"
+            }
+          }
+        ]
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+      },
+      "attributes": [
+        [
+          {
+            "uuid": "39062cb3-4ae8-4c0d-889b-038a55179946",
+            "mdoReference": {
+              "type": "STANDARD_ATTRIBUTE",
+              "mdoRef": "Document.Анкета.TabularSection.Состав.StandardAttribute.LineNumber",
+              "mdoRefRu": "Документ.Анкета.ТабличнаяЧасть.Состав.СтандартныйРеквизит.НомерСтроки"
+            },
+            "comment": "",
+            "synonym": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+            },
+            "passwordMode": false,
+            "kind": "STANDARD",
+            "type": {
+              "types": [
+                {
+                  "default": {
+                    "tag": 4
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER"
+                }
+              ],
+              "composite": false,
+              "qualifiers": [
+                {
+                  "default": {
+                    "tag": 4
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                    "precision": 5,
+                    "scale": 0,
+                    "nonNegative": false,
+                    "description": {}
+                  }
+                }
+              ]
+            },
+            "fullName": {
+              "nameRu": "НомерСтроки",
+              "nameEn": "LineNumber"
+            },
+            "format": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "editFormat": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "markNegatives": false,
+            "mask": "",
+            "multiLine": false,
+            "extendedEdit": false,
+            "fillFromFillingValue": false
+          },
+          {
+            "uuid": "c62d4212-36ca-4afb-bac9-269b6f64ca51",
+            "name": "Вопрос",
+            "mdoReference": {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.Анкета.TabularSection.Состав.Attribute.Вопрос",
+              "mdoRefRu": "Документ.Анкета.ТабличнаяЧасть.Состав.Реквизит.Вопрос"
+            },
+            "objectBelonging": "OWN",
+            "comment": "",
+            "synonym": {
+              "content": [
+                {
+                  "default": {
+                    "tag": 2
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                    "langKey": "ru",
+                    "value": "Вопрос"
+                  }
+                }
+              ]
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+            },
+            "passwordMode": false,
+            "kind": "CUSTOM",
+            "indexing": "DONT_INDEX",
+            "type": {
+              "types": [
+                {
+                  "default": {
+                    "tag": 4
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                    "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[4]/type/types/java.util.CollSer/com.github._1c_syntax.bsl.types.value.CustomValueType"
+                  }
+                }
+              ],
+              "composite": false,
+              "qualifiers": []
+            },
+            "format": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "editFormat": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "markNegatives": false,
+            "mask": "",
+            "multiLine": false,
+            "extendedEdit": false,
+            "fillFromFillingValue": false
+          },
+          {
+            "uuid": "5cec5e16-46ad-4f8c-b869-f5b1cc487884",
+            "name": "ЭлементарныйВопрос",
+            "mdoReference": {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.Анкета.TabularSection.Состав.Attribute.ЭлементарныйВопрос",
+              "mdoRefRu": "Документ.Анкета.ТабличнаяЧасть.Состав.Реквизит.ЭлементарныйВопрос"
+            },
+            "objectBelonging": "OWN",
+            "comment": "",
+            "synonym": {
+              "content": [
+                {
+                  "default": {
+                    "tag": 2
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                    "langKey": "ru",
+                    "value": "Элементарный вопрос"
+                  }
+                }
+              ]
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+            },
+            "passwordMode": false,
+            "kind": "CUSTOM",
+            "indexing": "DONT_INDEX",
+            "type": {
+              "types": [
+                {
+                  "default": {
+                    "tag": 4
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                    "fullName": {
+                      "nameRu": "ПланВидовХарактеристикСсылка.ВопросыДляАнкетирования",
+                      "nameEn": "ChartOfCharacteristicTypesRef.ВопросыДляАнкетирования"
+                    },
+                    "variant": "METADATA",
+                    "kind": "CHART_OF_CHARACTERISTIC_TYPES"
+                  }
+                }
+              ],
+              "composite": false,
+              "qualifiers": []
+            },
+            "format": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "editFormat": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "markNegatives": false,
+            "mask": "",
+            "multiLine": false,
+            "extendedEdit": false,
+            "fillFromFillingValue": false
+          },
+          {
+            "uuid": "ca0363bb-81c2-4fce-b2f0-e8f42d118a74",
+            "name": "НомерЯчейки",
+            "mdoReference": {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.Анкета.TabularSection.Состав.Attribute.НомерЯчейки",
+              "mdoRefRu": "Документ.Анкета.ТабличнаяЧасть.Состав.Реквизит.НомерЯчейки"
+            },
+            "objectBelonging": "OWN",
+            "comment": "",
+            "synonym": {
+              "content": [
+                {
+                  "default": {
+                    "tag": 2
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                    "langKey": "ru",
+                    "value": "Номер ячейки"
+                  }
+                }
+              ]
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+            },
+            "passwordMode": false,
+            "kind": "CUSTOM",
+            "indexing": "DONT_INDEX",
+            "type": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[14]/type"
+            },
+            "format": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "editFormat": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "markNegatives": false,
+            "mask": "",
+            "multiLine": false,
+            "extendedEdit": false,
+            "fillFromFillingValue": false
+          },
+          {
+            "uuid": "7aacdf81-49fd-47a3-a36a-c483f1b05872",
+            "name": "Ответ",
+            "mdoReference": {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.Анкета.TabularSection.Состав.Attribute.Ответ",
+              "mdoRefRu": "Документ.Анкета.ТабличнаяЧасть.Состав.Реквизит.Ответ"
+            },
+            "objectBelonging": "OWN",
+            "comment": "",
+            "synonym": {
+              "content": [
+                {
+                  "default": {
+                    "tag": 2
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                    "langKey": "ru",
+                    "value": "Ответ"
+                  }
+                }
+              ]
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+            },
+            "passwordMode": false,
+            "kind": "CUSTOM",
+            "indexing": "DONT_INDEX",
+            "type": {
+              "types": [
+                {
+                  "default": {
+                    "tag": 4
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                    "fullName": {
+                      "nameRu": "Характеристика.ВопросыДляАнкетирования",
+                      "nameEn": "Characteristic.ВопросыДляАнкетирования"
+                    },
+                    "variant": "METADATA",
+                    "kind": "CHART_OF_CHARACTERISTIC_TYPES"
+                  }
+                }
+              ],
+              "composite": false,
+              "qualifiers": []
+            },
+            "format": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "editFormat": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "markNegatives": false,
+            "mask": "",
+            "multiLine": false,
+            "extendedEdit": false,
+            "fillFromFillingValue": false
+          },
+          {
+            "uuid": "857015e2-afb2-403d-bfb7-7acb5080797b",
+            "name": "ОткрытыйОтвет",
+            "mdoReference": {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.Анкета.TabularSection.Состав.Attribute.ОткрытыйОтвет",
+              "mdoRefRu": "Документ.Анкета.ТабличнаяЧасть.Состав.Реквизит.ОткрытыйОтвет"
+            },
+            "objectBelonging": "OWN",
+            "comment": "",
+            "synonym": {
+              "content": [
+                {
+                  "default": {
+                    "tag": 2
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                    "langKey": "ru",
+                    "value": "Открытый ответ"
+                  }
+                }
+              ]
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+            },
+            "passwordMode": false,
+            "kind": "CUSTOM",
+            "indexing": "DONT_INDEX",
+            "type": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[5]/type"
+            },
+            "format": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "editFormat": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "markNegatives": false,
+            "mask": "",
+            "multiLine": false,
+            "extendedEdit": false,
+            "fillFromFillingValue": false
+          },
+          {
+            "uuid": "100ec1d0-3719-4feb-8a66-02f2c89fcd36",
+            "name": "БезОтвета",
+            "mdoReference": {
+              "type": "ATTRIBUTE",
+              "mdoRef": "Document.Анкета.TabularSection.Состав.Attribute.БезОтвета",
+              "mdoRefRu": "Документ.Анкета.ТабличнаяЧасть.Состав.Реквизит.БезОтвета"
+            },
+            "objectBelonging": "OWN",
+            "comment": "",
+            "synonym": {
+              "content": [
+                {
+                  "default": {
+                    "tag": 2
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                    "langKey": "ru",
+                    "value": "Без ответа"
+                  }
+                }
+              ]
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/tabularSections/com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection/mdoReference"
+            },
+            "passwordMode": false,
+            "kind": "CUSTOM",
+            "indexing": "DONT_INDEX",
+            "type": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+            },
+            "format": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "editFormat": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Document/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "markNegatives": false,
+            "mask": "",
+            "multiLine": false,
+            "extendedEdit": false,
+            "fillFromFillingValue": false
+          }
+        ],
+        []
+      ]
+    }
+  ],
+  "templates": [],
+  "uuid": "73eff626-a363-4a5a-879e-61ef6ce0726f"
+}}

--- a/src/test/resources/fixtures/ssl_3_2/Enums.СтатусыОбработчиковОбновления.json
+++ b/src/test/resources/fixtures/ssl_3_2/Enums.СтатусыОбработчиковОбновления.json
@@ -1,0 +1,327 @@
+{"com.github._1c_syntax.bsl.mdo.Enum": {
+  "attributes": [
+    [
+      {
+        "uuid": "36b15776-5211-4afa-9b6c-c042121218c0",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Enum.СтатусыОбработчиковОбновления.StandardAttribute.Order",
+          "mdoRefRu": "Перечисление.СтатусыОбработчиковОбновления.СтандартныйРеквизит.Порядок"
+        },
+        "comment": "",
+        "synonym": {
+          "content": []
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "type": "ENUM",
+          "mdoRef": "Enum.СтатусыОбработчиковОбновления",
+          "mdoRefRu": "Перечисление.СтатусыОбработчиковОбновления"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                "precision": 5,
+                "scale": 0,
+                "nonNegative": false,
+                "description": {}
+              }
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "Порядок",
+          "nameEn": "Order"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Enum/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Enum/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "36b15776-5211-4afa-9b6c-c042121218c0",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Enum.СтатусыОбработчиковОбновления.StandardAttribute.Ref",
+          "mdoRefRu": "Перечисление.СтатусыОбработчиковОбновления.СтандартныйРеквизит.Ссылка"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Enum/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Enum/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "ПеречислениеСсылка.СтатусыОбработчиковОбновления",
+                  "nameEn": "EnumRef.СтатусыОбработчиковОбновления"
+                },
+                "variant": "METADATA",
+                "kind": "ENUM"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 0
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "Ссылка",
+          "nameEn": "Ref"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Enum/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Enum/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      }
+    ],
+    []
+  ],
+  "commands": [],
+  "comment": "",
+  "description": "Статусы обработчиков обновления",
+  "enumValues": [
+    [
+      {
+        "uuid": "422a0e10-361f-46ba-b92e-3088d81e12a4",
+        "name": "Выполнен",
+        "mdoReference": {
+          "type": "ENUM_VALUE",
+          "mdoRef": "Enum.СтатусыОбработчиковОбновления.EnumValue.Выполнен",
+          "mdoRefRu": "Перечисление.СтатусыОбработчиковОбновления.ЗначениеПеречисления.Выполнен"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Выполнен"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Enum/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        }
+      },
+      {
+        "uuid": "f37b7b25-abd2-4e19-9712-78aafceb4f43",
+        "name": "НеВыполнялся",
+        "mdoReference": {
+          "type": "ENUM_VALUE",
+          "mdoRef": "Enum.СтатусыОбработчиковОбновления.EnumValue.НеВыполнялся",
+          "mdoRefRu": "Перечисление.СтатусыОбработчиковОбновления.ЗначениеПеречисления.НеВыполнялся"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Не выполнялся"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Enum/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        }
+      },
+      {
+        "uuid": "7cd4c6ea-5795-4bea-a159-1e66650c42fe",
+        "name": "Выполняется",
+        "mdoReference": {
+          "type": "ENUM_VALUE",
+          "mdoRef": "Enum.СтатусыОбработчиковОбновления.EnumValue.Выполняется",
+          "mdoRefRu": "Перечисление.СтатусыОбработчиковОбновления.ЗначениеПеречисления.Выполняется"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Выполняется"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Enum/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        }
+      },
+      {
+        "uuid": "091fcffa-da7e-4375-bf0b-11cc4950b5ad",
+        "name": "Приостановлен",
+        "mdoReference": {
+          "type": "ENUM_VALUE",
+          "mdoRef": "Enum.СтатусыОбработчиковОбновления.EnumValue.Приостановлен",
+          "mdoRefRu": "Перечисление.СтатусыОбработчиковОбновления.ЗначениеПеречисления.Приостановлен"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Приостановлен"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Enum/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        }
+      },
+      {
+        "uuid": "57e91491-73b6-43f7-b7f8-26efec56ce9e",
+        "name": "Ошибка",
+        "mdoReference": {
+          "type": "ENUM_VALUE",
+          "mdoRef": "Enum.СтатусыОбработчиковОбновления.EnumValue.Ошибка",
+          "mdoRefRu": "Перечисление.СтатусыОбработчиковОбновления.ЗначениеПеречисления.Ошибка"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Ошибка"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Enum/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        }
+      }
+    ],
+    []
+  ],
+  "explanation": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.Enum/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+  },
+  "forms": [],
+  "mdoReference": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.Enum/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+  },
+  "mdoType": "ENUM",
+  "moduleTypes": [
+    [
+      "ManagerModule",
+      [
+        "src/test/resources/ext/designer/ssl_3_2/src/cf/Enums/СтатусыОбработчиковОбновления/Ext/ManagerModule.bsl"
+      ]
+    ]
+  ],
+  "modules": [
+    {
+      "moduleType": "ManagerModule",
+      "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/Enums/СтатусыОбработчиковОбновления/Ext/ManagerModule.bsl",
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.Enum/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "isProtected": false
+    }
+  ],
+  "name": "СтатусыОбработчиковОбновления",
+  "objectBelonging": "OWN",
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "content": [
+      {
+        "default": {
+          "tag": 2
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+          "langKey": "ru",
+          "value": "Статусы обработчиков обновления"
+        }
+      }
+    ]
+  },
+  "templates": [],
+  "uuid": "36b15776-5211-4afa-9b6c-c042121218c0"
+}}

--- a/src/test/resources/fixtures/ssl_3_2/Enums.СтатусыОбработчиковОбновления_edt.json
+++ b/src/test/resources/fixtures/ssl_3_2/Enums.СтатусыОбработчиковОбновления_edt.json
@@ -1,0 +1,327 @@
+{"com.github._1c_syntax.bsl.mdo.Enum": {
+  "attributes": [
+    [
+      {
+        "uuid": "36b15776-5211-4afa-9b6c-c042121218c0",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Enum.СтатусыОбработчиковОбновления.StandardAttribute.Order",
+          "mdoRefRu": "Перечисление.СтатусыОбработчиковОбновления.СтандартныйРеквизит.Порядок"
+        },
+        "comment": "",
+        "synonym": {
+          "content": []
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "type": "ENUM",
+          "mdoRef": "Enum.СтатусыОбработчиковОбновления",
+          "mdoRefRu": "Перечисление.СтатусыОбработчиковОбновления"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                "precision": 5,
+                "scale": 0,
+                "nonNegative": false,
+                "description": {}
+              }
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "Порядок",
+          "nameEn": "Order"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Enum/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Enum/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "36b15776-5211-4afa-9b6c-c042121218c0",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Enum.СтатусыОбработчиковОбновления.StandardAttribute.Ref",
+          "mdoRefRu": "Перечисление.СтатусыОбработчиковОбновления.СтандартныйРеквизит.Ссылка"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Enum/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Enum/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "ПеречислениеСсылка.СтатусыОбработчиковОбновления",
+                  "nameEn": "EnumRef.СтатусыОбработчиковОбновления"
+                },
+                "variant": "METADATA",
+                "kind": "ENUM"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 0
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "Ссылка",
+          "nameEn": "Ref"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Enum/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Enum/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      }
+    ],
+    []
+  ],
+  "commands": [],
+  "comment": "",
+  "description": "Статусы обработчиков обновления",
+  "enumValues": [
+    [
+      {
+        "uuid": "422a0e10-361f-46ba-b92e-3088d81e12a4",
+        "name": "Выполнен",
+        "mdoReference": {
+          "type": "ENUM_VALUE",
+          "mdoRef": "Enum.СтатусыОбработчиковОбновления.EnumValue.Выполнен",
+          "mdoRefRu": "Перечисление.СтатусыОбработчиковОбновления.ЗначениеПеречисления.Выполнен"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Выполнен"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Enum/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        }
+      },
+      {
+        "uuid": "f37b7b25-abd2-4e19-9712-78aafceb4f43",
+        "name": "НеВыполнялся",
+        "mdoReference": {
+          "type": "ENUM_VALUE",
+          "mdoRef": "Enum.СтатусыОбработчиковОбновления.EnumValue.НеВыполнялся",
+          "mdoRefRu": "Перечисление.СтатусыОбработчиковОбновления.ЗначениеПеречисления.НеВыполнялся"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Не выполнялся"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Enum/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        }
+      },
+      {
+        "uuid": "7cd4c6ea-5795-4bea-a159-1e66650c42fe",
+        "name": "Выполняется",
+        "mdoReference": {
+          "type": "ENUM_VALUE",
+          "mdoRef": "Enum.СтатусыОбработчиковОбновления.EnumValue.Выполняется",
+          "mdoRefRu": "Перечисление.СтатусыОбработчиковОбновления.ЗначениеПеречисления.Выполняется"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Выполняется"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Enum/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        }
+      },
+      {
+        "uuid": "091fcffa-da7e-4375-bf0b-11cc4950b5ad",
+        "name": "Приостановлен",
+        "mdoReference": {
+          "type": "ENUM_VALUE",
+          "mdoRef": "Enum.СтатусыОбработчиковОбновления.EnumValue.Приостановлен",
+          "mdoRefRu": "Перечисление.СтатусыОбработчиковОбновления.ЗначениеПеречисления.Приостановлен"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Приостановлен"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Enum/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        }
+      },
+      {
+        "uuid": "57e91491-73b6-43f7-b7f8-26efec56ce9e",
+        "name": "Ошибка",
+        "mdoReference": {
+          "type": "ENUM_VALUE",
+          "mdoRef": "Enum.СтатусыОбработчиковОбновления.EnumValue.Ошибка",
+          "mdoRefRu": "Перечисление.СтатусыОбработчиковОбновления.ЗначениеПеречисления.Ошибка"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Ошибка"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Enum/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        }
+      }
+    ],
+    []
+  ],
+  "explanation": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.Enum/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+  },
+  "forms": [],
+  "mdoReference": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.Enum/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+  },
+  "mdoType": "ENUM",
+  "moduleTypes": [
+    [
+      "ManagerModule",
+      [
+        "src/test/resources/ext/edt/ssl_3_2/configuration/src/Enums/СтатусыОбработчиковОбновления/ManagerModule.bsl"
+      ]
+    ]
+  ],
+  "modules": [
+    {
+      "moduleType": "ManagerModule",
+      "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/Enums/СтатусыОбработчиковОбновления/ManagerModule.bsl",
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.Enum/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "isProtected": false
+    }
+  ],
+  "name": "СтатусыОбработчиковОбновления",
+  "objectBelonging": "OWN",
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "content": [
+      {
+        "default": {
+          "tag": 2
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+          "langKey": "ru",
+          "value": "Статусы обработчиков обновления"
+        }
+      }
+    ]
+  },
+  "templates": [],
+  "uuid": "36b15776-5211-4afa-9b6c-c042121218c0"
+}}

--- a/src/test/resources/fixtures/ssl_3_2/EventSubscriptions.ВариантыОтчетовПередУдалениемИдентификатораОбъектаМетаданных.json
+++ b/src/test/resources/fixtures/ssl_3_2/EventSubscriptions.ВариантыОтчетовПередУдалениемИдентификатораОбъектаМетаданных.json
@@ -1,0 +1,69 @@
+{"com.github._1c_syntax.bsl.mdo.EventSubscription": {
+  "comment": "",
+  "description": "Варианты отчетов перед удалением идентификатора объекта метаданных",
+  "event": "BeforeDelete",
+  "handler": {
+    "methodPath": "CommonModule.ВариантыОтчетов.ПередУдалениемИдентификатораОбъектаМетаданных",
+    "moduleName": "ВариантыОтчетов",
+    "methodName": "ПередУдалениемИдентификатораОбъектаМетаданных"
+  },
+  "mdoReference": {
+    "type": "EVENT_SUBSCRIPTION",
+    "mdoRef": "EventSubscription.ВариантыОтчетовПередУдалениемИдентификатораОбъектаМетаданных",
+    "mdoRefRu": "ПодпискаНаСобытие.ВариантыОтчетовПередУдалениемИдентификатораОбъектаМетаданных"
+  },
+  "mdoType": "EVENT_SUBSCRIPTION",
+  "name": "ВариантыОтчетовПередУдалениемИдентификатораОбъектаМетаданных",
+  "objectBelonging": "OWN",
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "content": [
+      {
+        "default": {
+          "tag": 2
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+          "langKey": "ru",
+          "value": "Варианты отчетов перед удалением идентификатора объекта метаданных"
+        }
+      }
+    ]
+  },
+  "uuid": "a64b15fa-fc34-43fe-a366-d27c0f1c3df2",
+  "valueType": {
+    "types": [
+      {
+        "default": {
+          "tag": 4
+        },
+        "int": 2,
+        "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+          "fullName": {
+            "nameRu": "СправочникОбъект.ИдентификаторыОбъектовМетаданных",
+            "nameEn": "CatalogObject.ИдентификаторыОбъектовМетаданных"
+          },
+          "variant": "METADATA",
+          "kind": "CATALOG"
+        },
+        "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+          "fullName": {
+            "nameRu": "СправочникОбъект.ИдентификаторыОбъектовРасширений",
+            "nameEn": "CatalogObject.ИдентификаторыОбъектовРасширений"
+          },
+          "variant": "METADATA",
+          "kind": "CATALOG"
+        }
+      }
+    ],
+    "composite": true,
+    "qualifiers": [
+      {
+        "default": {
+          "tag": 4
+        },
+        "int": 0
+      }
+    ]
+  }
+}}

--- a/src/test/resources/fixtures/ssl_3_2/ExchangePlans.ОбновлениеИнформационнойБазы.json
+++ b/src/test/resources/fixtures/ssl_3_2/ExchangePlans.ОбновлениеИнформационнойБазы.json
@@ -1,0 +1,3897 @@
+{"com.github._1c_syntax.bsl.mdo.ExchangePlan": {
+  "attributes": [
+    [
+      {
+        "uuid": "3fc019d1-aec8-4835-96c5-3bbf43da0b94",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "ExchangePlan.ОбновлениеИнформационнойБазы.StandardAttribute.ExchangeDate",
+          "mdoRefRu": "ПланОбмена.ОбновлениеИнформационнойБазы.СтандартныйРеквизит.ДатаОбмена"
+        },
+        "comment": "",
+        "synonym": {
+          "content": []
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "type": "EXCHANGE_PLAN",
+          "mdoRef": "ExchangePlan.ОбновлениеИнформационнойБазы",
+          "mdoRefRu": "ПланОбмена.ОбновлениеИнформационнойБазы"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "DATE"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.DateQualifiers": {
+                "dateFractions": 2,
+                "description": {
+                  "value": {
+                    "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                    "nameRu": "КвалификаторыДаты (ДатаВремя)",
+                    "nameEn": "DateQualifiers (DateTime)"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "ДатаОбмена",
+          "nameEn": "ExchangeDate"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "3fc019d1-aec8-4835-96c5-3bbf43da0b94",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "ExchangePlan.ОбновлениеИнформационнойБазы.StandardAttribute.ThisNode",
+          "mdoRefRu": "ПланОбмена.ОбновлениеИнформационнойБазы.СтандартныйРеквизит.ЭтотУзел"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "ПланОбменаСсылка.ОбновлениеИнформационнойБазы",
+                  "nameEn": "ExchangePlanRef.ОбновлениеИнформационнойБазы"
+                },
+                "variant": "METADATA",
+                "kind": "EXCHANGE_PLAN"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 0
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "ЭтотУзел",
+          "nameEn": "ThisNode"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "3fc019d1-aec8-4835-96c5-3bbf43da0b94",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "ExchangePlan.ОбновлениеИнформационнойБазы.StandardAttribute.ReceivedNo",
+          "mdoRefRu": "ПланОбмена.ОбновлениеИнформационнойБазы.СтандартныйРеквизит.НомерПринятого"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                "precision": 5,
+                "scale": 0,
+                "nonNegative": false,
+                "description": {}
+              }
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "НомерПринятого",
+          "nameEn": "ReceivedNo"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "3fc019d1-aec8-4835-96c5-3bbf43da0b94",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "ExchangePlan.ОбновлениеИнформационнойБазы.StandardAttribute.SentNo",
+          "mdoRefRu": "ПланОбмена.ОбновлениеИнформационнойБазы.СтандартныйРеквизит.НомерОтправленного"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[3]/type"
+        },
+        "fullName": {
+          "nameRu": "НомерОтправленного",
+          "nameEn": "SentNo"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "3fc019d1-aec8-4835-96c5-3bbf43da0b94",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "ExchangePlan.ОбновлениеИнформационнойБазы.StandardAttribute.Ref",
+          "mdoRefRu": "ПланОбмена.ОбновлениеИнформационнойБазы.СтандартныйРеквизит.Ссылка"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[2]/type"
+        },
+        "fullName": {
+          "nameRu": "Ссылка",
+          "nameEn": "Ref"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "3fc019d1-aec8-4835-96c5-3bbf43da0b94",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "ExchangePlan.ОбновлениеИнформационнойБазы.StandardAttribute.DeletionMark",
+          "mdoRefRu": "ПланОбмена.ОбновлениеИнформационнойБазы.СтандартныйРеквизит.ПометкаУдаления"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "BOOLEAN"
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "fullName": {
+          "nameRu": "ПометкаУдаления",
+          "nameEn": "DeletionMark"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "3fc019d1-aec8-4835-96c5-3bbf43da0b94",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "ExchangePlan.ОбновлениеИнформационнойБазы.StandardAttribute.Description",
+          "mdoRefRu": "ПланОбмена.ОбновлениеИнформационнойБазы.СтандартныйРеквизит.Наименование"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                "length": 25,
+                "allowedLength": 0,
+                "description": {}
+              }
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "Наименование",
+          "nameEn": "Description"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "3fc019d1-aec8-4835-96c5-3bbf43da0b94",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "ExchangePlan.ОбновлениеИнформационнойБазы.StandardAttribute.Code",
+          "mdoRefRu": "ПланОбмена.ОбновлениеИнформационнойБазы.СтандартныйРеквизит.Код"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                "precision": 9,
+                "scale": 0,
+                "nonNegative": false,
+                "description": {}
+              }
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "Код",
+          "nameEn": "Code"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "5371672a-c8e0-4c12-834e-f23dd885b49a",
+        "name": "Очередь",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ExchangePlan.ОбновлениеИнформационнойБазы.Attribute.Очередь",
+          "mdoRefRu": "ПланОбмена.ОбновлениеИнформационнойБазы.Реквизит.Очередь"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Очередь"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                "precision": 10,
+                "scale": 0,
+                "nonNegative": false,
+                "description": {
+                  "value": {
+                    "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                    "nameRu": "КвалификаторыЧисла (10.0)",
+                    "nameEn": "NumberQualifiers (10.0)"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "8583ca82-a4f5-4f2a-9b9a-7807b4560e85",
+        "name": "Временная",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ExchangePlan.ОбновлениеИнформационнойБазы.Attribute.Временная",
+          "mdoRefRu": "ПланОбмена.ОбновлениеИнформационнойБазы.Реквизит.Временная"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Временная"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[6]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      }
+    ],
+    []
+  ],
+  "commands": [],
+  "comment": "",
+  "content": [
+    [
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ИсторияРассылкиОтчетов",
+          "mdoRefRu": "РегистрСведений.ИсторияРассылкиОтчетов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СостоянияРассылокОтчетов",
+          "mdoRefRu": "РегистрСведений.СостоянияРассылокОтчетов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ЭлектронноеПисьмоВходящееПрисоединенныеФайлы",
+          "mdoRefRu": "Справочник.ЭлектронноеПисьмоВходящееПрисоединенныеФайлы"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ЭкземплярыСервераDSS",
+          "mdoRefRu": "Справочник.ЭкземплярыСервераDSS"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ШаблоныАнкет",
+          "mdoRefRu": "Справочник.ШаблоныАнкет"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ПроцессыДляЗапуска",
+          "mdoRefRu": "РегистрСведений.ПроцессыДляЗапуска"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.НаличиеФайлов",
+          "mdoRefRu": "РегистрСведений.НаличиеФайлов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьПочтовыйКлиент",
+          "mdoRefRu": "Константа.ИспользоватьПочтовыйКлиент"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.УдалитьХранимыеФайлыВерсий",
+          "mdoRefRu": "РегистрСведений.УдалитьХранимыеФайлыВерсий"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ПараметрыАдминистрированияИБ",
+          "mdoRefRu": "Константа.ПараметрыАдминистрированияИБ"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьШаблоныСообщений",
+          "mdoRefRu": "Константа.ИспользоватьШаблоныСообщений"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ПараметрыИтоговИАгрегатов",
+          "mdoRefRu": "Константа.ПараметрыИтоговИАгрегатов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СообщенияОбменаДанными",
+          "mdoRefRu": "РегистрСведений.СообщенияОбменаДанными"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.НаборыДополнительныхРеквизитовИСведений",
+          "mdoRefRu": "Справочник.НаборыДополнительныхРеквизитовИСведений"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ПериодыНерабочихДнейКалендаря",
+          "mdoRefRu": "РегистрСведений.ПериодыНерабочихДнейКалендаря"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.АрхивСообщенийОбменов",
+          "mdoRefRu": "РегистрСведений.АрхивСообщенийОбменов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ПапкиЭлектронныхПисем",
+          "mdoRefRu": "Справочник.ПапкиЭлектронныхПисем"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ВариантыОтчетов",
+          "mdoRefRu": "Справочник.ВариантыОтчетов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ОтветыНаВопросыАнкет",
+          "mdoRefRu": "РегистрСведений.ОтветыНаВопросыАнкет"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ВерсииОбъектов",
+          "mdoRefRu": "РегистрСведений.ВерсииОбъектов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ДатаУведомленияОНовыхЗадачах",
+          "mdoRefRu": "Константа.ДатаУведомленияОНовыхЗадачах"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.КэшПереводов",
+          "mdoRefRu": "РегистрСведений.КэшПереводов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ЗамерыКомментарииСтатистики",
+          "mdoRefRu": "РегистрСведений.ЗамерыКомментарииСтатистики"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьЭлектронныеПодписи",
+          "mdoRefRu": "Константа.ИспользоватьЭлектронныеПодписи"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ПрофилиКлючевыхОпераций",
+          "mdoRefRu": "Справочник.ПрофилиКлючевыхОпераций"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ПараметрыРезервногоКопирования",
+          "mdoRefRu": "Константа.ПараметрыРезервногоКопирования"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьДополнительныеОтчетыИОбработки",
+          "mdoRefRu": "Константа.ИспользоватьДополнительныеОтчетыИОбработки"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СтатистикаКонфигурации",
+          "mdoRefRu": "РегистрСведений.СтатистикаКонфигурации"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.НомераОтсканированныхФайлов",
+          "mdoRefRu": "РегистрСведений.НомераОтсканированныхФайлов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CHART_OF_CHARACTERISTIC_TYPES",
+          "mdoRef": "ChartOfCharacteristicTypes.РазделыДатЗапретаИзменения",
+          "mdoRefRu": "ПланВидовХарактеристик.РазделыДатЗапретаИзменения"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.НеудаленныеОбъекты",
+          "mdoRefRu": "РегистрСведений.НеудаленныеОбъекты"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ПериодХраненияЗамеров",
+          "mdoRefRu": "Константа.ПериодХраненияЗамеров"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.НастройкиПодчиненногоУзлаРИБ",
+          "mdoRefRu": "Константа.НастройкиПодчиненногоУзлаРИБ"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.НепринятыеКОбработкеПочтовымСерверомИсходящиеПисьма",
+          "mdoRefRu": "РегистрСведений.НепринятыеКОбработкеПочтовымСерверомИсходящиеПисьма"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ВопросыШаблонаАнкеты",
+          "mdoRefRu": "Справочник.ВопросыШаблонаАнкеты"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ЗамерыВремени",
+          "mdoRefRu": "РегистрСведений.ЗамерыВремени"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CHART_OF_CHARACTERISTIC_TYPES",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.КурсыВалют",
+          "mdoRefRu": "РегистрСведений.КурсыВалют"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ВерсияДатЗапретаИзменения",
+          "mdoRefRu": "Константа.ВерсияДатЗапретаИзменения"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ОбъектыНезарегистрированныеПриЗацикливании",
+          "mdoRefRu": "РегистрСведений.ОбъектыНезарегистрированныеПриЗацикливании"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьСервисМобильнойПодписи",
+          "mdoRefRu": "Константа.ИспользоватьСервисМобильнойПодписи"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.НастройкаПроксиСервера",
+          "mdoRefRu": "Константа.НастройкаПроксиСервера"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ЗапрещатьЗагрузкуФайловПоРасширению",
+          "mdoRefRu": "Константа.ЗапрещатьЗагрузкуФайловПоРасширению"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ОбработчикиСобытийСинхронизацииДанных",
+          "mdoRefRu": "РегистрСведений.ОбработчикиСобытийСинхронизацииДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ЗаявленияНаВыпускСертификата",
+          "mdoRefRu": "РегистрСведений.ЗаявленияНаВыпускСертификата"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ВнешниеКомпоненты",
+          "mdoRefRu": "Справочник.ВнешниеКомпоненты"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.АдресПубликацииИнформационнойБазыВИнтернете",
+          "mdoRefRu": "Константа.АдресПубликацииИнформационнойБазыВИнтернете"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.КлючиДоступа",
+          "mdoRefRu": "Справочник.КлючиДоступа"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.НаборыЗначенийДоступа",
+          "mdoRefRu": "РегистрСведений.НаборыЗначенийДоступа"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.НастройкиУчетныхЗаписейЭлектроннойПочты",
+          "mdoRefRu": "РегистрСведений.НастройкиУчетныхЗаписейЭлектроннойПочты"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.КалендарныеГрафики",
+          "mdoRefRu": "РегистрСведений.КалендарныеГрафики"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ЗапретитьОтображениеНебезопасногоСодержимогоВПисьмах",
+          "mdoRefRu": "Константа.ЗапретитьОтображениеНебезопасногоСодержимогоВПисьмах"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ШаблоныСообщенийПрисоединенныеФайлы",
+          "mdoRefRu": "Справочник.ШаблоныСообщенийПрисоединенныеФайлы"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.Календари",
+          "mdoRefRu": "Справочник.Календари"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ИдентификаторыПолученныхЭлектронныхПисем",
+          "mdoRefRu": "РегистрСведений.ИдентификаторыПолученныхЭлектронныхПисем"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ОбновлениеКлючейДоступаКДанным",
+          "mdoRefRu": "РегистрСведений.ОбновлениеКлючейДоступаКДанным"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.Валюты",
+          "mdoRefRu": "Справочник.Валюты"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ШаблоныСообщений",
+          "mdoRefRu": "Справочник.ШаблоныСообщений"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ЗависимостиПравДоступа",
+          "mdoRefRu": "РегистрСведений.ЗависимостиПравДоступа"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СлужебныеАдресныеСведения",
+          "mdoRefRu": "РегистрСведений.СлужебныеАдресныеСведения"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.УровниСокращенийАдресныхСведений",
+          "mdoRefRu": "РегистрСведений.УровниСокращенийАдресныхСведений"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.РазрешитьДоступКИнтернетСервисам",
+          "mdoRefRu": "Константа.РазрешитьДоступКИнтернетСервисам"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СостоянияОригиналовПервичныхДокументов",
+          "mdoRefRu": "РегистрСведений.СостоянияОригиналовПервичныхДокументов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СоответствияОбъектовИнформационныхБаз",
+          "mdoRefRu": "РегистрСведений.СоответствияОбъектовИнформационныхБаз"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьСинхронизациюДанныхВЛокальномРежиме",
+          "mdoRefRu": "Константа.ИспользоватьСинхронизациюДанныхВЛокальномРежиме"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ЗадачиОбменаДаннымиВнутренняяПубликация",
+          "mdoRefRu": "РегистрСведений.ЗадачиОбменаДаннымиВнутренняяПубликация"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ИсторияАдминистративнойИерархии",
+          "mdoRefRu": "РегистрСведений.ИсторияАдминистративнойИерархии"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ВерсияКлассификатораБанков",
+          "mdoRefRu": "Константа.ВерсияКлассификатораБанков"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ВыполнятьЗамерыПроизводительности",
+          "mdoRefRu": "Константа.ВыполнятьЗамерыПроизводительности"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ПрофильБезопасностиИнформационнойБазы",
+          "mdoRefRu": "Константа.ПрофильБезопасностиИнформационнойБазы"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ПодписантыСервисаМобильнойПодписи",
+          "mdoRefRu": "Справочник.ПодписантыСервисаМобильнойПодписи"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ЗапланированноеВзаимодействиеПрисоединенныеФайлы",
+          "mdoRefRu": "Справочник.ЗапланированноеВзаимодействиеПрисоединенныеФайлы"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ИерархияГруппПользователей",
+          "mdoRefRu": "РегистрСведений.ИерархияГруппПользователей"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.НастройкиОбменаДаннымиXDTO",
+          "mdoRefRu": "РегистрСведений.НастройкиОбменаДаннымиXDTO"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьПризнакРассмотрено",
+          "mdoRefRu": "Константа.ИспользоватьПризнакРассмотрено"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СервисМобильнойПодписиСтатусы",
+          "mdoRefRu": "РегистрСведений.СервисМобильнойПодписиСтатусы"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ПредопределенныеВариантыОтчетовВерсийРасширений",
+          "mdoRefRu": "РегистрСведений.ПредопределенныеВариантыОтчетовВерсийРасширений"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.НастройкиРегистрацииСобытийДоступаКДанным",
+          "mdoRefRu": "Константа.НастройкиРегистрацииСобытийДоступаКДанным"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СубъектыДляСкрытияПерсональныхДанных",
+          "mdoRefRu": "РегистрСведений.СубъектыДляСкрытияПерсональныхДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.СписокРасширенийФайловOpenDocumentОбластиДанных",
+          "mdoRefRu": "Константа.СписокРасширенийФайловOpenDocumentОбластиДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьСинхронизациюДанныхВМоделиСервиса",
+          "mdoRefRu": "Константа.ИспользоватьСинхронизациюДанныхВМоделиСервиса"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ИспользованиеПоставляемыхДополнительныхОтчетовИОбработокВОбластяхДанных",
+          "mdoRefRu": "РегистрСведений.ИспользованиеПоставляемыхДополнительныхОтчетовИОбработокВОбластяхДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.РазрешенияНаИспользованиеВнешнихРесурсов",
+          "mdoRefRu": "РегистрСведений.РазрешенияНаИспользованиеВнешнихРесурсов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.НастройкиСинхронизацииФайлов",
+          "mdoRefRu": "РегистрСведений.НастройкиСинхронизацииФайлов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ПрогрессОбновления",
+          "mdoRefRu": "РегистрСведений.ПрогрессОбновления"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.УдалитьОбластиПерсональныхДанных",
+          "mdoRefRu": "РегистрСведений.УдалитьОбластиПерсональныхДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.КлючевыеОперации",
+          "mdoRefRu": "Справочник.КлючевыеОперации"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ВидыПроверок",
+          "mdoRefRu": "Справочник.ВидыПроверок"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.НезависимоеИспользованиеДополнительныхОтчетовИОбработокВМоделиСервиса",
+          "mdoRefRu": "Константа.НезависимоеИспользованиеДополнительныхОтчетовИОбработокВМоделиСервиса"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ВариантыОтветовАнкет",
+          "mdoRefRu": "Справочник.ВариантыОтветовАнкет"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.Заметки",
+          "mdoRefRu": "Справочник.Заметки"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.АдресДляВосстановленияПароляУчетнойЗаписи",
+          "mdoRefRu": "Константа.АдресДляВосстановленияПароляУчетнойЗаписи"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "TASK",
+          "mdoRef": "Task.ЗадачаИсполнителя",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ДополнительныеСведения",
+          "mdoRefRu": "РегистрСведений.ДополнительныеСведения"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СнимкиОтчетов",
+          "mdoRefRu": "РегистрСведений.СнимкиОтчетов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ПредопределенныеВариантыОтчетовРасширений",
+          "mdoRefRu": "Справочник.ПредопределенныеВариантыОтчетовРасширений"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.КлючиДоступаКРегиструРезультатыПроверкиУчета",
+          "mdoRefRu": "РегистрСведений.КлючиДоступаКРегиструРезультатыПроверкиУчета"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ПутиКПрограммамЭлектроннойПодписиИШифрованияНаСерверахLinux",
+          "mdoRefRu": "РегистрСведений.ПутиКПрограммамЭлектроннойПодписиИШифрованияНаСерверахLinux"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СостоянияПроверокВеденияУчета",
+          "mdoRefRu": "РегистрСведений.СостоянияПроверокВеденияУчета"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "DOCUMENT",
+          "mdoRef": "Document.НазначениеОпросов",
+          "mdoRefRu": "Документ.НазначениеОпросов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.СценарииОбменовДанными",
+          "mdoRefRu": "Справочник.СценарииОбменовДанными"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьСкрытиеПерсональныхДанныхСубъектов",
+          "mdoRefRu": "Константа.ИспользоватьСкрытиеПерсональныхДанныхСубъектов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СрокиХраненияПерсональныхДанных",
+          "mdoRefRu": "РегистрСведений.СрокиХраненияПерсональныхДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ИдентификаторыОбъектовМетаданных",
+          "mdoRefRu": "Справочник.ИдентификаторыОбъектовМетаданных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ФайлыВРабочемКаталоге",
+          "mdoRefRu": "РегистрСведений.ФайлыВРабочемКаталоге"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьШифрование",
+          "mdoRefRu": "Константа.ИспользоватьШифрование"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ДанныеОбработанныеВЦентральномУзлеРИБ",
+          "mdoRefRu": "РегистрСведений.ДанныеОбработанныеВЦентральномУзлеРИБ"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ОбработчикиОбновления",
+          "mdoRefRu": "РегистрСведений.ОбработчикиОбновления"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ИсполнителиЗадач",
+          "mdoRefRu": "РегистрСведений.ИсполнителиЗадач"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.УчетныеЗаписиDSS",
+          "mdoRefRu": "Справочник.УчетныеЗаписиDSS"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "DOCUMENT",
+          "mdoRef": "Document.ТелефонныйЗвонок",
+          "mdoRefRu": "Документ.ТелефонныйЗвонок"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.НастройкиВерсионированияОбъектов",
+          "mdoRefRu": "РегистрСведений.НастройкиВерсионированияОбъектов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.РолиИсполнителей",
+          "mdoRefRu": "Справочник.РолиИсполнителей"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ОбщиеВнешниеКомпоненты",
+          "mdoRefRu": "Справочник.ОбщиеВнешниеКомпоненты"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.РазрешитьДоступКИнтернетСервисамЭлектроннойПодписи",
+          "mdoRefRu": "Константа.РазрешитьДоступКИнтернетСервисамЭлектроннойПодписи"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.СписокЗапрещенныхРасширенийОбластиДанных",
+          "mdoRefRu": "Константа.СписокЗапрещенныхРасширенийОбластиДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.МашиночитаемыеДоверенности",
+          "mdoRefRu": "Справочник.МашиночитаемыеДоверенности"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.НастройкиТранспортаОбменаОбластейДанных",
+          "mdoRefRu": "РегистрСведений.НастройкиТранспортаОбменаОбластейДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ОтправлятьПисьмаВФорматеHTML",
+          "mdoRefRu": "Константа.ОтправлятьПисьмаВФорматеHTML"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьПодчиненныеБизнесПроцессы",
+          "mdoRefRu": "Константа.ИспользоватьПодчиненныеБизнесПроцессы"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.УдалитьЛогинДоступаКСервисуMorpher",
+          "mdoRefRu": "Константа.УдалитьЛогинДоступаКСервисуMorpher"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СостоянияКонтактовВзаимодействий",
+          "mdoRefRu": "РегистрСведений.СостоянияКонтактовВзаимодействий"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ОбластиПерсональныхДанных",
+          "mdoRefRu": "РегистрСведений.ОбластиПерсональныхДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СтатусыСинхронизацииФайловСОблачнымСервисом",
+          "mdoRefRu": "РегистрСведений.СтатусыСинхронизацииФайловСОблачнымСервисом"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьДатыЗапретаЗагрузки",
+          "mdoRefRu": "Константа.ИспользоватьДатыЗапретаЗагрузки"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ДанныеПроизводственногоКалендаря",
+          "mdoRefRu": "РегистрСведений.ДанныеПроизводственногоКалендаря"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьВерсионированиеОбъектов",
+          "mdoRefRu": "Константа.ИспользоватьВерсионированиеОбъектов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.СеансыОбменовДанными",
+          "mdoRefRu": "Справочник.СеансыОбменовДанными"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ВерсииРасширений",
+          "mdoRefRu": "Справочник.ВерсииРасширений"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.НаследованиеНастроекПравОбъектов",
+          "mdoRefRu": "РегистрСведений.НаследованиеНастроекПравОбъектов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ПричиныИзмененияАдресныхСведений",
+          "mdoRefRu": "РегистрСведений.ПричиныИзмененияАдресныхСведений"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ХранилищеФайлов",
+          "mdoRefRu": "РегистрСведений.ХранилищеФайлов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СессииОбменаСообщениямиСистемы",
+          "mdoRefRu": "РегистрСведений.СессииОбменаСообщениямиСистемы"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.СписокРасширенийТекстовыхФайлов",
+          "mdoRefRu": "Константа.СписокРасширенийТекстовыхФайлов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.БезопасноеХранилищеДанныхОбластейДанных",
+          "mdoRefRu": "РегистрСведений.БезопасноеХранилищеДанныхОбластейДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ЗагруженныеВерсииАдресныхСведений",
+          "mdoRefRu": "РегистрСведений.ЗагруженныеВерсииАдресныхСведений"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ПраваРолей",
+          "mdoRefRu": "РегистрСведений.ПраваРолей"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ТелефонныйЗвонокПрисоединенныеФайлы",
+          "mdoRefRu": "Справочник.ТелефонныйЗвонокПрисоединенныеФайлы"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "DOCUMENT",
+          "mdoRef": "Document.ЗапланированноеВзаимодействие",
+          "mdoRefRu": "Документ.ЗапланированноеВзаимодействие"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.СписокРасширенийФайловOpenDocument",
+          "mdoRefRu": "Константа.СписокРасширенийФайловOpenDocument"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ПравилаПроверкиУчета",
+          "mdoRefRu": "Справочник.ПравилаПроверкиУчета"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ДатаПоследнейВыгрузкиЗамеровПроизводительностиUTC",
+          "mdoRefRu": "Константа.ДатаПоследнейВыгрузкиЗамеровПроизводительностиUTC"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "DOCUMENT",
+          "mdoRef": "Document.Встреча",
+          "mdoRefRu": "Документ.Встреча"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.Пользователи",
+          "mdoRefRu": "Справочник.Пользователи"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ЗагрузитьСообщениеОбменаДанными",
+          "mdoRefRu": "Константа.ЗагрузитьСообщениеОбменаДанными"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ПроверятьЭлектронныеПодписиНаСервере",
+          "mdoRefRu": "Константа.ПроверятьЭлектронныеПодписиНаСервере"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ПровайдерSMS",
+          "mdoRefRu": "Константа.ПровайдерSMS"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ПользовательСтандартногоИнтерфейсаOData",
+          "mdoRefRu": "Константа.ПользовательСтандартногоИнтерфейсаOData"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ВерсииПодсистем",
+          "mdoRefRu": "РегистрСведений.ВерсииПодсистем"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ПользовательскиеНастройкиОтчетов",
+          "mdoRefRu": "Справочник.ПользовательскиеНастройкиОтчетов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СостоянияОбменовДанными",
+          "mdoRefRu": "РегистрСведений.СостоянияОбменовДанными"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ОповещенияПользователейСертификатов",
+          "mdoRefRu": "РегистрСведений.ОповещенияПользователейСертификатов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьАвтономнуюРаботуВМоделиСервиса",
+          "mdoRefRu": "Константа.ИспользоватьАвтономнуюРаботуВМоделиСервиса"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ПредметыПапкиВзаимодействий",
+          "mdoRefRu": "РегистрСведений.ПредметыПапкиВзаимодействий"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ЗначенияГруппДоступаПоУмолчанию",
+          "mdoRefRu": "РегистрСведений.ЗначенияГруппДоступаПоУмолчанию"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ОсновныеПечатныеФормыКонтрагентов",
+          "mdoRefRu": "РегистрСведений.ОсновныеПечатныеФормыКонтрагентов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.РазрешенныеНеаккредитованныеУЦ",
+          "mdoRefRu": "Константа.РазрешенныеНеаккредитованныеУЦ"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ОтложенноеОбновлениеЗавершеноУспешно",
+          "mdoRefRu": "Константа.ОтложенноеОбновлениеЗавершеноУспешно"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИзвлекатьТекстыФайловНаСервере",
+          "mdoRefRu": "Константа.ИзвлекатьТекстыФайловНаСервере"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьПрофилиБезопасностиДляДОО",
+          "mdoRefRu": "Константа.ИспользоватьПрофилиБезопасностиДляДОО"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.КоличествоЗамеровВПакетеЭкспорта",
+          "mdoRefRu": "Константа.КоличествоЗамеровВПакетеЭкспорта"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьДополнительныеРеквизитыИСведения",
+          "mdoRefRu": "Константа.ИспользоватьДополнительныеРеквизитыИСведения"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.КлючиДоступаВнешнихПользователей",
+          "mdoRefRu": "РегистрСведений.КлючиДоступаВнешнихПользователей"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.РазрешитьВыполнениеДООРегламентнымиЗаданиямиВМоделиСервиса",
+          "mdoRefRu": "Константа.РазрешитьВыполнениеДООРегламентнымиЗаданиямиВМоделиСервиса"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "DOCUMENT",
+          "mdoRef": "Document.СообщениеSMS",
+          "mdoRefRu": "Документ.СообщениеSMS"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ОчередьИзвлеченияТекста",
+          "mdoRefRu": "РегистрСведений.ОчередьИзвлеченияТекста"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьАнкетирование",
+          "mdoRefRu": "Константа.ИспользоватьАнкетирование"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.УчетныеЗаписиЭлектроннойПочты",
+          "mdoRefRu": "Справочник.УчетныеЗаписиЭлектроннойПочты"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.МаксимальныйРазмерФайла",
+          "mdoRefRu": "Константа.МаксимальныйРазмерФайла"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ЗапросыРазрешенийНаИспользованиеВнешнихРесурсов",
+          "mdoRefRu": "РегистрСведений.ЗапросыРазрешенийНаИспользованиеВнешнихРесурсов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ПользовательскиеНастройкиДоступаКОбработкам",
+          "mdoRefRu": "РегистрСведений.ПользовательскиеНастройкиДоступаКОбработкам"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ПакетыИнформацииПриЗапуске",
+          "mdoRefRu": "РегистрСведений.ПакетыИнформацииПриЗапуске"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ЗамерыОбластиСтатистики",
+          "mdoRefRu": "РегистрСведений.ЗамерыОбластиСтатистики"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ПараметрыБлокировкиРаботыСВнешнимиРесурсами",
+          "mdoRefRu": "Константа.ПараметрыБлокировкиРаботыСВнешнимиРесурсами"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СертификатыПолучателейРассылкиОтчетов",
+          "mdoRefRu": "РегистрСведений.СертификатыПолучателейРассылкиОтчетов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ПриоритетОбновленияВОбластяхДанных",
+          "mdoRefRu": "Константа.ПриоритетОбновленияВОбластяхДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "DOCUMENT",
+          "mdoRef": "Document.Анкета",
+          "mdoRefRu": "Документ.Анкета"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.КлючиДоступаНаборовГруппДоступа",
+          "mdoRefRu": "РегистрСведений.КлючиДоступаНаборовГруппДоступа"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.УдалитьНастройкиВходаПользователей",
+          "mdoRefRu": "Константа.УдалитьНастройкиВходаПользователей"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ПараметрыАдресногоКлассификатора",
+          "mdoRefRu": "Константа.ПараметрыАдресногоКлассификатора"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ПроизводственныеКалендари",
+          "mdoRefRu": "Справочник.ПроизводственныеКалендари"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.СтроковыеКонтактыВзаимодействий",
+          "mdoRefRu": "Справочник.СтроковыеКонтактыВзаимодействий"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ПоставляемыеДополнительныеОтчетыИОбработки",
+          "mdoRefRu": "Справочник.ПоставляемыеДополнительныеОтчетыИОбработки"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ЭлектронноеПисьмоИсходящееПрисоединенныеФайлы",
+          "mdoRefRu": "Справочник.ЭлектронноеПисьмоИсходящееПрисоединенныеФайлы"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.НазначениеДополнительныхОбработок",
+          "mdoRefRu": "РегистрСведений.НазначениеДополнительныхОбработок"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ВидыКонтактнойИнформации",
+          "mdoRefRu": "Справочник.ВидыКонтактнойИнформации"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.СтраныМира",
+          "mdoRefRu": "Справочник.СтраныМира"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.МашиночитаемыеДоверенностиСтатусы",
+          "mdoRefRu": "РегистрСведений.МашиночитаемыеДоверенностиСтатусы"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.СоздаватьЭлектронныеПодписиНаСервере",
+          "mdoRefRu": "Константа.СоздаватьЭлектронныеПодписиНаСервере"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьГруппыВнешнихПользователей",
+          "mdoRefRu": "Константа.ИспользоватьГруппыВнешнихПользователей"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьДатуИВремяВСрокахЗадач",
+          "mdoRefRu": "Константа.ИспользоватьДатуИВремяВСрокахЗадач"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СклоненияПредставленийОбъектов",
+          "mdoRefRu": "РегистрСведений.СклоненияПредставленийОбъектов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СогласияНаОбработкуПерсональныхДанных",
+          "mdoRefRu": "РегистрСведений.СогласияНаОбработкуПерсональныхДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ПубличныеИдентификаторыСинхронизируемыхОбъектов",
+          "mdoRefRu": "РегистрСведений.ПубличныеИдентификаторыСинхронизируемыхОбъектов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "DOCUMENT",
+          "mdoRef": "Document.ОтзывСогласияНаОбработкуПерсональныхДанных",
+          "mdoRefRu": "Документ.ОтзывСогласияНаОбработкуПерсональныхДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.КлассификаторыМЧД",
+          "mdoRefRu": "РегистрСведений.КлассификаторыМЧД"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьКомандуЗаметки",
+          "mdoRefRu": "Константа.ИспользоватьКомандуЗаметки"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.СертификатыКлючейЭлектроннойПодписиИШифрования",
+          "mdoRefRu": "Справочник.СертификатыКлючейЭлектроннойПодписиИШифрования"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ДополнительныеАдресныеСведения",
+          "mdoRefRu": "РегистрСведений.ДополнительныеАдресныеСведения"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.УдалитьНастройкиТранспортаОбменаДанными",
+          "mdoRefRu": "РегистрСведений.УдалитьНастройкиТранспортаОбменаДанными"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.СтатусОбновленияКонфигурации",
+          "mdoRefRu": "Константа.СтатусОбновленияКонфигурации"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьОтправкуSMSВШаблонахСообщений",
+          "mdoRefRu": "Константа.ИспользоватьОтправкуSMSВШаблонахСообщений"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ОбновлениеКлючейДоступаТекущиеЗадания",
+          "mdoRefRu": "РегистрСведений.ОбновлениеКлючейДоступаТекущиеЗадания"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СведенияОФайлах",
+          "mdoRefRu": "РегистрСведений.СведенияОФайлах"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.КонтурСинхронизации",
+          "mdoRefRu": "РегистрСведений.КонтурСинхронизации"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.КоличествоПотоковОбновленияДоступа",
+          "mdoRefRu": "Константа.КоличествоПотоковОбновленияДоступа"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СоставыГруппПользователей",
+          "mdoRefRu": "РегистрСведений.СоставыГруппПользователей"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ПотокиОбновления",
+          "mdoRefRu": "РегистрСведений.ПотокиОбновления"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьКомандуНапоминаний",
+          "mdoRefRu": "Константа.ИспользоватьКомандуНапоминаний"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ПользовательскиеМакетыПечати",
+          "mdoRefRu": "РегистрСведений.ПользовательскиеМакетыПечати"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.УдалитьБезопасноеХранилищеДанныхОбластейДанных",
+          "mdoRefRu": "РегистрСведений.УдалитьБезопасноеХранилищеДанныхОбластейДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.МуниципальнаяИерархия",
+          "mdoRefRu": "РегистрСведений.МуниципальнаяИерархия"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ТаблицыГруппДоступа",
+          "mdoRefRu": "РегистрСведений.ТаблицыГруппДоступа"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ЗакладкиВзаимодействий",
+          "mdoRefRu": "Справочник.ЗакладкиВзаимодействий"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.СостоянияОригиналовПервичныхДокументов",
+          "mdoRefRu": "Справочник.СостоянияОригиналовПервичныхДокументов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ИзмененияОбщихДанныхУзлов",
+          "mdoRefRu": "РегистрСведений.ИзмененияОбщихДанныхУзлов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ОбновлениеКлючейДоступаПользователей",
+          "mdoRefRu": "РегистрСведений.ОбновлениеКлючейДоступаПользователей"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.РассылкиОтчетов",
+          "mdoRefRu": "Справочник.РассылкиОтчетов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.НеразделенныеПользователи",
+          "mdoRefRu": "РегистрСведений.НеразделенныеПользователи"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.УведомленияОПрочтении",
+          "mdoRefRu": "РегистрСведений.УведомленияОПрочтении"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ДанныеОбъектовДляРегистрацииВОбменах",
+          "mdoRefRu": "РегистрСведений.ДанныеОбъектовДляРегистрацииВОбменах"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ДанныеБизнесПроцессов",
+          "mdoRefRu": "РегистрСведений.ДанныеБизнесПроцессов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "DOCUMENT",
+          "mdoRef": "Document.ЭлектронноеПисьмоИсходящее",
+          "mdoRefRu": "Документ.ЭлектронноеПисьмоИсходящее"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СпискиОтзываСертификатов",
+          "mdoRefRu": "РегистрСведений.СпискиОтзываСертификатов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.МинимальныйИнтервалРегламентныхЗаданийДОИОВМоделиСервиса",
+          "mdoRefRu": "Константа.МинимальныйИнтервалРегламентныхЗаданийДОИОВМоделиСервиса"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользованиеКаталогаДополнительныхОтчетовИОбработокВМоделиСервиса",
+          "mdoRefRu": "Константа.ИспользованиеКаталогаДополнительныхОтчетовИОбработокВМоделиСервиса"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ДлительныеОперации",
+          "mdoRefRu": "РегистрСведений.ДлительныеОперации"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.УдалитьЗамерыВремени3",
+          "mdoRefRu": "РегистрСведений.УдалитьЗамерыВремени3"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.НастройкиПравОбъектов",
+          "mdoRefRu": "РегистрСведений.НастройкиПравОбъектов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ДополнительныеОтчетыИОбработки",
+          "mdoRefRu": "Справочник.ДополнительныеОтчетыИОбработки"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ВнешниеПользователи",
+          "mdoRefRu": "Справочник.ВнешниеПользователи"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ПапкиФайлов",
+          "mdoRefRu": "Справочник.ПапкиФайлов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СубъектыДляРасчетаСроковХранения",
+          "mdoRefRu": "РегистрСведений.СубъектыДляРасчетаСроковХранения"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.НапоминанияПользователя",
+          "mdoRefRu": "РегистрСведений.НапоминанияПользователя"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ДатаОбновленияПовторноИспользуемыхЗначенийМРО",
+          "mdoRefRu": "Константа.ДатаОбновленияПовторноИспользуемыхЗначенийМРО"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.НастройкиПолномочийМЧД",
+          "mdoRefRu": "РегистрСведений.НастройкиПолномочийМЧД"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ЗначенияГруппДоступа",
+          "mdoRefRu": "РегистрСведений.ЗначенияГруппДоступа"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ИсторияМуниципальнойИерархии",
+          "mdoRefRu": "РегистрСведений.ИсторияМуниципальнойИерархии"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьАльтернативныйСерверДляЗагрузкиКурсовВалют",
+          "mdoRefRu": "Константа.ИспользоватьАльтернативныйСерверДляЗагрузкиКурсовВалют"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьПолнотекстовыйПоиск",
+          "mdoRefRu": "Константа.ИспользоватьПолнотекстовыйПоиск"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.КаталогСообщенийОбменаДаннымиДляWindows",
+          "mdoRefRu": "Константа.КаталогСообщенийОбменаДаннымиДляWindows"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.АвтоматическиНастраиватьРазрешенияВПрофиляхБезопасности",
+          "mdoRefRu": "Константа.АвтоматическиНастраиватьРазрешенияВПрофиляхБезопасности"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.РежимОчисткиФайлов",
+          "mdoRefRu": "Константа.РежимОчисткиФайлов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.КэшПрограммныхИнтерфейсов",
+          "mdoRefRu": "РегистрСведений.КэшПрограммныхИнтерфейсов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ГруппыЗначенийДоступа",
+          "mdoRefRu": "РегистрСведений.ГруппыЗначенийДоступа"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.НастройкиКомандПечати",
+          "mdoRefRu": "РегистрСведений.НастройкиКомандПечати"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ДанныеДляОтложенногоОбновления",
+          "mdoRefRu": "Константа.ДанныеДляОтложенногоОбновления"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.СервисПереводаТекста",
+          "mdoRefRu": "Константа.СервисПереводаТекста"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.НеИспользоватьРазделениеПоОбластямДанных",
+          "mdoRefRu": "Константа.НеИспользоватьРазделениеПоОбластямДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.КаталогСообщенийОбменаДаннымиДляLinux",
+          "mdoRefRu": "Константа.КаталогСообщенийОбменаДаннымиДляLinux"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.СведенияОБлокируемыхОбъектах",
+          "mdoRefRu": "Константа.СведенияОБлокируемыхОбъектах"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ПредопределенныеВариантыОтчетов",
+          "mdoRefRu": "Справочник.ПредопределенныеВариантыОтчетов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьЭлектроннуюПочтуВШаблонахСообщений",
+          "mdoRefRu": "Константа.ИспользоватьЭлектроннуюПочтуВШаблонахСообщений"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьСинхронизациюДанныхВМоделиСервисаСПриложениемВИнтернете",
+          "mdoRefRu": "Константа.ИспользоватьСинхронизациюДанныхВМоделиСервисаСПриложениемВИнтернете"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ОценкаПроизводительностиПериодЗаписи",
+          "mdoRefRu": "Константа.ОценкаПроизводительностиПериодЗаписи"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ГлавныйУзел",
+          "mdoRefRu": "Константа.ГлавныйУзел"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.АдресСервисаМЧДРР",
+          "mdoRefRu": "Константа.АдресСервисаМЧДРР"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ЗаголовокСистемы",
+          "mdoRefRu": "Константа.ЗаголовокСистемы"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.РучныеИзмененияГрафиковРаботы",
+          "mdoRefRu": "РегистрСведений.РучныеИзмененияГрафиковРаботы"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьБизнесПроцессыИЗадачи",
+          "mdoRefRu": "Константа.ИспользоватьБизнесПроцессыИЗадачи"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СостоянияОбменовДаннымиОбластейДанных",
+          "mdoRefRu": "РегистрСведений.СостоянияОбменовДаннымиОбластейДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ГруппыПользователей",
+          "mdoRefRu": "Справочник.ГруппыПользователей"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользуютсяПрофилиБезопасности",
+          "mdoRefRu": "Константа.ИспользуютсяПрофилиБезопасности"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.СтандартныеПодсистемыВАвтономномРежиме",
+          "mdoRefRu": "Константа.СтандартныеПодсистемыВАвтономномРежиме"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ОграничиватьДоступНаУровнеЗаписейУниверсально",
+          "mdoRefRu": "Константа.ОграничиватьДоступНаУровнеЗаписейУниверсально"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписиМЧД",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписиМЧД"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ЗарегистрированыИзмененияДанных",
+          "mdoRefRu": "Константа.ЗарегистрированыИзмененияДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.НастройкиОчисткиФайлов",
+          "mdoRefRu": "РегистрСведений.НастройкиОчисткиФайлов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ОбщиеНастройкиУзловИнформационныхБаз",
+          "mdoRefRu": "РегистрСведений.ОбщиеНастройкиУзловИнформационныхБаз"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ЗначенияСвойствОбъектовИерархия",
+          "mdoRefRu": "Справочник.ЗначенияСвойствОбъектовИерархия"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.МаксимальныйРазмерФайлаОбластиДанных",
+          "mdoRefRu": "Константа.МаксимальныйРазмерФайлаОбластиДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьВнешнихПользователей",
+          "mdoRefRu": "Константа.ИспользоватьВнешнихПользователей"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.УчетныеЗаписиСинхронизацииФайлов",
+          "mdoRefRu": "Справочник.УчетныеЗаписиСинхронизацииФайлов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ПараметрыРаботыПрограммы",
+          "mdoRefRu": "РегистрСведений.ПараметрыРаботыПрограммы"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ПрограммыЭлектроннойПодписиИШифрования",
+          "mdoRefRu": "Справочник.ПрограммыЭлектроннойПодписиИШифрования"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ИдентификаторыОбъектовРасширений",
+          "mdoRefRu": "Справочник.ИдентификаторыОбъектовРасширений"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СостоянияПапокПисем",
+          "mdoRefRu": "РегистрСведений.СостоянияПапокПисем"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.НастройкиКолонтитулов",
+          "mdoRefRu": "Константа.НастройкиКолонтитулов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СертификатыПользователяDSS",
+          "mdoRefRu": "РегистрСведений.СертификатыПользователяDSS"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.АдминистративнаяИерархия",
+          "mdoRefRu": "РегистрСведений.АдминистративнаяИерархия"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.УдалитьНастройкиТранспортаОбмена",
+          "mdoRefRu": "РегистрСведений.УдалитьНастройкиТранспортаОбмена"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CHART_OF_CHARACTERISTIC_TYPES",
+          "mdoRef": "ChartOfCharacteristicTypes.ОбъектыАдресацииЗадач",
+          "mdoRefRu": "ПланВидовХарактеристик.ОбъектыАдресацииЗадач"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьГруппыПользователей",
+          "mdoRefRu": "Константа.ИспользоватьГруппыПользователей"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.СинхронизироватьДанныеСПриложениемВИнтернетеПриНачалеРаботыПрограммы",
+          "mdoRefRu": "Константа.СинхронизироватьДанныеСПриложениемВИнтернетеПриНачалеРаботыПрограммы"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.НастройкиВходаПользователей",
+          "mdoRefRu": "Константа.НастройкиВходаПользователей"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ПсевдонимыПредопределенныхУзлов",
+          "mdoRefRu": "РегистрСведений.ПсевдонимыПредопределенныхУзлов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СостоянияУспешныхОбменовДаннымиОбластейДанных",
+          "mdoRefRu": "РегистрСведений.СостоянияУспешныхОбменовДаннымиОбластейДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьНесколькоПроизводственныхКалендарей",
+          "mdoRefRu": "Константа.ИспользоватьНесколькоПроизводственныхКалендарей"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ПравилаДляОбменаДанными",
+          "mdoRefRu": "РегистрСведений.ПравилаДляОбменаДанными"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ОбластиСтатистики",
+          "mdoRefRu": "РегистрСведений.ОбластиСтатистики"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.НастройкаПодчиненногоУзлаРИБЗавершена",
+          "mdoRefRu": "Константа.НастройкаПодчиненногоУзлаРИБЗавершена"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ГруппыИсполнителейЗадач",
+          "mdoRefRu": "Справочник.ГруппыИсполнителейЗадач"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.НастройкиТранспортаСообщенийОбмена",
+          "mdoRefRu": "Справочник.НастройкиТранспортаСообщенийОбмена"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ЗначенияСвойствОбъектов",
+          "mdoRefRu": "Справочник.ЗначенияСвойствОбъектов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ДатыПоследнейЗагрузкиПочтовыхСообщений",
+          "mdoRefRu": "РегистрСведений.ДатыПоследнейЗагрузкиПочтовыхСообщений"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ПараметрыОграниченияДоступа",
+          "mdoRefRu": "РегистрСведений.ПараметрыОграниченияДоступа"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.КлассификаторБанков",
+          "mdoRefRu": "Справочник.КлассификаторБанков"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ЗемельныеУчастки",
+          "mdoRefRu": "РегистрСведений.ЗемельныеУчастки"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ИсторияАдресныхОбъектов",
+          "mdoRefRu": "РегистрСведений.ИсторияАдресныхОбъектов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.СписокЗапрещенныхРасширений",
+          "mdoRefRu": "Константа.СписокЗапрещенныхРасширений"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ПериодическиеСерверныеОповещения",
+          "mdoRefRu": "РегистрСведений.ПериодическиеСерверныеОповещения"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СообщенияОбменаДаннымиОбластейДанных",
+          "mdoRefRu": "РегистрСведений.СообщенияОбменаДаннымиОбластейДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.НастройкиВариантовОтчетов",
+          "mdoRefRu": "РегистрСведений.НастройкиВариантовОтчетов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.СообщениеSMSПрисоединенныеФайлы",
+          "mdoRefRu": "Справочник.СообщениеSMSПрисоединенныеФайлы"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СертификатыШифрования",
+          "mdoRefRu": "РегистрСведений.СертификатыШифрования"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.УдалитьРезультатыОбменаДанными",
+          "mdoRefRu": "РегистрСведений.УдалитьРезультатыОбменаДанными"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ИспользованиеДополнительныхОтчетовИОбработокСервисаВАвтономномРабочемМесте",
+          "mdoRefRu": "РегистрСведений.ИспользованиеДополнительныхОтчетовИОбработокСервисаВАвтономномРабочемМесте"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ЗаблокированныеДляПолученияУчетныеЗаписи",
+          "mdoRefRu": "РегистрСведений.ЗаблокированныеДляПолученияУчетныеЗаписи"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ПараметрыРаботыВерсийРасширений",
+          "mdoRefRu": "РегистрСведений.ПараметрыРаботыВерсийРасширений"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ХранилищеДвоичныхДанных",
+          "mdoRefRu": "Справочник.ХранилищеДвоичныхДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ОсновныеПечатныеФормыОбъектов",
+          "mdoRefRu": "РегистрСведений.ОсновныеПечатныеФормыОбъектов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.НастройкиТранспортаОбменаОбластиДанных",
+          "mdoRefRu": "РегистрСведений.НастройкиТранспортаОбменаОбластиДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьНапоминанияПользователя",
+          "mdoRefRu": "Константа.ИспользоватьНапоминанияПользователя"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.УничтоженныеПерсональныеДанные",
+          "mdoRefRu": "РегистрСведений.УничтоженныеПерсональныеДанные"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ПрефиксУзлаРаспределеннойИнформационнойБазы",
+          "mdoRefRu": "Константа.ПрефиксУзлаРаспределеннойИнформационнойБазы"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.СообщениеОбменаДаннымиИзГлавногоУзла",
+          "mdoRefRu": "Константа.СообщениеОбменаДаннымиИзГлавногоУзла"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьЗаметки",
+          "mdoRefRu": "Константа.ИспользоватьЗаметки"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ОчередьИнсталляцииПоставляемыхДополнительныхОтчетовИОбработокВОбластиДанных",
+          "mdoRefRu": "РегистрСведений.ОчередьИнсталляцииПоставляемыхДополнительныхОтчетовИОбработокВОбластиДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ЯзыкиПечатныхФорм",
+          "mdoRefRu": "Справочник.ЯзыкиПечатныхФорм"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьСервисПереводаТекста",
+          "mdoRefRu": "Константа.ИспользоватьСервисПереводаТекста"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "DOCUMENT",
+          "mdoRef": "Document.СогласиеНаОбработкуПерсональныхДанных",
+          "mdoRefRu": "Документ.СогласиеНаОбработкуПерсональныхДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.РезультатыОбменаДанными",
+          "mdoRefRu": "РегистрСведений.РезультатыОбменаДанными"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.БуферОперацийСтатистики",
+          "mdoRefRu": "РегистрСведений.БуферОперацийСтатистики"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ОтправленныеСерверныеОповещения",
+          "mdoRefRu": "РегистрСведений.ОтправленныеСерверныеОповещения"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ПараметрыЦентраМониторинга",
+          "mdoRefRu": "Константа.ПараметрыЦентраМониторинга"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ОграничиватьДоступНаУровнеЗаписей",
+          "mdoRefRu": "Константа.ОграничиватьДоступНаУровнеЗаписей"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.АдресныеОбъекты",
+          "mdoRefRu": "РегистрСведений.АдресныеОбъекты"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СвойстваРасширений",
+          "mdoRefRu": "РегистрСведений.СвойстваРасширений"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "DOCUMENT",
+          "mdoRef": "Document.АктОбУничтоженииПерсональныхДанных",
+          "mdoRefRu": "Документ.АктОбУничтоженииПерсональныхДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ГруппыВнешнихПользователей",
+          "mdoRefRu": "Справочник.ГруппыВнешнихПользователей"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ЗамерыВремениТехнологические",
+          "mdoRefRu": "РегистрСведений.ЗамерыВремениТехнологические"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьРазделениеПоОбластямДанных",
+          "mdoRefRu": "Константа.ИспользоватьРазделениеПоОбластямДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ХранитьФайлыВТомахНаДиске",
+          "mdoRefRu": "Константа.ХранитьФайлыВТомахНаДиске"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьСервисСклоненияMorpher",
+          "mdoRefRu": "Константа.ИспользоватьСервисСклоненияMorpher"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.СведенияОбОбновленииИБ",
+          "mdoRefRu": "Константа.СведенияОбОбновленииИБ"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ГруппыДоступа",
+          "mdoRefRu": "Справочник.ГруппыДоступа"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ОбщиеПоставляемыеМакетыПечати",
+          "mdoRefRu": "РегистрСведений.ОбщиеПоставляемыеМакетыПечати"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.КоличествоПотоковОбновленияИнформационнойБазы",
+          "mdoRefRu": "Константа.КоличествоПотоковОбновленияИнформационнойБазы"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СостоянияУспешныхОбменовДанными",
+          "mdoRefRu": "РегистрСведений.СостоянияУспешныхОбменовДанными"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ИспользуемыеВидыДоступа",
+          "mdoRefRu": "РегистрСведений.ИспользуемыеВидыДоступа"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ОтложенноеОбновлениеВГлавномУзлеЗавершеноУспешно",
+          "mdoRefRu": "Константа.ОтложенноеОбновлениеВГлавномУзлеЗавершеноУспешно"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ДатыЗапретаИзменения",
+          "mdoRefRu": "РегистрСведений.ДатыЗапретаИзменения"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.УдаляемыеОбъекты",
+          "mdoRefRu": "РегистрСведений.УдаляемыеОбъекты"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ВстречаПрисоединенныеФайлы",
+          "mdoRefRu": "Справочник.ВстречаПрисоединенныеФайлы"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.КлючиДоступаКРегистрам",
+          "mdoRefRu": "РегистрСведений.КлючиДоступаКРегистрам"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьДатыЗапретаИзменения",
+          "mdoRefRu": "Константа.ИспользоватьДатыЗапретаИзменения"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.КлючиДоступаКОбъектам",
+          "mdoRefRu": "РегистрСведений.КлючиДоступаКОбъектам"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьПрочиеВзаимодействия",
+          "mdoRefRu": "Константа.ИспользоватьПрочиеВзаимодействия"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ЭтоАвтономноеРабочееМесто",
+          "mdoRefRu": "Константа.ЭтоАвтономноеРабочееМесто"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.НаборыГруппДоступа",
+          "mdoRefRu": "Справочник.НаборыГруппДоступа"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ТомаХраненияФайлов",
+          "mdoRefRu": "Справочник.ТомаХраненияФайлов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ВерсииПодсистемОбластейДанных",
+          "mdoRefRu": "РегистрСведений.ВерсииПодсистемОбластейДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ПравилаОбработкиЭлектроннойПочты",
+          "mdoRefRu": "Справочник.ПравилаОбработкиЭлектроннойПочты"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CHART_OF_CHARACTERISTIC_TYPES",
+          "mdoRef": "ChartOfCharacteristicTypes.ВопросыДляАнкетирования",
+          "mdoRefRu": "ПланВидовХарактеристик.ВопросыДляАнкетирования"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "BUSINESS_PROCESS",
+          "mdoRef": "BusinessProcess.Задание",
+          "mdoRefRu": "БизнесПроцесс.Задание"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.НастройкиАрхиваСообщенийОбменов",
+          "mdoRefRu": "РегистрСведений.НастройкиАрхиваСообщенийОбменов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.МакетыПечатныхФорм",
+          "mdoRefRu": "Справочник.МакетыПечатныхФорм"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ИдентификаторыОбъектовВерсийРасширений",
+          "mdoRefRu": "РегистрСведений.ИдентификаторыОбъектовВерсийРасширений"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ФиксацияОбработкиДанныхОбработчиками",
+          "mdoRefRu": "РегистрСведений.ФиксацияОбработкиДанныхОбработчиками"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.СинхронизироватьДанныеСПриложениемВИнтернетеПриЗавершенииРаботыПрограммы",
+          "mdoRefRu": "Константа.СинхронизироватьДанныеСПриложениемВИнтернетеПриЗавершенииРаботыПрограммы"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.КоличествоЭлементовВТранзакцииЗагрузкиДанных",
+          "mdoRefRu": "Константа.КоличествоЭлементовВТранзакцииЗагрузкиДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ЗагрузитьРасширенияИзменяющиеСтруктуруДанных",
+          "mdoRefRu": "Константа.ЗагрузитьРасширенияИзменяющиеСтруктуруДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.КлючиДоступаПользователей",
+          "mdoRefRu": "РегистрСведений.КлючиДоступаПользователей"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.КлючиДоступаГруппДоступа",
+          "mdoRefRu": "РегистрСведений.КлючиДоступаГруппДоступа"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.МашиночитаемыеДоверенностиПрисоединенныеФайлы",
+          "mdoRefRu": "Справочник.МашиночитаемыеДоверенностиПрисоединенныеФайлы"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ДомаЗданияСтроения",
+          "mdoRefRu": "РегистрСведений.ДомаЗданияСтроения"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ИспользуемыеВидыДоступаПоТаблицам",
+          "mdoRefRu": "РегистрСведений.ИспользуемыеВидыДоступаПоТаблицам"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.МашиночитаемыеДоверенностиПредставителиИДоверители",
+          "mdoRefRu": "РегистрСведений.МашиночитаемыеДоверенностиПредставителиИДоверители"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ДампыПлатформы",
+          "mdoRefRu": "РегистрСведений.ДампыПлатформы"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.АдресПубликацииИнформационнойБазыВЛокальнойСети",
+          "mdoRefRu": "Константа.АдресПубликацииИнформационнойБазыВЛокальнойСети"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.КодировкиФайлов",
+          "mdoRefRu": "РегистрСведений.КодировкиФайлов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ЗамерыОперацииСтатистики",
+          "mdoRefRu": "РегистрСведений.ЗамерыОперацииСтатистики"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ПоследнееОбновлениеДоступа",
+          "mdoRefRu": "Константа.ПоследнееОбновлениеДоступа"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.Файлы",
+          "mdoRefRu": "Справочник.Файлы"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ПрефиксПоследнегоАвтономногоРабочегоМеста",
+          "mdoRefRu": "Константа.ПрефиксПоследнегоАвтономногоРабочегоМеста"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИсточникДанныхАдресногоКлассификатора",
+          "mdoRefRu": "Константа.ИсточникДанныхАдресногоКлассификатора"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ЗамерыСтатистики",
+          "mdoRefRu": "РегистрСведений.ЗамерыСтатистики"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.КомментарииСтатистики",
+          "mdoRefRu": "РегистрСведений.КомментарииСтатистики"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.СинхронизироватьФайлы",
+          "mdoRefRu": "Константа.СинхронизироватьФайлы"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ВерсииФайлов",
+          "mdoRefRu": "Справочник.ВерсииФайлов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ОперацииСтатистики",
+          "mdoRefRu": "РегистрСведений.ОперацииСтатистики"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.УдалитьДвоичныеДанныеФайлов",
+          "mdoRefRu": "РегистрСведений.УдалитьДвоичныеДанныеФайлов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ОбработчикиОбновленияОбщихДанных",
+          "mdoRefRu": "РегистрСведений.ОбработчикиОбновленияОбщихДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ПовторитьЗагрузкуСообщенияОбменаДаннымиПередЗапуском",
+          "mdoRefRu": "Константа.ПовторитьЗагрузкуСообщенияОбменаДаннымиПередЗапуском"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.КомментарииОперацииСтатистики",
+          "mdoRefRu": "РегистрСведений.КомментарииОперацииСтатистики"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.КонтактыВзаимодействий",
+          "mdoRefRu": "РегистрСведений.КонтактыВзаимодействий"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.РабочиеКаталогиФайлов",
+          "mdoRefRu": "РегистрСведений.РабочиеКаталогиФайлов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ПакетыДляОтправки",
+          "mdoRefRu": "РегистрСведений.ПакетыДляОтправки"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ДетализироватьОбновлениеИБВЖурналеРегистрации",
+          "mdoRefRu": "Константа.ДетализироватьОбновлениеИБВЖурналеРегистрации"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ПрофилиГруппДоступа",
+          "mdoRefRu": "Справочник.ПрофилиГруппДоступа"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "DOCUMENT",
+          "mdoRef": "Document.ЭлектронноеПисьмоВходящее",
+          "mdoRefRu": "Документ.ЭлектронноеПисьмоВходящее"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьСинхронизациюДанных",
+          "mdoRefRu": "Константа.ИспользоватьСинхронизациюДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИдентификаторИнформационнойБазы",
+          "mdoRefRu": "Константа.ИдентификаторИнформационнойБазы"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ПоставляемыеМакетыПечати",
+          "mdoRefRu": "РегистрСведений.ПоставляемыеМакетыПечати"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИзменятьЗаданияЗаднимЧислом",
+          "mdoRefRu": "Константа.ИзменятьЗаданияЗаднимЧислом"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.РежимыПодключенияВнешнихМодулей",
+          "mdoRefRu": "РегистрСведений.РежимыПодключенияВнешнихМодулей"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.БезопасноеХранилищеДанных",
+          "mdoRefRu": "РегистрСведений.БезопасноеХранилищеДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СостоянияПредметовВзаимодействий",
+          "mdoRefRu": "РегистрСведений.СостоянияПредметовВзаимодействий"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.РезультатыПроверкиУчета",
+          "mdoRefRu": "РегистрСведений.РезультатыПроверкиУчета"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьСинхронизациюДанныхВМоделиСервисаСЛокальнойПрограммой",
+          "mdoRefRu": "Константа.ИспользоватьСинхронизациюДанныхВМоделиСервисаСЛокальнойПрограммой"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СведенияОПользователях",
+          "mdoRefRu": "РегистрСведений.СведенияОПользователях"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.БлокировкиСеансовОбластейДанных",
+          "mdoRefRu": "РегистрСведений.БлокировкиСеансовОбластейДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьУдалениеПомеченныхОбъектов",
+          "mdoRefRu": "Константа.ИспользоватьУдалениеПомеченныхОбъектов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьДатуНачалаЗадач",
+          "mdoRefRu": "Константа.ИспользоватьДатуНачалаЗадач"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.НастройкиАвторизацииИнтернетСервисов",
+          "mdoRefRu": "Справочник.НастройкиАвторизацииИнтернетСервисов"
+        },
+        "allow": false
+      }
+    ],
+    []
+  ],
+  "description": "Обновление информационной базы",
+  "distributedInfoBase": false,
+  "explanation": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+  },
+  "forms": [],
+  "includeConfigurationExtensions": false,
+  "mdoReference": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+  },
+  "mdoType": "EXCHANGE_PLAN",
+  "moduleTypes": [
+    [
+      "ManagerModule",
+      [
+        "src/test/resources/ext/designer/ssl_3_2/src/cf/ExchangePlans/ОбновлениеИнформационно_Базы/Ext/ManagerModule.bsl"
+      ]
+    ],
+    [
+      "ObjectModule",
+      [
+        "src/test/resources/ext/designer/ssl_3_2/src/cf/ExchangePlans/ОбновлениеИнформационно_Базы/Ext/ObjectModule.bsl"
+      ]
+    ]
+  ],
+  "modules": [
+    {
+      "moduleType": "ManagerModule",
+      "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/ExchangePlans/ОбновлениеИнформационно_Базы/Ext/ManagerModule.bsl",
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "isProtected": false
+    },
+    {
+      "moduleType": "ObjectModule",
+      "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/ExchangePlans/ОбновлениеИнформационно_Базы/Ext/ObjectModule.bsl",
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "isProtected": false
+    }
+  ],
+  "name": "ОбновлениеИнформационнойБазы",
+  "objectBelonging": "OWN",
+  "possibleRights": [
+    {
+      "default": {
+        "tag": 4
+      },
+      "int": 21,
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INSERT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "DELETE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "VIEW",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "EDIT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INPUT_BY_STRING",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_DELETE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_INSERT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_SET_DELETION_MARK",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_CLEAR_DELETION_MARK",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_DELETE_MARKED",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "VIEW_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ_DATA_HISTORY_OF_MISSING_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_OF_MISSING_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_SETTINGS",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_VERSION_COMMENT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "EDIT_DATA_HISTORY_VERSION_COMMENT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "SWITCH_TO_DATA_HISTORY_VERSION"
+    }
+  ],
+  "predefinedValues": [],
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "content": [
+      {
+        "default": {
+          "tag": 2
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+          "langKey": "ru",
+          "value": "Обновление информационной базы"
+        }
+      }
+    ]
+  },
+  "tabularSections": [],
+  "templates": [],
+  "uuid": "3fc019d1-aec8-4835-96c5-3bbf43da0b94"
+}}

--- a/src/test/resources/fixtures/ssl_3_2/ExchangePlans.ОбновлениеИнформационнойБазы.json
+++ b/src/test/resources/fixtures/ssl_3_2/ExchangePlans.ОбновлениеИнформационнойБазы.json
@@ -582,6 +582,14 @@
       },
       {
         "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.МестаХраненияДвоичныхДанных",
+          "mdoRefRu": "РегистрСведений.МестаХраненияДвоичныхДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
           "type": "CATALOG",
           "mdoRef": "Catalog.ШаблоныАнкет",
           "mdoRefRu": "Справочник.ШаблоныАнкет"
@@ -609,14 +617,6 @@
           "type": "CONSTANT",
           "mdoRef": "Constant.ИспользоватьПочтовыйКлиент",
           "mdoRefRu": "Константа.ИспользоватьПочтовыйКлиент"
-        },
-        "allow": false
-      },
-      {
-        "metadata": {
-          "type": "INFORMATION_REGISTER",
-          "mdoRef": "InformationRegister.УдалитьХранимыеФайлыВерсий",
-          "mdoRefRu": "РегистрСведений.УдалитьХранимыеФайлыВерсий"
         },
         "allow": false
       },
@@ -1206,6 +1206,14 @@
       },
       {
         "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.НастройкиОтправкиВГосключ",
+          "mdoRefRu": "Справочник.НастройкиОтправкиВГосключ"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
           "type": "INFORMATION_REGISTER",
           "mdoRef": "InformationRegister.РазрешенияНаИспользованиеВнешнихРесурсов",
           "mdoRefRu": "РегистрСведений.РазрешенияНаИспользованиеВнешнихРесурсов"
@@ -1223,16 +1231,24 @@
       {
         "metadata": {
           "type": "INFORMATION_REGISTER",
-          "mdoRef": "InformationRegister.ПрогрессОбновления",
-          "mdoRefRu": "РегистрСведений.ПрогрессОбновления"
+          "mdoRef": "InformationRegister.ИсторияРезервногоКопированияВстроенногоХранилищаДвоичныхДанных",
+          "mdoRefRu": "РегистрСведений.ИсторияРезервногоКопированияВстроенногоХранилищаДвоичныхДанных"
         },
         "allow": false
       },
       {
         "metadata": {
           "type": "INFORMATION_REGISTER",
-          "mdoRef": "InformationRegister.УдалитьОбластиПерсональныхДанных",
-          "mdoRefRu": "РегистрСведений.УдалитьОбластиПерсональныхДанных"
+          "mdoRef": "InformationRegister.НастройкиРаботыСФайловымАрхивом",
+          "mdoRefRu": "РегистрСведений.НастройкиРаботыСФайловымАрхивом"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ПрогрессОбновления",
+          "mdoRefRu": "РегистрСведений.ПрогрессОбновления"
         },
         "allow": false
       },
@@ -1505,14 +1521,6 @@
           "type": "CONSTANT",
           "mdoRef": "Constant.ИспользоватьПодчиненныеБизнесПроцессы",
           "mdoRefRu": "Константа.ИспользоватьПодчиненныеБизнесПроцессы"
-        },
-        "allow": false
-      },
-      {
-        "metadata": {
-          "type": "CONSTANT",
-          "mdoRef": "Constant.УдалитьЛогинДоступаКСервисуMorpher",
-          "mdoRefRu": "Константа.УдалитьЛогинДоступаКСервисуMorpher"
         },
         "allow": false
       },
@@ -2078,6 +2086,14 @@
       },
       {
         "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьГосключ",
+          "mdoRefRu": "Константа.ИспользоватьГосключ"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
           "type": "INFORMATION_REGISTER",
           "mdoRef": "InformationRegister.СклоненияПредставленийОбъектов",
           "mdoRefRu": "РегистрСведений.СклоненияПредставленийОбъектов"
@@ -2137,14 +2153,6 @@
           "type": "INFORMATION_REGISTER",
           "mdoRef": "InformationRegister.ДополнительныеАдресныеСведения",
           "mdoRefRu": "РегистрСведений.ДополнительныеАдресныеСведения"
-        },
-        "allow": false
-      },
-      {
-        "metadata": {
-          "type": "INFORMATION_REGISTER",
-          "mdoRef": "InformationRegister.УдалитьНастройкиТранспортаОбменаДанными",
-          "mdoRefRu": "РегистрСведений.УдалитьНастройкиТранспортаОбменаДанными"
         },
         "allow": false
       },
@@ -2790,14 +2798,6 @@
       },
       {
         "metadata": {
-          "type": "INFORMATION_REGISTER",
-          "mdoRef": "InformationRegister.УдалитьНастройкиТранспортаОбмена",
-          "mdoRefRu": "РегистрСведений.УдалитьНастройкиТранспортаОбмена"
-        },
-        "allow": false
-      },
-      {
-        "metadata": {
           "type": "CHART_OF_CHARACTERISTIC_TYPES",
           "mdoRef": "ChartOfCharacteristicTypes.ОбъектыАдресацииЗадач",
           "mdoRefRu": "ПланВидовХарактеристик.ОбъектыАдресацииЗадач"
@@ -2886,6 +2886,14 @@
       },
       {
         "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.КвартирыОфисыПомещения",
+          "mdoRefRu": "РегистрСведений.КвартирыОфисыПомещения"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
           "type": "CATALOG",
           "mdoRef": "Catalog.НастройкиТранспортаСообщенийОбмена",
           "mdoRefRu": "Справочник.НастройкиТранспортаСообщенийОбмена"
@@ -2897,6 +2905,14 @@
           "type": "CATALOG",
           "mdoRef": "Catalog.ЗначенияСвойствОбъектов",
           "mdoRefRu": "Справочник.ЗначенияСвойствОбъектов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ОбщиеНастройкиАвторизацииИнтернетСервисов",
+          "mdoRefRu": "Справочник.ОбщиеНастройкиАвторизацииИнтернетСервисов"
         },
         "allow": false
       },
@@ -2993,14 +3009,6 @@
           "type": "INFORMATION_REGISTER",
           "mdoRef": "InformationRegister.СертификатыШифрования",
           "mdoRefRu": "РегистрСведений.СертификатыШифрования"
-        },
-        "allow": false
-      },
-      {
-        "metadata": {
-          "type": "INFORMATION_REGISTER",
-          "mdoRef": "InformationRegister.УдалитьРезультатыОбменаДанными",
-          "mdoRefRu": "РегистрСведений.УдалитьРезультатыОбменаДанными"
         },
         "allow": false
       },
@@ -3641,6 +3649,14 @@
           "type": "INFORMATION_REGISTER",
           "mdoRef": "InformationRegister.КонтактыВзаимодействий",
           "mdoRefRu": "РегистрСведений.КонтактыВзаимодействий"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СведенияОХраненииДедуплицированныхФайлов",
+          "mdoRefRu": "РегистрСведений.СведенияОХраненииДедуплицированныхФайлов"
         },
         "allow": false
       },

--- a/src/test/resources/fixtures/ssl_3_2/ExchangePlans.ОбновлениеИнформационнойБазы_edt.json
+++ b/src/test/resources/fixtures/ssl_3_2/ExchangePlans.ОбновлениеИнформационнойБазы_edt.json
@@ -582,6 +582,14 @@
       },
       {
         "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.МестаХраненияДвоичныхДанных",
+          "mdoRefRu": "РегистрСведений.МестаХраненияДвоичныхДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
           "type": "CATALOG",
           "mdoRef": "Catalog.ШаблоныАнкет",
           "mdoRefRu": "Справочник.ШаблоныАнкет"
@@ -609,14 +617,6 @@
           "type": "CONSTANT",
           "mdoRef": "Constant.ИспользоватьПочтовыйКлиент",
           "mdoRefRu": "Константа.ИспользоватьПочтовыйКлиент"
-        },
-        "allow": false
-      },
-      {
-        "metadata": {
-          "type": "INFORMATION_REGISTER",
-          "mdoRef": "InformationRegister.УдалитьХранимыеФайлыВерсий",
-          "mdoRefRu": "РегистрСведений.УдалитьХранимыеФайлыВерсий"
         },
         "allow": false
       },
@@ -1206,6 +1206,14 @@
       },
       {
         "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.НастройкиОтправкиВГосключ",
+          "mdoRefRu": "Справочник.НастройкиОтправкиВГосключ"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
           "type": "INFORMATION_REGISTER",
           "mdoRef": "InformationRegister.РазрешенияНаИспользованиеВнешнихРесурсов",
           "mdoRefRu": "РегистрСведений.РазрешенияНаИспользованиеВнешнихРесурсов"
@@ -1223,16 +1231,24 @@
       {
         "metadata": {
           "type": "INFORMATION_REGISTER",
-          "mdoRef": "InformationRegister.ПрогрессОбновления",
-          "mdoRefRu": "РегистрСведений.ПрогрессОбновления"
+          "mdoRef": "InformationRegister.ИсторияРезервногоКопированияВстроенногоХранилищаДвоичныхДанных",
+          "mdoRefRu": "РегистрСведений.ИсторияРезервногоКопированияВстроенногоХранилищаДвоичныхДанных"
         },
         "allow": false
       },
       {
         "metadata": {
           "type": "INFORMATION_REGISTER",
-          "mdoRef": "InformationRegister.УдалитьОбластиПерсональныхДанных",
-          "mdoRefRu": "РегистрСведений.УдалитьОбластиПерсональныхДанных"
+          "mdoRef": "InformationRegister.НастройкиРаботыСФайловымАрхивом",
+          "mdoRefRu": "РегистрСведений.НастройкиРаботыСФайловымАрхивом"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ПрогрессОбновления",
+          "mdoRefRu": "РегистрСведений.ПрогрессОбновления"
         },
         "allow": false
       },
@@ -1505,14 +1521,6 @@
           "type": "CONSTANT",
           "mdoRef": "Constant.ИспользоватьПодчиненныеБизнесПроцессы",
           "mdoRefRu": "Константа.ИспользоватьПодчиненныеБизнесПроцессы"
-        },
-        "allow": false
-      },
-      {
-        "metadata": {
-          "type": "CONSTANT",
-          "mdoRef": "Constant.УдалитьЛогинДоступаКСервисуMorpher",
-          "mdoRefRu": "Константа.УдалитьЛогинДоступаКСервисуMorpher"
         },
         "allow": false
       },
@@ -2078,6 +2086,14 @@
       },
       {
         "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьГосключ",
+          "mdoRefRu": "Константа.ИспользоватьГосключ"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
           "type": "INFORMATION_REGISTER",
           "mdoRef": "InformationRegister.СклоненияПредставленийОбъектов",
           "mdoRefRu": "РегистрСведений.СклоненияПредставленийОбъектов"
@@ -2137,14 +2153,6 @@
           "type": "INFORMATION_REGISTER",
           "mdoRef": "InformationRegister.ДополнительныеАдресныеСведения",
           "mdoRefRu": "РегистрСведений.ДополнительныеАдресныеСведения"
-        },
-        "allow": false
-      },
-      {
-        "metadata": {
-          "type": "INFORMATION_REGISTER",
-          "mdoRef": "InformationRegister.УдалитьНастройкиТранспортаОбменаДанными",
-          "mdoRefRu": "РегистрСведений.УдалитьНастройкиТранспортаОбменаДанными"
         },
         "allow": false
       },
@@ -2790,14 +2798,6 @@
       },
       {
         "metadata": {
-          "type": "INFORMATION_REGISTER",
-          "mdoRef": "InformationRegister.УдалитьНастройкиТранспортаОбмена",
-          "mdoRefRu": "РегистрСведений.УдалитьНастройкиТранспортаОбмена"
-        },
-        "allow": false
-      },
-      {
-        "metadata": {
           "type": "CHART_OF_CHARACTERISTIC_TYPES",
           "mdoRef": "ChartOfCharacteristicTypes.ОбъектыАдресацииЗадач",
           "mdoRefRu": "ПланВидовХарактеристик.ОбъектыАдресацииЗадач"
@@ -2886,6 +2886,14 @@
       },
       {
         "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.КвартирыОфисыПомещения",
+          "mdoRefRu": "РегистрСведений.КвартирыОфисыПомещения"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
           "type": "CATALOG",
           "mdoRef": "Catalog.НастройкиТранспортаСообщенийОбмена",
           "mdoRefRu": "Справочник.НастройкиТранспортаСообщенийОбмена"
@@ -2897,6 +2905,14 @@
           "type": "CATALOG",
           "mdoRef": "Catalog.ЗначенияСвойствОбъектов",
           "mdoRefRu": "Справочник.ЗначенияСвойствОбъектов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ОбщиеНастройкиАвторизацииИнтернетСервисов",
+          "mdoRefRu": "Справочник.ОбщиеНастройкиАвторизацииИнтернетСервисов"
         },
         "allow": false
       },
@@ -2993,14 +3009,6 @@
           "type": "INFORMATION_REGISTER",
           "mdoRef": "InformationRegister.СертификатыШифрования",
           "mdoRefRu": "РегистрСведений.СертификатыШифрования"
-        },
-        "allow": false
-      },
-      {
-        "metadata": {
-          "type": "INFORMATION_REGISTER",
-          "mdoRef": "InformationRegister.УдалитьРезультатыОбменаДанными",
-          "mdoRefRu": "РегистрСведений.УдалитьРезультатыОбменаДанными"
         },
         "allow": false
       },
@@ -3641,6 +3649,14 @@
           "type": "INFORMATION_REGISTER",
           "mdoRef": "InformationRegister.КонтактыВзаимодействий",
           "mdoRefRu": "РегистрСведений.КонтактыВзаимодействий"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СведенияОХраненииДедуплицированныхФайлов",
+          "mdoRefRu": "РегистрСведений.СведенияОХраненииДедуплицированныхФайлов"
         },
         "allow": false
       },

--- a/src/test/resources/fixtures/ssl_3_2/ExchangePlans.ОбновлениеИнформационнойБазы_edt.json
+++ b/src/test/resources/fixtures/ssl_3_2/ExchangePlans.ОбновлениеИнформационнойБазы_edt.json
@@ -1,0 +1,3897 @@
+{"com.github._1c_syntax.bsl.mdo.ExchangePlan": {
+  "attributes": [
+    [
+      {
+        "uuid": "3fc019d1-aec8-4835-96c5-3bbf43da0b94",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "ExchangePlan.ОбновлениеИнформационнойБазы.StandardAttribute.ExchangeDate",
+          "mdoRefRu": "ПланОбмена.ОбновлениеИнформационнойБазы.СтандартныйРеквизит.ДатаОбмена"
+        },
+        "comment": "",
+        "synonym": {
+          "content": []
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "type": "EXCHANGE_PLAN",
+          "mdoRef": "ExchangePlan.ОбновлениеИнформационнойБазы",
+          "mdoRefRu": "ПланОбмена.ОбновлениеИнформационнойБазы"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "DATE"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.DateQualifiers": {
+                "dateFractions": 2,
+                "description": {
+                  "value": {
+                    "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                    "nameRu": "КвалификаторыДаты (ДатаВремя)",
+                    "nameEn": "DateQualifiers (DateTime)"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "ДатаОбмена",
+          "nameEn": "ExchangeDate"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "3fc019d1-aec8-4835-96c5-3bbf43da0b94",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "ExchangePlan.ОбновлениеИнформационнойБазы.StandardAttribute.ThisNode",
+          "mdoRefRu": "ПланОбмена.ОбновлениеИнформационнойБазы.СтандартныйРеквизит.ЭтотУзел"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "ПланОбменаСсылка.ОбновлениеИнформационнойБазы",
+                  "nameEn": "ExchangePlanRef.ОбновлениеИнформационнойБазы"
+                },
+                "variant": "METADATA",
+                "kind": "EXCHANGE_PLAN"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 0
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "ЭтотУзел",
+          "nameEn": "ThisNode"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "3fc019d1-aec8-4835-96c5-3bbf43da0b94",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "ExchangePlan.ОбновлениеИнформационнойБазы.StandardAttribute.ReceivedNo",
+          "mdoRefRu": "ПланОбмена.ОбновлениеИнформационнойБазы.СтандартныйРеквизит.НомерПринятого"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                "precision": 5,
+                "scale": 0,
+                "nonNegative": false,
+                "description": {}
+              }
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "НомерПринятого",
+          "nameEn": "ReceivedNo"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "3fc019d1-aec8-4835-96c5-3bbf43da0b94",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "ExchangePlan.ОбновлениеИнформационнойБазы.StandardAttribute.SentNo",
+          "mdoRefRu": "ПланОбмена.ОбновлениеИнформационнойБазы.СтандартныйРеквизит.НомерОтправленного"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[3]/type"
+        },
+        "fullName": {
+          "nameRu": "НомерОтправленного",
+          "nameEn": "SentNo"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "3fc019d1-aec8-4835-96c5-3bbf43da0b94",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "ExchangePlan.ОбновлениеИнформационнойБазы.StandardAttribute.Ref",
+          "mdoRefRu": "ПланОбмена.ОбновлениеИнформационнойБазы.СтандартныйРеквизит.Ссылка"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[2]/type"
+        },
+        "fullName": {
+          "nameRu": "Ссылка",
+          "nameEn": "Ref"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "3fc019d1-aec8-4835-96c5-3bbf43da0b94",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "ExchangePlan.ОбновлениеИнформационнойБазы.StandardAttribute.DeletionMark",
+          "mdoRefRu": "ПланОбмена.ОбновлениеИнформационнойБазы.СтандартныйРеквизит.ПометкаУдаления"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "BOOLEAN"
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "fullName": {
+          "nameRu": "ПометкаУдаления",
+          "nameEn": "DeletionMark"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "3fc019d1-aec8-4835-96c5-3bbf43da0b94",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "ExchangePlan.ОбновлениеИнформационнойБазы.StandardAttribute.Description",
+          "mdoRefRu": "ПланОбмена.ОбновлениеИнформационнойБазы.СтандартныйРеквизит.Наименование"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                "length": 25,
+                "allowedLength": 0,
+                "description": {}
+              }
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "Наименование",
+          "nameEn": "Description"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "3fc019d1-aec8-4835-96c5-3bbf43da0b94",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "ExchangePlan.ОбновлениеИнформационнойБазы.StandardAttribute.Code",
+          "mdoRefRu": "ПланОбмена.ОбновлениеИнформационнойБазы.СтандартныйРеквизит.Код"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                "precision": 9,
+                "scale": 0,
+                "nonNegative": false,
+                "description": {}
+              }
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "Код",
+          "nameEn": "Code"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "5371672a-c8e0-4c12-834e-f23dd885b49a",
+        "name": "Очередь",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ExchangePlan.ОбновлениеИнформационнойБазы.Attribute.Очередь",
+          "mdoRefRu": "ПланОбмена.ОбновлениеИнформационнойБазы.Реквизит.Очередь"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Очередь"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                "precision": 10,
+                "scale": 0,
+                "nonNegative": false,
+                "description": {
+                  "value": {
+                    "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                    "nameRu": "КвалификаторыЧисла (10.0)",
+                    "nameEn": "NumberQualifiers (10.0)"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "8583ca82-a4f5-4f2a-9b9a-7807b4560e85",
+        "name": "Временная",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "ExchangePlan.ОбновлениеИнформационнойБазы.Attribute.Временная",
+          "mdoRefRu": "ПланОбмена.ОбновлениеИнформационнойБазы.Реквизит.Временная"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Временная"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[6]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      }
+    ],
+    []
+  ],
+  "commands": [],
+  "comment": "",
+  "content": [
+    [
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ИсторияРассылкиОтчетов",
+          "mdoRefRu": "РегистрСведений.ИсторияРассылкиОтчетов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СостоянияРассылокОтчетов",
+          "mdoRefRu": "РегистрСведений.СостоянияРассылокОтчетов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ЭлектронноеПисьмоВходящееПрисоединенныеФайлы",
+          "mdoRefRu": "Справочник.ЭлектронноеПисьмоВходящееПрисоединенныеФайлы"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ЭкземплярыСервераDSS",
+          "mdoRefRu": "Справочник.ЭкземплярыСервераDSS"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ШаблоныАнкет",
+          "mdoRefRu": "Справочник.ШаблоныАнкет"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ПроцессыДляЗапуска",
+          "mdoRefRu": "РегистрСведений.ПроцессыДляЗапуска"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.НаличиеФайлов",
+          "mdoRefRu": "РегистрСведений.НаличиеФайлов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьПочтовыйКлиент",
+          "mdoRefRu": "Константа.ИспользоватьПочтовыйКлиент"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.УдалитьХранимыеФайлыВерсий",
+          "mdoRefRu": "РегистрСведений.УдалитьХранимыеФайлыВерсий"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ПараметрыАдминистрированияИБ",
+          "mdoRefRu": "Константа.ПараметрыАдминистрированияИБ"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьШаблоныСообщений",
+          "mdoRefRu": "Константа.ИспользоватьШаблоныСообщений"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ПараметрыИтоговИАгрегатов",
+          "mdoRefRu": "Константа.ПараметрыИтоговИАгрегатов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СообщенияОбменаДанными",
+          "mdoRefRu": "РегистрСведений.СообщенияОбменаДанными"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.НаборыДополнительныхРеквизитовИСведений",
+          "mdoRefRu": "Справочник.НаборыДополнительныхРеквизитовИСведений"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ПериодыНерабочихДнейКалендаря",
+          "mdoRefRu": "РегистрСведений.ПериодыНерабочихДнейКалендаря"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.АрхивСообщенийОбменов",
+          "mdoRefRu": "РегистрСведений.АрхивСообщенийОбменов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ПапкиЭлектронныхПисем",
+          "mdoRefRu": "Справочник.ПапкиЭлектронныхПисем"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ВариантыОтчетов",
+          "mdoRefRu": "Справочник.ВариантыОтчетов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ОтветыНаВопросыАнкет",
+          "mdoRefRu": "РегистрСведений.ОтветыНаВопросыАнкет"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ВерсииОбъектов",
+          "mdoRefRu": "РегистрСведений.ВерсииОбъектов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ДатаУведомленияОНовыхЗадачах",
+          "mdoRefRu": "Константа.ДатаУведомленияОНовыхЗадачах"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.КэшПереводов",
+          "mdoRefRu": "РегистрСведений.КэшПереводов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ЗамерыКомментарииСтатистики",
+          "mdoRefRu": "РегистрСведений.ЗамерыКомментарииСтатистики"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьЭлектронныеПодписи",
+          "mdoRefRu": "Константа.ИспользоватьЭлектронныеПодписи"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ПрофилиКлючевыхОпераций",
+          "mdoRefRu": "Справочник.ПрофилиКлючевыхОпераций"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ПараметрыРезервногоКопирования",
+          "mdoRefRu": "Константа.ПараметрыРезервногоКопирования"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьДополнительныеОтчетыИОбработки",
+          "mdoRefRu": "Константа.ИспользоватьДополнительныеОтчетыИОбработки"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СтатистикаКонфигурации",
+          "mdoRefRu": "РегистрСведений.СтатистикаКонфигурации"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.НомераОтсканированныхФайлов",
+          "mdoRefRu": "РегистрСведений.НомераОтсканированныхФайлов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CHART_OF_CHARACTERISTIC_TYPES",
+          "mdoRef": "ChartOfCharacteristicTypes.РазделыДатЗапретаИзменения",
+          "mdoRefRu": "ПланВидовХарактеристик.РазделыДатЗапретаИзменения"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.НеудаленныеОбъекты",
+          "mdoRefRu": "РегистрСведений.НеудаленныеОбъекты"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ПериодХраненияЗамеров",
+          "mdoRefRu": "Константа.ПериодХраненияЗамеров"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.НастройкиПодчиненногоУзлаРИБ",
+          "mdoRefRu": "Константа.НастройкиПодчиненногоУзлаРИБ"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.НепринятыеКОбработкеПочтовымСерверомИсходящиеПисьма",
+          "mdoRefRu": "РегистрСведений.НепринятыеКОбработкеПочтовымСерверомИсходящиеПисьма"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ВопросыШаблонаАнкеты",
+          "mdoRefRu": "Справочник.ВопросыШаблонаАнкеты"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ЗамерыВремени",
+          "mdoRefRu": "РегистрСведений.ЗамерыВремени"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CHART_OF_CHARACTERISTIC_TYPES",
+          "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения",
+          "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.КурсыВалют",
+          "mdoRefRu": "РегистрСведений.КурсыВалют"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ВерсияДатЗапретаИзменения",
+          "mdoRefRu": "Константа.ВерсияДатЗапретаИзменения"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ОбъектыНезарегистрированныеПриЗацикливании",
+          "mdoRefRu": "РегистрСведений.ОбъектыНезарегистрированныеПриЗацикливании"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьСервисМобильнойПодписи",
+          "mdoRefRu": "Константа.ИспользоватьСервисМобильнойПодписи"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.НастройкаПроксиСервера",
+          "mdoRefRu": "Константа.НастройкаПроксиСервера"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ЗапрещатьЗагрузкуФайловПоРасширению",
+          "mdoRefRu": "Константа.ЗапрещатьЗагрузкуФайловПоРасширению"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ОбработчикиСобытийСинхронизацииДанных",
+          "mdoRefRu": "РегистрСведений.ОбработчикиСобытийСинхронизацииДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ЗаявленияНаВыпускСертификата",
+          "mdoRefRu": "РегистрСведений.ЗаявленияНаВыпускСертификата"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ВнешниеКомпоненты",
+          "mdoRefRu": "Справочник.ВнешниеКомпоненты"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.АдресПубликацииИнформационнойБазыВИнтернете",
+          "mdoRefRu": "Константа.АдресПубликацииИнформационнойБазыВИнтернете"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.КлючиДоступа",
+          "mdoRefRu": "Справочник.КлючиДоступа"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.НаборыЗначенийДоступа",
+          "mdoRefRu": "РегистрСведений.НаборыЗначенийДоступа"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.НастройкиУчетныхЗаписейЭлектроннойПочты",
+          "mdoRefRu": "РегистрСведений.НастройкиУчетныхЗаписейЭлектроннойПочты"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.КалендарныеГрафики",
+          "mdoRefRu": "РегистрСведений.КалендарныеГрафики"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ЗапретитьОтображениеНебезопасногоСодержимогоВПисьмах",
+          "mdoRefRu": "Константа.ЗапретитьОтображениеНебезопасногоСодержимогоВПисьмах"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ШаблоныСообщенийПрисоединенныеФайлы",
+          "mdoRefRu": "Справочник.ШаблоныСообщенийПрисоединенныеФайлы"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.Календари",
+          "mdoRefRu": "Справочник.Календари"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ИдентификаторыПолученныхЭлектронныхПисем",
+          "mdoRefRu": "РегистрСведений.ИдентификаторыПолученныхЭлектронныхПисем"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ОбновлениеКлючейДоступаКДанным",
+          "mdoRefRu": "РегистрСведений.ОбновлениеКлючейДоступаКДанным"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.Валюты",
+          "mdoRefRu": "Справочник.Валюты"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ШаблоныСообщений",
+          "mdoRefRu": "Справочник.ШаблоныСообщений"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ЗависимостиПравДоступа",
+          "mdoRefRu": "РегистрСведений.ЗависимостиПравДоступа"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СлужебныеАдресныеСведения",
+          "mdoRefRu": "РегистрСведений.СлужебныеАдресныеСведения"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.УровниСокращенийАдресныхСведений",
+          "mdoRefRu": "РегистрСведений.УровниСокращенийАдресныхСведений"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.РазрешитьДоступКИнтернетСервисам",
+          "mdoRefRu": "Константа.РазрешитьДоступКИнтернетСервисам"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СостоянияОригиналовПервичныхДокументов",
+          "mdoRefRu": "РегистрСведений.СостоянияОригиналовПервичныхДокументов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СоответствияОбъектовИнформационныхБаз",
+          "mdoRefRu": "РегистрСведений.СоответствияОбъектовИнформационныхБаз"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьСинхронизациюДанныхВЛокальномРежиме",
+          "mdoRefRu": "Константа.ИспользоватьСинхронизациюДанныхВЛокальномРежиме"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ЗадачиОбменаДаннымиВнутренняяПубликация",
+          "mdoRefRu": "РегистрСведений.ЗадачиОбменаДаннымиВнутренняяПубликация"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ИсторияАдминистративнойИерархии",
+          "mdoRefRu": "РегистрСведений.ИсторияАдминистративнойИерархии"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ВерсияКлассификатораБанков",
+          "mdoRefRu": "Константа.ВерсияКлассификатораБанков"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ВыполнятьЗамерыПроизводительности",
+          "mdoRefRu": "Константа.ВыполнятьЗамерыПроизводительности"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ПрофильБезопасностиИнформационнойБазы",
+          "mdoRefRu": "Константа.ПрофильБезопасностиИнформационнойБазы"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ПодписантыСервисаМобильнойПодписи",
+          "mdoRefRu": "Справочник.ПодписантыСервисаМобильнойПодписи"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ЗапланированноеВзаимодействиеПрисоединенныеФайлы",
+          "mdoRefRu": "Справочник.ЗапланированноеВзаимодействиеПрисоединенныеФайлы"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ИерархияГруппПользователей",
+          "mdoRefRu": "РегистрСведений.ИерархияГруппПользователей"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.НастройкиОбменаДаннымиXDTO",
+          "mdoRefRu": "РегистрСведений.НастройкиОбменаДаннымиXDTO"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьПризнакРассмотрено",
+          "mdoRefRu": "Константа.ИспользоватьПризнакРассмотрено"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СервисМобильнойПодписиСтатусы",
+          "mdoRefRu": "РегистрСведений.СервисМобильнойПодписиСтатусы"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ПредопределенныеВариантыОтчетовВерсийРасширений",
+          "mdoRefRu": "РегистрСведений.ПредопределенныеВариантыОтчетовВерсийРасширений"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.НастройкиРегистрацииСобытийДоступаКДанным",
+          "mdoRefRu": "Константа.НастройкиРегистрацииСобытийДоступаКДанным"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СубъектыДляСкрытияПерсональныхДанных",
+          "mdoRefRu": "РегистрСведений.СубъектыДляСкрытияПерсональныхДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.СписокРасширенийФайловOpenDocumentОбластиДанных",
+          "mdoRefRu": "Константа.СписокРасширенийФайловOpenDocumentОбластиДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьСинхронизациюДанныхВМоделиСервиса",
+          "mdoRefRu": "Константа.ИспользоватьСинхронизациюДанныхВМоделиСервиса"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ИспользованиеПоставляемыхДополнительныхОтчетовИОбработокВОбластяхДанных",
+          "mdoRefRu": "РегистрСведений.ИспользованиеПоставляемыхДополнительныхОтчетовИОбработокВОбластяхДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.РазрешенияНаИспользованиеВнешнихРесурсов",
+          "mdoRefRu": "РегистрСведений.РазрешенияНаИспользованиеВнешнихРесурсов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.НастройкиСинхронизацииФайлов",
+          "mdoRefRu": "РегистрСведений.НастройкиСинхронизацииФайлов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ПрогрессОбновления",
+          "mdoRefRu": "РегистрСведений.ПрогрессОбновления"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.УдалитьОбластиПерсональныхДанных",
+          "mdoRefRu": "РегистрСведений.УдалитьОбластиПерсональныхДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.КлючевыеОперации",
+          "mdoRefRu": "Справочник.КлючевыеОперации"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ВидыПроверок",
+          "mdoRefRu": "Справочник.ВидыПроверок"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.НезависимоеИспользованиеДополнительныхОтчетовИОбработокВМоделиСервиса",
+          "mdoRefRu": "Константа.НезависимоеИспользованиеДополнительныхОтчетовИОбработокВМоделиСервиса"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ВариантыОтветовАнкет",
+          "mdoRefRu": "Справочник.ВариантыОтветовАнкет"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.Заметки",
+          "mdoRefRu": "Справочник.Заметки"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.АдресДляВосстановленияПароляУчетнойЗаписи",
+          "mdoRefRu": "Константа.АдресДляВосстановленияПароляУчетнойЗаписи"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "TASK",
+          "mdoRef": "Task.ЗадачаИсполнителя",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ДополнительныеСведения",
+          "mdoRefRu": "РегистрСведений.ДополнительныеСведения"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СнимкиОтчетов",
+          "mdoRefRu": "РегистрСведений.СнимкиОтчетов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ПредопределенныеВариантыОтчетовРасширений",
+          "mdoRefRu": "Справочник.ПредопределенныеВариантыОтчетовРасширений"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.КлючиДоступаКРегиструРезультатыПроверкиУчета",
+          "mdoRefRu": "РегистрСведений.КлючиДоступаКРегиструРезультатыПроверкиУчета"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ПутиКПрограммамЭлектроннойПодписиИШифрованияНаСерверахLinux",
+          "mdoRefRu": "РегистрСведений.ПутиКПрограммамЭлектроннойПодписиИШифрованияНаСерверахLinux"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СостоянияПроверокВеденияУчета",
+          "mdoRefRu": "РегистрСведений.СостоянияПроверокВеденияУчета"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "DOCUMENT",
+          "mdoRef": "Document.НазначениеОпросов",
+          "mdoRefRu": "Документ.НазначениеОпросов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.СценарииОбменовДанными",
+          "mdoRefRu": "Справочник.СценарииОбменовДанными"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьСкрытиеПерсональныхДанныхСубъектов",
+          "mdoRefRu": "Константа.ИспользоватьСкрытиеПерсональныхДанныхСубъектов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СрокиХраненияПерсональныхДанных",
+          "mdoRefRu": "РегистрСведений.СрокиХраненияПерсональныхДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ИдентификаторыОбъектовМетаданных",
+          "mdoRefRu": "Справочник.ИдентификаторыОбъектовМетаданных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ФайлыВРабочемКаталоге",
+          "mdoRefRu": "РегистрСведений.ФайлыВРабочемКаталоге"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьШифрование",
+          "mdoRefRu": "Константа.ИспользоватьШифрование"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ДанныеОбработанныеВЦентральномУзлеРИБ",
+          "mdoRefRu": "РегистрСведений.ДанныеОбработанныеВЦентральномУзлеРИБ"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ОбработчикиОбновления",
+          "mdoRefRu": "РегистрСведений.ОбработчикиОбновления"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ИсполнителиЗадач",
+          "mdoRefRu": "РегистрСведений.ИсполнителиЗадач"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.УчетныеЗаписиDSS",
+          "mdoRefRu": "Справочник.УчетныеЗаписиDSS"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "DOCUMENT",
+          "mdoRef": "Document.ТелефонныйЗвонок",
+          "mdoRefRu": "Документ.ТелефонныйЗвонок"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.НастройкиВерсионированияОбъектов",
+          "mdoRefRu": "РегистрСведений.НастройкиВерсионированияОбъектов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.РолиИсполнителей",
+          "mdoRefRu": "Справочник.РолиИсполнителей"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ОбщиеВнешниеКомпоненты",
+          "mdoRefRu": "Справочник.ОбщиеВнешниеКомпоненты"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.РазрешитьДоступКИнтернетСервисамЭлектроннойПодписи",
+          "mdoRefRu": "Константа.РазрешитьДоступКИнтернетСервисамЭлектроннойПодписи"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.СписокЗапрещенныхРасширенийОбластиДанных",
+          "mdoRefRu": "Константа.СписокЗапрещенныхРасширенийОбластиДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.МашиночитаемыеДоверенности",
+          "mdoRefRu": "Справочник.МашиночитаемыеДоверенности"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.НастройкиТранспортаОбменаОбластейДанных",
+          "mdoRefRu": "РегистрСведений.НастройкиТранспортаОбменаОбластейДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ОтправлятьПисьмаВФорматеHTML",
+          "mdoRefRu": "Константа.ОтправлятьПисьмаВФорматеHTML"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьПодчиненныеБизнесПроцессы",
+          "mdoRefRu": "Константа.ИспользоватьПодчиненныеБизнесПроцессы"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.УдалитьЛогинДоступаКСервисуMorpher",
+          "mdoRefRu": "Константа.УдалитьЛогинДоступаКСервисуMorpher"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СостоянияКонтактовВзаимодействий",
+          "mdoRefRu": "РегистрСведений.СостоянияКонтактовВзаимодействий"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ОбластиПерсональныхДанных",
+          "mdoRefRu": "РегистрСведений.ОбластиПерсональныхДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СтатусыСинхронизацииФайловСОблачнымСервисом",
+          "mdoRefRu": "РегистрСведений.СтатусыСинхронизацииФайловСОблачнымСервисом"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьДатыЗапретаЗагрузки",
+          "mdoRefRu": "Константа.ИспользоватьДатыЗапретаЗагрузки"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ДанныеПроизводственногоКалендаря",
+          "mdoRefRu": "РегистрСведений.ДанныеПроизводственногоКалендаря"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьВерсионированиеОбъектов",
+          "mdoRefRu": "Константа.ИспользоватьВерсионированиеОбъектов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.СеансыОбменовДанными",
+          "mdoRefRu": "Справочник.СеансыОбменовДанными"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ВерсииРасширений",
+          "mdoRefRu": "Справочник.ВерсииРасширений"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.НаследованиеНастроекПравОбъектов",
+          "mdoRefRu": "РегистрСведений.НаследованиеНастроекПравОбъектов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ПричиныИзмененияАдресныхСведений",
+          "mdoRefRu": "РегистрСведений.ПричиныИзмененияАдресныхСведений"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ХранилищеФайлов",
+          "mdoRefRu": "РегистрСведений.ХранилищеФайлов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СессииОбменаСообщениямиСистемы",
+          "mdoRefRu": "РегистрСведений.СессииОбменаСообщениямиСистемы"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.СписокРасширенийТекстовыхФайлов",
+          "mdoRefRu": "Константа.СписокРасширенийТекстовыхФайлов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.БезопасноеХранилищеДанныхОбластейДанных",
+          "mdoRefRu": "РегистрСведений.БезопасноеХранилищеДанныхОбластейДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ЗагруженныеВерсииАдресныхСведений",
+          "mdoRefRu": "РегистрСведений.ЗагруженныеВерсииАдресныхСведений"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ПраваРолей",
+          "mdoRefRu": "РегистрСведений.ПраваРолей"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ТелефонныйЗвонокПрисоединенныеФайлы",
+          "mdoRefRu": "Справочник.ТелефонныйЗвонокПрисоединенныеФайлы"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "DOCUMENT",
+          "mdoRef": "Document.ЗапланированноеВзаимодействие",
+          "mdoRefRu": "Документ.ЗапланированноеВзаимодействие"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.СписокРасширенийФайловOpenDocument",
+          "mdoRefRu": "Константа.СписокРасширенийФайловOpenDocument"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ПравилаПроверкиУчета",
+          "mdoRefRu": "Справочник.ПравилаПроверкиУчета"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ДатаПоследнейВыгрузкиЗамеровПроизводительностиUTC",
+          "mdoRefRu": "Константа.ДатаПоследнейВыгрузкиЗамеровПроизводительностиUTC"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "DOCUMENT",
+          "mdoRef": "Document.Встреча",
+          "mdoRefRu": "Документ.Встреча"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.Пользователи",
+          "mdoRefRu": "Справочник.Пользователи"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ЗагрузитьСообщениеОбменаДанными",
+          "mdoRefRu": "Константа.ЗагрузитьСообщениеОбменаДанными"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ПроверятьЭлектронныеПодписиНаСервере",
+          "mdoRefRu": "Константа.ПроверятьЭлектронныеПодписиНаСервере"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ПровайдерSMS",
+          "mdoRefRu": "Константа.ПровайдерSMS"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ПользовательСтандартногоИнтерфейсаOData",
+          "mdoRefRu": "Константа.ПользовательСтандартногоИнтерфейсаOData"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ВерсииПодсистем",
+          "mdoRefRu": "РегистрСведений.ВерсииПодсистем"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ПользовательскиеНастройкиОтчетов",
+          "mdoRefRu": "Справочник.ПользовательскиеНастройкиОтчетов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СостоянияОбменовДанными",
+          "mdoRefRu": "РегистрСведений.СостоянияОбменовДанными"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ОповещенияПользователейСертификатов",
+          "mdoRefRu": "РегистрСведений.ОповещенияПользователейСертификатов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьАвтономнуюРаботуВМоделиСервиса",
+          "mdoRefRu": "Константа.ИспользоватьАвтономнуюРаботуВМоделиСервиса"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ПредметыПапкиВзаимодействий",
+          "mdoRefRu": "РегистрСведений.ПредметыПапкиВзаимодействий"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ЗначенияГруппДоступаПоУмолчанию",
+          "mdoRefRu": "РегистрСведений.ЗначенияГруппДоступаПоУмолчанию"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ОсновныеПечатныеФормыКонтрагентов",
+          "mdoRefRu": "РегистрСведений.ОсновныеПечатныеФормыКонтрагентов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.РазрешенныеНеаккредитованныеУЦ",
+          "mdoRefRu": "Константа.РазрешенныеНеаккредитованныеУЦ"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ОтложенноеОбновлениеЗавершеноУспешно",
+          "mdoRefRu": "Константа.ОтложенноеОбновлениеЗавершеноУспешно"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИзвлекатьТекстыФайловНаСервере",
+          "mdoRefRu": "Константа.ИзвлекатьТекстыФайловНаСервере"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьПрофилиБезопасностиДляДОО",
+          "mdoRefRu": "Константа.ИспользоватьПрофилиБезопасностиДляДОО"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.КоличествоЗамеровВПакетеЭкспорта",
+          "mdoRefRu": "Константа.КоличествоЗамеровВПакетеЭкспорта"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьДополнительныеРеквизитыИСведения",
+          "mdoRefRu": "Константа.ИспользоватьДополнительныеРеквизитыИСведения"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.КлючиДоступаВнешнихПользователей",
+          "mdoRefRu": "РегистрСведений.КлючиДоступаВнешнихПользователей"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.РазрешитьВыполнениеДООРегламентнымиЗаданиямиВМоделиСервиса",
+          "mdoRefRu": "Константа.РазрешитьВыполнениеДООРегламентнымиЗаданиямиВМоделиСервиса"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "DOCUMENT",
+          "mdoRef": "Document.СообщениеSMS",
+          "mdoRefRu": "Документ.СообщениеSMS"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ОчередьИзвлеченияТекста",
+          "mdoRefRu": "РегистрСведений.ОчередьИзвлеченияТекста"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьАнкетирование",
+          "mdoRefRu": "Константа.ИспользоватьАнкетирование"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.УчетныеЗаписиЭлектроннойПочты",
+          "mdoRefRu": "Справочник.УчетныеЗаписиЭлектроннойПочты"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.МаксимальныйРазмерФайла",
+          "mdoRefRu": "Константа.МаксимальныйРазмерФайла"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ЗапросыРазрешенийНаИспользованиеВнешнихРесурсов",
+          "mdoRefRu": "РегистрСведений.ЗапросыРазрешенийНаИспользованиеВнешнихРесурсов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ПользовательскиеНастройкиДоступаКОбработкам",
+          "mdoRefRu": "РегистрСведений.ПользовательскиеНастройкиДоступаКОбработкам"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ПакетыИнформацииПриЗапуске",
+          "mdoRefRu": "РегистрСведений.ПакетыИнформацииПриЗапуске"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ЗамерыОбластиСтатистики",
+          "mdoRefRu": "РегистрСведений.ЗамерыОбластиСтатистики"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ПараметрыБлокировкиРаботыСВнешнимиРесурсами",
+          "mdoRefRu": "Константа.ПараметрыБлокировкиРаботыСВнешнимиРесурсами"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СертификатыПолучателейРассылкиОтчетов",
+          "mdoRefRu": "РегистрСведений.СертификатыПолучателейРассылкиОтчетов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ПриоритетОбновленияВОбластяхДанных",
+          "mdoRefRu": "Константа.ПриоритетОбновленияВОбластяхДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "DOCUMENT",
+          "mdoRef": "Document.Анкета",
+          "mdoRefRu": "Документ.Анкета"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.КлючиДоступаНаборовГруппДоступа",
+          "mdoRefRu": "РегистрСведений.КлючиДоступаНаборовГруппДоступа"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.УдалитьНастройкиВходаПользователей",
+          "mdoRefRu": "Константа.УдалитьНастройкиВходаПользователей"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ПараметрыАдресногоКлассификатора",
+          "mdoRefRu": "Константа.ПараметрыАдресногоКлассификатора"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ПроизводственныеКалендари",
+          "mdoRefRu": "Справочник.ПроизводственныеКалендари"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.СтроковыеКонтактыВзаимодействий",
+          "mdoRefRu": "Справочник.СтроковыеКонтактыВзаимодействий"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ПоставляемыеДополнительныеОтчетыИОбработки",
+          "mdoRefRu": "Справочник.ПоставляемыеДополнительныеОтчетыИОбработки"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ЭлектронноеПисьмоИсходящееПрисоединенныеФайлы",
+          "mdoRefRu": "Справочник.ЭлектронноеПисьмоИсходящееПрисоединенныеФайлы"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.НазначениеДополнительныхОбработок",
+          "mdoRefRu": "РегистрСведений.НазначениеДополнительныхОбработок"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ВидыКонтактнойИнформации",
+          "mdoRefRu": "Справочник.ВидыКонтактнойИнформации"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.СтраныМира",
+          "mdoRefRu": "Справочник.СтраныМира"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.МашиночитаемыеДоверенностиСтатусы",
+          "mdoRefRu": "РегистрСведений.МашиночитаемыеДоверенностиСтатусы"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.СоздаватьЭлектронныеПодписиНаСервере",
+          "mdoRefRu": "Константа.СоздаватьЭлектронныеПодписиНаСервере"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьГруппыВнешнихПользователей",
+          "mdoRefRu": "Константа.ИспользоватьГруппыВнешнихПользователей"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьДатуИВремяВСрокахЗадач",
+          "mdoRefRu": "Константа.ИспользоватьДатуИВремяВСрокахЗадач"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СклоненияПредставленийОбъектов",
+          "mdoRefRu": "РегистрСведений.СклоненияПредставленийОбъектов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СогласияНаОбработкуПерсональныхДанных",
+          "mdoRefRu": "РегистрСведений.СогласияНаОбработкуПерсональныхДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ПубличныеИдентификаторыСинхронизируемыхОбъектов",
+          "mdoRefRu": "РегистрСведений.ПубличныеИдентификаторыСинхронизируемыхОбъектов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "DOCUMENT",
+          "mdoRef": "Document.ОтзывСогласияНаОбработкуПерсональныхДанных",
+          "mdoRefRu": "Документ.ОтзывСогласияНаОбработкуПерсональныхДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.КлассификаторыМЧД",
+          "mdoRefRu": "РегистрСведений.КлассификаторыМЧД"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьКомандуЗаметки",
+          "mdoRefRu": "Константа.ИспользоватьКомандуЗаметки"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.СертификатыКлючейЭлектроннойПодписиИШифрования",
+          "mdoRefRu": "Справочник.СертификатыКлючейЭлектроннойПодписиИШифрования"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ДополнительныеАдресныеСведения",
+          "mdoRefRu": "РегистрСведений.ДополнительныеАдресныеСведения"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.УдалитьНастройкиТранспортаОбменаДанными",
+          "mdoRefRu": "РегистрСведений.УдалитьНастройкиТранспортаОбменаДанными"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.СтатусОбновленияКонфигурации",
+          "mdoRefRu": "Константа.СтатусОбновленияКонфигурации"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьОтправкуSMSВШаблонахСообщений",
+          "mdoRefRu": "Константа.ИспользоватьОтправкуSMSВШаблонахСообщений"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ОбновлениеКлючейДоступаТекущиеЗадания",
+          "mdoRefRu": "РегистрСведений.ОбновлениеКлючейДоступаТекущиеЗадания"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СведенияОФайлах",
+          "mdoRefRu": "РегистрСведений.СведенияОФайлах"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.КонтурСинхронизации",
+          "mdoRefRu": "РегистрСведений.КонтурСинхронизации"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.КоличествоПотоковОбновленияДоступа",
+          "mdoRefRu": "Константа.КоличествоПотоковОбновленияДоступа"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СоставыГруппПользователей",
+          "mdoRefRu": "РегистрСведений.СоставыГруппПользователей"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ПотокиОбновления",
+          "mdoRefRu": "РегистрСведений.ПотокиОбновления"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьКомандуНапоминаний",
+          "mdoRefRu": "Константа.ИспользоватьКомандуНапоминаний"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ПользовательскиеМакетыПечати",
+          "mdoRefRu": "РегистрСведений.ПользовательскиеМакетыПечати"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.УдалитьБезопасноеХранилищеДанныхОбластейДанных",
+          "mdoRefRu": "РегистрСведений.УдалитьБезопасноеХранилищеДанныхОбластейДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.МуниципальнаяИерархия",
+          "mdoRefRu": "РегистрСведений.МуниципальнаяИерархия"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ТаблицыГруппДоступа",
+          "mdoRefRu": "РегистрСведений.ТаблицыГруппДоступа"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ЗакладкиВзаимодействий",
+          "mdoRefRu": "Справочник.ЗакладкиВзаимодействий"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.СостоянияОригиналовПервичныхДокументов",
+          "mdoRefRu": "Справочник.СостоянияОригиналовПервичныхДокументов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ИзмененияОбщихДанныхУзлов",
+          "mdoRefRu": "РегистрСведений.ИзмененияОбщихДанныхУзлов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ОбновлениеКлючейДоступаПользователей",
+          "mdoRefRu": "РегистрСведений.ОбновлениеКлючейДоступаПользователей"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.РассылкиОтчетов",
+          "mdoRefRu": "Справочник.РассылкиОтчетов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.НеразделенныеПользователи",
+          "mdoRefRu": "РегистрСведений.НеразделенныеПользователи"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.УведомленияОПрочтении",
+          "mdoRefRu": "РегистрСведений.УведомленияОПрочтении"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ДанныеОбъектовДляРегистрацииВОбменах",
+          "mdoRefRu": "РегистрСведений.ДанныеОбъектовДляРегистрацииВОбменах"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ДанныеБизнесПроцессов",
+          "mdoRefRu": "РегистрСведений.ДанныеБизнесПроцессов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "DOCUMENT",
+          "mdoRef": "Document.ЭлектронноеПисьмоИсходящее",
+          "mdoRefRu": "Документ.ЭлектронноеПисьмоИсходящее"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СпискиОтзываСертификатов",
+          "mdoRefRu": "РегистрСведений.СпискиОтзываСертификатов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.МинимальныйИнтервалРегламентныхЗаданийДОИОВМоделиСервиса",
+          "mdoRefRu": "Константа.МинимальныйИнтервалРегламентныхЗаданийДОИОВМоделиСервиса"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользованиеКаталогаДополнительныхОтчетовИОбработокВМоделиСервиса",
+          "mdoRefRu": "Константа.ИспользованиеКаталогаДополнительныхОтчетовИОбработокВМоделиСервиса"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ДлительныеОперации",
+          "mdoRefRu": "РегистрСведений.ДлительныеОперации"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.УдалитьЗамерыВремени3",
+          "mdoRefRu": "РегистрСведений.УдалитьЗамерыВремени3"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.НастройкиПравОбъектов",
+          "mdoRefRu": "РегистрСведений.НастройкиПравОбъектов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ДополнительныеОтчетыИОбработки",
+          "mdoRefRu": "Справочник.ДополнительныеОтчетыИОбработки"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ВнешниеПользователи",
+          "mdoRefRu": "Справочник.ВнешниеПользователи"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ПапкиФайлов",
+          "mdoRefRu": "Справочник.ПапкиФайлов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СубъектыДляРасчетаСроковХранения",
+          "mdoRefRu": "РегистрСведений.СубъектыДляРасчетаСроковХранения"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.НапоминанияПользователя",
+          "mdoRefRu": "РегистрСведений.НапоминанияПользователя"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ДатаОбновленияПовторноИспользуемыхЗначенийМРО",
+          "mdoRefRu": "Константа.ДатаОбновленияПовторноИспользуемыхЗначенийМРО"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.НастройкиПолномочийМЧД",
+          "mdoRefRu": "РегистрСведений.НастройкиПолномочийМЧД"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ЗначенияГруппДоступа",
+          "mdoRefRu": "РегистрСведений.ЗначенияГруппДоступа"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ИсторияМуниципальнойИерархии",
+          "mdoRefRu": "РегистрСведений.ИсторияМуниципальнойИерархии"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьАльтернативныйСерверДляЗагрузкиКурсовВалют",
+          "mdoRefRu": "Константа.ИспользоватьАльтернативныйСерверДляЗагрузкиКурсовВалют"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьПолнотекстовыйПоиск",
+          "mdoRefRu": "Константа.ИспользоватьПолнотекстовыйПоиск"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.КаталогСообщенийОбменаДаннымиДляWindows",
+          "mdoRefRu": "Константа.КаталогСообщенийОбменаДаннымиДляWindows"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.АвтоматическиНастраиватьРазрешенияВПрофиляхБезопасности",
+          "mdoRefRu": "Константа.АвтоматическиНастраиватьРазрешенияВПрофиляхБезопасности"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.РежимОчисткиФайлов",
+          "mdoRefRu": "Константа.РежимОчисткиФайлов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.КэшПрограммныхИнтерфейсов",
+          "mdoRefRu": "РегистрСведений.КэшПрограммныхИнтерфейсов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ГруппыЗначенийДоступа",
+          "mdoRefRu": "РегистрСведений.ГруппыЗначенийДоступа"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.НастройкиКомандПечати",
+          "mdoRefRu": "РегистрСведений.НастройкиКомандПечати"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ДанныеДляОтложенногоОбновления",
+          "mdoRefRu": "Константа.ДанныеДляОтложенногоОбновления"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.СервисПереводаТекста",
+          "mdoRefRu": "Константа.СервисПереводаТекста"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.НеИспользоватьРазделениеПоОбластямДанных",
+          "mdoRefRu": "Константа.НеИспользоватьРазделениеПоОбластямДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.КаталогСообщенийОбменаДаннымиДляLinux",
+          "mdoRefRu": "Константа.КаталогСообщенийОбменаДаннымиДляLinux"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.СведенияОБлокируемыхОбъектах",
+          "mdoRefRu": "Константа.СведенияОБлокируемыхОбъектах"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ПредопределенныеВариантыОтчетов",
+          "mdoRefRu": "Справочник.ПредопределенныеВариантыОтчетов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьЭлектроннуюПочтуВШаблонахСообщений",
+          "mdoRefRu": "Константа.ИспользоватьЭлектроннуюПочтуВШаблонахСообщений"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьСинхронизациюДанныхВМоделиСервисаСПриложениемВИнтернете",
+          "mdoRefRu": "Константа.ИспользоватьСинхронизациюДанныхВМоделиСервисаСПриложениемВИнтернете"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ОценкаПроизводительностиПериодЗаписи",
+          "mdoRefRu": "Константа.ОценкаПроизводительностиПериодЗаписи"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ГлавныйУзел",
+          "mdoRefRu": "Константа.ГлавныйУзел"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.АдресСервисаМЧДРР",
+          "mdoRefRu": "Константа.АдресСервисаМЧДРР"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ЗаголовокСистемы",
+          "mdoRefRu": "Константа.ЗаголовокСистемы"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.РучныеИзмененияГрафиковРаботы",
+          "mdoRefRu": "РегистрСведений.РучныеИзмененияГрафиковРаботы"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьБизнесПроцессыИЗадачи",
+          "mdoRefRu": "Константа.ИспользоватьБизнесПроцессыИЗадачи"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СостоянияОбменовДаннымиОбластейДанных",
+          "mdoRefRu": "РегистрСведений.СостоянияОбменовДаннымиОбластейДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ГруппыПользователей",
+          "mdoRefRu": "Справочник.ГруппыПользователей"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользуютсяПрофилиБезопасности",
+          "mdoRefRu": "Константа.ИспользуютсяПрофилиБезопасности"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.СтандартныеПодсистемыВАвтономномРежиме",
+          "mdoRefRu": "Константа.СтандартныеПодсистемыВАвтономномРежиме"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ОграничиватьДоступНаУровнеЗаписейУниверсально",
+          "mdoRefRu": "Константа.ОграничиватьДоступНаУровнеЗаписейУниверсально"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписиМЧД",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписиМЧД"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ЗарегистрированыИзмененияДанных",
+          "mdoRefRu": "Константа.ЗарегистрированыИзмененияДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.НастройкиОчисткиФайлов",
+          "mdoRefRu": "РегистрСведений.НастройкиОчисткиФайлов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ОбщиеНастройкиУзловИнформационныхБаз",
+          "mdoRefRu": "РегистрСведений.ОбщиеНастройкиУзловИнформационныхБаз"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ЗначенияСвойствОбъектовИерархия",
+          "mdoRefRu": "Справочник.ЗначенияСвойствОбъектовИерархия"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.МаксимальныйРазмерФайлаОбластиДанных",
+          "mdoRefRu": "Константа.МаксимальныйРазмерФайлаОбластиДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьВнешнихПользователей",
+          "mdoRefRu": "Константа.ИспользоватьВнешнихПользователей"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.УчетныеЗаписиСинхронизацииФайлов",
+          "mdoRefRu": "Справочник.УчетныеЗаписиСинхронизацииФайлов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ПараметрыРаботыПрограммы",
+          "mdoRefRu": "РегистрСведений.ПараметрыРаботыПрограммы"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ПрограммыЭлектроннойПодписиИШифрования",
+          "mdoRefRu": "Справочник.ПрограммыЭлектроннойПодписиИШифрования"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ИдентификаторыОбъектовРасширений",
+          "mdoRefRu": "Справочник.ИдентификаторыОбъектовРасширений"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СостоянияПапокПисем",
+          "mdoRefRu": "РегистрСведений.СостоянияПапокПисем"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.НастройкиКолонтитулов",
+          "mdoRefRu": "Константа.НастройкиКолонтитулов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СертификатыПользователяDSS",
+          "mdoRefRu": "РегистрСведений.СертификатыПользователяDSS"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.АдминистративнаяИерархия",
+          "mdoRefRu": "РегистрСведений.АдминистративнаяИерархия"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.УдалитьНастройкиТранспортаОбмена",
+          "mdoRefRu": "РегистрСведений.УдалитьНастройкиТранспортаОбмена"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CHART_OF_CHARACTERISTIC_TYPES",
+          "mdoRef": "ChartOfCharacteristicTypes.ОбъектыАдресацииЗадач",
+          "mdoRefRu": "ПланВидовХарактеристик.ОбъектыАдресацииЗадач"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьГруппыПользователей",
+          "mdoRefRu": "Константа.ИспользоватьГруппыПользователей"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.СинхронизироватьДанныеСПриложениемВИнтернетеПриНачалеРаботыПрограммы",
+          "mdoRefRu": "Константа.СинхронизироватьДанныеСПриложениемВИнтернетеПриНачалеРаботыПрограммы"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.НастройкиВходаПользователей",
+          "mdoRefRu": "Константа.НастройкиВходаПользователей"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ПсевдонимыПредопределенныхУзлов",
+          "mdoRefRu": "РегистрСведений.ПсевдонимыПредопределенныхУзлов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СостоянияУспешныхОбменовДаннымиОбластейДанных",
+          "mdoRefRu": "РегистрСведений.СостоянияУспешныхОбменовДаннымиОбластейДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьНесколькоПроизводственныхКалендарей",
+          "mdoRefRu": "Константа.ИспользоватьНесколькоПроизводственныхКалендарей"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ПравилаДляОбменаДанными",
+          "mdoRefRu": "РегистрСведений.ПравилаДляОбменаДанными"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ОбластиСтатистики",
+          "mdoRefRu": "РегистрСведений.ОбластиСтатистики"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.НастройкаПодчиненногоУзлаРИБЗавершена",
+          "mdoRefRu": "Константа.НастройкаПодчиненногоУзлаРИБЗавершена"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ГруппыИсполнителейЗадач",
+          "mdoRefRu": "Справочник.ГруппыИсполнителейЗадач"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.НастройкиТранспортаСообщенийОбмена",
+          "mdoRefRu": "Справочник.НастройкиТранспортаСообщенийОбмена"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ЗначенияСвойствОбъектов",
+          "mdoRefRu": "Справочник.ЗначенияСвойствОбъектов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ДатыПоследнейЗагрузкиПочтовыхСообщений",
+          "mdoRefRu": "РегистрСведений.ДатыПоследнейЗагрузкиПочтовыхСообщений"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ПараметрыОграниченияДоступа",
+          "mdoRefRu": "РегистрСведений.ПараметрыОграниченияДоступа"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.КлассификаторБанков",
+          "mdoRefRu": "Справочник.КлассификаторБанков"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ЗемельныеУчастки",
+          "mdoRefRu": "РегистрСведений.ЗемельныеУчастки"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ИсторияАдресныхОбъектов",
+          "mdoRefRu": "РегистрСведений.ИсторияАдресныхОбъектов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.СписокЗапрещенныхРасширений",
+          "mdoRefRu": "Константа.СписокЗапрещенныхРасширений"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ПериодическиеСерверныеОповещения",
+          "mdoRefRu": "РегистрСведений.ПериодическиеСерверныеОповещения"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СообщенияОбменаДаннымиОбластейДанных",
+          "mdoRefRu": "РегистрСведений.СообщенияОбменаДаннымиОбластейДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.НастройкиВариантовОтчетов",
+          "mdoRefRu": "РегистрСведений.НастройкиВариантовОтчетов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.СообщениеSMSПрисоединенныеФайлы",
+          "mdoRefRu": "Справочник.СообщениеSMSПрисоединенныеФайлы"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СертификатыШифрования",
+          "mdoRefRu": "РегистрСведений.СертификатыШифрования"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.УдалитьРезультатыОбменаДанными",
+          "mdoRefRu": "РегистрСведений.УдалитьРезультатыОбменаДанными"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ИспользованиеДополнительныхОтчетовИОбработокСервисаВАвтономномРабочемМесте",
+          "mdoRefRu": "РегистрСведений.ИспользованиеДополнительныхОтчетовИОбработокСервисаВАвтономномРабочемМесте"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ЗаблокированныеДляПолученияУчетныеЗаписи",
+          "mdoRefRu": "РегистрСведений.ЗаблокированныеДляПолученияУчетныеЗаписи"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ПараметрыРаботыВерсийРасширений",
+          "mdoRefRu": "РегистрСведений.ПараметрыРаботыВерсийРасширений"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ХранилищеДвоичныхДанных",
+          "mdoRefRu": "Справочник.ХранилищеДвоичныхДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ОсновныеПечатныеФормыОбъектов",
+          "mdoRefRu": "РегистрСведений.ОсновныеПечатныеФормыОбъектов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.НастройкиТранспортаОбменаОбластиДанных",
+          "mdoRefRu": "РегистрСведений.НастройкиТранспортаОбменаОбластиДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьНапоминанияПользователя",
+          "mdoRefRu": "Константа.ИспользоватьНапоминанияПользователя"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.УничтоженныеПерсональныеДанные",
+          "mdoRefRu": "РегистрСведений.УничтоженныеПерсональныеДанные"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ПрефиксУзлаРаспределеннойИнформационнойБазы",
+          "mdoRefRu": "Константа.ПрефиксУзлаРаспределеннойИнформационнойБазы"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.СообщениеОбменаДаннымиИзГлавногоУзла",
+          "mdoRefRu": "Константа.СообщениеОбменаДаннымиИзГлавногоУзла"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьЗаметки",
+          "mdoRefRu": "Константа.ИспользоватьЗаметки"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ОчередьИнсталляцииПоставляемыхДополнительныхОтчетовИОбработокВОбластиДанных",
+          "mdoRefRu": "РегистрСведений.ОчередьИнсталляцииПоставляемыхДополнительныхОтчетовИОбработокВОбластиДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ЯзыкиПечатныхФорм",
+          "mdoRefRu": "Справочник.ЯзыкиПечатныхФорм"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьСервисПереводаТекста",
+          "mdoRefRu": "Константа.ИспользоватьСервисПереводаТекста"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "DOCUMENT",
+          "mdoRef": "Document.СогласиеНаОбработкуПерсональныхДанных",
+          "mdoRefRu": "Документ.СогласиеНаОбработкуПерсональныхДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.РезультатыОбменаДанными",
+          "mdoRefRu": "РегистрСведений.РезультатыОбменаДанными"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.БуферОперацийСтатистики",
+          "mdoRefRu": "РегистрСведений.БуферОперацийСтатистики"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ОтправленныеСерверныеОповещения",
+          "mdoRefRu": "РегистрСведений.ОтправленныеСерверныеОповещения"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ПараметрыЦентраМониторинга",
+          "mdoRefRu": "Константа.ПараметрыЦентраМониторинга"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ОграничиватьДоступНаУровнеЗаписей",
+          "mdoRefRu": "Константа.ОграничиватьДоступНаУровнеЗаписей"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.АдресныеОбъекты",
+          "mdoRefRu": "РегистрСведений.АдресныеОбъекты"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СвойстваРасширений",
+          "mdoRefRu": "РегистрСведений.СвойстваРасширений"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "DOCUMENT",
+          "mdoRef": "Document.АктОбУничтоженииПерсональныхДанных",
+          "mdoRefRu": "Документ.АктОбУничтоженииПерсональныхДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ГруппыВнешнихПользователей",
+          "mdoRefRu": "Справочник.ГруппыВнешнихПользователей"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ЗамерыВремениТехнологические",
+          "mdoRefRu": "РегистрСведений.ЗамерыВремениТехнологические"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьРазделениеПоОбластямДанных",
+          "mdoRefRu": "Константа.ИспользоватьРазделениеПоОбластямДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ХранитьФайлыВТомахНаДиске",
+          "mdoRefRu": "Константа.ХранитьФайлыВТомахНаДиске"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьСервисСклоненияMorpher",
+          "mdoRefRu": "Константа.ИспользоватьСервисСклоненияMorpher"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.СведенияОбОбновленииИБ",
+          "mdoRefRu": "Константа.СведенияОбОбновленииИБ"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ГруппыДоступа",
+          "mdoRefRu": "Справочник.ГруппыДоступа"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ОбщиеПоставляемыеМакетыПечати",
+          "mdoRefRu": "РегистрСведений.ОбщиеПоставляемыеМакетыПечати"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.КоличествоПотоковОбновленияИнформационнойБазы",
+          "mdoRefRu": "Константа.КоличествоПотоковОбновленияИнформационнойБазы"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СостоянияУспешныхОбменовДанными",
+          "mdoRefRu": "РегистрСведений.СостоянияУспешныхОбменовДанными"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ИспользуемыеВидыДоступа",
+          "mdoRefRu": "РегистрСведений.ИспользуемыеВидыДоступа"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ОтложенноеОбновлениеВГлавномУзлеЗавершеноУспешно",
+          "mdoRefRu": "Константа.ОтложенноеОбновлениеВГлавномУзлеЗавершеноУспешно"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ДатыЗапретаИзменения",
+          "mdoRefRu": "РегистрСведений.ДатыЗапретаИзменения"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.УдаляемыеОбъекты",
+          "mdoRefRu": "РегистрСведений.УдаляемыеОбъекты"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ВстречаПрисоединенныеФайлы",
+          "mdoRefRu": "Справочник.ВстречаПрисоединенныеФайлы"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.КлючиДоступаКРегистрам",
+          "mdoRefRu": "РегистрСведений.КлючиДоступаКРегистрам"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьДатыЗапретаИзменения",
+          "mdoRefRu": "Константа.ИспользоватьДатыЗапретаИзменения"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.КлючиДоступаКОбъектам",
+          "mdoRefRu": "РегистрСведений.КлючиДоступаКОбъектам"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьПрочиеВзаимодействия",
+          "mdoRefRu": "Константа.ИспользоватьПрочиеВзаимодействия"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ЭтоАвтономноеРабочееМесто",
+          "mdoRefRu": "Константа.ЭтоАвтономноеРабочееМесто"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.НаборыГруппДоступа",
+          "mdoRefRu": "Справочник.НаборыГруппДоступа"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ТомаХраненияФайлов",
+          "mdoRefRu": "Справочник.ТомаХраненияФайлов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ВерсииПодсистемОбластейДанных",
+          "mdoRefRu": "РегистрСведений.ВерсииПодсистемОбластейДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ПравилаОбработкиЭлектроннойПочты",
+          "mdoRefRu": "Справочник.ПравилаОбработкиЭлектроннойПочты"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CHART_OF_CHARACTERISTIC_TYPES",
+          "mdoRef": "ChartOfCharacteristicTypes.ВопросыДляАнкетирования",
+          "mdoRefRu": "ПланВидовХарактеристик.ВопросыДляАнкетирования"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "BUSINESS_PROCESS",
+          "mdoRef": "BusinessProcess.Задание",
+          "mdoRefRu": "БизнесПроцесс.Задание"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.НастройкиАрхиваСообщенийОбменов",
+          "mdoRefRu": "РегистрСведений.НастройкиАрхиваСообщенийОбменов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.МакетыПечатныхФорм",
+          "mdoRefRu": "Справочник.МакетыПечатныхФорм"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ИдентификаторыОбъектовВерсийРасширений",
+          "mdoRefRu": "РегистрСведений.ИдентификаторыОбъектовВерсийРасширений"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ФиксацияОбработкиДанныхОбработчиками",
+          "mdoRefRu": "РегистрСведений.ФиксацияОбработкиДанныхОбработчиками"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.СинхронизироватьДанныеСПриложениемВИнтернетеПриЗавершенииРаботыПрограммы",
+          "mdoRefRu": "Константа.СинхронизироватьДанныеСПриложениемВИнтернетеПриЗавершенииРаботыПрограммы"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.КоличествоЭлементовВТранзакцииЗагрузкиДанных",
+          "mdoRefRu": "Константа.КоличествоЭлементовВТранзакцииЗагрузкиДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ЗагрузитьРасширенияИзменяющиеСтруктуруДанных",
+          "mdoRefRu": "Константа.ЗагрузитьРасширенияИзменяющиеСтруктуруДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.КлючиДоступаПользователей",
+          "mdoRefRu": "РегистрСведений.КлючиДоступаПользователей"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.КлючиДоступаГруппДоступа",
+          "mdoRefRu": "РегистрСведений.КлючиДоступаГруппДоступа"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.МашиночитаемыеДоверенностиПрисоединенныеФайлы",
+          "mdoRefRu": "Справочник.МашиночитаемыеДоверенностиПрисоединенныеФайлы"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ДомаЗданияСтроения",
+          "mdoRefRu": "РегистрСведений.ДомаЗданияСтроения"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ИспользуемыеВидыДоступаПоТаблицам",
+          "mdoRefRu": "РегистрСведений.ИспользуемыеВидыДоступаПоТаблицам"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.МашиночитаемыеДоверенностиПредставителиИДоверители",
+          "mdoRefRu": "РегистрСведений.МашиночитаемыеДоверенностиПредставителиИДоверители"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ДампыПлатформы",
+          "mdoRefRu": "РегистрСведений.ДампыПлатформы"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.АдресПубликацииИнформационнойБазыВЛокальнойСети",
+          "mdoRefRu": "Константа.АдресПубликацииИнформационнойБазыВЛокальнойСети"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.КодировкиФайлов",
+          "mdoRefRu": "РегистрСведений.КодировкиФайлов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ЗамерыОперацииСтатистики",
+          "mdoRefRu": "РегистрСведений.ЗамерыОперацииСтатистики"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ПоследнееОбновлениеДоступа",
+          "mdoRefRu": "Константа.ПоследнееОбновлениеДоступа"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.Файлы",
+          "mdoRefRu": "Справочник.Файлы"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ПрефиксПоследнегоАвтономногоРабочегоМеста",
+          "mdoRefRu": "Константа.ПрефиксПоследнегоАвтономногоРабочегоМеста"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИсточникДанныхАдресногоКлассификатора",
+          "mdoRefRu": "Константа.ИсточникДанныхАдресногоКлассификатора"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ЗамерыСтатистики",
+          "mdoRefRu": "РегистрСведений.ЗамерыСтатистики"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.КомментарииСтатистики",
+          "mdoRefRu": "РегистрСведений.КомментарииСтатистики"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.СинхронизироватьФайлы",
+          "mdoRefRu": "Константа.СинхронизироватьФайлы"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ВерсииФайлов",
+          "mdoRefRu": "Справочник.ВерсииФайлов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ОперацииСтатистики",
+          "mdoRefRu": "РегистрСведений.ОперацииСтатистики"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.УдалитьДвоичныеДанныеФайлов",
+          "mdoRefRu": "РегистрСведений.УдалитьДвоичныеДанныеФайлов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ОбработчикиОбновленияОбщихДанных",
+          "mdoRefRu": "РегистрСведений.ОбработчикиОбновленияОбщихДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ПовторитьЗагрузкуСообщенияОбменаДаннымиПередЗапуском",
+          "mdoRefRu": "Константа.ПовторитьЗагрузкуСообщенияОбменаДаннымиПередЗапуском"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.КомментарииОперацииСтатистики",
+          "mdoRefRu": "РегистрСведений.КомментарииОперацииСтатистики"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.КонтактыВзаимодействий",
+          "mdoRefRu": "РегистрСведений.КонтактыВзаимодействий"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.РабочиеКаталогиФайлов",
+          "mdoRefRu": "РегистрСведений.РабочиеКаталогиФайлов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ПакетыДляОтправки",
+          "mdoRefRu": "РегистрСведений.ПакетыДляОтправки"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ДетализироватьОбновлениеИБВЖурналеРегистрации",
+          "mdoRefRu": "Константа.ДетализироватьОбновлениеИБВЖурналеРегистрации"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.ПрофилиГруппДоступа",
+          "mdoRefRu": "Справочник.ПрофилиГруппДоступа"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "DOCUMENT",
+          "mdoRef": "Document.ЭлектронноеПисьмоВходящее",
+          "mdoRefRu": "Документ.ЭлектронноеПисьмоВходящее"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьСинхронизациюДанных",
+          "mdoRefRu": "Константа.ИспользоватьСинхронизациюДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИдентификаторИнформационнойБазы",
+          "mdoRefRu": "Константа.ИдентификаторИнформационнойБазы"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ПоставляемыеМакетыПечати",
+          "mdoRefRu": "РегистрСведений.ПоставляемыеМакетыПечати"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИзменятьЗаданияЗаднимЧислом",
+          "mdoRefRu": "Константа.ИзменятьЗаданияЗаднимЧислом"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.РежимыПодключенияВнешнихМодулей",
+          "mdoRefRu": "РегистрСведений.РежимыПодключенияВнешнихМодулей"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.БезопасноеХранилищеДанных",
+          "mdoRefRu": "РегистрСведений.БезопасноеХранилищеДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СостоянияПредметовВзаимодействий",
+          "mdoRefRu": "РегистрСведений.СостоянияПредметовВзаимодействий"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.РезультатыПроверкиУчета",
+          "mdoRefRu": "РегистрСведений.РезультатыПроверкиУчета"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьСинхронизациюДанныхВМоделиСервисаСЛокальнойПрограммой",
+          "mdoRefRu": "Константа.ИспользоватьСинхронизациюДанныхВМоделиСервисаСЛокальнойПрограммой"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СведенияОПользователях",
+          "mdoRefRu": "РегистрСведений.СведенияОПользователях"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.БлокировкиСеансовОбластейДанных",
+          "mdoRefRu": "РегистрСведений.БлокировкиСеансовОбластейДанных"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьУдалениеПомеченныхОбъектов",
+          "mdoRefRu": "Константа.ИспользоватьУдалениеПомеченныхОбъектов"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CONSTANT",
+          "mdoRef": "Constant.ИспользоватьДатуНачалаЗадач",
+          "mdoRefRu": "Константа.ИспользоватьДатуНачалаЗадач"
+        },
+        "allow": false
+      },
+      {
+        "metadata": {
+          "type": "CATALOG",
+          "mdoRef": "Catalog.НастройкиАвторизацииИнтернетСервисов",
+          "mdoRefRu": "Справочник.НастройкиАвторизацииИнтернетСервисов"
+        },
+        "allow": false
+      }
+    ],
+    []
+  ],
+  "description": "Обновление информационной базы",
+  "distributedInfoBase": false,
+  "explanation": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+  },
+  "forms": [],
+  "includeConfigurationExtensions": false,
+  "mdoReference": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+  },
+  "mdoType": "EXCHANGE_PLAN",
+  "moduleTypes": [
+    [
+      "ManagerModule",
+      [
+        "src/test/resources/ext/edt/ssl_3_2/configuration/src/ExchangePlans/ОбновлениеИнформационно_Базы/ManagerModule.bsl"
+      ]
+    ],
+    [
+      "ObjectModule",
+      [
+        "src/test/resources/ext/edt/ssl_3_2/configuration/src/ExchangePlans/ОбновлениеИнформационно_Базы/ObjectModule.bsl"
+      ]
+    ]
+  ],
+  "modules": [
+    {
+      "moduleType": "ManagerModule",
+      "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/ExchangePlans/ОбновлениеИнформационно_Базы/ManagerModule.bsl",
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "isProtected": false
+    },
+    {
+      "moduleType": "ObjectModule",
+      "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/ExchangePlans/ОбновлениеИнформационно_Базы/ObjectModule.bsl",
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.ExchangePlan/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "isProtected": false
+    }
+  ],
+  "name": "ОбновлениеИнформационнойБазы",
+  "objectBelonging": "OWN",
+  "possibleRights": [
+    {
+      "default": {
+        "tag": 4
+      },
+      "int": 21,
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INSERT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "DELETE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "VIEW",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "EDIT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INPUT_BY_STRING",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_DELETE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_INSERT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_SET_DELETION_MARK",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_CLEAR_DELETION_MARK",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_DELETE_MARKED",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "VIEW_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ_DATA_HISTORY_OF_MISSING_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_OF_MISSING_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_SETTINGS",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_VERSION_COMMENT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "EDIT_DATA_HISTORY_VERSION_COMMENT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "SWITCH_TO_DATA_HISTORY_VERSION"
+    }
+  ],
+  "predefinedValues": [],
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "content": [
+      {
+        "default": {
+          "tag": 2
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+          "langKey": "ru",
+          "value": "Обновление информационной базы"
+        }
+      }
+    ]
+  },
+  "tabularSections": [],
+  "templates": [],
+  "uuid": "3fc019d1-aec8-4835-96c5-3bbf43da0b94"
+}}

--- a/src/test/resources/fixtures/ssl_3_2/FilterCriteria.СвязанныеДокументы.json
+++ b/src/test/resources/fixtures/ssl_3_2/FilterCriteria.СвязанныеДокументы.json
@@ -1,0 +1,45 @@
+{"com.github._1c_syntax.bsl.mdo.FilterCriterion": {
+  "commands": [],
+  "comment": "",
+  "content": [],
+  "description": "Связанные документы",
+  "explanation": {
+    "content": []
+  },
+  "forms": [],
+  "mdoReference": {
+    "type": "FILTER_CRITERION",
+    "mdoRef": "FilterCriterion.СвязанныеДокументы",
+    "mdoRefRu": "КритерийОтбора.СвязанныеДокументы"
+  },
+  "mdoType": "FILTER_CRITERION",
+  "moduleTypes": [],
+  "modules": [],
+  "name": "СвязанныеДокументы",
+  "objectBelonging": "OWN",
+  "possibleRights": [
+    {
+      "default": {
+        "tag": 4
+      },
+      "int": 1,
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "VIEW"
+    }
+  ],
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "content": [
+      {
+        "default": {
+          "tag": 2
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+          "langKey": "ru",
+          "value": "Связанные документы"
+        }
+      }
+    ]
+  },
+  "uuid": "18bf6916-83cc-41e5-a35b-1489450ae632"
+}}

--- a/src/test/resources/fixtures/ssl_3_2/FilterCriteria.СвязанныеДокументы_edt.json
+++ b/src/test/resources/fixtures/ssl_3_2/FilterCriteria.СвязанныеДокументы_edt.json
@@ -1,0 +1,45 @@
+{"com.github._1c_syntax.bsl.mdo.FilterCriterion": {
+  "commands": [],
+  "comment": "",
+  "content": [],
+  "description": "Связанные документы",
+  "explanation": {
+    "content": []
+  },
+  "forms": [],
+  "mdoReference": {
+    "type": "FILTER_CRITERION",
+    "mdoRef": "FilterCriterion.СвязанныеДокументы",
+    "mdoRefRu": "КритерийОтбора.СвязанныеДокументы"
+  },
+  "mdoType": "FILTER_CRITERION",
+  "moduleTypes": [],
+  "modules": [],
+  "name": "СвязанныеДокументы",
+  "objectBelonging": "OWN",
+  "possibleRights": [
+    {
+      "default": {
+        "tag": 4
+      },
+      "int": 1,
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "VIEW"
+    }
+  ],
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "content": [
+      {
+        "default": {
+          "tag": 2
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+          "langKey": "ru",
+          "value": "Связанные документы"
+        }
+      }
+    ]
+  },
+  "uuid": "18bf6916-83cc-41e5-a35b-1489450ae632"
+}}

--- a/src/test/resources/fixtures/ssl_3_2/FunctionalOptions.ИспользоватьАнкетирование.json
+++ b/src/test/resources/fixtures/ssl_3_2/FunctionalOptions.ИспользоватьАнкетирование.json
@@ -1,0 +1,94 @@
+{"com.github._1c_syntax.bsl.mdo.FunctionalOption": {
+  "comment": "",
+  "content": [
+    [
+      {
+        "type": "CHART_OF_CHARACTERISTIC_TYPES",
+        "mdoRef": "ChartOfCharacteristicTypes.ВопросыДляАнкетирования",
+        "mdoRefRu": "ПланВидовХарактеристик.ВопросыДляАнкетирования"
+      },
+      {
+        "type": "CATALOG",
+        "mdoRef": "Catalog.ВариантыОтветовАнкет",
+        "mdoRefRu": "Справочник.ВариантыОтветовАнкет"
+      },
+      {
+        "type": "DOCUMENT",
+        "mdoRef": "Document.НазначениеОпросов",
+        "mdoRefRu": "Документ.НазначениеОпросов"
+      },
+      {
+        "type": "DOCUMENT",
+        "mdoRef": "Document.Анкета",
+        "mdoRefRu": "Документ.Анкета"
+      },
+      {
+        "type": "INFORMATION_REGISTER",
+        "mdoRef": "InformationRegister.ОтветыНаВопросыАнкет",
+        "mdoRefRu": "РегистрСведений.ОтветыНаВопросыАнкет"
+      },
+      {
+        "type": "REPORT",
+        "mdoRef": "Report.АнализОпроса",
+        "mdoRefRu": "Отчет.АнализОпроса"
+      },
+      {
+        "type": "CATALOG",
+        "mdoRef": "Catalog.ШаблоныАнкет",
+        "mdoRefRu": "Справочник.ШаблоныАнкет"
+      },
+      {
+        "type": "CATALOG",
+        "mdoRef": "Catalog.ВопросыШаблонаАнкеты",
+        "mdoRefRu": "Справочник.ВопросыШаблонаАнкеты"
+      },
+      {
+        "type": "REPORT",
+        "mdoRef": "Report.АналитическийОтчетПоАнкетированию",
+        "mdoRefRu": "Отчет.АналитическийОтчетПоАнкетированию"
+      },
+      {
+        "type": "DATA_PROCESSOR",
+        "mdoRef": "DataProcessor.ДоступныеАнкеты",
+        "mdoRefRu": "Обработка.ДоступныеАнкеты"
+      },
+      {
+        "type": "COMMON_COMMAND",
+        "mdoRef": "CommonCommand.НачатьИнтервью",
+        "mdoRefRu": "ОбщаяКоманда.НачатьИнтервью"
+      }
+    ],
+    []
+  ],
+  "description": "Использовать анкетирование",
+  "location": {
+    "type": "CONSTANT",
+    "mdoRef": "Constant.ИспользоватьАнкетирование",
+    "mdoRefRu": "Константа.ИспользоватьАнкетирование"
+  },
+  "mdoReference": {
+    "type": "FUNCTIONAL_OPTION",
+    "mdoRef": "FunctionalOption.ИспользоватьАнкетирование",
+    "mdoRefRu": "ФункциональнаяОпция.ИспользоватьАнкетирование"
+  },
+  "mdoType": "FUNCTIONAL_OPTION",
+  "name": "ИспользоватьАнкетирование",
+  "objectBelonging": "OWN",
+  "privilegedGetMode": true,
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "content": [
+      {
+        "default": {
+          "tag": 2
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+          "langKey": "ru",
+          "value": "Использовать анкетирование"
+        }
+      }
+    ]
+  },
+  "uuid": "697d5715-dd04-40be-9b28-539734725158"
+}}

--- a/src/test/resources/fixtures/ssl_3_2/FunctionalOptionsParameters.ТипВерсионируемогоОбъекта.json
+++ b/src/test/resources/fixtures/ssl_3_2/FunctionalOptionsParameters.ТипВерсионируемогоОбъекта.json
@@ -1,0 +1,33 @@
+{"com.github._1c_syntax.bsl.mdo.FunctionalOptionsParameter": {
+  "comment": "",
+  "description": "Тип версионируемого объекта",
+  "mdoReference": {
+    "type": "FUNCTIONAL_OPTIONS_PARAMETER",
+    "mdoRef": "FunctionalOptionsParameter.ТипВерсионируемогоОбъекта",
+    "mdoRefRu": "ПараметрФункциональныхОпций.ТипВерсионируемогоОбъекта"
+  },
+  "mdoType": "FUNCTIONAL_OPTIONS_PARAMETER",
+  "name": "ТипВерсионируемогоОбъекта",
+  "objectBelonging": "OWN",
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "content": [
+      {
+        "default": {
+          "tag": 2
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+          "langKey": "ru",
+          "value": "Тип версионируемого объекта"
+        }
+      }
+    ]
+  },
+  "use": {
+    "type": "DIMENSION",
+    "mdoRef": "InformationRegister.НастройкиВерсионированияОбъектов.Dimension.ТипОбъекта",
+    "mdoRefRu": "РегистрСведений.НастройкиВерсионированияОбъектов.Измерение.ТипОбъекта"
+  },
+  "uuid": "245c07a9-98b0-452b-b899-dc8751ab7ce0"
+}}

--- a/src/test/resources/fixtures/ssl_3_2/InformationRegisters.СклоненияПредставленийОбъектов.json
+++ b/src/test/resources/fixtures/ssl_3_2/InformationRegisters.СклоненияПредставленийОбъектов.json
@@ -1,0 +1,814 @@
+{"com.github._1c_syntax.bsl.mdo.InformationRegister": {
+  "attributes": [
+    [
+      {
+        "uuid": "7bf36370-3761-4fd5-bea5-90fa142a9d57",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "InformationRegister.СклоненияПредставленийОбъектов.StandardAttribute.Active",
+          "mdoRefRu": "РегистрСведений.СклоненияПредставленийОбъектов.СтандартныйРеквизит.Активность"
+        },
+        "comment": "",
+        "synonym": {
+          "content": []
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СклоненияПредставленийОбъектов",
+          "mdoRefRu": "РегистрСведений.СклоненияПредставленийОбъектов"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "BOOLEAN"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 0
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "Активность",
+          "nameEn": "Active"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "7bf36370-3761-4fd5-bea5-90fa142a9d57",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "InformationRegister.СклоненияПредставленийОбъектов.StandardAttribute.LineNumber",
+          "mdoRefRu": "РегистрСведений.СклоненияПредставленийОбъектов.СтандартныйРеквизит.НомерСтроки"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                "precision": 5,
+                "scale": 0,
+                "nonNegative": false,
+                "description": {}
+              }
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "НомерСтроки",
+          "nameEn": "LineNumber"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "7bf36370-3761-4fd5-bea5-90fa142a9d57",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "InformationRegister.СклоненияПредставленийОбъектов.StandardAttribute.Recorder",
+          "mdoRefRu": "РегистрСведений.СклоненияПредставленийОбъектов.СтандартныйРеквизит.Регистратор"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [],
+          "composite": false,
+          "qualifiers": []
+        },
+        "fullName": {
+          "nameRu": "Регистратор",
+          "nameEn": "Recorder"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "7bf36370-3761-4fd5-bea5-90fa142a9d57",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "InformationRegister.СклоненияПредставленийОбъектов.StandardAttribute.Period",
+          "mdoRefRu": "РегистрСведений.СклоненияПредставленийОбъектов.СтандартныйРеквизит.Период"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "DATE"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.DateQualifiers": {
+                "dateFractions": 2,
+                "description": {
+                  "value": {
+                    "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                    "nameRu": "КвалификаторыДаты (ДатаВремя)",
+                    "nameEn": "DateQualifiers (DateTime)"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "Период",
+          "nameEn": "Period"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      }
+    ],
+    []
+  ],
+  "commands": [],
+  "comment": "",
+  "description": "Склонения представлений объектов",
+  "dimensions": [
+    [
+      {
+        "uuid": "1541ad74-3e73-4699-bccf-c13313fbedfe",
+        "name": "ХешПредставления",
+        "mdoReference": {
+          "type": "DIMENSION",
+          "mdoRef": "InformationRegister.СклоненияПредставленийОбъектов.Dimension.ХешПредставления",
+          "mdoRefRu": "РегистрСведений.СклоненияПредставленийОбъектов.Измерение.ХешПредставления"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Хеш представления"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                "length": 40,
+                "allowedLength": 0,
+                "description": {}
+              }
+            }
+          ]
+        },
+        "master": false,
+        "denyIncompleteValues": true,
+        "useInTotals": true
+      },
+      {
+        "uuid": "1037ecb7-6819-4ba2-8c93-eccbbdf825be",
+        "name": "Объект",
+        "mdoReference": {
+          "type": "DIMENSION",
+          "mdoRef": "InformationRegister.СклоненияПредставленийОбъектов.Dimension.Объект",
+          "mdoRefRu": "РегистрСведений.СклоненияПредставленийОбъектов.Измерение.Объект"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Объект"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "ОпределяемыйТип.ОбъектСклонения",
+                  "nameEn": "DefinedType.ОбъектСклонения"
+                },
+                "variant": "METADATA",
+                "kind": "DEFINED_TYPE"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "master": true,
+        "denyIncompleteValues": false,
+        "useInTotals": true
+      }
+    ],
+    []
+  ],
+  "explanation": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+  },
+  "forms": [
+    {
+      "uuid": "823f925c-b71f-42b1-a71e-0aab823f59c6",
+      "name": "ФормаЗаписи",
+      "mdoReference": {
+        "type": "FORM",
+        "mdoRef": "InformationRegister.СклоненияПредставленийОбъектов.Form.ФормаЗаписи",
+        "mdoRefRu": "РегистрСведений.СклоненияПредставленийОбъектов.Форма.ФормаЗаписи"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": [
+          {
+            "default": {
+              "tag": 2
+            },
+            "int": 1,
+            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+              "langKey": "ru",
+              "value": "Форма записи"
+            }
+          }
+        ]
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "modules": [
+        {
+          "moduleType": "FormModule",
+          "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/InformationRegisters/СклоненияПредставлени_Объектов/Forms/ФормаЗаписи/Ext/Form/Module.bsl",
+          "owner": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/forms/com.github._1c_syntax.bsl.mdo.children.ObjectForm/mdoReference"
+          },
+          "supportVariant": "NOT_EDITABLE",
+          "isProtected": false
+        }
+      ],
+      "formType": "MANAGED",
+      "data": {
+        "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+        "title": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "handlers": [
+          {
+            "event": "OnCreateAtServer",
+            "name": "ПриСозданииНаСервере"
+          }
+        ],
+        "items": [
+          [
+            {
+              "type": "INPUT_FIELD",
+              "id": 1,
+              "name": "ХешПредставления",
+              "title": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "dataPath": "Запись.ХешПредставления",
+              "items": []
+            },
+            {
+              "type": "INPUT_FIELD",
+              "id": 4,
+              "name": "Объект",
+              "title": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "dataPath": "Запись.Объект",
+              "items": []
+            },
+            {
+              "type": "INPUT_FIELD",
+              "id": 7,
+              "name": "ИменительныйПадеж",
+              "title": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "dataPath": "Запись.ИменительныйПадеж",
+              "items": []
+            },
+            {
+              "type": "INPUT_FIELD",
+              "id": 10,
+              "name": "РодительныйПадеж",
+              "title": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "dataPath": "Запись.РодительныйПадеж",
+              "items": []
+            },
+            {
+              "type": "INPUT_FIELD",
+              "id": 13,
+              "name": "ДательныйПадеж",
+              "title": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "dataPath": "Запись.ДательныйПадеж",
+              "items": []
+            },
+            {
+              "type": "INPUT_FIELD",
+              "id": 16,
+              "name": "ВинительныйПадеж",
+              "title": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "dataPath": "Запись.ВинительныйПадеж",
+              "items": []
+            },
+            {
+              "type": "INPUT_FIELD",
+              "id": 19,
+              "name": "ТворительныйПадеж",
+              "title": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "dataPath": "Запись.ТворительныйПадеж",
+              "items": []
+            },
+            {
+              "type": "INPUT_FIELD",
+              "id": 22,
+              "name": "ПредложныйПадеж",
+              "title": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "dataPath": "Запись.ПредложныйПадеж",
+              "items": []
+            }
+          ],
+          []
+        ],
+        "attributes": [
+          {
+            "id": 1,
+            "name": "Запись",
+            "title": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "type": {
+              "types": [
+                {
+                  "default": {
+                    "tag": 4
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                    "fullName": {
+                      "nameRu": "РегистрСведенийМенеджерЗаписи.СклоненияПредставленийОбъектов",
+                      "nameEn": "InformationRegisterRecordManager.СклоненияПредставленийОбъектов"
+                    },
+                    "variant": "METADATA",
+                    "kind": "INFORMATION_REGISTER"
+                  }
+                }
+              ],
+              "composite": false,
+              "qualifiers": []
+            }
+          }
+        ]
+      },
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+      },
+      "usePurposes": [
+        [
+          "PLATFORM_APPLICATION",
+          "MOBILE_PLATFORM_APPLICATION"
+        ],
+        []
+      ]
+    }
+  ],
+  "mdoReference": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+  },
+  "mdoType": "INFORMATION_REGISTER",
+  "moduleTypes": [],
+  "modules": [],
+  "name": "СклоненияПредставленийОбъектов",
+  "objectBelonging": "OWN",
+  "possibleRights": [
+    {
+      "default": {
+        "tag": 4
+      },
+      "int": 14,
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "VIEW",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "EDIT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "TOTALS_CONTROL",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "VIEW_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ_DATA_HISTORY_OF_MISSING_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_OF_MISSING_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_SETTINGS",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_VERSION_COMMENT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "EDIT_DATA_HISTORY_VERSION_COMMENT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "SWITCH_TO_DATA_HISTORY_VERSION"
+    }
+  ],
+  "resources": [
+    [
+      {
+        "uuid": "3b81427f-cf64-4a5e-adb3-5415d515fecd",
+        "name": "ИменительныйПадеж",
+        "mdoReference": {
+          "type": "RESOURCE",
+          "mdoRef": "InformationRegister.СклоненияПредставленийОбъектов.Resource.ИменительныйПадеж",
+          "mdoRefRu": "РегистрСведений.СклоненияПредставленийОбъектов.Ресурс.ИменительныйПадеж"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Именительный падеж"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                "length": 0,
+                "allowedLength": 0,
+                "description": {
+                  "value": {
+                    "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                    "nameRu": "КвалификаторыСтроки (0, Переменная)",
+                    "nameEn": "StringQualifiers (0, Variable)"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      {
+        "uuid": "e9f2b604-7181-476d-8b34-3a544cbb353d",
+        "name": "РодительныйПадеж",
+        "mdoReference": {
+          "type": "RESOURCE",
+          "mdoRef": "InformationRegister.СклоненияПредставленийОбъектов.Resource.РодительныйПадеж",
+          "mdoRefRu": "РегистрСведений.СклоненияПредставленийОбъектов.Ресурс.РодительныйПадеж"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Родительный падеж"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/resources/c/com.github._1c_syntax.bsl.mdo.children.Resource/type"
+        }
+      },
+      {
+        "uuid": "73773919-d01c-41dd-bb31-9c66648ac0ff",
+        "name": "ДательныйПадеж",
+        "mdoReference": {
+          "type": "RESOURCE",
+          "mdoRef": "InformationRegister.СклоненияПредставленийОбъектов.Resource.ДательныйПадеж",
+          "mdoRefRu": "РегистрСведений.СклоненияПредставленийОбъектов.Ресурс.ДательныйПадеж"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Дательный падеж"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/resources/c/com.github._1c_syntax.bsl.mdo.children.Resource/type"
+        }
+      },
+      {
+        "uuid": "5d1afad0-3d7e-4214-b52a-72c184490084",
+        "name": "ВинительныйПадеж",
+        "mdoReference": {
+          "type": "RESOURCE",
+          "mdoRef": "InformationRegister.СклоненияПредставленийОбъектов.Resource.ВинительныйПадеж",
+          "mdoRefRu": "РегистрСведений.СклоненияПредставленийОбъектов.Ресурс.ВинительныйПадеж"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Винительный падеж"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/resources/c/com.github._1c_syntax.bsl.mdo.children.Resource/type"
+        }
+      },
+      {
+        "uuid": "5f7901a1-f992-42fa-9ddb-d63574da3b56",
+        "name": "ТворительныйПадеж",
+        "mdoReference": {
+          "type": "RESOURCE",
+          "mdoRef": "InformationRegister.СклоненияПредставленийОбъектов.Resource.ТворительныйПадеж",
+          "mdoRefRu": "РегистрСведений.СклоненияПредставленийОбъектов.Ресурс.ТворительныйПадеж"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Творительный падеж"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/resources/c/com.github._1c_syntax.bsl.mdo.children.Resource/type"
+        }
+      },
+      {
+        "uuid": "26abd45a-12b3-4312-88fb-53c90a6e6679",
+        "name": "ПредложныйПадеж",
+        "mdoReference": {
+          "type": "RESOURCE",
+          "mdoRef": "InformationRegister.СклоненияПредставленийОбъектов.Resource.ПредложныйПадеж",
+          "mdoRefRu": "РегистрСведений.СклоненияПредставленийОбъектов.Ресурс.ПредложныйПадеж"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Предложный падеж"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/resources/c/com.github._1c_syntax.bsl.mdo.children.Resource/type"
+        }
+      }
+    ],
+    []
+  ],
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "content": [
+      {
+        "default": {
+          "tag": 2
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+          "langKey": "ru",
+          "value": "Склонения представлений объектов"
+        }
+      }
+    ]
+  },
+  "templates": [],
+  "uuid": "7bf36370-3761-4fd5-bea5-90fa142a9d57"
+}}

--- a/src/test/resources/fixtures/ssl_3_2/InformationRegisters.СклоненияПредставленийОбъектов_edt.json
+++ b/src/test/resources/fixtures/ssl_3_2/InformationRegisters.СклоненияПредставленийОбъектов_edt.json
@@ -1,0 +1,814 @@
+{"com.github._1c_syntax.bsl.mdo.InformationRegister": {
+  "attributes": [
+    [
+      {
+        "uuid": "7bf36370-3761-4fd5-bea5-90fa142a9d57",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "InformationRegister.СклоненияПредставленийОбъектов.StandardAttribute.Active",
+          "mdoRefRu": "РегистрСведений.СклоненияПредставленийОбъектов.СтандартныйРеквизит.Активность"
+        },
+        "comment": "",
+        "synonym": {
+          "content": []
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.СклоненияПредставленийОбъектов",
+          "mdoRefRu": "РегистрСведений.СклоненияПредставленийОбъектов"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "BOOLEAN"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 0
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "Активность",
+          "nameEn": "Active"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "7bf36370-3761-4fd5-bea5-90fa142a9d57",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "InformationRegister.СклоненияПредставленийОбъектов.StandardAttribute.LineNumber",
+          "mdoRefRu": "РегистрСведений.СклоненияПредставленийОбъектов.СтандартныйРеквизит.НомерСтроки"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                "precision": 5,
+                "scale": 0,
+                "nonNegative": false,
+                "description": {}
+              }
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "НомерСтроки",
+          "nameEn": "LineNumber"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "7bf36370-3761-4fd5-bea5-90fa142a9d57",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "InformationRegister.СклоненияПредставленийОбъектов.StandardAttribute.Recorder",
+          "mdoRefRu": "РегистрСведений.СклоненияПредставленийОбъектов.СтандартныйРеквизит.Регистратор"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [],
+          "composite": false,
+          "qualifiers": []
+        },
+        "fullName": {
+          "nameRu": "Регистратор",
+          "nameEn": "Recorder"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "7bf36370-3761-4fd5-bea5-90fa142a9d57",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "InformationRegister.СклоненияПредставленийОбъектов.StandardAttribute.Period",
+          "mdoRefRu": "РегистрСведений.СклоненияПредставленийОбъектов.СтандартныйРеквизит.Период"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "DATE"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.DateQualifiers": {
+                "dateFractions": 2,
+                "description": {
+                  "value": {
+                    "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                    "nameRu": "КвалификаторыДаты (ДатаВремя)",
+                    "nameEn": "DateQualifiers (DateTime)"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "Период",
+          "nameEn": "Period"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      }
+    ],
+    []
+  ],
+  "commands": [],
+  "comment": "",
+  "description": "Склонения представлений объектов",
+  "dimensions": [
+    [
+      {
+        "uuid": "1541ad74-3e73-4699-bccf-c13313fbedfe",
+        "name": "ХешПредставления",
+        "mdoReference": {
+          "type": "DIMENSION",
+          "mdoRef": "InformationRegister.СклоненияПредставленийОбъектов.Dimension.ХешПредставления",
+          "mdoRefRu": "РегистрСведений.СклоненияПредставленийОбъектов.Измерение.ХешПредставления"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Хеш представления"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                "length": 40,
+                "allowedLength": 0,
+                "description": {}
+              }
+            }
+          ]
+        },
+        "master": false,
+        "denyIncompleteValues": true,
+        "useInTotals": true
+      },
+      {
+        "uuid": "1037ecb7-6819-4ba2-8c93-eccbbdf825be",
+        "name": "Объект",
+        "mdoReference": {
+          "type": "DIMENSION",
+          "mdoRef": "InformationRegister.СклоненияПредставленийОбъектов.Dimension.Объект",
+          "mdoRefRu": "РегистрСведений.СклоненияПредставленийОбъектов.Измерение.Объект"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Объект"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "ОпределяемыйТип.ОбъектСклонения",
+                  "nameEn": "DefinedType.ОбъектСклонения"
+                },
+                "variant": "METADATA",
+                "kind": "DEFINED_TYPE"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "master": true,
+        "denyIncompleteValues": false,
+        "useInTotals": true
+      }
+    ],
+    []
+  ],
+  "explanation": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+  },
+  "forms": [
+    {
+      "uuid": "823f925c-b71f-42b1-a71e-0aab823f59c6",
+      "name": "ФормаЗаписи",
+      "mdoReference": {
+        "type": "FORM",
+        "mdoRef": "InformationRegister.СклоненияПредставленийОбъектов.Form.ФормаЗаписи",
+        "mdoRefRu": "РегистрСведений.СклоненияПредставленийОбъектов.Форма.ФормаЗаписи"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": [
+          {
+            "default": {
+              "tag": 2
+            },
+            "int": 1,
+            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+              "langKey": "ru",
+              "value": "Форма записи"
+            }
+          }
+        ]
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "modules": [
+        {
+          "moduleType": "FormModule",
+          "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/InformationRegisters/СклоненияПредставлени_Объектов/Forms/ФормаЗаписи/Module.bsl",
+          "owner": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/forms/com.github._1c_syntax.bsl.mdo.children.ObjectForm/mdoReference"
+          },
+          "supportVariant": "NOT_EDITABLE",
+          "isProtected": false
+        }
+      ],
+      "formType": "MANAGED",
+      "data": {
+        "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+        "title": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "handlers": [
+          {
+            "event": "OnCreateAtServer",
+            "name": "ПриСозданииНаСервере"
+          }
+        ],
+        "items": [
+          [
+            {
+              "type": "INPUT_FIELD",
+              "id": 1,
+              "name": "ХешПредставления",
+              "title": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "dataPath": "Запись.ХешПредставления",
+              "items": []
+            },
+            {
+              "type": "INPUT_FIELD",
+              "id": 4,
+              "name": "Объект",
+              "title": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "dataPath": "Запись.Объект",
+              "items": []
+            },
+            {
+              "type": "INPUT_FIELD",
+              "id": 7,
+              "name": "ИменительныйПадеж",
+              "title": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "dataPath": "Запись.ИменительныйПадеж",
+              "items": []
+            },
+            {
+              "type": "INPUT_FIELD",
+              "id": 10,
+              "name": "РодительныйПадеж",
+              "title": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "dataPath": "Запись.РодительныйПадеж",
+              "items": []
+            },
+            {
+              "type": "INPUT_FIELD",
+              "id": 13,
+              "name": "ДательныйПадеж",
+              "title": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "dataPath": "Запись.ДательныйПадеж",
+              "items": []
+            },
+            {
+              "type": "INPUT_FIELD",
+              "id": 16,
+              "name": "ВинительныйПадеж",
+              "title": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "dataPath": "Запись.ВинительныйПадеж",
+              "items": []
+            },
+            {
+              "type": "INPUT_FIELD",
+              "id": 19,
+              "name": "ТворительныйПадеж",
+              "title": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "dataPath": "Запись.ТворительныйПадеж",
+              "items": []
+            },
+            {
+              "type": "INPUT_FIELD",
+              "id": 22,
+              "name": "ПредложныйПадеж",
+              "title": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+              },
+              "dataPath": "Запись.ПредложныйПадеж",
+              "items": []
+            }
+          ],
+          []
+        ],
+        "attributes": [
+          {
+            "id": 1,
+            "name": "Запись",
+            "title": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+            },
+            "type": {
+              "types": [
+                {
+                  "default": {
+                    "tag": 4
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                    "fullName": {
+                      "nameRu": "РегистрСведенийМенеджерЗаписи.СклоненияПредставленийОбъектов",
+                      "nameEn": "InformationRegisterRecordManager.СклоненияПредставленийОбъектов"
+                    },
+                    "variant": "METADATA",
+                    "kind": "INFORMATION_REGISTER"
+                  }
+                }
+              ],
+              "composite": false,
+              "qualifiers": []
+            }
+          }
+        ]
+      },
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+      },
+      "usePurposes": [
+        [
+          "PLATFORM_APPLICATION",
+          "MOBILE_PLATFORM_APPLICATION"
+        ],
+        []
+      ]
+    }
+  ],
+  "mdoReference": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+  },
+  "mdoType": "INFORMATION_REGISTER",
+  "moduleTypes": [],
+  "modules": [],
+  "name": "СклоненияПредставленийОбъектов",
+  "objectBelonging": "OWN",
+  "possibleRights": [
+    {
+      "default": {
+        "tag": 4
+      },
+      "int": 14,
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "VIEW",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "EDIT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "TOTALS_CONTROL",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "VIEW_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ_DATA_HISTORY_OF_MISSING_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_OF_MISSING_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_SETTINGS",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_VERSION_COMMENT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "EDIT_DATA_HISTORY_VERSION_COMMENT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "SWITCH_TO_DATA_HISTORY_VERSION"
+    }
+  ],
+  "resources": [
+    [
+      {
+        "uuid": "3b81427f-cf64-4a5e-adb3-5415d515fecd",
+        "name": "ИменительныйПадеж",
+        "mdoReference": {
+          "type": "RESOURCE",
+          "mdoRef": "InformationRegister.СклоненияПредставленийОбъектов.Resource.ИменительныйПадеж",
+          "mdoRefRu": "РегистрСведений.СклоненияПредставленийОбъектов.Ресурс.ИменительныйПадеж"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Именительный падеж"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                "length": 0,
+                "allowedLength": 0,
+                "description": {
+                  "value": {
+                    "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                    "nameRu": "КвалификаторыСтроки (0, Переменная)",
+                    "nameEn": "StringQualifiers (0, Variable)"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      {
+        "uuid": "e9f2b604-7181-476d-8b34-3a544cbb353d",
+        "name": "РодительныйПадеж",
+        "mdoReference": {
+          "type": "RESOURCE",
+          "mdoRef": "InformationRegister.СклоненияПредставленийОбъектов.Resource.РодительныйПадеж",
+          "mdoRefRu": "РегистрСведений.СклоненияПредставленийОбъектов.Ресурс.РодительныйПадеж"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Родительный падеж"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/resources/c/com.github._1c_syntax.bsl.mdo.children.Resource/type"
+        }
+      },
+      {
+        "uuid": "73773919-d01c-41dd-bb31-9c66648ac0ff",
+        "name": "ДательныйПадеж",
+        "mdoReference": {
+          "type": "RESOURCE",
+          "mdoRef": "InformationRegister.СклоненияПредставленийОбъектов.Resource.ДательныйПадеж",
+          "mdoRefRu": "РегистрСведений.СклоненияПредставленийОбъектов.Ресурс.ДательныйПадеж"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Дательный падеж"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/resources/c/com.github._1c_syntax.bsl.mdo.children.Resource/type"
+        }
+      },
+      {
+        "uuid": "5d1afad0-3d7e-4214-b52a-72c184490084",
+        "name": "ВинительныйПадеж",
+        "mdoReference": {
+          "type": "RESOURCE",
+          "mdoRef": "InformationRegister.СклоненияПредставленийОбъектов.Resource.ВинительныйПадеж",
+          "mdoRefRu": "РегистрСведений.СклоненияПредставленийОбъектов.Ресурс.ВинительныйПадеж"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Винительный падеж"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/resources/c/com.github._1c_syntax.bsl.mdo.children.Resource/type"
+        }
+      },
+      {
+        "uuid": "5f7901a1-f992-42fa-9ddb-d63574da3b56",
+        "name": "ТворительныйПадеж",
+        "mdoReference": {
+          "type": "RESOURCE",
+          "mdoRef": "InformationRegister.СклоненияПредставленийОбъектов.Resource.ТворительныйПадеж",
+          "mdoRefRu": "РегистрСведений.СклоненияПредставленийОбъектов.Ресурс.ТворительныйПадеж"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Творительный падеж"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/resources/c/com.github._1c_syntax.bsl.mdo.children.Resource/type"
+        }
+      },
+      {
+        "uuid": "26abd45a-12b3-4312-88fb-53c90a6e6679",
+        "name": "ПредложныйПадеж",
+        "mdoReference": {
+          "type": "RESOURCE",
+          "mdoRef": "InformationRegister.СклоненияПредставленийОбъектов.Resource.ПредложныйПадеж",
+          "mdoRefRu": "РегистрСведений.СклоненияПредставленийОбъектов.Ресурс.ПредложныйПадеж"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Предложный падеж"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/resources/c/com.github._1c_syntax.bsl.mdo.children.Resource/type"
+        }
+      }
+    ],
+    []
+  ],
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "content": [
+      {
+        "default": {
+          "tag": 2
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+          "langKey": "ru",
+          "value": "Склонения представлений объектов"
+        }
+      }
+    ]
+  },
+  "templates": [],
+  "uuid": "7bf36370-3761-4fd5-bea5-90fa142a9d57"
+}}

--- a/src/test/resources/fixtures/ssl_3_2/InformationRegisters.ЭлектронныеПодписи.json
+++ b/src/test/resources/fixtures/ssl_3_2/InformationRegisters.ЭлектронныеПодписи.json
@@ -1,0 +1,1469 @@
+{"com.github._1c_syntax.bsl.mdo.InformationRegister": {
+  "attributes": [
+    [
+      {
+        "uuid": "b50f3157-3c3a-4553-a16a-7fcd660e2824",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи.StandardAttribute.Active",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи.СтандартныйРеквизит.Активность"
+        },
+        "comment": "",
+        "synonym": {
+          "content": []
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "BOOLEAN"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 0
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "Активность",
+          "nameEn": "Active"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "b50f3157-3c3a-4553-a16a-7fcd660e2824",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи.StandardAttribute.LineNumber",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи.СтандартныйРеквизит.НомерСтроки"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                "precision": 5,
+                "scale": 0,
+                "nonNegative": false,
+                "description": {}
+              }
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "НомерСтроки",
+          "nameEn": "LineNumber"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "b50f3157-3c3a-4553-a16a-7fcd660e2824",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи.StandardAttribute.Recorder",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи.СтандартныйРеквизит.Регистратор"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [],
+          "composite": false,
+          "qualifiers": []
+        },
+        "fullName": {
+          "nameRu": "Регистратор",
+          "nameEn": "Recorder"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "b50f3157-3c3a-4553-a16a-7fcd660e2824",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи.StandardAttribute.Period",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи.СтандартныйРеквизит.Период"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "DATE"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.DateQualifiers": {
+                "dateFractions": 2,
+                "description": {
+                  "value": {
+                    "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                    "nameRu": "КвалификаторыДаты (ДатаВремя)",
+                    "nameEn": "DateQualifiers (DateTime)"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "Период",
+          "nameEn": "Period"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "54bfe81c-06b2-45a8-8bc1-bd22240cfe32",
+        "name": "ОшибкаПриАвтоматическомПродлении",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи.Attribute.ОшибкаПриАвтоматическомПродлении",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи.Реквизит.ОшибкаПриАвтоматическомПродлении"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Ошибка при автоматическом продлении"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "46f71ecc-5cee-4b8d-9f6d-d38a86787a76",
+        "name": "ПропуститьПриПродлении",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи.Attribute.ПропуститьПриПродлении",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи.Реквизит.ПропуститьПриПродлении"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Пропустить при продлении"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "b896cd10-5da4-4c90-b2cf-5b98bd173122",
+        "name": "ИдентификаторПодписи",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи.Attribute.ИдентификаторПодписи",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи.Реквизит.ИдентификаторПодписи"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Идентификатор подписи"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.V8ValueType": "UUID"
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "216410ad-91e5-4c41-b08b-905faa830410",
+        "name": "ПодписьМатематическиВерна",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи.Attribute.ПодписьМатематическиВерна",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи.Реквизит.ПодписьМатематическиВерна"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Подпись математически верна"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "df2bf85a-9e42-40d2-ae10-d8f5dbf06e61",
+        "name": "ОшибкаМатематическойПроверкиПодписи",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи.Attribute.ОшибкаМатематическойПроверкиПодписи",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи.Реквизит.ОшибкаМатематическойПроверкиПодписи"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Ошибка математической проверки подписи"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                "length": 0,
+                "allowedLength": 0,
+                "description": {
+                  "value": {
+                    "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                    "nameRu": "КвалификаторыСтроки (0, Переменная)",
+                    "nameEn": "StringQualifiers (0, Variable)"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "1e0a3a73-3fd9-43f7-8ee5-e54565264232",
+        "name": "ОшибкаПроверкиДополнительныхАтрибутов",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи.Attribute.ОшибкаПроверкиДополнительныхАтрибутов",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи.Реквизит.ОшибкаПроверкиДополнительныхАтрибутов"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Ошибка проверки дополнительных атрибутов"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[5]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "0f4de605-5df9-4bb9-92e8-f37c6903396e",
+        "name": "ДополнительныеАтрибутыПровереныВручную",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи.Attribute.ДополнительныеАтрибутыПровереныВручную",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи.Реквизит.ДополнительныеАтрибутыПровереныВручную"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Дополнительные атрибуты проверены вручную"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "66c8a1f2-248d-4b2a-b427-38fb4f63410a",
+        "name": "АвторРучнойПроверкиДополнительныхАтрибутов",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи.Attribute.АвторРучнойПроверкиДополнительныхАтрибутов",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи.Реквизит.АвторРучнойПроверкиДополнительныхАтрибутов"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Автор ручной проверки дополнительных атрибутов"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "СправочникСсылка.Пользователи",
+                  "nameEn": "CatalogRef.Пользователи"
+                },
+                "variant": "METADATA",
+                "kind": "CATALOG"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "a4b3ed40-b440-49f4-ab22-53fdad8c66c6",
+        "name": "ОбоснованиеРучнойПроверкиДополнительныхАтрибутов",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи.Attribute.ОбоснованиеРучнойПроверкиДополнительныхАтрибутов",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи.Реквизит.ОбоснованиеРучнойПроверкиДополнительныхАтрибутов"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Обоснование ручной проверки дополнительных атрибутов"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[5]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      }
+    ],
+    []
+  ],
+  "commands": [],
+  "comment": "",
+  "description": "Электронные подписи",
+  "dimensions": [
+    [
+      {
+        "uuid": "f6dae699-06eb-41ef-878b-3fdfe1b1f213",
+        "name": "ПодписанныйОбъект",
+        "mdoReference": {
+          "type": "DIMENSION",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи.Dimension.ПодписанныйОбъект",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи.Измерение.ПодписанныйОбъект"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Подписанный объект"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "ОпределяемыйТип.ПодписанныйОбъект",
+                  "nameEn": "DefinedType.ПодписанныйОбъект"
+                },
+                "variant": "METADATA",
+                "kind": "DEFINED_TYPE"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "master": true,
+        "denyIncompleteValues": false,
+        "useInTotals": true
+      },
+      {
+        "uuid": "fe6de86a-54c9-4ae2-9f17-cfce38b7b560",
+        "name": "ПорядковыйНомер",
+        "mdoReference": {
+          "type": "DIMENSION",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи.Dimension.ПорядковыйНомер",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи.Измерение.ПорядковыйНомер"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Порядковый номер"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                "precision": 10,
+                "scale": 0,
+                "nonNegative": true,
+                "description": {}
+              }
+            }
+          ]
+        },
+        "master": false,
+        "denyIncompleteValues": false,
+        "useInTotals": true
+      }
+    ],
+    []
+  ],
+  "explanation": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+  },
+  "forms": [
+    {
+      "uuid": "9ba59a76-ed54-4d17-83f1-f315a5722a1e",
+      "name": "ОбоснованиеДостоверностиПодписи",
+      "mdoReference": {
+        "type": "FORM",
+        "mdoRef": "InformationRegister.ЭлектронныеПодписи.Form.ОбоснованиеДостоверностиПодписи",
+        "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи.Форма.ОбоснованиеДостоверностиПодписи"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": [
+          {
+            "default": {
+              "tag": 2
+            },
+            "int": 1,
+            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+              "langKey": "ru",
+              "value": "Обоснование достоверности подписи"
+            }
+          }
+        ]
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "modules": [
+        {
+          "moduleType": "FormModule",
+          "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/InformationRegisters/ЭлектронныеПодписи/Forms/ОбоснованиеДостоверностиПодписи/Ext/Form/Module.bsl",
+          "owner": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/forms/com.github._1c_syntax.bsl.mdo.children.ObjectForm/mdoReference"
+          },
+          "supportVariant": "NOT_EDITABLE",
+          "isProtected": false
+        }
+      ],
+      "formType": "MANAGED",
+      "data": {
+        "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+        "title": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "handlers": [],
+        "items": [
+          {
+            "type": "USUAL_GROUP",
+            "id": 9,
+            "name": "ГруппаОбоснование",
+            "title": {
+              "content": [
+                {
+                  "default": {
+                    "tag": 2
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                    "langKey": "ru",
+                    "value": "Обоснование"
+                  }
+                }
+              ]
+            },
+            "dataPath": "",
+            "items": [
+              [
+                {
+                  "type": "LABEL_DECORATION",
+                  "id": 4,
+                  "name": "ДекорацияПояснение",
+                  "title": {
+                    "content": [
+                      {
+                        "default": {
+                          "tag": 2
+                        },
+                        "int": 1,
+                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                          "langKey": "ru",
+                          "value": "Введите обоснование, по которому подпись можно считать верной, если подпись не проходит автоматическую проверку. Например, допустимые причины:\n- недоступен список отзыва, но известно, что сертификат не отозван; \n- не удается проверить цепочку сертификатов, но это не важно для данной подписи;\n- подпись является неквалифицированной (не важна юридическая значимость подписи);\n- другие ситуации, не связанные с несоответствием подписи документу (когда документ изменен).\n\n"
+                        }
+                      }
+                    ]
+                  },
+                  "dataPath": "",
+                  "items": []
+                },
+                {
+                  "type": "INPUT_FIELD",
+                  "id": 1,
+                  "name": "ОбоснованиеРучнойПроверкиДополнительныхАтрибутов",
+                  "title": {
+                    "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[9]/synonym"
+                  },
+                  "dataPath": "ОбоснованиеРучнойПроверкиДополнительныхАтрибутов",
+                  "items": []
+                },
+                {
+                  "type": "LABEL_DECORATION",
+                  "id": 11,
+                  "name": "ДекорацияПояснение2",
+                  "title": {
+                    "content": [
+                      {
+                        "default": {
+                          "tag": 2
+                        },
+                        "int": 1,
+                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                          "langKey": "ru",
+                          "value": "Статус подписи может измениться (например, будет отозван или просрочен сертификат), но отметка о проверке с обоснованием останется. При необходимости перепроверьте подпись позднее. "
+                        }
+                      }
+                    ]
+                  },
+                  "dataPath": "",
+                  "items": []
+                }
+              ],
+              []
+            ]
+          }
+        ],
+        "attributes": [
+          {
+            "id": 1,
+            "name": "ОбоснованиеРучнойПроверкиДополнительныхАтрибутов",
+            "title": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[9]/synonym"
+            },
+            "type": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[5]/type"
+            }
+          }
+        ]
+      },
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+      },
+      "usePurposes": [
+        [
+          "PLATFORM_APPLICATION",
+          "MOBILE_PLATFORM_APPLICATION"
+        ],
+        []
+      ]
+    }
+  ],
+  "mdoReference": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+  },
+  "mdoType": "INFORMATION_REGISTER",
+  "moduleTypes": [
+    [
+      "ManagerModule",
+      [
+        "src/test/resources/ext/designer/ssl_3_2/src/cf/InformationRegisters/ЭлектронныеПодписи/Ext/ManagerModule.bsl"
+      ]
+    ]
+  ],
+  "modules": [
+    {
+      "moduleType": "ManagerModule",
+      "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/InformationRegisters/ЭлектронныеПодписи/Ext/ManagerModule.bsl",
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "isProtected": false
+    }
+  ],
+  "name": "ЭлектронныеПодписи",
+  "objectBelonging": "OWN",
+  "possibleRights": [
+    {
+      "default": {
+        "tag": 4
+      },
+      "int": 14,
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "VIEW",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "EDIT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "TOTALS_CONTROL",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "VIEW_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ_DATA_HISTORY_OF_MISSING_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_OF_MISSING_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_SETTINGS",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_VERSION_COMMENT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "EDIT_DATA_HISTORY_VERSION_COMMENT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "SWITCH_TO_DATA_HISTORY_VERSION"
+    }
+  ],
+  "resources": [
+    [
+      {
+        "uuid": "895aea8f-4c4e-44e5-b720-0a2e683191b3",
+        "name": "ТребуетсяПроверка",
+        "mdoReference": {
+          "type": "RESOURCE",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи.Resource.ТребуетсяПроверка",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи.Ресурс.ТребуетсяПроверка"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Требуется проверка"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+        }
+      },
+      {
+        "uuid": "a3b14a36-049d-4f94-bafc-cf7b874f9bf0",
+        "name": "ТипПодписи",
+        "mdoReference": {
+          "type": "RESOURCE",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи.Resource.ТипПодписи",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи.Ресурс.ТипПодписи"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Тип подписи"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "ПеречислениеСсылка.ТипыПодписиКриптографии",
+                  "nameEn": "EnumRef.ТипыПодписиКриптографии"
+                },
+                "variant": "METADATA",
+                "kind": "ENUM"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        }
+      },
+      {
+        "uuid": "6c954862-62d0-4901-8448-ea62a1174660",
+        "name": "СрокДействияПоследнейМеткиВремени",
+        "mdoReference": {
+          "type": "RESOURCE",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи.Resource.СрокДействияПоследнейМеткиВремени",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи.Ресурс.СрокДействияПоследнейМеткиВремени"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Срок действия последней метки времени"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[4]/type"
+        }
+      },
+      {
+        "uuid": "19858faf-2bc5-4cfb-b258-cb101ab66e87",
+        "name": "ДатаПроверкиПодписи",
+        "mdoReference": {
+          "type": "RESOURCE",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи.Resource.ДатаПроверкиПодписи",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи.Ресурс.ДатаПроверкиПодписи"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Дата проверки подписи"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[4]/type"
+        }
+      },
+      {
+        "uuid": "308358bc-773a-43fa-adff-dcc5884a2bd4",
+        "name": "Комментарий",
+        "mdoReference": {
+          "type": "RESOURCE",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи.Resource.Комментарий",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи.Ресурс.Комментарий"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Комментарий"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[5]/type"
+        }
+      },
+      {
+        "uuid": "ed541a1c-a842-40a9-b357-612db71ec32c",
+        "name": "КомуВыданСертификат",
+        "mdoReference": {
+          "type": "RESOURCE",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи.Resource.КомуВыданСертификат",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи.Ресурс.КомуВыданСертификат"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Кому выдан сертификат"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[5]/type"
+        }
+      },
+      {
+        "uuid": "b0e37495-7d9e-41d0-8225-652f9ac328cf",
+        "name": "Отпечаток",
+        "mdoReference": {
+          "type": "RESOURCE",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи.Resource.Отпечаток",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи.Ресурс.Отпечаток"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Отпечаток"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                "length": 28,
+                "allowedLength": 0,
+                "description": {}
+              }
+            }
+          ]
+        }
+      },
+      {
+        "uuid": "3bd2e1c8-9ef3-449b-acf6-397b90669c49",
+        "name": "Подпись",
+        "mdoReference": {
+          "type": "RESOURCE",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи.Resource.Подпись",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи.Ресурс.Подпись"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Подпись"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.V8ValueType": "VALUE_STORAGE"
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        }
+      },
+      {
+        "uuid": "cb334191-2ff3-439e-bdaf-4b8fe6561c3b",
+        "name": "ПодписьВерна",
+        "mdoReference": {
+          "type": "RESOURCE",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи.Resource.ПодписьВерна",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи.Ресурс.ПодписьВерна"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Подпись верна"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+        }
+      },
+      {
+        "uuid": "5f3a30b0-1ba8-423c-9bc2-f9a87cafe818",
+        "name": "ДатаПодписи",
+        "mdoReference": {
+          "type": "RESOURCE",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи.Resource.ДатаПодписи",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи.Ресурс.ДатаПодписи"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Дата подписи"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[4]/type"
+        }
+      },
+      {
+        "uuid": "766d8852-3bb4-4a6c-81c0-911722af4e8e",
+        "name": "УстановившийПодпись",
+        "mdoReference": {
+          "type": "RESOURCE",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи.Resource.УстановившийПодпись",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи.Ресурс.УстановившийПодпись"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Установивший подпись"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[8]/type"
+        }
+      }
+    ],
+    []
+  ],
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "content": [
+      {
+        "default": {
+          "tag": 2
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+          "langKey": "ru",
+          "value": "Электронные подписи"
+        }
+      }
+    ]
+  },
+  "templates": [],
+  "uuid": "b50f3157-3c3a-4553-a16a-7fcd660e2824"
+}}

--- a/src/test/resources/fixtures/ssl_3_2/InformationRegisters.ЭлектронныеПодписи_edt.json
+++ b/src/test/resources/fixtures/ssl_3_2/InformationRegisters.ЭлектронныеПодписи_edt.json
@@ -1,0 +1,1469 @@
+{"com.github._1c_syntax.bsl.mdo.InformationRegister": {
+  "attributes": [
+    [
+      {
+        "uuid": "b50f3157-3c3a-4553-a16a-7fcd660e2824",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи.StandardAttribute.Active",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи.СтандартныйРеквизит.Активность"
+        },
+        "comment": "",
+        "synonym": {
+          "content": []
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "type": "INFORMATION_REGISTER",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "BOOLEAN"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 0
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "Активность",
+          "nameEn": "Active"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "b50f3157-3c3a-4553-a16a-7fcd660e2824",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи.StandardAttribute.LineNumber",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи.СтандартныйРеквизит.НомерСтроки"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                "precision": 5,
+                "scale": 0,
+                "nonNegative": false,
+                "description": {}
+              }
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "НомерСтроки",
+          "nameEn": "LineNumber"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "b50f3157-3c3a-4553-a16a-7fcd660e2824",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи.StandardAttribute.Recorder",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи.СтандартныйРеквизит.Регистратор"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [],
+          "composite": false,
+          "qualifiers": []
+        },
+        "fullName": {
+          "nameRu": "Регистратор",
+          "nameEn": "Recorder"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "b50f3157-3c3a-4553-a16a-7fcd660e2824",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи.StandardAttribute.Period",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи.СтандартныйРеквизит.Период"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "DATE"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.DateQualifiers": {
+                "dateFractions": 2,
+                "description": {
+                  "value": {
+                    "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                    "nameRu": "КвалификаторыДаты (ДатаВремя)",
+                    "nameEn": "DateQualifiers (DateTime)"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "Период",
+          "nameEn": "Period"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "54bfe81c-06b2-45a8-8bc1-bd22240cfe32",
+        "name": "ОшибкаПриАвтоматическомПродлении",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи.Attribute.ОшибкаПриАвтоматическомПродлении",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи.Реквизит.ОшибкаПриАвтоматическомПродлении"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Ошибка при автоматическом продлении"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "46f71ecc-5cee-4b8d-9f6d-d38a86787a76",
+        "name": "ПропуститьПриПродлении",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи.Attribute.ПропуститьПриПродлении",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи.Реквизит.ПропуститьПриПродлении"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Пропустить при продлении"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "b896cd10-5da4-4c90-b2cf-5b98bd173122",
+        "name": "ИдентификаторПодписи",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи.Attribute.ИдентификаторПодписи",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи.Реквизит.ИдентификаторПодписи"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Идентификатор подписи"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.V8ValueType": "UUID"
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "216410ad-91e5-4c41-b08b-905faa830410",
+        "name": "ПодписьМатематическиВерна",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи.Attribute.ПодписьМатематическиВерна",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи.Реквизит.ПодписьМатематическиВерна"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Подпись математически верна"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "df2bf85a-9e42-40d2-ae10-d8f5dbf06e61",
+        "name": "ОшибкаМатематическойПроверкиПодписи",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи.Attribute.ОшибкаМатематическойПроверкиПодписи",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи.Реквизит.ОшибкаМатематическойПроверкиПодписи"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Ошибка математической проверки подписи"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                "length": 0,
+                "allowedLength": 0,
+                "description": {
+                  "value": {
+                    "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                    "nameRu": "КвалификаторыСтроки (0, Переменная)",
+                    "nameEn": "StringQualifiers (0, Variable)"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "1e0a3a73-3fd9-43f7-8ee5-e54565264232",
+        "name": "ОшибкаПроверкиДополнительныхАтрибутов",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи.Attribute.ОшибкаПроверкиДополнительныхАтрибутов",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи.Реквизит.ОшибкаПроверкиДополнительныхАтрибутов"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Ошибка проверки дополнительных атрибутов"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[5]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "0f4de605-5df9-4bb9-92e8-f37c6903396e",
+        "name": "ДополнительныеАтрибутыПровереныВручную",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи.Attribute.ДополнительныеАтрибутыПровереныВручную",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи.Реквизит.ДополнительныеАтрибутыПровереныВручную"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Дополнительные атрибуты проверены вручную"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "66c8a1f2-248d-4b2a-b427-38fb4f63410a",
+        "name": "АвторРучнойПроверкиДополнительныхАтрибутов",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи.Attribute.АвторРучнойПроверкиДополнительныхАтрибутов",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи.Реквизит.АвторРучнойПроверкиДополнительныхАтрибутов"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Автор ручной проверки дополнительных атрибутов"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "СправочникСсылка.Пользователи",
+                  "nameEn": "CatalogRef.Пользователи"
+                },
+                "variant": "METADATA",
+                "kind": "CATALOG"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "a4b3ed40-b440-49f4-ab22-53fdad8c66c6",
+        "name": "ОбоснованиеРучнойПроверкиДополнительныхАтрибутов",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи.Attribute.ОбоснованиеРучнойПроверкиДополнительныхАтрибутов",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи.Реквизит.ОбоснованиеРучнойПроверкиДополнительныхАтрибутов"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Обоснование ручной проверки дополнительных атрибутов"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[5]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      }
+    ],
+    []
+  ],
+  "commands": [],
+  "comment": "",
+  "description": "Электронные подписи",
+  "dimensions": [
+    [
+      {
+        "uuid": "f6dae699-06eb-41ef-878b-3fdfe1b1f213",
+        "name": "ПодписанныйОбъект",
+        "mdoReference": {
+          "type": "DIMENSION",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи.Dimension.ПодписанныйОбъект",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи.Измерение.ПодписанныйОбъект"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Подписанный объект"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "ОпределяемыйТип.ПодписанныйОбъект",
+                  "nameEn": "DefinedType.ПодписанныйОбъект"
+                },
+                "variant": "METADATA",
+                "kind": "DEFINED_TYPE"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "master": true,
+        "denyIncompleteValues": false,
+        "useInTotals": true
+      },
+      {
+        "uuid": "fe6de86a-54c9-4ae2-9f17-cfce38b7b560",
+        "name": "ПорядковыйНомер",
+        "mdoReference": {
+          "type": "DIMENSION",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи.Dimension.ПорядковыйНомер",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи.Измерение.ПорядковыйНомер"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Порядковый номер"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                "precision": 10,
+                "scale": 0,
+                "nonNegative": true,
+                "description": {}
+              }
+            }
+          ]
+        },
+        "master": false,
+        "denyIncompleteValues": false,
+        "useInTotals": true
+      }
+    ],
+    []
+  ],
+  "explanation": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+  },
+  "forms": [
+    {
+      "uuid": "9ba59a76-ed54-4d17-83f1-f315a5722a1e",
+      "name": "ОбоснованиеДостоверностиПодписи",
+      "mdoReference": {
+        "type": "FORM",
+        "mdoRef": "InformationRegister.ЭлектронныеПодписи.Form.ОбоснованиеДостоверностиПодписи",
+        "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи.Форма.ОбоснованиеДостоверностиПодписи"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": [
+          {
+            "default": {
+              "tag": 2
+            },
+            "int": 1,
+            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+              "langKey": "ru",
+              "value": "Обоснование достоверности подписи"
+            }
+          }
+        ]
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "modules": [
+        {
+          "moduleType": "FormModule",
+          "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/InformationRegisters/ЭлектронныеПодписи/Forms/ОбоснованиеДостоверностиПодписи/Module.bsl",
+          "owner": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/forms/com.github._1c_syntax.bsl.mdo.children.ObjectForm/mdoReference"
+          },
+          "supportVariant": "NOT_EDITABLE",
+          "isProtected": false
+        }
+      ],
+      "formType": "MANAGED",
+      "data": {
+        "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+        "title": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "handlers": [],
+        "items": [
+          {
+            "type": "USUAL_GROUP",
+            "id": 9,
+            "name": "ГруппаОбоснование",
+            "title": {
+              "content": [
+                {
+                  "default": {
+                    "tag": 2
+                  },
+                  "int": 1,
+                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                    "langKey": "ru",
+                    "value": "Обоснование"
+                  }
+                }
+              ]
+            },
+            "dataPath": "",
+            "items": [
+              [
+                {
+                  "type": "LABEL",
+                  "id": 4,
+                  "name": "ДекорацияПояснение",
+                  "title": {
+                    "content": [
+                      {
+                        "default": {
+                          "tag": 2
+                        },
+                        "int": 1,
+                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                          "langKey": "ru",
+                          "value": "Введите обоснование, по которому подпись можно считать верной, если подпись не проходит автоматическую проверку. Например, допустимые причины:\n- недоступен список отзыва, но известно, что сертификат не отозван; \n- не удается проверить цепочку сертификатов, но это не важно для данной подписи;\n- подпись является неквалифицированной (не важна юридическая значимость подписи);\n- другие ситуации, не связанные с несоответствием подписи документу (когда документ изменен).\n\n"
+                        }
+                      }
+                    ]
+                  },
+                  "dataPath": "",
+                  "items": []
+                },
+                {
+                  "type": "INPUT_FIELD",
+                  "id": 1,
+                  "name": "ОбоснованиеРучнойПроверкиДополнительныхАтрибутов",
+                  "title": {
+                    "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[9]/synonym"
+                  },
+                  "dataPath": "ОбоснованиеРучнойПроверкиДополнительныхАтрибутов",
+                  "items": []
+                },
+                {
+                  "type": "LABEL",
+                  "id": 11,
+                  "name": "ДекорацияПояснение2",
+                  "title": {
+                    "content": [
+                      {
+                        "default": {
+                          "tag": 2
+                        },
+                        "int": 1,
+                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                          "langKey": "ru",
+                          "value": "Статус подписи может измениться (например, будет отозван или просрочен сертификат), но отметка о проверке с обоснованием останется. При необходимости перепроверьте подпись позднее. "
+                        }
+                      }
+                    ]
+                  },
+                  "dataPath": "",
+                  "items": []
+                }
+              ],
+              []
+            ]
+          }
+        ],
+        "attributes": [
+          {
+            "id": 1,
+            "name": "ОбоснованиеРучнойПроверкиДополнительныхАтрибутов",
+            "title": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[9]/synonym"
+            },
+            "type": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[5]/type"
+            }
+          }
+        ]
+      },
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+      },
+      "usePurposes": [
+        [
+          "PLATFORM_APPLICATION",
+          "MOBILE_PLATFORM_APPLICATION"
+        ],
+        []
+      ]
+    }
+  ],
+  "mdoReference": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+  },
+  "mdoType": "INFORMATION_REGISTER",
+  "moduleTypes": [
+    [
+      "ManagerModule",
+      [
+        "src/test/resources/ext/edt/ssl_3_2/configuration/src/InformationRegisters/ЭлектронныеПодписи/ManagerModule.bsl"
+      ]
+    ]
+  ],
+  "modules": [
+    {
+      "moduleType": "ManagerModule",
+      "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/InformationRegisters/ЭлектронныеПодписи/ManagerModule.bsl",
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "isProtected": false
+    }
+  ],
+  "name": "ЭлектронныеПодписи",
+  "objectBelonging": "OWN",
+  "possibleRights": [
+    {
+      "default": {
+        "tag": 4
+      },
+      "int": 14,
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "VIEW",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "EDIT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "TOTALS_CONTROL",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "VIEW_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ_DATA_HISTORY_OF_MISSING_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_OF_MISSING_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_SETTINGS",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_VERSION_COMMENT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "EDIT_DATA_HISTORY_VERSION_COMMENT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "SWITCH_TO_DATA_HISTORY_VERSION"
+    }
+  ],
+  "resources": [
+    [
+      {
+        "uuid": "895aea8f-4c4e-44e5-b720-0a2e683191b3",
+        "name": "ТребуетсяПроверка",
+        "mdoReference": {
+          "type": "RESOURCE",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи.Resource.ТребуетсяПроверка",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи.Ресурс.ТребуетсяПроверка"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Требуется проверка"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+        }
+      },
+      {
+        "uuid": "a3b14a36-049d-4f94-bafc-cf7b874f9bf0",
+        "name": "ТипПодписи",
+        "mdoReference": {
+          "type": "RESOURCE",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи.Resource.ТипПодписи",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи.Ресурс.ТипПодписи"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Тип подписи"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "ПеречислениеСсылка.ТипыПодписиКриптографии",
+                  "nameEn": "EnumRef.ТипыПодписиКриптографии"
+                },
+                "variant": "METADATA",
+                "kind": "ENUM"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        }
+      },
+      {
+        "uuid": "6c954862-62d0-4901-8448-ea62a1174660",
+        "name": "СрокДействияПоследнейМеткиВремени",
+        "mdoReference": {
+          "type": "RESOURCE",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи.Resource.СрокДействияПоследнейМеткиВремени",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи.Ресурс.СрокДействияПоследнейМеткиВремени"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Срок действия последней метки времени"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[4]/type"
+        }
+      },
+      {
+        "uuid": "19858faf-2bc5-4cfb-b258-cb101ab66e87",
+        "name": "ДатаПроверкиПодписи",
+        "mdoReference": {
+          "type": "RESOURCE",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи.Resource.ДатаПроверкиПодписи",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи.Ресурс.ДатаПроверкиПодписи"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Дата проверки подписи"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[4]/type"
+        }
+      },
+      {
+        "uuid": "308358bc-773a-43fa-adff-dcc5884a2bd4",
+        "name": "Комментарий",
+        "mdoReference": {
+          "type": "RESOURCE",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи.Resource.Комментарий",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи.Ресурс.Комментарий"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Комментарий"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[5]/type"
+        }
+      },
+      {
+        "uuid": "ed541a1c-a842-40a9-b357-612db71ec32c",
+        "name": "КомуВыданСертификат",
+        "mdoReference": {
+          "type": "RESOURCE",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи.Resource.КомуВыданСертификат",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи.Ресурс.КомуВыданСертификат"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Кому выдан сертификат"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[5]/type"
+        }
+      },
+      {
+        "uuid": "b0e37495-7d9e-41d0-8225-652f9ac328cf",
+        "name": "Отпечаток",
+        "mdoReference": {
+          "type": "RESOURCE",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи.Resource.Отпечаток",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи.Ресурс.Отпечаток"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Отпечаток"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                "length": 28,
+                "allowedLength": 0,
+                "description": {}
+              }
+            }
+          ]
+        }
+      },
+      {
+        "uuid": "3bd2e1c8-9ef3-449b-acf6-397b90669c49",
+        "name": "Подпись",
+        "mdoReference": {
+          "type": "RESOURCE",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи.Resource.Подпись",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи.Ресурс.Подпись"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Подпись"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.V8ValueType": "VALUE_STORAGE"
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        }
+      },
+      {
+        "uuid": "cb334191-2ff3-439e-bdaf-4b8fe6561c3b",
+        "name": "ПодписьВерна",
+        "mdoReference": {
+          "type": "RESOURCE",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи.Resource.ПодписьВерна",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи.Ресурс.ПодписьВерна"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Подпись верна"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+        }
+      },
+      {
+        "uuid": "5f3a30b0-1ba8-423c-9bc2-f9a87cafe818",
+        "name": "ДатаПодписи",
+        "mdoReference": {
+          "type": "RESOURCE",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи.Resource.ДатаПодписи",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи.Ресурс.ДатаПодписи"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Дата подписи"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[4]/type"
+        }
+      },
+      {
+        "uuid": "766d8852-3bb4-4a6c-81c0-911722af4e8e",
+        "name": "УстановившийПодпись",
+        "mdoReference": {
+          "type": "RESOURCE",
+          "mdoRef": "InformationRegister.ЭлектронныеПодписи.Resource.УстановившийПодпись",
+          "mdoRefRu": "РегистрСведений.ЭлектронныеПодписи.Ресурс.УстановившийПодпись"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Установивший подпись"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.InformationRegister/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[8]/type"
+        }
+      }
+    ],
+    []
+  ],
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "content": [
+      {
+        "default": {
+          "tag": 2
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+          "langKey": "ru",
+          "value": "Электронные подписи"
+        }
+      }
+    ]
+  },
+  "templates": [],
+  "uuid": "b50f3157-3c3a-4553-a16a-7fcd660e2824"
+}}

--- a/src/test/resources/fixtures/ssl_3_2/Languages.Русский.json
+++ b/src/test/resources/fixtures/ssl_3_2/Languages.Русский.json
@@ -1,0 +1,29 @@
+{"com.github._1c_syntax.bsl.mdo.Language": {
+  "comment": "",
+  "description": "Русский",
+  "languageCode": "ru",
+  "mdoReference": {
+    "type": "LANGUAGE",
+    "mdoRef": "Language.Русский",
+    "mdoRefRu": "Язык.Русский"
+  },
+  "mdoType": "LANGUAGE",
+  "name": "Русский",
+  "objectBelonging": "OWN",
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "content": [
+      {
+        "default": {
+          "tag": 2
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+          "langKey": "ru",
+          "value": "Русский"
+        }
+      }
+    ]
+  },
+  "uuid": "db4a9ccb-9ef5-4b3c-8577-b6fe5db1b62e"
+}}

--- a/src/test/resources/fixtures/ssl_3_2/Reports.АнализВерсийОбъектов.json
+++ b/src/test/resources/fixtures/ssl_3_2/Reports.АнализВерсийОбъектов.json
@@ -1,0 +1,115 @@
+{"com.github._1c_syntax.bsl.mdo.Report": {
+  "attributes": [],
+  "commands": [],
+  "comment": "",
+  "description": "Анализ версий объектов",
+  "explanation": {
+    "content": []
+  },
+  "forms": [],
+  "mdoReference": {
+    "type": "REPORT",
+    "mdoRef": "Report.АнализВерсийОбъектов",
+    "mdoRefRu": "Отчет.АнализВерсийОбъектов"
+  },
+  "mdoType": "REPORT",
+  "moduleTypes": [],
+  "modules": [],
+  "name": "АнализВерсийОбъектов",
+  "objectBelonging": "OWN",
+  "possibleRights": [
+    {
+      "default": {
+        "tag": 4
+      },
+      "int": 3,
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "EDIT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "USE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "VIEW"
+    }
+  ],
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "content": [
+      {
+        "default": {
+          "tag": 2
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+          "langKey": "ru",
+          "value": "Анализ версий объектов"
+        }
+      }
+    ]
+  },
+  "tabularSections": [],
+  "templates": [
+    {
+      "uuid": "9111e28e-c1c7-414b-9288-61bd06a04d04",
+      "name": "ОсновнаяСхемаКомпоновкиДанных",
+      "mdoReference": {
+        "type": "TEMPLATE",
+        "mdoRef": "Report.АнализВерсийОбъектов.Template.ОсновнаяСхемаКомпоновкиДанных",
+        "mdoRefRu": "Отчет.АнализВерсийОбъектов.Макет.ОсновнаяСхемаКомпоновкиДанных"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": [
+          {
+            "default": {
+              "tag": 2
+            },
+            "int": 1,
+            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+              "langKey": "ru",
+              "value": "Основная схема компоновки данных"
+            }
+          }
+        ]
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "modules": [],
+      "templateType": "DATA_COMPOSITION_SCHEME",
+      "data": {
+        "@class": "com.github._1c_syntax.bsl.mdo.storage.DataCompositionSchema",
+        "dataSets": [
+          {
+            "name": "НаборДанных1",
+            "type": "DATA_SET_QUERY",
+            "dataSource": "ИсточникДанных1",
+            "items": [],
+            "querySource": {
+              "line": 46,
+              "column": 10,
+              "textQuery": "ВЫБРАТЬ\n\tТИПЗНАЧЕНИЯ(ВерсииОбъектов.Объект) КАК ТипОбъекта,\n\tСУММА(ВерсииОбъектов.РазмерДанных / 1024 / 1024) КАК РазмерДанных,\n\tКОЛИЧЕСТВО(1) КАК Количество\nИЗ\n\tРегистрСведений.ВерсииОбъектов КАК ВерсииОбъектов\nГДЕ\n\tВерсииОбъектов.РазмерДанных > 0\n\nСГРУППИРОВАТЬ ПО\n\tТИПЗНАЧЕНИЯ(ВерсииОбъектов.Объект)\n\nУПОРЯДОЧИТЬ ПО\n\tРазмерДанных УБЫВ,\n\tКоличество УБЫВ"
+            },
+            "fields": [
+              [
+                {
+                  "dataPath": "Количество",
+                  "name": "Количество"
+                },
+                {
+                  "dataPath": "РазмерДанных",
+                  "name": "РазмерДанных"
+                },
+                {
+                  "dataPath": "ТипОбъекта",
+                  "name": "ТипОбъекта"
+                }
+              ],
+              []
+            ]
+          }
+        ],
+        "dataPath": "src/test/resources/ext/designer/ssl_3_2/src/cf/Reports/АнализВерсийОбъектов/Templates/ОсновнаяСхемаКомпоновкиДанных/Ext/Template.xml"
+      },
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.Report/mdoReference"
+      }
+    }
+  ],
+  "uuid": "b3f7f763-bea9-4f59-9450-df95e5c3d89d"
+}}

--- a/src/test/resources/fixtures/ssl_3_2/Reports.АнализВерсийОбъектов_edt.json
+++ b/src/test/resources/fixtures/ssl_3_2/Reports.АнализВерсийОбъектов_edt.json
@@ -1,0 +1,115 @@
+{"com.github._1c_syntax.bsl.mdo.Report": {
+  "attributes": [],
+  "commands": [],
+  "comment": "",
+  "description": "Анализ версий объектов",
+  "explanation": {
+    "content": []
+  },
+  "forms": [],
+  "mdoReference": {
+    "type": "REPORT",
+    "mdoRef": "Report.АнализВерсийОбъектов",
+    "mdoRefRu": "Отчет.АнализВерсийОбъектов"
+  },
+  "mdoType": "REPORT",
+  "moduleTypes": [],
+  "modules": [],
+  "name": "АнализВерсийОбъектов",
+  "objectBelonging": "OWN",
+  "possibleRights": [
+    {
+      "default": {
+        "tag": 4
+      },
+      "int": 3,
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "EDIT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "USE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "VIEW"
+    }
+  ],
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "content": [
+      {
+        "default": {
+          "tag": 2
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+          "langKey": "ru",
+          "value": "Анализ версий объектов"
+        }
+      }
+    ]
+  },
+  "tabularSections": [],
+  "templates": [
+    {
+      "uuid": "9111e28e-c1c7-414b-9288-61bd06a04d04",
+      "name": "ОсновнаяСхемаКомпоновкиДанных",
+      "mdoReference": {
+        "type": "TEMPLATE",
+        "mdoRef": "Report.АнализВерсийОбъектов.Template.ОсновнаяСхемаКомпоновкиДанных",
+        "mdoRefRu": "Отчет.АнализВерсийОбъектов.Макет.ОсновнаяСхемаКомпоновкиДанных"
+      },
+      "objectBelonging": "OWN",
+      "comment": "",
+      "synonym": {
+        "content": [
+          {
+            "default": {
+              "tag": 2
+            },
+            "int": 1,
+            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+              "langKey": "ru",
+              "value": "Основная схема компоновки данных"
+            }
+          }
+        ]
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "modules": [],
+      "templateType": "DATA_COMPOSITION_SCHEME",
+      "data": {
+        "@class": "com.github._1c_syntax.bsl.mdo.storage.DataCompositionSchema",
+        "dataSets": [
+          {
+            "name": "НаборДанных1",
+            "type": "DATA_SET_QUERY",
+            "dataSource": "ИсточникДанных1",
+            "items": [],
+            "querySource": {
+              "line": 46,
+              "column": 10,
+              "textQuery": "ВЫБРАТЬ\n\tТИПЗНАЧЕНИЯ(ВерсииОбъектов.Объект) КАК ТипОбъекта,\n\tСУММА(ВерсииОбъектов.РазмерДанных / 1024 / 1024) КАК РазмерДанных,\n\tКОЛИЧЕСТВО(1) КАК Количество\nИЗ\n\tРегистрСведений.ВерсииОбъектов КАК ВерсииОбъектов\nГДЕ\n\tВерсииОбъектов.РазмерДанных > 0\n\nСГРУППИРОВАТЬ ПО\n\tТИПЗНАЧЕНИЯ(ВерсииОбъектов.Объект)\n\nУПОРЯДОЧИТЬ ПО\n\tРазмерДанных УБЫВ,\n\tКоличество УБЫВ"
+            },
+            "fields": [
+              [
+                {
+                  "dataPath": "Количество",
+                  "name": "Количество"
+                },
+                {
+                  "dataPath": "РазмерДанных",
+                  "name": "РазмерДанных"
+                },
+                {
+                  "dataPath": "ТипОбъекта",
+                  "name": "ТипОбъекта"
+                }
+              ],
+              []
+            ]
+          }
+        ],
+        "dataPath": "src/test/resources/ext/edt/ssl_3_2/configuration/src/Reports/АнализВерсийОбъектов/Templates/ОсновнаяСхемаКомпоновкиДанных/Template.dcs"
+      },
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.Report/mdoReference"
+      }
+    }
+  ],
+  "uuid": "b3f7f763-bea9-4f59-9450-df95e5c3d89d"
+}}

--- a/src/test/resources/fixtures/ssl_3_2/Roles.БазовыеПраваБСП.json
+++ b/src/test/resources/fixtures/ssl_3_2/Roles.БазовыеПраваБСП.json
@@ -157,18 +157,6 @@
         },
         {
           "name": {
-            "type": "COMMON_FORM",
-            "mdoRef": "CommonForm.ПроверкаФайлаОбновления",
-            "mdoRefRu": "ОбщаяФорма.ПроверкаФайлаОбновления"
-          },
-          "rights": [
-            {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
-            }
-          ]
-        },
-        {
-          "name": {
             "type": "COMMAND",
             "mdoRef": "DataProcessor.Сканирование.Command.СканироватьЛист",
             "mdoRefRu": "Обработка.Сканирование.Команда.СканироватьЛист"
@@ -342,7 +330,7 @@
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[13]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[12]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
               }
             ],
             []
@@ -428,24 +416,6 @@
         },
         {
           "name": {
-            "type": "INFORMATION_REGISTER",
-            "mdoRef": "InformationRegister.ЗаявленияНаВыпускСертификата",
-            "mdoRefRu": "РегистрСведений.ЗаявленияНаВыпускСертификата"
-          },
-          "rights": [
-            [
-              {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
-              },
-              {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
-              }
-            ],
-            []
-          ]
-        },
-        {
-          "name": {
             "type": "CATALOG",
             "mdoRef": "Catalog.ВнешниеКомпоненты",
             "mdoRefRu": "Справочник.ВнешниеКомпоненты"
@@ -459,7 +429,7 @@
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[13]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[12]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
               }
             ],
             []
@@ -751,7 +721,7 @@
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[13]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[12]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
               }
             ],
             []
@@ -767,6 +737,24 @@
             {
               "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
             }
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ТекстИнформированияПользователяОНедоступностиФайлаВАрхиве",
+            "mdoRefRu": "Константа.ТекстИнформированияПользователяОНедоступностиФайлаВАрхиве"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
           ]
         },
         {
@@ -792,6 +780,24 @@
             "type": "CONSTANT",
             "mdoRef": "Constant.ИспользоватьПризнакРассмотрено",
             "mdoRefRu": "Константа.ИспользоватьПризнакРассмотрено"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "INFORMATION_REGISTER",
+            "mdoRef": "InformationRegister.СервисМобильнойПодписиСтатусы",
+            "mdoRefRu": "РегистрСведений.СервисМобильнойПодписиСтатусы"
           },
           "rights": [
             [
@@ -899,6 +905,27 @@
             {
               "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
             }
+          ]
+        },
+        {
+          "name": {
+            "type": "CATALOG",
+            "mdoRef": "Catalog.НастройкиОтправкиВГосключ",
+            "mdoRefRu": "Справочник.НастройкиОтправкиВГосключ"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[12]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
+              }
+            ],
+            []
           ]
         },
         {
@@ -1018,7 +1045,7 @@
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[13]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[12]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
               }
             ],
             []
@@ -1051,7 +1078,7 @@
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[13]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[12]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
               }
             ],
             []
@@ -1144,7 +1171,7 @@
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[13]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[12]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
               }
             ],
             []
@@ -1315,7 +1342,7 @@
           "rights": [
             [
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[31]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
@@ -1333,7 +1360,7 @@
           "rights": [
             [
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[31]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
@@ -1494,24 +1521,6 @@
         },
         {
           "name": {
-            "type": "DATA_PROCESSOR",
-            "mdoRef": "DataProcessor.ЗаявлениеНаВыпускНовогоКвалифицированногоСертификата",
-            "mdoRefRu": "Обработка.ЗаявлениеНаВыпускНовогоКвалифицированногоСертификата"
-          },
-          "rights": [
-            [
-              {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
-              },
-              {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
-              }
-            ],
-            []
-          ]
-        },
-        {
-          "name": {
             "type": "COMMON_FORM",
             "mdoRef": "CommonForm.ВводНаРазныхЯзыках",
             "mdoRefRu": "ОбщаяФорма.ВводНаРазныхЯзыках"
@@ -1586,7 +1595,7 @@
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[2]"
               },
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[13]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[12]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
               }
             ],
             []
@@ -1697,7 +1706,7 @@
           "rights": [
             [
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[31]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
@@ -1746,7 +1755,7 @@
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[13]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[12]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
               }
             ],
             []
@@ -1799,6 +1808,18 @@
             "type": "COMMON_FORM",
             "mdoRef": "CommonForm.ФормаПоиска",
             "mdoRefRu": "ОбщаяФорма.ФормаПоиска"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.ДополнительныеПараметрыПроксиСервера",
+            "mdoRefRu": "ОбщаяФорма.ДополнительныеПараметрыПроксиСервера"
           },
           "rights": [
             {
@@ -1892,7 +1913,7 @@
           },
           "rights": [
             {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[31]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
             }
           ]
         },
@@ -1923,7 +1944,7 @@
           "rights": [
             [
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[31]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
@@ -1959,7 +1980,7 @@
           "rights": [
             [
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[31]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
@@ -2007,7 +2028,7 @@
           "rights": [
             [
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[31]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
@@ -2037,7 +2058,7 @@
           "rights": [
             [
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[31]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
@@ -2133,7 +2154,7 @@
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[13]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[12]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
               }
             ],
             []
@@ -2148,7 +2169,7 @@
           "rights": [
             [
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[31]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
@@ -2172,7 +2193,7 @@
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[13]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[12]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
               }
             ],
             []
@@ -2193,7 +2214,7 @@
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[13]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[12]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
               }
             ],
             []
@@ -2285,6 +2306,18 @@
         },
         {
           "name": {
+            "type": "COMMAND",
+            "mdoRef": "Catalog.ПодписантыСервисаМобильнойПодписи.Command.ПодписантыСервисаМобильнойПодписи",
+            "mdoRefRu": "Справочник.ПодписантыСервисаМобильнойПодписи.Команда.ПодписантыСервисаМобильнойПодписи"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
             "type": "CONSTANT",
             "mdoRef": "Constant.ИспользоватьКомандуЗаметки",
             "mdoRefRu": "Константа.ИспользоватьКомандуЗаметки"
@@ -2296,27 +2329,6 @@
               },
               {
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
-              }
-            ],
-            []
-          ]
-        },
-        {
-          "name": {
-            "type": "CATALOG",
-            "mdoRef": "Catalog.СертификатыКлючейЭлектроннойПодписиИШифрования",
-            "mdoRefRu": "Справочник.СертификатыКлючейЭлектроннойПодписиИШифрования"
-          },
-          "rights": [
-            [
-              {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
-              },
-              {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
-              },
-              {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[13]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
               }
             ],
             []
@@ -2871,7 +2883,7 @@
           "rights": [
             [
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[31]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
@@ -2895,7 +2907,7 @@
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[13]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[12]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
               }
             ],
             []
@@ -2952,7 +2964,7 @@
           "rights": [
             [
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[31]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
@@ -3060,7 +3072,7 @@
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[13]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[12]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
               }
             ],
             []
@@ -3076,24 +3088,6 @@
             [
               {
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
-              },
-              {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
-              }
-            ],
-            []
-          ]
-        },
-        {
-          "name": {
-            "type": "REPORT",
-            "mdoRef": "Report.СертификатыЭлектроннойПодписи",
-            "mdoRefRu": "Отчет.СертификатыЭлектроннойПодписи"
-          },
-          "rights": [
-            [
-              {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
@@ -3177,7 +3171,7 @@
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[13]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[12]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
               }
             ],
             []
@@ -3246,7 +3240,7 @@
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[13]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[12]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
               }
             ],
             []
@@ -3279,7 +3273,7 @@
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[13]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[12]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
               }
             ],
             []
@@ -3300,7 +3294,7 @@
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[13]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[12]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
               }
             ],
             []
@@ -3380,35 +3374,17 @@
         },
         {
           "name": {
-            "type": "CONFIGURATION",
-            "mdoRef": "Configuration.БиблиотекаСтандартныхПодсистем",
-            "mdoRefRu": "Конфигурация.БиблиотекаСтандартныхПодсистем"
+            "type": "CONSTANT",
+            "mdoRef": "Constant.НастройкаПодчиненногоУзлаРИБЗавершена",
+            "mdoRefRu": "Константа.НастройкаПодчиненногоУзлаРИБЗавершена"
           },
           "rights": [
             [
               {
-                "name": "MAIN_WINDOW_MODE_NORMAL",
-                "value": true
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
-                "name": "MAIN_WINDOW_MODE_WORKPLACE",
-                "value": true
-              },
-              {
-                "name": "MAIN_WINDOW_MODE_EMBEDDED_WORKPLACE",
-                "value": true
-              },
-              {
-                "name": "MAIN_WINDOW_MODE_FULLSCREEN_WORKPLACE",
-                "value": true
-              },
-              {
-                "name": "MAIN_WINDOW_MODE_KIOSK",
-                "value": true
-              },
-              {
-                "name": "ANALYTICS_SYSTEM_CLIENT",
-                "value": true
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               }
             ],
             []
@@ -3416,9 +3392,9 @@
         },
         {
           "name": {
-            "type": "CONSTANT",
-            "mdoRef": "Constant.НастройкаПодчиненногоУзлаРИБЗавершена",
-            "mdoRefRu": "Константа.НастройкаПодчиненногоУзлаРИБЗавершена"
+            "type": "INFORMATION_REGISTER",
+            "mdoRef": "InformationRegister.КвартирыОфисыПомещения",
+            "mdoRefRu": "РегистрСведений.КвартирыОфисыПомещения"
           },
           "rights": [
             [
@@ -3447,7 +3423,7 @@
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[13]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[12]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
               }
             ],
             []
@@ -3492,7 +3468,7 @@
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[13]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[12]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
               }
             ],
             []
@@ -3771,7 +3747,7 @@
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[13]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[12]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
               }
             ],
             []
@@ -3816,7 +3792,7 @@
           "rights": [
             [
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[31]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
@@ -3936,7 +3912,7 @@
           "rights": [
             [
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[31]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
@@ -4006,6 +3982,42 @@
               },
               {
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONFIGURATION",
+            "mdoRef": "Configuration.БиблиотекаСтандартныхПодсистем",
+            "mdoRefRu": "Конфигурация.БиблиотекаСтандартныхПодсистем"
+          },
+          "rights": [
+            [
+              {
+                "name": "MAIN_WINDOW_MODE_NORMAL",
+                "value": true
+              },
+              {
+                "name": "MAIN_WINDOW_MODE_WORKPLACE",
+                "value": true
+              },
+              {
+                "name": "MAIN_WINDOW_MODE_EMBEDDED_WORKPLACE",
+                "value": true
+              },
+              {
+                "name": "MAIN_WINDOW_MODE_FULLSCREEN_WORKPLACE",
+                "value": true
+              },
+              {
+                "name": "MAIN_WINDOW_MODE_KIOSK",
+                "value": true
+              },
+              {
+                "name": "ANALYTICS_SYSTEM_CLIENT",
+                "value": true
               }
             ],
             []
@@ -4152,7 +4164,7 @@
           "rights": [
             [
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[31]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
@@ -4236,7 +4248,7 @@
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[13]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[12]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
               }
             ],
             []
@@ -4299,7 +4311,7 @@
           "rights": [
             [
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[31]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
@@ -4539,7 +4551,7 @@
           "rights": [
             [
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[31]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
@@ -4617,7 +4629,7 @@
           "rights": [
             [
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[31]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
@@ -4635,7 +4647,7 @@
           "rights": [
             [
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[31]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
@@ -4689,7 +4701,7 @@
           "rights": [
             [
               {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[31]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
               },
               {
                 "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
@@ -4792,18 +4804,6 @@
               }
             ],
             []
-          ]
-        },
-        {
-          "name": {
-            "type": "COMMON_FORM",
-            "mdoRef": "CommonForm.НовыйПароль",
-            "mdoRefRu": "ОбщаяФорма.НовыйПароль"
-          },
-          "rights": [
-            {
-              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
-            }
           ]
         }
       ],

--- a/src/test/resources/fixtures/ssl_3_2/Roles.БазовыеПраваБСП.json
+++ b/src/test/resources/fixtures/ssl_3_2/Roles.БазовыеПраваБСП.json
@@ -1,0 +1,4838 @@
+{"com.github._1c_syntax.bsl.mdo.Role": {
+  "comment": "Базовые права, которые должны быть у любого пользователя (кроме внешних пользователей).",
+  "data": {
+    "setForNewObjects": false,
+    "setForAttributesByDefault": true,
+    "independentRightsOfChildObjects": false,
+    "objectRights": [
+      [
+        {
+          "name": {
+            "type": "COMMON_ATTRIBUTE",
+            "mdoRef": "CommonAttribute.НаименованиеЯзык1",
+            "mdoRefRu": "ОбщийРеквизит.НаименованиеЯзык1"
+          },
+          "rights": [
+            [
+              {
+                "name": "VIEW",
+                "value": true
+              },
+              {
+                "name": "EDIT",
+                "value": true
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "SESSION_PARAMETER",
+            "mdoRef": "SessionParameter.ОбластьДанныхИспользование",
+            "mdoRefRu": "ПараметрСеанса.ОбластьДанныхИспользование"
+          },
+          "rights": [
+            {
+              "name": "GET",
+              "value": true
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "INFORMATION_REGISTER",
+            "mdoRef": "InformationRegister.НаличиеФайлов",
+            "mdoRefRu": "РегистрСведений.НаличиеФайлов"
+          },
+          "rights": [
+            [
+              {
+                "name": "READ",
+                "value": true
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "SESSION_PARAMETER",
+            "mdoRef": "SessionParameter.ПропуститьПроверкуЗапретаИзменения",
+            "mdoRefRu": "ПараметрСеанса.ПропуститьПроверкуЗапретаИзменения"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[2]/rights/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "SESSION_PARAMETER",
+            "mdoRef": "SessionParameter.СчетчикПроблемВеденияУчета",
+            "mdoRefRu": "ПараметрСеанса.СчетчикПроблемВеденияУчета"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[2]/rights/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "name": "SET",
+                "value": true
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ИспользоватьПочтовыйКлиент",
+            "mdoRefRu": "Константа.ИспользоватьПочтовыйКлиент"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ИспользоватьШаблоныСообщений",
+            "mdoRefRu": "Константа.ИспользоватьШаблоныСообщений"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ПараметрыИтоговИАгрегатов",
+            "mdoRefRu": "Константа.ПараметрыИтоговИАгрегатов"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CATALOG",
+            "mdoRef": "Catalog.НаборыДополнительныхРеквизитовИСведений",
+            "mdoRefRu": "Справочник.НаборыДополнительныхРеквизитовИСведений"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.ПроверкаФайлаОбновления",
+            "mdoRefRu": "ОбщаяФорма.ПроверкаФайлаОбновления"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMAND",
+            "mdoRef": "DataProcessor.Сканирование.Command.СканироватьЛист",
+            "mdoRefRu": "Обработка.Сканирование.Команда.СканироватьЛист"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "INFORMATION_REGISTER",
+            "mdoRef": "InformationRegister.ПериодыНерабочихДнейКалендаря",
+            "mdoRefRu": "РегистрСведений.ПериодыНерабочихДнейКалендаря"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CATALOG",
+            "mdoRef": "Catalog.ВариантыОтчетов",
+            "mdoRefRu": "Справочник.ВариантыОтчетов"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "name": "INPUT_BY_STRING",
+                "value": true
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ДатаУведомленияОНовыхЗадачах",
+            "mdoRefRu": "Константа.ДатаУведомленияОНовыхЗадачах"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.СохранениеПоФорматуВыгрузки",
+            "mdoRefRu": "ОбщаяФорма.СохранениеПоФорматуВыгрузки"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ИспользоватьЭлектронныеПодписи",
+            "mdoRefRu": "Константа.ИспользоватьЭлектронныеПодписи"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "SESSION_PARAMETER",
+            "mdoRef": "SessionParameter.ОбновитьВерсиюДатЗапретаИзмененияПослеЗагрузкиДанных",
+            "mdoRefRu": "ПараметрСеанса.ОбновитьВерсиюДатЗапретаИзмененияПослеЗагрузкиДанных"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[2]/rights/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_COMMAND",
+            "mdoRef": "CommonCommand.ПраваДоступа",
+            "mdoRefRu": "ОбщаяКоманда.ПраваДоступа"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ИспользоватьДополнительныеОтчетыИОбработки",
+            "mdoRefRu": "Константа.ИспользоватьДополнительныеОтчетыИОбработки"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "INFORMATION_REGISTER",
+            "mdoRef": "InformationRegister.НомераОтсканированныхФайлов",
+            "mdoRefRu": "РегистрСведений.НомераОтсканированныхФайлов"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CHART_OF_CHARACTERISTIC_TYPES",
+            "mdoRef": "ChartOfCharacteristicTypes.ДополнительныеРеквизитыИСведения",
+            "mdoRefRu": "ПланВидовХарактеристик.ДополнительныеРеквизитыИСведения"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[13]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ВерсияДатЗапретаИзменения",
+            "mdoRefRu": "Константа.ВерсияДатЗапретаИзменения"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.РазблокированиеРеквизитов",
+            "mdoRefRu": "ОбщаяФорма.РазблокированиеРеквизитов"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ЗапрещатьЗагрузкуФайловПоРасширению",
+            "mdoRefRu": "Константа.ЗапрещатьЗагрузкуФайловПоРасширению"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_ATTRIBUTE",
+            "mdoRef": "CommonAttribute.ОтредактированныеПредопределенныеРеквизиты",
+            "mdoRefRu": "ОбщийРеквизит.ОтредактированныеПредопределенныеРеквизиты"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[2]"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.РегиональныеНастройки",
+            "mdoRefRu": "ОбщаяФорма.РегиональныеНастройки"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "INFORMATION_REGISTER",
+            "mdoRef": "InformationRegister.ЗаявленияНаВыпускСертификата",
+            "mdoRefRu": "РегистрСведений.ЗаявленияНаВыпускСертификата"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CATALOG",
+            "mdoRef": "Catalog.ВнешниеКомпоненты",
+            "mdoRefRu": "Справочник.ВнешниеКомпоненты"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[13]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.АдресПубликацииИнформационнойБазыВИнтернете",
+            "mdoRefRu": "Константа.АдресПубликацииИнформационнойБазыВИнтернете"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.СоздаватьПодкаталогиСИменамиВладельцев",
+            "mdoRefRu": "Константа.СоздаватьПодкаталогиСИменамиВладельцев"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.ПанельОтчетов",
+            "mdoRefRu": "ОбщаяФорма.ПанельОтчетов"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.АутентификацияВСервисе",
+            "mdoRefRu": "ОбщаяФорма.АутентификацияВСервисе"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "DATA_PROCESSOR",
+            "mdoRef": "DataProcessor.НерекомендуемаяВерсияПлатформы",
+            "mdoRefRu": "Обработка.НерекомендуемаяВерсияПлатформы"
+          },
+          "rights": [
+            [
+              {
+                "name": "USE",
+                "value": true
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "SESSION_PARAMETER",
+            "mdoRef": "SessionParameter.БуферОбмена",
+            "mdoRefRu": "ПараметрСеанса.БуферОбмена"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[2]/rights/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[5]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[2]"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_COMMAND",
+            "mdoRef": "CommonCommand.НастроитьПрава",
+            "mdoRefRu": "ОбщаяКоманда.НастроитьПрава"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.СпособХраненияФайлов",
+            "mdoRefRu": "Константа.СпособХраненияФайлов"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "SESSION_PARAMETER",
+            "mdoRef": "SessionParameter.ТекущийПользователь",
+            "mdoRefRu": "ПараметрСеанса.ТекущийПользователь"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[2]/rights/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "INFORMATION_REGISTER",
+            "mdoRef": "InformationRegister.СлужебныеАдресныеСведения",
+            "mdoRefRu": "РегистрСведений.СлужебныеАдресныеСведения"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.ФормаВариантаОтчета",
+            "mdoRefRu": "ОбщаяФорма.ФормаВариантаОтчета"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.ВопросОбУстановкеРасширения1СПредприятия",
+            "mdoRefRu": "ОбщаяФорма.ВопросОбУстановкеРасширения1СПредприятия"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "INFORMATION_REGISTER",
+            "mdoRef": "InformationRegister.УровниСокращенийАдресныхСведений",
+            "mdoRefRu": "РегистрСведений.УровниСокращенийАдресныхСведений"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ИспользоватьСинхронизациюДанныхВЛокальномРежиме",
+            "mdoRefRu": "Константа.ИспользоватьСинхронизациюДанныхВЛокальномРежиме"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "INFORMATION_REGISTER",
+            "mdoRef": "InformationRegister.ИсторияАдминистративнойИерархии",
+            "mdoRefRu": "РегистрСведений.ИсторияАдминистративнойИерархии"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ВерсияКлассификатораБанков",
+            "mdoRefRu": "Константа.ВерсияКлассификатораБанков"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ВыполнятьЗамерыПроизводительности",
+            "mdoRefRu": "Константа.ВыполнятьЗамерыПроизводительности"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CATALOG",
+            "mdoRef": "Catalog.ПодписантыСервисаМобильнойПодписи",
+            "mdoRefRu": "Справочник.ПодписантыСервисаМобильнойПодписи"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[13]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMAND",
+            "mdoRef": "Catalog.ВариантыОтчетов.Command.Открыть",
+            "mdoRefRu": "Справочник.ВариантыОтчетов.Команда.Открыть"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "INFORMATION_REGISTER",
+            "mdoRef": "InformationRegister.ИерархияГруппПользователей",
+            "mdoRefRu": "РегистрСведений.ИерархияГруппПользователей"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ИспользоватьПризнакРассмотрено",
+            "mdoRefRu": "Константа.ИспользоватьПризнакРассмотрено"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "INFORMATION_REGISTER",
+            "mdoRef": "InformationRegister.ПредопределенныеВариантыОтчетовВерсийРасширений",
+            "mdoRefRu": "РегистрСведений.ПредопределенныеВариантыОтчетовВерсийРасширений"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ДобавлятьМеткиВремениАвтоматически",
+            "mdoRefRu": "Константа.ДобавлятьМеткиВремениАвтоматически"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.СписокРасширенийФайловOpenDocumentОбластиДанных",
+            "mdoRefRu": "Константа.СписокРасширенийФайловOpenDocumentОбластиДанных"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ИспользоватьСинхронизациюДанныхВМоделиСервиса",
+            "mdoRefRu": "Константа.ИспользоватьСинхронизациюДанныхВМоделиСервиса"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.ЭлектроннаяПодпись",
+            "mdoRefRu": "ОбщаяФорма.ЭлектроннаяПодпись"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "INFORMATION_REGISTER",
+            "mdoRef": "InformationRegister.ИспользованиеПоставляемыхДополнительныхОтчетовИОбработокВОбластяхДанных",
+            "mdoRefRu": "РегистрСведений.ИспользованиеПоставляемыхДополнительныхОтчетовИОбработокВОбластяхДанных"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.РедактированиеДокументаOfficeOpen",
+            "mdoRefRu": "ОбщаяФорма.РедактированиеДокументаOfficeOpen"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_ATTRIBUTE",
+            "mdoRef": "CommonAttribute.НаименованиеЯзык2",
+            "mdoRefRu": "ОбщийРеквизит.НаименованиеЯзык2"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[2]"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.НастройкиЭлектроннойПодписиИШифрования",
+            "mdoRefRu": "ОбщаяФорма.НастройкиЭлектроннойПодписиИШифрования"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.ФормаВыбораЦвета",
+            "mdoRefRu": "ОбщаяФорма.ФормаВыбораЦвета"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.УстановкаВнешнейКомпонентыНевозможна",
+            "mdoRefRu": "ОбщаяФорма.УстановкаВнешнейКомпонентыНевозможна"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.ВопросОбУстановкеВнешнейКомпоненты",
+            "mdoRefRu": "ОбщаяФорма.ВопросОбУстановкеВнешнейКомпоненты"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.ПраваДоступаУпрощенно",
+            "mdoRefRu": "ОбщаяФорма.ПраваДоступаУпрощенно"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.ВыборУзловПлановОбмена",
+            "mdoRefRu": "ОбщаяФорма.ВыборУзловПлановОбмена"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "CATALOG",
+            "mdoRef": "Catalog.ПредопределенныеВариантыОтчетовРасширений",
+            "mdoRefRu": "Справочник.ПредопределенныеВариантыОтчетовРасширений"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[13]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.ПредупрежденияПриЗавершенииРаботы",
+            "mdoRefRu": "ОбщаяФорма.ПредупрежденияПриЗавершенииРаботы"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "CATALOG",
+            "mdoRef": "Catalog.ИдентификаторыОбъектовМетаданных",
+            "mdoRefRu": "Справочник.ИдентификаторыОбъектовМетаданных"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[13]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.ПредупреждениеБезопасности",
+            "mdoRefRu": "ОбщаяФорма.ПредупреждениеБезопасности"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ИспользоватьШифрование",
+            "mdoRefRu": "Константа.ИспользоватьШифрование"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.ПараметрыПроксиСервера",
+            "mdoRefRu": "ОбщаяФорма.ПараметрыПроксиСервера"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "INFORMATION_REGISTER",
+            "mdoRef": "InformationRegister.ОбработчикиОбновления",
+            "mdoRefRu": "РегистрСведений.ОбработчикиОбновления"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.ВходВПрограммуЗапрещен",
+            "mdoRefRu": "ОбщаяФорма.ВходВПрограммуЗапрещен"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "CATALOG",
+            "mdoRef": "Catalog.ОбщиеВнешниеКомпоненты",
+            "mdoRefRu": "Справочник.ОбщиеВнешниеКомпоненты"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[13]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.СписокЗапрещенныхРасширенийОбластиДанных",
+            "mdoRefRu": "Константа.СписокЗапрещенныхРасширенийОбластиДанных"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ОтправлятьПисьмаВФорматеHTML",
+            "mdoRefRu": "Константа.ОтправлятьПисьмаВФорматеHTML"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ИспользоватьПодчиненныеБизнесПроцессы",
+            "mdoRefRu": "Константа.ИспользоватьПодчиненныеБизнесПроцессы"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "INFORMATION_REGISTER",
+            "mdoRef": "InformationRegister.СтатусыСинхронизацииФайловСОблачнымСервисом",
+            "mdoRefRu": "РегистрСведений.СтатусыСинхронизацииФайловСОблачнымСервисом"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ИспользоватьДатыЗапретаЗагрузки",
+            "mdoRefRu": "Константа.ИспользоватьДатыЗапретаЗагрузки"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "INFORMATION_REGISTER",
+            "mdoRef": "InformationRegister.ДанныеПроизводственногоКалендаря",
+            "mdoRefRu": "РегистрСведений.ДанныеПроизводственногоКалендаря"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ИспользоватьВерсионированиеОбъектов",
+            "mdoRefRu": "Константа.ИспользоватьВерсионированиеОбъектов"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "SESSION_PARAMETER",
+            "mdoRef": "SessionParameter.ВыполняетсяОбновлениеИБ",
+            "mdoRefRu": "ПараметрСеанса.ВыполняетсяОбновлениеИБ"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[2]/rights/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "INFORMATION_REGISTER",
+            "mdoRef": "InformationRegister.ПричиныИзмененияАдресныхСведений",
+            "mdoRefRu": "РегистрСведений.ПричиныИзмененияАдресныхСведений"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "DATA_PROCESSOR",
+            "mdoRef": "DataProcessor.УправлениеПодключениемDSS",
+            "mdoRefRu": "Обработка.УправлениеПодключениемDSS"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "DATA_PROCESSOR",
+            "mdoRef": "DataProcessor.ЗагрузкаДанныхИзФайла",
+            "mdoRefRu": "Обработка.ЗагрузкаДанныхИзФайла"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_COMMAND",
+            "mdoRef": "CommonCommand.ПредупрежденияПриЗавершенииРаботы",
+            "mdoRefRu": "ОбщаяКоманда.ПредупрежденияПриЗавершенииРаботы"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.СписокРасширенийТекстовыхФайлов",
+            "mdoRefRu": "Константа.СписокРасширенийТекстовыхФайлов"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.ВопросОбУстановкеРасширенияРаботыСКриптографией",
+            "mdoRefRu": "ОбщаяФорма.ВопросОбУстановкеРасширенияРаботыСКриптографией"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.ВыборРолиИсполнителя",
+            "mdoRefRu": "ОбщаяФорма.ВыборРолиИсполнителя"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "INFORMATION_REGISTER",
+            "mdoRef": "InformationRegister.ЗагруженныеВерсииАдресныхСведений",
+            "mdoRefRu": "РегистрСведений.ЗагруженныеВерсииАдресныхСведений"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "SESSION_PARAMETER",
+            "mdoRef": "SessionParameter.ВыполняетсяУдалениеОбъектов",
+            "mdoRefRu": "ПараметрСеанса.ВыполняетсяУдалениеОбъектов"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[2]/rights/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[5]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[2]"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMAND",
+            "mdoRef": "DataProcessor.ИнформацияПриЗапуске.Command.ИнформацияПриЗапуске",
+            "mdoRefRu": "Обработка.ИнформацияПриЗапуске.Команда.ИнформацияПриЗапуске"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.РедактированиеГиперссылки",
+            "mdoRefRu": "ОбщаяФорма.РедактированиеГиперссылки"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.УсовершенствоватьПодписиАвтоматически",
+            "mdoRefRu": "Константа.УсовершенствоватьПодписиАвтоматически"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.СписокРасширенийФайловOpenDocument",
+            "mdoRefRu": "Константа.СписокРасширенийФайловOpenDocument"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "DATA_PROCESSOR",
+            "mdoRef": "DataProcessor.ЗаявлениеНаВыпускНовогоКвалифицированногоСертификата",
+            "mdoRefRu": "Обработка.ЗаявлениеНаВыпускНовогоКвалифицированногоСертификата"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.ВводНаРазныхЯзыках",
+            "mdoRefRu": "ОбщаяФорма.ВводНаРазныхЯзыках"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.НастройкиПравОбъектов",
+            "mdoRefRu": "ОбщаяФорма.НастройкиПравОбъектов"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ДатаПоследнейВыгрузкиЗамеровПроизводительностиUTC",
+            "mdoRefRu": "Константа.ДатаПоследнейВыгрузкиЗамеровПроизводительностиUTC"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.Вопрос",
+            "mdoRefRu": "ОбщаяФорма.Вопрос"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "CATALOG",
+            "mdoRef": "Catalog.Пользователи",
+            "mdoRefRu": "Справочник.Пользователи"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "name": "UPDATE",
+                "value": true
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[2]"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[13]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.ВыборОбъектовМетаданных",
+            "mdoRefRu": "ОбщаяФорма.ВыборОбъектовМетаданных"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ЗагрузитьСообщениеОбменаДанными",
+            "mdoRefRu": "Константа.ЗагрузитьСообщениеОбменаДанными"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ПроверятьЭлектронныеПодписиНаСервере",
+            "mdoRefRu": "Константа.ПроверятьЭлектронныеПодписиНаСервере"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "SESSION_PARAMETER",
+            "mdoRef": "SessionParameter.ОграничениеДоступаНаУровнеЗаписейУниверсально",
+            "mdoRefRu": "ПараметрСеанса.ОграничениеДоступаНаУровнеЗаписейУниверсально"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[2]/rights/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ПровайдерSMS",
+            "mdoRefRu": "Константа.ПровайдерSMS"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ОсновнойЯзык",
+            "mdoRefRu": "Константа.ОсновнойЯзык"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "DATA_PROCESSOR",
+            "mdoRef": "DataProcessor.ВводКонтактнойИнформации",
+            "mdoRefRu": "Обработка.ВводКонтактнойИнформации"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ИспользоватьДополнительныйЯзык1",
+            "mdoRefRu": "Константа.ИспользоватьДополнительныйЯзык1"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CATALOG",
+            "mdoRef": "Catalog.ПользовательскиеНастройкиОтчетов",
+            "mdoRefRu": "Справочник.ПользовательскиеНастройкиОтчетов"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "name": "INSERT",
+                "value": true
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[99]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[2]"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[13]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "SESSION_PARAMETER",
+            "mdoRef": "SessionParameter.АвторизованныйПользователь",
+            "mdoRefRu": "ПараметрСеанса.АвторизованныйПользователь"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[2]/rights/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ХранитьИсториюРассылкиОтчетов",
+            "mdoRefRu": "Константа.ХранитьИсториюРассылкиОтчетов"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.ФормаНастроекОтчета",
+            "mdoRefRu": "ОбщаяФорма.ФормаНастроекОтчета"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.ФормаПоиска",
+            "mdoRefRu": "ОбщаяФорма.ФормаПоиска"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.РасширенноеПредставлениеОшибки",
+            "mdoRefRu": "ОбщаяФорма.РасширенноеПредставлениеОшибки"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.РазрешенныеНеаккредитованныеУЦ",
+            "mdoRefRu": "Константа.РазрешенныеНеаккредитованныеУЦ"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.ОтчетОСохраненииФайловЭлектронныхПодписей",
+            "mdoRefRu": "ОбщаяФорма.ОтчетОСохраненииФайловЭлектронныхПодписей"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ОтложенноеОбновлениеЗавершеноУспешно",
+            "mdoRefRu": "Константа.ОтложенноеОбновлениеЗавершеноУспешно"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ИзвлекатьТекстыФайловНаСервере",
+            "mdoRefRu": "Константа.ИзвлекатьТекстыФайловНаСервере"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "DATA_PROCESSOR",
+            "mdoRef": "DataProcessor.ЗаполнениеКалендарныхГрафиков",
+            "mdoRefRu": "Обработка.ЗаполнениеКалендарныхГрафиков"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ИспользоватьДополнительныеРеквизитыИСведения",
+            "mdoRefRu": "Константа.ИспользоватьДополнительныеРеквизитыИСведения"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "DATA_PROCESSOR",
+            "mdoRef": "DataProcessor.Сканирование",
+            "mdoRefRu": "Обработка.Сканирование"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ИспользоватьАнкетирование",
+            "mdoRefRu": "Константа.ИспользоватьАнкетирование"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "DATA_PROCESSOR",
+            "mdoRef": "DataProcessor.СдвигГраницыИтогов",
+            "mdoRefRu": "Обработка.СдвигГраницыИтогов"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.ВыборФорматаВложений",
+            "mdoRefRu": "ОбщаяФорма.ВыборФорматаВложений"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.МаксимальныйРазмерФайла",
+            "mdoRefRu": "Константа.МаксимальныйРазмерФайла"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "DATA_PROCESSOR",
+            "mdoRef": "DataProcessor.ПолнотекстовыйПоискВДанных",
+            "mdoRefRu": "Обработка.ПолнотекстовыйПоискВДанных"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "SESSION_PARAMETER",
+            "mdoRef": "SessionParameter.ВерсияРасширений",
+            "mdoRefRu": "ПараметрСеанса.ВерсияРасширений"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[2]/rights/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "DATA_PROCESSOR",
+            "mdoRef": "DataProcessor.РасширенныйВводКонтактнойИнформации",
+            "mdoRefRu": "Обработка.РасширенныйВводКонтактнойИнформации"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ПриоритетОбновленияВОбластяхДанных",
+            "mdoRefRu": "Константа.ПриоритетОбновленияВОбластяхДанных"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.ПраваДоступа",
+            "mdoRefRu": "ОбщаяФорма.ПраваДоступа"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ИспользоватьДополнительныйЯзык2",
+            "mdoRefRu": "Константа.ИспользоватьДополнительныйЯзык2"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.СменаПароля",
+            "mdoRefRu": "ОбщаяФорма.СменаПароля"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.ВыборИсполнителяБизнесПроцесса",
+            "mdoRefRu": "ОбщаяФорма.ВыборИсполнителяБизнесПроцесса"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "CATALOG",
+            "mdoRef": "Catalog.ПроизводственныеКалендари",
+            "mdoRefRu": "Справочник.ПроизводственныеКалендари"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[13]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "DATA_PROCESSOR",
+            "mdoRef": "DataProcessor.ЗаменаИОбъединениеЭлементов",
+            "mdoRefRu": "Обработка.ЗаменаИОбъединениеЭлементов"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CATALOG",
+            "mdoRef": "Catalog.ВидыКонтактнойИнформации",
+            "mdoRefRu": "Справочник.ВидыКонтактнойИнформации"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[13]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CATALOG",
+            "mdoRef": "Catalog.СтраныМира",
+            "mdoRefRu": "Справочник.СтраныМира"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[13]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.СоздаватьЭлектронныеПодписиНаСервере",
+            "mdoRefRu": "Константа.СоздаватьЭлектронныеПодписиНаСервере"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ИспользоватьГруппыВнешнихПользователей",
+            "mdoRefRu": "Константа.ИспользоватьГруппыВнешнихПользователей"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ИспользоватьДатуИВремяВСрокахЗадач",
+            "mdoRefRu": "Константа.ИспользоватьДатуИВремяВСрокахЗадач"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.СохранениеВместеСЭлектроннойПодписью",
+            "mdoRefRu": "ОбщаяФорма.СохранениеВместеСЭлектроннойПодписью"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "INFORMATION_REGISTER",
+            "mdoRef": "InformationRegister.КлассификаторыМЧД",
+            "mdoRefRu": "РегистрСведений.КлассификаторыМЧД"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ИспользоватьКомандуЗаметки",
+            "mdoRefRu": "Константа.ИспользоватьКомандуЗаметки"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CATALOG",
+            "mdoRef": "Catalog.СертификатыКлючейЭлектроннойПодписиИШифрования",
+            "mdoRefRu": "Справочник.СертификатыКлючейЭлектроннойПодписиИШифрования"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[13]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "INFORMATION_REGISTER",
+            "mdoRef": "InformationRegister.ДополнительныеАдресныеСведения",
+            "mdoRefRu": "РегистрСведений.ДополнительныеАдресныеСведения"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ИспользоватьСервисDSS",
+            "mdoRefRu": "Константа.ИспользоватьСервисDSS"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.Склонения",
+            "mdoRefRu": "ОбщаяФорма.Склонения"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.СтатусОбновленияКонфигурации",
+            "mdoRefRu": "Константа.СтатусОбновленияКонфигурации"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ИспользоватьОтправкуSMSВШаблонахСообщений",
+            "mdoRefRu": "Константа.ИспользоватьОтправкуSMSВШаблонахСообщений"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.КонтрольИзмененияРолейПользователяИБ",
+            "mdoRefRu": "ОбщаяФорма.КонтрольИзмененияРолейПользователяИБ"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "INFORMATION_REGISTER",
+            "mdoRef": "InformationRegister.СоставыГруппПользователей",
+            "mdoRefRu": "РегистрСведений.СоставыГруппПользователей"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "SESSION_PARAMETER",
+            "mdoRef": "SessionParameter.ИнтерактивнаяПроверкаЗаполненияКонтактнойИнформации",
+            "mdoRefRu": "ПараметрСеанса.ИнтерактивнаяПроверкаЗаполненияКонтактнойИнформации"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[2]/rights/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[5]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[2]"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ИспользоватьКомандуНапоминаний",
+            "mdoRefRu": "Константа.ИспользоватьКомандуНапоминаний"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "INFORMATION_REGISTER",
+            "mdoRef": "InformationRegister.ПользовательскиеМакетыПечати",
+            "mdoRefRu": "РегистрСведений.ПользовательскиеМакетыПечати"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "INFORMATION_REGISTER",
+            "mdoRef": "InformationRegister.МуниципальнаяИерархия",
+            "mdoRefRu": "РегистрСведений.МуниципальнаяИерархия"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_COMMAND",
+            "mdoRef": "CommonCommand.УстановитьРасширениеДляРаботыС1СПредприятием",
+            "mdoRefRu": "ОбщаяКоманда.УстановитьРасширениеДляРаботыС1СПредприятием"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.АдресаСерверовМетокВремени",
+            "mdoRefRu": "Константа.АдресаСерверовМетокВремени"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.ПодготовкаНовогоПисьма",
+            "mdoRefRu": "ОбщаяФорма.ПодготовкаНовогоПисьма"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.КоличествоМесяцевХраненияИсторииРассылкиОтчетов",
+            "mdoRefRu": "Константа.КоличествоМесяцевХраненияИсторииРассылкиОтчетов"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.КоличествоПотоковДлительныхОпераций",
+            "mdoRefRu": "Константа.КоличествоПотоковДлительныхОпераций"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.НапоминаниеПриРедактировании",
+            "mdoRefRu": "ОбщаяФорма.НапоминаниеПриРедактировании"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_ATTRIBUTE",
+            "mdoRef": "CommonAttribute.КомментарийЯзык1",
+            "mdoRefRu": "ОбщийРеквизит.КомментарийЯзык1"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[2]"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.ВыборДаты",
+            "mdoRefRu": "ОбщаяФорма.ВыборДаты"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "SESSION_PARAMETER",
+            "mdoRef": "SessionParameter.ОсновнойЯзык",
+            "mdoRefRu": "ПараметрСеанса.ОсновнойЯзык"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[2]/rights/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMAND",
+            "mdoRef": "DataProcessor.ПолнотекстовыйПоискВДанных.Command.ПолнотекстовыйПоиск",
+            "mdoRefRu": "Обработка.ПолнотекстовыйПоискВДанных.Команда.ПолнотекстовыйПоиск"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.СравнениеТабличныхДокументов",
+            "mdoRefRu": "ОбщаяФорма.СравнениеТабличныхДокументов"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ДатаОбновленияПовторноИспользуемыхЗначенийМРО",
+            "mdoRefRu": "Константа.ДатаОбновленияПовторноИспользуемыхЗначенийМРО"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "INFORMATION_REGISTER",
+            "mdoRef": "InformationRegister.ИсторияМуниципальнойИерархии",
+            "mdoRefRu": "РегистрСведений.ИсторияМуниципальнойИерархии"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ИспользоватьПолнотекстовыйПоиск",
+            "mdoRefRu": "Константа.ИспользоватьПолнотекстовыйПоиск"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ДополнительныйЯзык2",
+            "mdoRefRu": "Константа.ДополнительныйЯзык2"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.ПечатьДокументов",
+            "mdoRefRu": "ОбщаяФорма.ПечатьДокументов"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.ВыборТиповПользователей",
+            "mdoRefRu": "ОбщаяФорма.ВыборТиповПользователей"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "INFORMATION_REGISTER",
+            "mdoRef": "InformationRegister.НастройкиКомандПечати",
+            "mdoRefRu": "РегистрСведений.НастройкиКомандПечати"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.СервисПереводаТекста",
+            "mdoRefRu": "Константа.СервисПереводаТекста"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.НеИспользоватьРазделениеПоОбластямДанных",
+            "mdoRefRu": "Константа.НеИспользоватьРазделениеПоОбластямДанных"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.ФормаОтчета",
+            "mdoRefRu": "ОбщаяФорма.ФормаОтчета"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ПервоеОбновлениеДоступаЗавершилось",
+            "mdoRefRu": "Константа.ПервоеОбновлениеДоступаЗавершилось"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.СведенияОБлокируемыхОбъектах",
+            "mdoRefRu": "Константа.СведенияОБлокируемыхОбъектах"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "DATA_PROCESSOR",
+            "mdoRef": "DataProcessor.РекомендацияПоПовышениюСкоростиРаботы",
+            "mdoRefRu": "Обработка.РекомендацияПоПовышениюСкоростиРаботы"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CATALOG",
+            "mdoRef": "Catalog.ПредопределенныеВариантыОтчетов",
+            "mdoRefRu": "Справочник.ПредопределенныеВариантыОтчетов"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[13]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_COMMAND",
+            "mdoRef": "CommonCommand.СменитьПароль",
+            "mdoRefRu": "ОбщаяКоманда.СменитьПароль"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ИспользоватьЭлектроннуюПочтуВШаблонахСообщений",
+            "mdoRefRu": "Константа.ИспользоватьЭлектроннуюПочтуВШаблонахСообщений"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.ВспомогательнаяФормаНастроекОтчета",
+            "mdoRefRu": "ОбщаяФорма.ВспомогательнаяФормаНастроекОтчета"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "REPORT",
+            "mdoRef": "Report.ПраваДоступа",
+            "mdoRefRu": "Отчет.ПраваДоступа"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ОценкаПроизводительностиПериодЗаписи",
+            "mdoRefRu": "Константа.ОценкаПроизводительностиПериодЗаписи"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ГлавныйУзел",
+            "mdoRefRu": "Константа.ГлавныйУзел"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ЗаголовокСистемы",
+            "mdoRefRu": "Константа.ЗаголовокСистемы"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.РедактированиеТабличногоДокумента",
+            "mdoRefRu": "ОбщаяФорма.РедактированиеТабличногоДокумента"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ИспользоватьБизнесПроцессыИЗадачи",
+            "mdoRefRu": "Константа.ИспользоватьБизнесПроцессыИЗадачи"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CATALOG",
+            "mdoRef": "Catalog.ГруппыПользователей",
+            "mdoRefRu": "Справочник.ГруппыПользователей"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[13]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ИспользуютсяПрофилиБезопасности",
+            "mdoRefRu": "Константа.ИспользуютсяПрофилиБезопасности"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "REPORT",
+            "mdoRef": "Report.СертификатыЭлектроннойПодписи",
+            "mdoRefRu": "Отчет.СертификатыЭлектроннойПодписи"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.НастройкаРабочегоКаталога",
+            "mdoRefRu": "ОбщаяФорма.НастройкаРабочегоКаталога"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.СтандартныеПодсистемыВАвтономномРежиме",
+            "mdoRefRu": "Константа.СтандартныеПодсистемыВАвтономномРежиме"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.КонтрольДинамическогоОбновления",
+            "mdoRefRu": "ОбщаяФорма.КонтрольДинамическогоОбновления"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ОграничиватьДоступНаУровнеЗаписейУниверсально",
+            "mdoRefRu": "Константа.ОграничиватьДоступНаУровнеЗаписейУниверсально"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CATALOG",
+            "mdoRef": "Catalog.ЗначенияСвойствОбъектовИерархия",
+            "mdoRefRu": "Справочник.ЗначенияСвойствОбъектовИерархия"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[13]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.ФормаВыбораШрифта",
+            "mdoRefRu": "ОбщаяФорма.ФормаВыбораШрифта"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.МаксимальныйРазмерФайлаОбластиДанных",
+            "mdoRefRu": "Константа.МаксимальныйРазмерФайлаОбластиДанных"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ИспользоватьВнешнихПользователей",
+            "mdoRefRu": "Константа.ИспользоватьВнешнихПользователей"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CATALOG",
+            "mdoRef": "Catalog.УчетныеЗаписиСинхронизацииФайлов",
+            "mdoRefRu": "Справочник.УчетныеЗаписиСинхронизацииФайлов"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[13]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.НачалоРаботыСЭлектроннойПодписью",
+            "mdoRefRu": "ОбщаяФорма.НачалоРаботыСЭлектроннойПодписью"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "CATALOG",
+            "mdoRef": "Catalog.ПрограммыЭлектроннойПодписиИШифрования",
+            "mdoRefRu": "Справочник.ПрограммыЭлектроннойПодписиИШифрования"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[13]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CATALOG",
+            "mdoRef": "Catalog.ИдентификаторыОбъектовРасширений",
+            "mdoRefRu": "Справочник.ИдентификаторыОбъектовРасширений"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[13]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "SESSION_PARAMETER",
+            "mdoRef": "SessionParameter.ВыполняетсяЗаписьОбъекта",
+            "mdoRefRu": "ПараметрСеанса.ВыполняетсяЗаписьОбъекта"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[2]/rights/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[5]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[2]"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "INFORMATION_REGISTER",
+            "mdoRef": "InformationRegister.АдминистративнаяИерархия",
+            "mdoRefRu": "РегистрСведений.АдминистративнаяИерархия"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ИспользоватьГруппыПользователей",
+            "mdoRefRu": "Константа.ИспользоватьГруппыПользователей"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ИспользоватьНесколькоПроизводственныхКалендарей",
+            "mdoRefRu": "Константа.ИспользоватьНесколькоПроизводственныхКалендарей"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONFIGURATION",
+            "mdoRef": "Configuration.БиблиотекаСтандартныхПодсистем",
+            "mdoRefRu": "Конфигурация.БиблиотекаСтандартныхПодсистем"
+          },
+          "rights": [
+            [
+              {
+                "name": "MAIN_WINDOW_MODE_NORMAL",
+                "value": true
+              },
+              {
+                "name": "MAIN_WINDOW_MODE_WORKPLACE",
+                "value": true
+              },
+              {
+                "name": "MAIN_WINDOW_MODE_EMBEDDED_WORKPLACE",
+                "value": true
+              },
+              {
+                "name": "MAIN_WINDOW_MODE_FULLSCREEN_WORKPLACE",
+                "value": true
+              },
+              {
+                "name": "MAIN_WINDOW_MODE_KIOSK",
+                "value": true
+              },
+              {
+                "name": "ANALYTICS_SYSTEM_CLIENT",
+                "value": true
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.НастройкаПодчиненногоУзлаРИБЗавершена",
+            "mdoRefRu": "Константа.НастройкаПодчиненногоУзлаРИБЗавершена"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CATALOG",
+            "mdoRef": "Catalog.ЗначенияСвойствОбъектов",
+            "mdoRefRu": "Справочник.ЗначенияСвойствОбъектов"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[13]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMAND",
+            "mdoRef": "DataProcessor.НастройкиПользователей.Command.НастройкиПользователя",
+            "mdoRefRu": "Обработка.НастройкиПользователей.Команда.НастройкиПользователя"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.Сертификат",
+            "mdoRefRu": "ОбщаяФорма.Сертификат"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "CATALOG",
+            "mdoRef": "Catalog.КлассификаторБанков",
+            "mdoRefRu": "Справочник.КлассификаторБанков"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[13]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "INFORMATION_REGISTER",
+            "mdoRef": "InformationRegister.ЗемельныеУчастки",
+            "mdoRefRu": "РегистрСведений.ЗемельныеУчастки"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "INFORMATION_REGISTER",
+            "mdoRef": "InformationRegister.ИсторияАдресныхОбъектов",
+            "mdoRefRu": "РегистрСведений.ИсторияАдресныхОбъектов"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.ВыборДействияПриОбнаруженииОтличийФайла",
+            "mdoRefRu": "ОбщаяФорма.ВыборДействияПриОбнаруженииОтличийФайла"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.СписокЗапрещенныхРасширений",
+            "mdoRefRu": "Константа.СписокЗапрещенныхРасширений"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "SESSION_PARAMETER",
+            "mdoRef": "SessionParameter.ПараметрыОбработчикаОбновления",
+            "mdoRefRu": "ПараметрСеанса.ПараметрыОбработчикаОбновления"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[2]/rights/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "INFORMATION_REGISTER",
+            "mdoRef": "InformationRegister.НастройкиВариантовОтчетов",
+            "mdoRefRu": "РегистрСведений.НастройкиВариантовОтчетов"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[99]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[2]"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_COMMAND",
+            "mdoRef": "CommonCommand.ПрисоединенныеФайлы",
+            "mdoRefRu": "ОбщаяКоманда.ПрисоединенныеФайлы"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.ПоддерживаемыеКлиентскиеПриложения",
+            "mdoRefRu": "ОбщаяФорма.ПоддерживаемыеКлиентскиеПриложения"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_COMMAND",
+            "mdoRef": "CommonCommand.Обсуждения",
+            "mdoRefRu": "ОбщаяКоманда.Обсуждения"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "SESSION_PARAMETER",
+            "mdoRef": "SessionParameter.ИнтерактивнаяПроверкаЗаполненияСвойств",
+            "mdoRefRu": "ПараметрСеанса.ИнтерактивнаяПроверкаЗаполненияСвойств"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[2]/rights/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[5]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[2]"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.КаталогВременныхФайловДляWindows",
+            "mdoRefRu": "Константа.КаталогВременныхФайловДляWindows"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ИспользоватьНапоминанияПользователя",
+            "mdoRefRu": "Константа.ИспользоватьНапоминанияПользователя"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ТипПодписиКриптографииПоУмолчанию",
+            "mdoRefRu": "Константа.ТипПодписиКриптографииПоУмолчанию"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ПрефиксУзлаРаспределеннойИнформационнойБазы",
+            "mdoRefRu": "Константа.ПрефиксУзлаРаспределеннойИнформационнойБазы"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.СообщениеОбменаДаннымиИзГлавногоУзла",
+            "mdoRefRu": "Константа.СообщениеОбменаДаннымиИзГлавногоУзла"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ИспользоватьЗаметки",
+            "mdoRefRu": "Константа.ИспользоватьЗаметки"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CATALOG",
+            "mdoRef": "Catalog.ЯзыкиПечатныхФорм",
+            "mdoRefRu": "Справочник.ЯзыкиПечатныхФорм"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[13]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ИспользоватьСервисПереводаТекста",
+            "mdoRefRu": "Константа.ИспользоватьСервисПереводаТекста"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.СозданиеНачальногоОбразаСФайлами",
+            "mdoRefRu": "ОбщаяФорма.СозданиеНачальногоОбразаСФайлами"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "REPORT",
+            "mdoRef": "Report.МестаИспользованияСсылок",
+            "mdoRefRu": "Отчет.МестаИспользованияСсылок"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ПараметрыЦентраМониторинга",
+            "mdoRefRu": "Константа.ПараметрыЦентраМониторинга"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ОграничиватьДоступНаУровнеЗаписей",
+            "mdoRefRu": "Константа.ОграничиватьДоступНаУровнеЗаписей"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "INFORMATION_REGISTER",
+            "mdoRef": "InformationRegister.АдресныеОбъекты",
+            "mdoRefRu": "РегистрСведений.АдресныеОбъекты"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.РазрешенныеНеаккредитованныеУЦ",
+            "mdoRefRu": "ОбщаяФорма.РазрешенныеНеаккредитованныеУЦ"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ИспользоватьРазделениеПоОбластямДанных",
+            "mdoRefRu": "Константа.ИспользоватьРазделениеПоОбластямДанных"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ХранитьФайлыВТомахНаДиске",
+            "mdoRefRu": "Константа.ХранитьФайлыВТомахНаДиске"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "DATA_PROCESSOR",
+            "mdoRef": "DataProcessor.КонструкторФормул",
+            "mdoRefRu": "Обработка.КонструкторФормул"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ИспользоватьСервисСклоненияMorpher",
+            "mdoRefRu": "Константа.ИспользоватьСервисСклоненияMorpher"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.СведенияОбОбновленииИБ",
+            "mdoRefRu": "Константа.СведенияОбОбновленииИБ"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.РедактированиеМеток",
+            "mdoRefRu": "ОбщаяФорма.РедактированиеМеток"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.РегистрироватьИзмененияПравДоступа",
+            "mdoRefRu": "Константа.РегистрироватьИзмененияПравДоступа"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.ВводЗначенийСпискомСФлажками",
+            "mdoRefRu": "ОбщаяФорма.ВводЗначенийСпискомСФлажками"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "INFORMATION_REGISTER",
+            "mdoRef": "InformationRegister.ОбщиеПоставляемыеМакетыПечати",
+            "mdoRefRu": "РегистрСведений.ОбщиеПоставляемыеМакетыПечати"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.КоличествоПотоковОбновленияИнформационнойБазы",
+            "mdoRefRu": "Константа.КоличествоПотоковОбновленияИнформационнойБазы"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ОтложенноеОбновлениеВГлавномУзлеЗавершеноУспешно",
+            "mdoRefRu": "Константа.ОтложенноеОбновлениеВГлавномУзлеЗавершеноУспешно"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ИспользоватьДатыЗапретаИзменения",
+            "mdoRefRu": "Константа.ИспользоватьДатыЗапретаИзменения"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "SESSION_PARAMETER",
+            "mdoRef": "SessionParameter.ОтключениеОбновленияКлючейДоступа",
+            "mdoRefRu": "ПараметрСеанса.ОтключениеОбновленияКлючейДоступа"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[2]/rights/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ИспользоватьПрочиеВзаимодействия",
+            "mdoRefRu": "Константа.ИспользоватьПрочиеВзаимодействия"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ЭтоАвтономноеРабочееМесто",
+            "mdoRefRu": "Константа.ЭтоАвтономноеРабочееМесто"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "DATA_PROCESSOR",
+            "mdoRef": "DataProcessor.ИнформацияПриЗапуске",
+            "mdoRefRu": "Обработка.ИнформацияПриЗапуске"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "SESSION_PARAMETER",
+            "mdoRef": "SessionParameter.ПараметрыКлиентаНаСервере",
+            "mdoRefRu": "ПараметрСеанса.ПараметрыКлиентаНаСервере"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[2]/rights/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_ATTRIBUTE",
+            "mdoRef": "CommonAttribute.КомментарийЯзык2",
+            "mdoRefRu": "ОбщийРеквизит.КомментарийЯзык2"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[2]"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "SESSION_PARAMETER",
+            "mdoRef": "SessionParameter.ДатаОбновленияПовторноИспользуемыхЗначенийМРО",
+            "mdoRefRu": "ПараметрСеанса.ДатаОбновленияПовторноИспользуемыхЗначенийМРО"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[2]/rights/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.КаталогВременныхФайловДляLinux",
+            "mdoRefRu": "Константа.КаталогВременныхФайловДляLinux"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CATALOG",
+            "mdoRef": "Catalog.МакетыПечатныхФорм",
+            "mdoRefRu": "Справочник.МакетыПечатныхФорм"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[13]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right[3]"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "INFORMATION_REGISTER",
+            "mdoRef": "InformationRegister.ИдентификаторыОбъектовВерсийРасширений",
+            "mdoRefRu": "РегистрСведений.ИдентификаторыОбъектовВерсийРасширений"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.КоличествоЭлементовВТранзакцииЗагрузкиДанных",
+            "mdoRefRu": "Константа.КоличествоЭлементовВТранзакцииЗагрузкиДанных"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "SESSION_PARAMETER",
+            "mdoRef": "SessionParameter.ТекущийВнешнийПользователь",
+            "mdoRefRu": "ПараметрСеанса.ТекущийВнешнийПользователь"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[2]/rights/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "DATA_PROCESSOR",
+            "mdoRef": "DataProcessor.ГрупповоеИзменениеРеквизитов",
+            "mdoRefRu": "Обработка.ГрупповоеИзменениеРеквизитов"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ДополнительныйЯзык1",
+            "mdoRefRu": "Константа.ДополнительныйЯзык1"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "SESSION_PARAMETER",
+            "mdoRef": "SessionParameter.УстановленныеРасширения",
+            "mdoRefRu": "ПараметрСеанса.УстановленныеРасширения"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[2]/rights/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.ПечатьДокументовOfficeOpen",
+            "mdoRefRu": "ОбщаяФорма.ПечатьДокументовOfficeOpen"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_COMMAND",
+            "mdoRef": "CommonCommand.ПерсональнаяНастройкаПроксиСервера",
+            "mdoRefRu": "ОбщаяКоманда.ПерсональнаяНастройкаПроксиСервера"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "INFORMATION_REGISTER",
+            "mdoRef": "InformationRegister.ДомаЗданияСтроения",
+            "mdoRefRu": "РегистрСведений.ДомаЗданияСтроения"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.ПустойРабочийСтол",
+            "mdoRefRu": "ОбщаяФорма.ПустойРабочийСтол"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.ВыборОсновнойПечатнойФормы",
+            "mdoRefRu": "ОбщаяФорма.ВыборОсновнойПечатнойФормы"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.АдресПубликацииИнформационнойБазыВЛокальнойСети",
+            "mdoRefRu": "Константа.АдресПубликацииИнформационнойБазыВЛокальнойСети"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "INFORMATION_REGISTER",
+            "mdoRef": "InformationRegister.КодировкиФайлов",
+            "mdoRefRu": "РегистрСведений.КодировкиФайлов"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ИсточникДанныхАдресногоКлассификатора",
+            "mdoRefRu": "Константа.ИсточникДанныхАдресногоКлассификатора"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.СвойстваИсправленийПередОбновлениемИБ",
+            "mdoRefRu": "Константа.СвойстваИсправленийПередОбновлениемИБ"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "SESSION_PARAMETER",
+            "mdoRef": "SessionParameter.ДействующиеДатыЗапретаИзменения",
+            "mdoRefRu": "ПараметрСеанса.ДействующиеДатыЗапретаИзменения"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[2]/rights/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "SESSION_PARAMETER",
+            "mdoRef": "SessionParameter.РаботаСВнешнимиРесурсамиЗаблокирована",
+            "mdoRefRu": "ПараметрСеанса.РаботаСВнешнимиРесурсамиЗаблокирована"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[2]/rights/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ПараметрыХраненияФайловВИБ",
+            "mdoRefRu": "Константа.ПараметрыХраненияФайловВИБ"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.ДлительнаяОперация",
+            "mdoRefRu": "ОбщаяФорма.ДлительнаяОперация"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "DATA_PROCESSOR",
+            "mdoRef": "DataProcessor.РезультатыОбновленияПрограммы",
+            "mdoRefRu": "Обработка.РезультатыОбновленияПрограммы"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.СохранениеПечатнойФормы",
+            "mdoRefRu": "ОбщаяФорма.СохранениеПечатнойФормы"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ПовторитьЗагрузкуСообщенияОбменаДаннымиПередЗапуском",
+            "mdoRefRu": "Константа.ПовторитьЗагрузкуСообщенияОбменаДаннымиПередЗапуском"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "SESSION_PARAMETER",
+            "mdoRef": "SessionParameter.ПодключенныеРасширения",
+            "mdoRefRu": "ПараметрСеанса.ПодключенныеРасширения"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[2]/rights/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ДетализироватьОбновлениеИБВЖурналеРегистрации",
+            "mdoRefRu": "Константа.ДетализироватьОбновлениеИБВЖурналеРегистрации"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "DATA_PROCESSOR",
+            "mdoRef": "DataProcessor.НастройкиПользователей",
+            "mdoRefRu": "Обработка.НастройкиПользователей"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "DATA_PROCESSOR",
+            "mdoRef": "DataProcessor.ПоискИУдалениеДублей",
+            "mdoRefRu": "Обработка.ПоискИУдалениеДублей"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ИспользоватьСинхронизациюДанных",
+            "mdoRefRu": "Константа.ИспользоватьСинхронизациюДанных"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ИдентификаторИнформационнойБазы",
+            "mdoRefRu": "Константа.ИдентификаторИнформационнойБазы"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "DATA_PROCESSOR",
+            "mdoRef": "DataProcessor.ПрограммыЭлектроннойПодписиИШифрования",
+            "mdoRefRu": "Обработка.ПрограммыЭлектроннойПодписиИШифрования"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[33]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "INFORMATION_REGISTER",
+            "mdoRef": "InformationRegister.ПоставляемыеМакетыПечати",
+            "mdoRefRu": "РегистрСведений.ПоставляемыеМакетыПечати"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ИзменятьЗаданияЗаднимЧислом",
+            "mdoRefRu": "Константа.ИзменятьЗаданияЗаднимЧислом"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.ВыборПутиКАрхивуФайловТомов",
+            "mdoRefRu": "ОбщаяФорма.ВыборПутиКАрхивуФайловТомов"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "SESSION_PARAMETER",
+            "mdoRef": "SessionParameter.ОбластьДанныхЗначение",
+            "mdoRefRu": "ПараметрСеанса.ОбластьДанныхЗначение"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[2]/rights/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.УсовершенствоватьПодписиСДаты",
+            "mdoRefRu": "Константа.УсовершенствоватьПодписиСДаты"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "CONSTANT",
+            "mdoRef": "Constant.ИспользоватьДатуНачалаЗадач",
+            "mdoRefRu": "Константа.ИспользоватьДатуНачалаЗадач"
+          },
+          "rights": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight[3]/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": {
+            "type": "COMMON_FORM",
+            "mdoRef": "CommonForm.НовыйПароль",
+            "mdoRefRu": "ОбщаяФорма.НовыйПароль"
+          },
+          "rights": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Role/data/objectRights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight/rights/c/com.github._1c_syntax.bsl.mdo.storage.RoleData$Right"
+            }
+          ]
+        }
+      ],
+      []
+    ]
+  },
+  "description": "Базовые права БСП",
+  "mdoReference": {
+    "type": "ROLE",
+    "mdoRef": "Role.БазовыеПраваБСП",
+    "mdoRefRu": "Роль.БазовыеПраваБСП"
+  },
+  "mdoType": "ROLE",
+  "name": "БазовыеПраваБСП",
+  "objectBelonging": "OWN",
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "content": [
+      {
+        "default": {
+          "tag": 2
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+          "langKey": "ru",
+          "value": "Базовые права БСП"
+        }
+      }
+    ]
+  },
+  "uuid": "cf19f220-f6d4-4c9e-b5d5-9d94234f0a2c"
+}}

--- a/src/test/resources/fixtures/ssl_3_2/ScheduledJobs.ОбновлениеАгрегатов.json
+++ b/src/test/resources/fixtures/ssl_3_2/ScheduledJobs.ОбновлениеАгрегатов.json
@@ -1,0 +1,38 @@
+{"com.github._1c_syntax.bsl.mdo.ScheduledJob": {
+  "comment": "",
+  "description": "",
+  "key": "ОбновлениеАгрегатов",
+  "mdoReference": {
+    "type": "SCHEDULED_JOB",
+    "mdoRef": "ScheduledJob.ОбновлениеАгрегатов",
+    "mdoRefRu": "РегламентноеЗадание.ОбновлениеАгрегатов"
+  },
+  "mdoType": "SCHEDULED_JOB",
+  "methodName": {
+    "methodPath": "CommonModule.УправлениеИтогамиИАгрегатамиСлужебный.ОбновлениеАгрегатовОбработчикЗадания",
+    "moduleName": "УправлениеИтогамиИАгрегатамиСлужебный",
+    "methodName": "ОбновлениеАгрегатовОбработчикЗадания"
+  },
+  "name": "ОбновлениеАгрегатов",
+  "objectBelonging": "OWN",
+  "predefined": true,
+  "restartCountOnFailure": 3,
+  "restartIntervalOnFailure": 10,
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "content": [
+      {
+        "default": {
+          "tag": 2
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+          "langKey": "ru",
+          "value": "Обновление агрегатов"
+        }
+      }
+    ]
+  },
+  "use": false,
+  "uuid": "798bd34c-d0ee-4590-9b1d-8bc47e42ca8c"
+}}

--- a/src/test/resources/fixtures/ssl_3_2/SessionParameters.ТекущийПользователь.json
+++ b/src/test/resources/fixtures/ssl_3_2/SessionParameters.ТекущийПользователь.json
@@ -1,0 +1,65 @@
+{"com.github._1c_syntax.bsl.mdo.SessionParameter": {
+  "comment": "",
+  "description": "Текущий пользователь",
+  "mdoReference": {
+    "type": "SESSION_PARAMETER",
+    "mdoRef": "SessionParameter.ТекущийПользователь",
+    "mdoRefRu": "ПараметрСеанса.ТекущийПользователь"
+  },
+  "mdoType": "SESSION_PARAMETER",
+  "name": "ТекущийПользователь",
+  "objectBelonging": "OWN",
+  "possibleRights": [
+    {
+      "default": {
+        "tag": 4
+      },
+      "int": 2,
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "GET",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "SET"
+    }
+  ],
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "content": [
+      {
+        "default": {
+          "tag": 2
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+          "langKey": "ru",
+          "value": "Текущий пользователь"
+        }
+      }
+    ]
+  },
+  "uuid": "1ed910db-e434-4efd-9b12-c25353a31d5a",
+  "valueType": {
+    "types": [
+      {
+        "default": {
+          "tag": 4
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+          "fullName": {
+            "nameRu": "СправочникСсылка.Пользователи",
+            "nameEn": "CatalogRef.Пользователи"
+          },
+          "variant": "METADATA",
+          "kind": "CATALOG"
+        }
+      }
+    ],
+    "composite": false,
+    "qualifiers": [
+      {
+        "default": {
+          "tag": 4
+        },
+        "int": 0
+      }
+    ]
+  }
+}}

--- a/src/test/resources/fixtures/ssl_3_2/SettingsStorages.ХранилищеВариантовОтчетов.json
+++ b/src/test/resources/fixtures/ssl_3_2/SettingsStorages.ХранилищеВариантовОтчетов.json
@@ -1,0 +1,8746 @@
+{"com.github._1c_syntax.bsl.mdo.SettingsStorage": {
+  "comment": "",
+  "description": "Хранилище вариантов отчетов",
+  "forms": [
+    [
+      {
+        "uuid": "077e2c42-bc3b-48bf-bbc2-41effe20f613",
+        "name": "БыстрыеНастройкиОтчета",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "SettingsStorage.ХранилищеВариантовОтчетов.Form.БыстрыеНастройкиОтчета",
+          "mdoRefRu": "ХранилищеНастроек.ХранилищеВариантовОтчетов.Форма.БыстрыеНастройкиОтчета"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Быстрые настройки"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/SettingsStorages/ХранилищеВариантовОтчетов/Forms/БыстрыеНастро_киОтчета/Ext/Form/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "content": []
+          },
+          "handlers": [
+            [
+              {
+                "event": "OnOpen",
+                "name": "ПриОткрытии"
+              },
+              {
+                "event": "OnCreateAtServer",
+                "name": "ПриСозданииНаСервере"
+              }
+            ],
+            []
+          ],
+          "items": [
+            [
+              {
+                "type": "TABLE",
+                "id": 1,
+                "name": "БыстрыеНастройки",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/synonym"
+                },
+                "dataPath": "БыстрыеНастройки",
+                "items": [
+                  [
+                    {
+                      "type": "COLUMN_GROUP",
+                      "id": 38,
+                      "name": "БыстрыеНастройкиГруппаНастройка",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Настройка"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "CHECK_BOX_FIELD",
+                            "id": 14,
+                            "name": "БыстрыеНастройкиПометка",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Пометка"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "БыстрыеНастройки.Пометка",
+                            "items": []
+                          },
+                          {
+                            "type": "PICTURE_FIELD",
+                            "id": 56,
+                            "name": "БыстрыеНастройкиКартинкаНастройки",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Картинка настройки"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "БыстрыеНастройки.КартинкаНастройки",
+                            "items": []
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 20,
+                            "name": "БыстрыеНастройкиЗаголовок",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                            },
+                            "dataPath": "БыстрыеНастройки.Заголовок",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 93,
+                      "name": "БыстрыеНастройкиВидСравнения",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Условие"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "БыстрыеНастройки.ВидСравнения",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "CHECK_BOX_FIELD",
+                "id": 106,
+                "name": "ВыводитьЗаголовкиНастроек",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Выводить заголовки настроек"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "ВыводитьЗаголовкиНастроек",
+                "items": []
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 96,
+                "name": "КоманднаяПанель",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Командная панель"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 109,
+                      "name": "ДополнительныеВозможности",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Дополнительные возможности"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        {
+                          "type": "HYPERLINK",
+                          "id": 104,
+                          "name": "ПерейтиКРасширеннымНастройкам",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Больше возможностей..."
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": []
+                        }
+                      ]
+                    },
+                    {
+                      "type": "COMMAND_BAR",
+                      "id": 98,
+                      "name": "КомандыОсновные",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Команды основные"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "COMMAND_BAR_BUTTON",
+                            "id": 100,
+                            "name": "Применить",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Применить"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "COMMAND_BAR_BUTTON",
+                            "id": 102,
+                            "name": "Отмена",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "БыстрыеНастройки",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/synonym"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "VALUE_TABLE"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 0
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 2,
+                "name": "КомпоновщикНастроек",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "SETTINGS_COMPOSER"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 3,
+                "name": "НастройкиОтчета",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "types": [],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 4,
+                "name": "ВариантМодифицирован",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "BOOLEAN"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 5,
+                "name": "КлючТекущегоВарианта",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                        "length": 0,
+                        "allowedLength": 0,
+                        "description": {
+                          "value": {
+                            "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                            "nameRu": "КвалификаторыСтроки (0, Переменная)",
+                            "nameEn": "StringQualifiers (0, Variable)"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 6,
+                "name": "ВыводитьЗаголовкиНастроек",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "type": "SETTINGS_STORAGE",
+          "mdoRef": "SettingsStorage.ХранилищеВариантовОтчетов",
+          "mdoRefRu": "ХранилищеНастроек.ХранилищеВариантовОтчетов"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "57964dd6-4b0b-4590-bc44-de744cc423af",
+        "name": "ВыборВариантаОтчета",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "SettingsStorage.ХранилищеВариантовОтчетов.Form.ВыборВариантаОтчета",
+          "mdoRefRu": "ХранилищеНастроек.ХранилищеВариантовОтчетов.Форма.ВыборВариантаОтчета"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Выбор варианта отчета"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/SettingsStorages/ХранилищеВариантовОтчетов/Forms/ВыборВариантаОтчета/Ext/Form/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+          },
+          "handlers": [
+            [
+              {
+                "event": "NotificationProcessing",
+                "name": "ОбработкаОповещения"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[2]"
+              },
+              {
+                "event": "BeforeLoadDataFromSettingsAtServer",
+                "name": "ПередЗагрузкойДанныхИзНастроекНаСервере"
+              }
+            ],
+            []
+          ],
+          "items": [
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 22,
+                "name": "БыстрыеОтборы",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Быстрые фильтры"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  {
+                    "type": "INPUT_FIELD",
+                    "id": 56,
+                    "name": "ОтборАвтор",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Автор"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "ОтборАвтор",
+                    "items": []
+                  }
+                ]
+              },
+              {
+                "type": "COMMAND_BAR",
+                "id": 27,
+                "name": "ОсновнаяКоманднаяПанель",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Основная командная панель"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "COMMAND_BAR_BUTTON",
+                      "id": 6,
+                      "name": "Выбрать",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "COMMAND_BAR_BUTTON",
+                      "id": 7,
+                      "name": "Изменить",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "COMMAND_BAR_BUTTON",
+                      "id": 15,
+                      "name": "Удалить",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Пометить на удаление / Снять пометку"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "COMMAND_BAR_BUTTON",
+                      "id": 13,
+                      "name": "ПоказыватьЛичныеВариантыОтчетовДругихАвторов",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Показывать личные варианты отчетов других авторов"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "COMMAND_BAR_BUTTON",
+                      "id": 28,
+                      "name": "ФормаОбновить",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Обновить"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "BUTTON_GROUP",
+                      "id": 8,
+                      "name": "КоманднаяПанельДерева",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Командная панель дерева"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        {
+                          "type": "SEARCH_STRING_ADDITION",
+                          "id": 59,
+                          "name": "СтрокаПоиска",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                          },
+                          "dataPath": "",
+                          "items": []
+                        }
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "TABLE",
+                "id": 1,
+                "name": "ДеревоВариантовОтчета",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Дерево вариантов отчета"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "ДеревоВариантовОтчета",
+                "items": [
+                  [
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 4,
+                      "name": "ДеревоВариантовОтчетаПредставление",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Наименование"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "ДеревоВариантовОтчета.Наименование",
+                      "items": []
+                    },
+                    {
+                      "type": "PICTURE_FIELD",
+                      "id": 29,
+                      "name": "ДеревоВариантовОтчетаКартинкаАвтора",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Картинка автора"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "ДеревоВариантовОтчета.КартинкаАвтора",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 18,
+                      "name": "ДеревоВариантовОтчетаАвтор",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                      },
+                      "dataPath": "ДеревоВариантовОтчета.Автор",
+                      "items": []
+                    },
+                    {
+                      "type": "PICTURE_FIELD",
+                      "id": 62,
+                      "name": "ДеревоВариантовОтчетаКартинкаНазначение",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Картинка назначение"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "ДеревоВариантовОтчета.КартинкаНазначение",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "INPUT_FIELD",
+                "id": 11,
+                "name": "ВариантОписание",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Описание"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "ВариантОписание",
+                "items": []
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "ДеревоВариантовОтчета",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "VALUE_TREE"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 4,
+                "name": "ТекущийПользователь",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "СправочникСсылка.Пользователи",
+                          "nameEn": "CatalogRef.Пользователи"
+                        },
+                        "variant": "METADATA",
+                        "kind": "CATALOG"
+                      }
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 2,
+                "name": "ОтчетИнформация",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 3,
+                "name": "ПолныеПраваНаВарианты",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 6,
+                "name": "ВариантОписание",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 7,
+                "name": "ПоказыватьЛичныеВариантыОтчетовДругихАвторов",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 8,
+                "name": "КлючВарианта",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 9,
+                "name": "ОтборАвтор",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 2,
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "СправочникСсылка.ВнешниеПользователи",
+                          "nameEn": "CatalogRef.ВнешниеПользователи"
+                        },
+                        "variant": "METADATA",
+                        "kind": "CATALOG"
+                      },
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[2]/type/types/java.util.CollSer/com.github._1c_syntax.bsl.types.value.CustomValueType"
+                      }
+                    }
+                  ],
+                  "composite": true,
+                  "qualifiers": []
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "f5bb88eb-c239-4ae3-a297-dfbbd679e008",
+        "name": "ВыборПоляОтчета",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "SettingsStorage.ХранилищеВариантовОтчетов.Form.ВыборПоляОтчета",
+          "mdoRefRu": "ХранилищеНастроек.ХранилищеВариантовОтчетов.Форма.ВыборПоляОтчета"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Выбор поля отчета"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/SettingsStorages/ХранилищеВариантовОтчетов/Forms/ВыборПоляОтчета/Ext/Form/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/synonym"
+          },
+          "handlers": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[2]"
+            }
+          ],
+          "items": [
+            {
+              "type": "USUAL_GROUP",
+              "id": 94,
+              "name": "ГруппаДоступныеПоля",
+              "title": {
+                "content": [
+                  {
+                    "default": {
+                      "tag": 2
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                      "langKey": "ru",
+                      "value": "Доступные поля"
+                    }
+                  }
+                ]
+              },
+              "dataPath": "",
+              "items": []
+            }
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "КомпоновщикНастроек",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[2]/type"
+                }
+              },
+              {
+                "id": 3,
+                "name": "НастройкиОтчета",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 4,
+                "name": "ИмяКоллекцииПолей",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 5,
+                "name": "ИдентификаторЭлементаСтруктурыНастроек",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 7,
+                "name": "Режим",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "c888ccc1-9116-4b88-b950-aeabd54191c0",
+        "name": "ВыборФинансовогоПериода",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "SettingsStorage.ХранилищеВариантовОтчетов.Form.ВыборФинансовогоПериода",
+          "mdoRefRu": "ХранилищеНастроек.ХранилищеВариантовОтчетов.Форма.ВыборФинансовогоПериода"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Выбор финансового периода"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/SettingsStorages/ХранилищеВариантовОтчетов/Forms/ВыборФинансовогоПериода/Ext/Form/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "content": [
+              {
+                "default": {
+                  "tag": 2
+                },
+                "int": 1,
+                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                  "langKey": "ru",
+                  "value": "Выбор периода"
+                }
+              }
+            ]
+          },
+          "handlers": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[2]"
+            }
+          ],
+          "items": [
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 99,
+                "name": "ГруппаВыборГода",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Выбор года"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 187,
+                      "name": "ПерейтиНаГодНазадВарианты",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Перейти на год назад (варианты)"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "USUAL_BUTTON",
+                            "id": 90,
+                            "name": "ПерейтиНаГодНазадДоступно",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "<"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "LABEL_DECORATION",
+                            "id": 184,
+                            "name": "ПерейтиНаГодНазадНедоступно",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 92,
+                      "name": "ДатаНачалаГода",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Дата начала года"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "ДатаНачалаГода",
+                      "items": []
+                    },
+                    {
+                      "type": "USUAL_BUTTON",
+                      "id": 95,
+                      "name": "ПерейтиНаГодВперед",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": ">"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 176,
+                "name": "ГруппаВыборПериода",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/title"
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 178,
+                      "name": "Месяцы",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Месяцы"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 150,
+                            "name": "Квартал1",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Квартал 1"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "USUAL_BUTTON",
+                                  "id": 101,
+                                  "name": "ВыбратьМесяц1",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "январь"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "USUAL_BUTTON",
+                                  "id": 103,
+                                  "name": "ВыбратьМесяц2",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "февраль"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "USUAL_BUTTON",
+                                  "id": 105,
+                                  "name": "ВыбратьМесяц3",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "март"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          },
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 154,
+                            "name": "Квартал2",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Квартал 2"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "USUAL_BUTTON",
+                                  "id": 109,
+                                  "name": "ВыбратьМесяц4",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "апрель"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "USUAL_BUTTON",
+                                  "id": 111,
+                                  "name": "ВыбратьМесяц5",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "май"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "USUAL_BUTTON",
+                                  "id": 113,
+                                  "name": "ВыбратьМесяц6",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "июнь"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          },
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 158,
+                            "name": "Квартал3",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Квартал 3"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "USUAL_BUTTON",
+                                  "id": 117,
+                                  "name": "ВыбратьМесяц7",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "июль"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "USUAL_BUTTON",
+                                  "id": 119,
+                                  "name": "ВыбратьМесяц8",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "август"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "USUAL_BUTTON",
+                                  "id": 121,
+                                  "name": "ВыбратьМесяц9",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "сентябрь"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          },
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 162,
+                            "name": "Квартал4",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Квартал 4"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "USUAL_BUTTON",
+                                  "id": 125,
+                                  "name": "ВыбратьМесяц10",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "октябрь"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "USUAL_BUTTON",
+                                  "id": 127,
+                                  "name": "ВыбратьМесяц11",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "ноябрь"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "USUAL_BUTTON",
+                                  "id": 129,
+                                  "name": "ВыбратьМесяц12",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "декабрь"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 180,
+                      "name": "Кварталы",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Кварталы"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "USUAL_BUTTON",
+                            "id": 107,
+                            "name": "ВыбратьКвартал1",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "1 квартал"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "USUAL_BUTTON",
+                            "id": 115,
+                            "name": "ВыбратьКвартал2",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "2 квартал"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "USUAL_BUTTON",
+                            "id": 123,
+                            "name": "ВыбратьКвартал3",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "3 квартал"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "USUAL_BUTTON",
+                            "id": 131,
+                            "name": "ВыбратьКвартал4",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "4 квартал"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 182,
+                      "name": "НарастающимИтогом",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Нарастающим итогом"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "USUAL_BUTTON",
+                            "id": 174,
+                            "name": "ВыбратьДень",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "день..."
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "USUAL_BUTTON",
+                            "id": 133,
+                            "name": "ВыбратьПолугодие",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "полугодие"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "USUAL_BUTTON",
+                            "id": 137,
+                            "name": "Выбрать9Месяцев",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "9 месяцев"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "USUAL_BUTTON",
+                            "id": 139,
+                            "name": "ВыбратьГод",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "год"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 193,
+                "name": "ГруппаОчиститьПериод",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Очистить период"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "USUAL_BUTTON",
+                      "id": 189,
+                      "name": "ОчиститьПериод",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "за все время"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "USUAL_BUTTON",
+                      "id": 195,
+                      "name": "ПерейтиКСтандартномуВариантуПериода",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Стандартный вариант"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 2,
+                "name": "НачалоПериода",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "DATE"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.qualifiers.DateQualifiers": {
+                        "dateFractions": 1,
+                        "description": {
+                          "value": {
+                            "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                            "nameRu": "КвалификаторыДаты (Дата)",
+                            "nameEn": "DateQualifiers (Date)"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 3,
+                "name": "КонецПериода",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 4,
+                "name": "ДатаНачалаГода",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 5,
+                "name": "ИмяТекущегоЭлемента",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 1,
+                "name": "ОграничениеСнизу",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 6,
+                "name": "ВыбранныйГодОграничен",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 7,
+                "name": "Период",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "STANDARD_PERIOD"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 8,
+                "name": "ИмяКоманды",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/owner"
+        },
+        "usePurposes": [
+          "PLATFORM_APPLICATION"
+        ]
+      },
+      {
+        "uuid": "ff4d92a7-5fa3-4a46-a6f5-47c3952edb22",
+        "name": "ВыборФинансовогоПериодаДень",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "SettingsStorage.ХранилищеВариантовОтчетов.Form.ВыборФинансовогоПериодаДень",
+          "mdoRefRu": "ХранилищеНастроек.ХранилищеВариантовОтчетов.Форма.ВыборФинансовогоПериодаДень"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Выбор финансового периода день"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/SettingsStorages/ХранилищеВариантовОтчетов/Forms/ВыборФинансовогоПериодаДень/Ext/Form/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[5]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "content": [
+              {
+                "default": {
+                  "tag": 2
+                },
+                "int": 1,
+                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                  "langKey": "ru",
+                  "value": "Выбор дня"
+                }
+              }
+            ]
+          },
+          "handlers": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[2]"
+            }
+          ],
+          "items": [
+            {
+              "type": "CALENDAR_FIELD",
+              "id": 1,
+              "name": "День",
+              "title": {
+                "content": [
+                  {
+                    "default": {
+                      "tag": 2
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                      "langKey": "ru",
+                      "value": "День"
+                    }
+                  }
+                ]
+              },
+              "dataPath": "День",
+              "items": []
+            }
+          ],
+          "attributes": [
+            {
+              "id": 1,
+              "name": "День",
+              "title": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[5]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+              },
+              "type": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+              }
+            }
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "bb350b39-1f4d-460a-98c9-8d2308cf22f0",
+        "name": "ГруппаВыбранныхПолей",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "SettingsStorage.ХранилищеВариантовОтчетов.Form.ГруппаВыбранныхПолей",
+          "mdoRefRu": "ХранилищеНастроек.ХранилищеВариантовОтчетов.Форма.ГруппаВыбранныхПолей"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Группа выбранных полей"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/SettingsStorages/ХранилищеВариантовОтчетов/Forms/ГруппаВыбранныхПоле_/Ext/Form/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+          },
+          "handlers": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[2]"
+            }
+          ],
+          "items": [
+            [
+              {
+                "type": "INPUT_FIELD",
+                "id": 1,
+                "name": "ЗаголовокГруппы",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Заголовок"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "ЗаголовокГруппы",
+                "items": []
+              },
+              {
+                "type": "RADIO_BUTTON_FIELD",
+                "id": 4,
+                "name": "Расположение",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Расположение"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "РасположениеГруппы",
+                "items": []
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "ЗаголовокГруппы",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 2,
+                "name": "РасположениеГруппы",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "eaeb5aa8-8edf-4f74-8011-2d476f543bf6",
+        "name": "НастройкаПоля",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "SettingsStorage.ХранилищеВариантовОтчетов.Form.НастройкаПоля",
+          "mdoRefRu": "ХранилищеНастроек.ХранилищеВариантовОтчетов.Форма.НастройкаПоля"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Настройка поля"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/SettingsStorages/ХранилищеВариантовОтчетов/Forms/Настро_каПоля/Ext/Form/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+          },
+          "handlers": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[2]"
+              }
+            ],
+            []
+          ],
+          "items": [
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 266,
+                "name": "Сортировка",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Сортировка"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "USUAL_BUTTON",
+                      "id": 1,
+                      "name": "СортироватьПоВозрастанию",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Сортировать по возрастанию"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "USUAL_BUTTON",
+                      "id": 3,
+                      "name": "СортироватьПоУбыванию",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Сортировать по убыванию"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 16,
+                "name": "ФильтрПоЗначению",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Фильтр по значению"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  {
+                    "type": "PAGES",
+                    "id": 404,
+                    "name": "ФильтрПоЗначениюСтраницы",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "PAGE",
+                          "id": 406,
+                          "name": "ЗначенияФильтра",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Значения"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "TABLE",
+                                "id": 18,
+                                "name": "Значения",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                },
+                                "dataPath": "Значения",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "CHECK_BOX_FIELD",
+                                      "id": 34,
+                                      "name": "ЗначенияПометка",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                      },
+                                      "dataPath": "Значения.Check",
+                                      "items": []
+                                    },
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 31,
+                                      "name": "ЗначенияЗначение",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Значение"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "Значения.Value",
+                                      "items": []
+                                    }
+                                  ],
+                                  []
+                                ]
+                              },
+                              {
+                                "type": "USUAL_GROUP",
+                                "id": 435,
+                                "name": "ОпцииЗаполненияФильтраПоЗначению",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Опции заполнения фильтра по значению"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "LABEL_DECORATION",
+                                      "id": 415,
+                                      "name": "СтатистикаФильтраПоЗначению",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                      },
+                                      "dataPath": "",
+                                      "items": []
+                                    },
+                                    {
+                                      "type": "LABEL_DECORATION",
+                                      "id": 437,
+                                      "name": "ВывестиВсеЗначенияРазделаОтчета",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Вывести все"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": []
+                                    }
+                                  ],
+                                  []
+                                ]
+                              }
+                            ],
+                            []
+                          ]
+                        },
+                        {
+                          "type": "PAGE",
+                          "id": 408,
+                          "name": "Ожидание",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Ожидание"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            {
+                              "type": "PAGES",
+                              "id": 423,
+                              "name": "СтатусыОжидания",
+                              "title": {
+                                "content": [
+                                  {
+                                    "default": {
+                                      "tag": 2
+                                    },
+                                    "int": 1,
+                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                      "langKey": "ru",
+                                      "value": "Статусы ожидания"
+                                    }
+                                  }
+                                ]
+                              },
+                              "dataPath": "",
+                              "items": [
+                                [
+                                  {
+                                    "type": "PAGE",
+                                    "id": 421,
+                                    "name": "ОжиданиеЗаполнения",
+                                    "title": {
+                                      "content": [
+                                        {
+                                          "default": {
+                                            "tag": 2
+                                          },
+                                          "int": 1,
+                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                            "langKey": "ru",
+                                            "value": "Ожидание заполнения"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    "dataPath": "",
+                                    "items": [
+                                      [
+                                        {
+                                          "type": "PICTURE_DECORATION",
+                                          "id": 410,
+                                          "name": "ИндикаторДлительнойОперации",
+                                          "title": {
+                                            "content": [
+                                              {
+                                                "default": {
+                                                  "tag": 2
+                                                },
+                                                "int": 1,
+                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                  "langKey": "ru",
+                                                  "value": "Индикатор длительной операции"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "dataPath": "",
+                                          "items": []
+                                        },
+                                        {
+                                          "type": "LABEL_DECORATION",
+                                          "id": 418,
+                                          "name": "ПредставлениеДлительнойОперации",
+                                          "title": {
+                                            "content": [
+                                              {
+                                                "default": {
+                                                  "tag": 2
+                                                },
+                                                "int": 1,
+                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                  "langKey": "ru",
+                                                  "value": "Выполняется чтение строк поля"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "dataPath": "",
+                                          "items": []
+                                        }
+                                      ],
+                                      []
+                                    ]
+                                  },
+                                  {
+                                    "type": "PAGE",
+                                    "id": 425,
+                                    "name": "ОшибкаЗаполнения",
+                                    "title": {
+                                      "content": [
+                                        {
+                                          "default": {
+                                            "tag": 2
+                                          },
+                                          "int": 1,
+                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                            "langKey": "ru",
+                                            "value": "Ошибка заполнения"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    "dataPath": "",
+                                    "items": [
+                                      [
+                                        {
+                                          "type": "PICTURE_DECORATION",
+                                          "id": 430,
+                                          "name": "ИндикаторОшибки",
+                                          "title": {
+                                            "content": [
+                                              {
+                                                "default": {
+                                                  "tag": 2
+                                                },
+                                                "int": 1,
+                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                  "langKey": "ru",
+                                                  "value": "Индикатор ошибки"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "dataPath": "",
+                                          "items": []
+                                        },
+                                        {
+                                          "type": "LABEL_DECORATION",
+                                          "id": 427,
+                                          "name": "ОписаниеОшибкиЗаполнения",
+                                          "title": {
+                                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                          },
+                                          "dataPath": "",
+                                          "items": []
+                                        }
+                                      ],
+                                      []
+                                    ]
+                                  }
+                                ],
+                                []
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      []
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 8,
+                "name": "ФильтрПоУсловию",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Фильтр по условию"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 376,
+                      "name": "СвойстваФильтраПоУсловиюСлева",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Свойства фильтра по условию слева"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        {
+                          "type": "CHECK_BOX_FIELD",
+                          "id": 373,
+                          "name": "Использование",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Использование"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "Использование",
+                          "items": []
+                        }
+                      ]
+                    },
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 378,
+                      "name": "СвойстваФильтраПоУсловиюСправа",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Свойства фильтра по условию справа"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 10,
+                            "name": "ВидСравнения",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Вид сравнения"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "ВидСравнения",
+                            "items": []
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 13,
+                            "name": "ПравоеЗначение",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Правое значение"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "ПравоеЗначение",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 299,
+                "name": "КоманднаяПанель",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 212,
+                      "name": "ДополнительныеВозможности",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Еще"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "LABEL_DECORATION",
+                            "id": 294,
+                            "name": "ДополнительныеВозможностиОтступ",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 292,
+                            "name": "КомандыДополнительныхВозможностей",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Команды дополнительных возможностей"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "USUAL_BUTTON",
+                                  "id": 440,
+                                  "name": "СгруппироватьПоВыбранномуПолю",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Сгруппировать по полю"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "LABEL_DECORATION",
+                                  "id": 442,
+                                  "name": "СгруппироватьГраницаГруппы",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "USUAL_GROUP",
+                                  "id": 196,
+                                  "name": "Поле",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Поле"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "USUAL_GROUP",
+                                        "id": 198,
+                                        "name": "Вставка",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Вставка"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": [
+                                          [
+                                            {
+                                              "type": "USUAL_GROUP",
+                                              "id": 445,
+                                              "name": "ВставкаКолонки",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Вставка колонки"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "",
+                                              "items": [
+                                                [
+                                                  {
+                                                    "type": "USUAL_GROUP",
+                                                    "id": 447,
+                                                    "name": "ВставкаКолонка1",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "Вставка колонка 1"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": [
+                                                      [
+                                                        {
+                                                          "type": "USUAL_BUTTON",
+                                                          "id": 156,
+                                                          "name": "ВставитьПолеСлева",
+                                                          "title": {
+                                                            "content": [
+                                                              {
+                                                                "default": {
+                                                                  "tag": 2
+                                                                },
+                                                                "int": 1,
+                                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                  "langKey": "ru",
+                                                                  "value": "Вставить поле слева"
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          "dataPath": "",
+                                                          "items": []
+                                                        },
+                                                        {
+                                                          "type": "USUAL_BUTTON",
+                                                          "id": 160,
+                                                          "name": "ВставитьГруппировкуВыше",
+                                                          "title": {
+                                                            "content": [
+                                                              {
+                                                                "default": {
+                                                                  "tag": 2
+                                                                },
+                                                                "int": 1,
+                                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                  "langKey": "ru",
+                                                                  "value": "Вставить группировку выше"
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          "dataPath": "",
+                                                          "items": []
+                                                        }
+                                                      ],
+                                                      []
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "USUAL_GROUP",
+                                                    "id": 449,
+                                                    "name": "ВставкаКолонка2",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "Вставка колонка 2"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": [
+                                                      [
+                                                        {
+                                                          "type": "USUAL_BUTTON",
+                                                          "id": 158,
+                                                          "name": "ВставитьПолеСправа",
+                                                          "title": {
+                                                            "content": [
+                                                              {
+                                                                "default": {
+                                                                  "tag": 2
+                                                                },
+                                                                "int": 1,
+                                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                  "langKey": "ru",
+                                                                  "value": "Вставить поле справа"
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          "dataPath": "",
+                                                          "items": []
+                                                        },
+                                                        {
+                                                          "type": "USUAL_BUTTON",
+                                                          "id": 162,
+                                                          "name": "ВставитьГруппировкуНиже",
+                                                          "title": {
+                                                            "content": [
+                                                              {
+                                                                "default": {
+                                                                  "tag": 2
+                                                                },
+                                                                "int": 1,
+                                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                  "langKey": "ru",
+                                                                  "value": "Вставить группировку ниже"
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          "dataPath": "",
+                                                          "items": []
+                                                        }
+                                                      ],
+                                                      []
+                                                    ]
+                                                  }
+                                                ],
+                                                []
+                                              ]
+                                            },
+                                            {
+                                              "type": "LABEL_DECORATION",
+                                              "id": 356,
+                                              "name": "ВставкаГраницаГруппы",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                              },
+                                              "dataPath": "",
+                                              "items": []
+                                            }
+                                          ],
+                                          []
+                                        ]
+                                      },
+                                      {
+                                        "type": "USUAL_GROUP",
+                                        "id": 200,
+                                        "name": "Перемещение",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Перемещение"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": [
+                                          [
+                                            {
+                                              "type": "USUAL_GROUP",
+                                              "id": 451,
+                                              "name": "ПеремещениеКолонки",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Перемещение колонки"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "",
+                                              "items": [
+                                                [
+                                                  {
+                                                    "type": "USUAL_GROUP",
+                                                    "id": 453,
+                                                    "name": "ПеремещениеКолонка1",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "Перемещение колонка 1"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": [
+                                                      [
+                                                        {
+                                                          "type": "USUAL_BUTTON",
+                                                          "id": 186,
+                                                          "name": "ПереместитьПолеВлево",
+                                                          "title": {
+                                                            "content": [
+                                                              {
+                                                                "default": {
+                                                                  "tag": 2
+                                                                },
+                                                                "int": 1,
+                                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                  "langKey": "ru",
+                                                                  "value": "Переместить влево"
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          "dataPath": "",
+                                                          "items": []
+                                                        },
+                                                        {
+                                                          "type": "USUAL_BUTTON",
+                                                          "id": 190,
+                                                          "name": "ПереместитьПолеВыше",
+                                                          "title": {
+                                                            "content": [
+                                                              {
+                                                                "default": {
+                                                                  "tag": 2
+                                                                },
+                                                                "int": 1,
+                                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                  "langKey": "ru",
+                                                                  "value": "Переместить выше"
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          "dataPath": "",
+                                                          "items": []
+                                                        }
+                                                      ],
+                                                      []
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "USUAL_GROUP",
+                                                    "id": 455,
+                                                    "name": "ПеремещениеКолонка2",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "Перемещение колонка 2"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": [
+                                                      [
+                                                        {
+                                                          "type": "USUAL_BUTTON",
+                                                          "id": 188,
+                                                          "name": "ПереместитьПолеВправо",
+                                                          "title": {
+                                                            "content": [
+                                                              {
+                                                                "default": {
+                                                                  "tag": 2
+                                                                },
+                                                                "int": 1,
+                                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                  "langKey": "ru",
+                                                                  "value": "Переместить вправо"
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          "dataPath": "",
+                                                          "items": []
+                                                        },
+                                                        {
+                                                          "type": "USUAL_BUTTON",
+                                                          "id": 192,
+                                                          "name": "ПереместитьПолеНиже",
+                                                          "title": {
+                                                            "content": [
+                                                              {
+                                                                "default": {
+                                                                  "tag": 2
+                                                                },
+                                                                "int": 1,
+                                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                  "langKey": "ru",
+                                                                  "value": "Переместить ниже"
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          "dataPath": "",
+                                                          "items": []
+                                                        }
+                                                      ],
+                                                      []
+                                                    ]
+                                                  }
+                                                ],
+                                                []
+                                              ]
+                                            },
+                                            {
+                                              "type": "LABEL_DECORATION",
+                                              "id": 359,
+                                              "name": "ПеремещениеГраницаГруппы",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                              },
+                                              "dataPath": "",
+                                              "items": []
+                                            }
+                                          ],
+                                          []
+                                        ]
+                                      },
+                                      {
+                                        "type": "USUAL_GROUP",
+                                        "id": 248,
+                                        "name": "СкрытиеПереименование",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Скрытие, переименование"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": [
+                                          [
+                                            {
+                                              "type": "USUAL_BUTTON",
+                                              "id": 164,
+                                              "name": "СкрытьПоле",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Скрыть"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "",
+                                              "items": []
+                                            },
+                                            {
+                                              "type": "USUAL_GROUP",
+                                              "id": 303,
+                                              "name": "Переименование",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Переименование"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "",
+                                              "items": [
+                                                [
+                                                  {
+                                                    "type": "USUAL_BUTTON",
+                                                    "id": 166,
+                                                    "name": "ПереименоватьПоле",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "Переименовать"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": []
+                                                  },
+                                                  {
+                                                    "type": "INPUT_FIELD",
+                                                    "id": 305,
+                                                    "name": "ПредставлениеПоля",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "Представление поля"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "ПредставлениеПоля",
+                                                    "items": []
+                                                  },
+                                                  {
+                                                    "type": "USUAL_BUTTON",
+                                                    "id": 393,
+                                                    "name": "ПереименоватьПолеЕще",
+                                                    "title": {
+                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": []
+                                                  }
+                                                ],
+                                                []
+                                              ]
+                                            },
+                                            {
+                                              "type": "LABEL_DECORATION",
+                                              "id": 362,
+                                              "name": "СкрытиеПереименованиеГраницаГруппы",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                              },
+                                              "dataPath": "",
+                                              "items": []
+                                            }
+                                          ],
+                                          []
+                                        ]
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                },
+                                {
+                                  "type": "USUAL_GROUP",
+                                  "id": 202,
+                                  "name": "Оформление",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Оформление"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "USUAL_GROUP",
+                                        "id": 204,
+                                        "name": "УстановкаЦвета",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Установка цвета"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": [
+                                          [
+                                            {
+                                              "type": "USUAL_GROUP",
+                                              "id": 457,
+                                              "name": "УстановкаЦветаКолонки",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Установка цвета колонки"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "",
+                                              "items": [
+                                                [
+                                                  {
+                                                    "type": "USUAL_GROUP",
+                                                    "id": 459,
+                                                    "name": "УстановкаЦветаКолонка1",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "Установка цвета колонка 1"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": [
+                                                      {
+                                                        "type": "USUAL_BUTTON",
+                                                        "id": 172,
+                                                        "name": "ОформитьОтрицательные",
+                                                        "title": {
+                                                          "content": [
+                                                            {
+                                                              "default": {
+                                                                "tag": 2
+                                                              },
+                                                              "int": 1,
+                                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                "langKey": "ru",
+                                                                "value": "Отрицательные красным"
+                                                              }
+                                                            }
+                                                          ]
+                                                        },
+                                                        "dataPath": "",
+                                                        "items": []
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "USUAL_GROUP",
+                                                    "id": 461,
+                                                    "name": "УстановкаЦветаКолонка2",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "Установка цвета колонка 2"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": [
+                                                      {
+                                                        "type": "USUAL_BUTTON",
+                                                        "id": 174,
+                                                        "name": "ОформитьПоложительные",
+                                                        "title": {
+                                                          "content": [
+                                                            {
+                                                              "default": {
+                                                                "tag": 2
+                                                              },
+                                                              "int": 1,
+                                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                "langKey": "ru",
+                                                                "value": "Положительные зеленым"
+                                                              }
+                                                            }
+                                                          ]
+                                                        },
+                                                        "dataPath": "",
+                                                        "items": []
+                                                      }
+                                                    ]
+                                                  }
+                                                ],
+                                                []
+                                              ]
+                                            },
+                                            {
+                                              "type": "LABEL_DECORATION",
+                                              "id": 365,
+                                              "name": "УстановкаЦветаГраницаГруппы",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                              },
+                                              "dataPath": "",
+                                              "items": []
+                                            }
+                                          ],
+                                          []
+                                        ]
+                                      },
+                                      {
+                                        "type": "USUAL_GROUP",
+                                        "id": 384,
+                                        "name": "ГруппаШиринаВысота",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Ширина высота"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": [
+                                          [
+                                            {
+                                              "type": "USUAL_GROUP",
+                                              "id": 206,
+                                              "name": "УстановкаШириныВысоты",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Установка ширины, высоты"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "",
+                                              "items": [
+                                                [
+                                                  {
+                                                    "type": "USUAL_GROUP",
+                                                    "id": 308,
+                                                    "name": "УстановкаВысотыСтроки",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "Установка высоты строки"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": [
+                                                      [
+                                                        {
+                                                          "type": "USUAL_BUTTON",
+                                                          "id": 380,
+                                                          "name": "УстановитьВысотуСтроки",
+                                                          "title": {
+                                                            "content": [
+                                                              {
+                                                                "default": {
+                                                                  "tag": 2
+                                                                },
+                                                                "int": 1,
+                                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                  "langKey": "ru",
+                                                                  "value": "Высота строки"
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          "dataPath": "",
+                                                          "items": []
+                                                        },
+                                                        {
+                                                          "type": "INPUT_FIELD",
+                                                          "id": 310,
+                                                          "name": "ВысотаСтроки",
+                                                          "title": {
+                                                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                                          },
+                                                          "dataPath": "ВысотаСтроки",
+                                                          "items": []
+                                                        },
+                                                        {
+                                                          "type": "USUAL_BUTTON",
+                                                          "id": 389,
+                                                          "name": "УстановитьВысотуСтрокиЕще",
+                                                          "title": {
+                                                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                                          },
+                                                          "dataPath": "",
+                                                          "items": []
+                                                        }
+                                                      ],
+                                                      []
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "USUAL_GROUP",
+                                                    "id": 313,
+                                                    "name": "УстановкаШириныКолонки",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "Установка ширины колонки"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": [
+                                                      [
+                                                        {
+                                                          "type": "USUAL_BUTTON",
+                                                          "id": 382,
+                                                          "name": "УстановитьШиринуКолонки",
+                                                          "title": {
+                                                            "content": [
+                                                              {
+                                                                "default": {
+                                                                  "tag": 2
+                                                                },
+                                                                "int": 1,
+                                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                  "langKey": "ru",
+                                                                  "value": "Ширина колонки"
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          "dataPath": "",
+                                                          "items": []
+                                                        },
+                                                        {
+                                                          "type": "INPUT_FIELD",
+                                                          "id": 315,
+                                                          "name": "ШиринаКолонки",
+                                                          "title": {
+                                                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                                          },
+                                                          "dataPath": "ШиринаКолонки",
+                                                          "items": []
+                                                        },
+                                                        {
+                                                          "type": "USUAL_BUTTON",
+                                                          "id": 391,
+                                                          "name": "УстановитьШиринуКолонкиЕще",
+                                                          "title": {
+                                                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                                          },
+                                                          "dataPath": "",
+                                                          "items": []
+                                                        }
+                                                      ],
+                                                      []
+                                                    ]
+                                                  }
+                                                ],
+                                                []
+                                              ]
+                                            },
+                                            {
+                                              "type": "LABEL_DECORATION",
+                                              "id": 386,
+                                              "name": "Отступ",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                              },
+                                              "dataPath": "",
+                                              "items": []
+                                            }
+                                          ],
+                                          []
+                                        ]
+                                      },
+                                      {
+                                        "type": "LABEL_DECORATION",
+                                        "id": 368,
+                                        "name": "УстановкаШириныВысотыГраницаГруппы",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "USUAL_BUTTON",
+                                        "id": 182,
+                                        "name": "ОформитьЕще",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Оформление..."
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                }
+                              ],
+                              []
+                            ]
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "COMMAND_BAR",
+                      "id": 301,
+                      "name": "КомандыОсновные",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "COMMAND_BAR_BUTTON",
+                            "id": 318,
+                            "name": "ПрименитьИСформировать",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Применить и сформировать"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "COMMAND_BAR_BUTTON",
+                            "id": 320,
+                            "name": "Применить",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "COMMAND_BAR_BUTTON",
+                            "id": 284,
+                            "name": "Отмена",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "ВидСравнения",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 2,
+                "name": "ПравоеЗначение",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 3,
+                "name": "Значения",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "VALUE_LIST"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 4,
+                "name": "Использование",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 7,
+                "name": "КомпоновщикНастроек",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[2]/type"
+                }
+              },
+              {
+                "id": 8,
+                "name": "ПредставлениеПоля",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                        "length": 150,
+                        "allowedLength": 0,
+                        "description": {}
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 9,
+                "name": "ВысотаСтроки",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                        "precision": 5,
+                        "scale": 0,
+                        "nonNegative": true,
+                        "description": {}
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 10,
+                "name": "ШиринаКолонки",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[7]/type"
+                }
+              },
+              {
+                "id": 11,
+                "name": "НастройкиОтчета",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 12,
+                "name": "СвойстваЗаголовка",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 13,
+                "name": "ИдентификаторЭлементаСтруктурыНастроек",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 5,
+                "name": "ДоступныеЗначения",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 6,
+                "name": "СнятьФильтрПоУсловию",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 14,
+                "name": "ИндексыГруппИЭлементов",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 17,
+                "name": "КоличествоСтрокВРазделеОтчета",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                        "precision": 10,
+                        "scale": 0,
+                        "nonNegative": true,
+                        "description": {}
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 15,
+                "name": "ВыведеныВсеЗначенияРазделаОтчета",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 16,
+                "name": "КоличествоПервыхЧитаемыхСтрок",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[15]/type"
+                }
+              },
+              {
+                "id": 18,
+                "name": "АдресДанныхРасшифровки",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 19,
+                "name": "Документ",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "SPREADSHEET_DOCUMENT"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "b2f17ef1-3f6f-4029-b3e2-28d6b79c5b76",
+        "name": "ПанельДругихОтчетов",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "SettingsStorage.ХранилищеВариантовОтчетов.Form.ПанельДругихОтчетов",
+          "mdoRefRu": "ХранилищеНастроек.ХранилищеВариантовОтчетов.Форма.ПанельДругихОтчетов"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Панель других отчетов"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/SettingsStorages/ХранилищеВариантовОтчетов/Forms/ПанельДругихОтчетов/Ext/Form/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[8]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "content": [
+              {
+                "default": {
+                  "tag": 2
+                },
+                "int": 1,
+                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                  "langKey": "ru",
+                  "value": "Другие отчеты"
+                }
+              }
+            ]
+          },
+          "handlers": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[2]"
+            }
+          ],
+          "items": [
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 1,
+                "name": "СтраницаДругиеОтчеты",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Страница другие отчеты"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  {
+                    "type": "USUAL_GROUP",
+                    "id": 3,
+                    "name": "ГруппаДругиеВариантыОтчета",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Варианты отчета"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "",
+                    "items": []
+                  }
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 19,
+                "name": "ГруппаДругихОтчетовНет",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Других отчетов нет"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "PICTURE_DECORATION",
+                      "id": 21,
+                      "name": "КартинкаДругихОтчетовНет",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Картинка других отчетов нет"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_DECORATION",
+                      "id": 16,
+                      "name": "НадписьДругихОтчетовНет",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[8]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 5,
+                "name": "ГруппаПодвал",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Подвал"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "CHECK_BOX_FIELD",
+                      "id": 7,
+                      "name": "ЗакрыватьПослеВыбора",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Закрывать это окно после перехода к отчету"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "ЗакрыватьПослеВыбора",
+                      "items": []
+                    },
+                    {
+                      "type": "COMMAND_BAR",
+                      "id": 10,
+                      "name": "ГруппаКоманднаяПанель",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "COMMAND_BAR_BUTTON",
+                            "id": 12,
+                            "name": "Закрыть",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "COMMAND_BAR_BUTTON",
+                            "id": 14,
+                            "name": "ФормаСправка",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "ВариантСсылка",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "СправочникСсылка.ВариантыОтчетов",
+                          "nameEn": "CatalogRef.ВариантыОтчетов"
+                        },
+                        "variant": "METADATA",
+                        "kind": "CATALOG"
+                      }
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 2,
+                "name": "ПодсистемаСсылка",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 2,
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "СправочникСсылка.ИдентификаторыОбъектовМетаданных",
+                          "nameEn": "CatalogRef.ИдентификаторыОбъектовМетаданных"
+                        },
+                        "variant": "METADATA",
+                        "kind": "CATALOG"
+                      },
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "СправочникСсылка.ИдентификаторыОбъектовРасширений",
+                          "nameEn": "CatalogRef.ИдентификаторыОбъектовРасширений"
+                        },
+                        "variant": "METADATA",
+                        "kind": "CATALOG"
+                      }
+                    }
+                  ],
+                  "composite": true,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 3,
+                "name": "ОтчетСсылка",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 3,
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "СправочникСсылка.ДополнительныеОтчетыИОбработки",
+                          "nameEn": "CatalogRef.ДополнительныеОтчетыИОбработки"
+                        },
+                        "variant": "METADATA",
+                        "kind": "CATALOG"
+                      },
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[8]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[2]/type/types/java.util.CollSer/com.github._1c_syntax.bsl.types.value.CustomValueType"
+                      },
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[8]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[2]/type/types/java.util.CollSer/com.github._1c_syntax.bsl.types.value.CustomValueType[2]"
+                      }
+                    }
+                  ],
+                  "composite": true,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 4,
+                "name": "ГруппыПодсистем",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 5,
+                "name": "ЕстьДругиеОтчеты",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 8,
+                "name": "ВариантыПанели",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 9,
+                "name": "ВариантыПанелиНомерЭлемента",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                        "precision": 10,
+                        "scale": 0,
+                        "nonNegative": false,
+                        "description": {
+                          "value": {
+                            "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                            "nameRu": "КвалификаторыЧисла (10.0)",
+                            "nameEn": "NumberQualifiers (10.0)"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 10,
+                "name": "ВариантыПанелиКлючТекущегоВарианта",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 11,
+                "name": "ЗакрыватьПослеВыбора",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[8]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 12,
+                "name": "ОтчетНаименование",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 6,
+                "name": "ВидимыеВарианты",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "364cbfe2-bc44-4387-aa7e-6b4aa086c9e9",
+        "name": "СохранениеВариантаОтчета",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "SettingsStorage.ХранилищеВариантовОтчетов.Form.СохранениеВариантаОтчета",
+          "mdoRefRu": "ХранилищеНастроек.ХранилищеВариантовОтчетов.Форма.СохранениеВариантаОтчета"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Сохранение варианта отчета"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/SettingsStorages/ХранилищеВариантовОтчетов/Forms/СохранениеВариантаОтчета/Ext/Form/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[9]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+          },
+          "handlers": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[2]"
+              },
+              {
+                "event": "FillCheckProcessingAtServer",
+                "name": "ОбработкаПроверкиЗаполненияНаСервере"
+              }
+            ],
+            []
+          ],
+          "items": [
+            [
+              {
+                "type": "PAGES",
+                "id": 24,
+                "name": "Страницы",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Страницы"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "PAGE",
+                      "id": 25,
+                      "name": "Основное",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Основное"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 52,
+                            "name": "Наименование",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                            },
+                            "dataPath": "Объект.Description",
+                            "items": []
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 252,
+                            "name": "Назначение",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                            },
+                            "dataPath": "Объект.Назначение",
+                            "items": []
+                          },
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 268,
+                            "name": "ГруппаДоступность",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Доступность"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "RADIO_BUTTON_FIELD",
+                                  "id": 98,
+                                  "name": "Доступен",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Доступен"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "Доступен",
+                                  "items": []
+                                },
+                                {
+                                  "type": "TABLE",
+                                  "id": 206,
+                                  "name": "ПользователиВарианта",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Показать в панелях отчетов пользователей (начальная настройка)"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "ПользователиВарианта",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "CHECK_BOX_FIELD",
+                                        "id": 236,
+                                        "name": "ПользователиВариантаПометка",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                        },
+                                        "dataPath": "ПользователиВарианта.Check",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "INPUT_FIELD",
+                                        "id": 219,
+                                        "name": "ПользователиВариантаЗначение",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                        },
+                                        "dataPath": "ПользователиВарианта.Value",
+                                        "items": []
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                },
+                                {
+                                  "type": "CHECK_BOX_FIELD",
+                                  "id": 247,
+                                  "name": "УведомитьПользователей",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Уведомить в чате об этом варианте отчета"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "УведомитьПользователей",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          },
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 250,
+                            "name": "ГруппаОписание",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                            },
+                            "dataPath": "",
+                            "items": [
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 8,
+                                "name": "Описание",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                },
+                                "dataPath": "Объект.Описание",
+                                "items": []
+                              }
+                            ]
+                          },
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 190,
+                            "name": "Страница1Подвал",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Страница 1 подвал"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              {
+                                "type": "PAGES",
+                                "id": 86,
+                                "name": "ЧтоБудетДальше",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Что будет дальше"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "PAGE",
+                                      "id": 88,
+                                      "name": "Новый",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Новый"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        {
+                                          "type": "LABEL_DECORATION",
+                                          "id": 187,
+                                          "name": "ДекорацияЧтоБудетДальшеНовый",
+                                          "title": {
+                                            "content": [
+                                              {
+                                                "default": {
+                                                  "tag": 2
+                                                },
+                                                "int": 1,
+                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                  "langKey": "ru",
+                                                  "value": "Будет сохранен новый вариант отчета.\nНажмите \"Далее\" для размещения варианта отчета в разделах приложения."
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "dataPath": "",
+                                          "items": []
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "PAGE",
+                                      "id": 87,
+                                      "name": "Перезапись",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Перезапись"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        {
+                                          "type": "LABEL_DECORATION",
+                                          "id": 184,
+                                          "name": "ДекорацияЧтоБудетДальшеПерезапись",
+                                          "title": {
+                                            "content": [
+                                              {
+                                                "default": {
+                                                  "tag": 2
+                                                },
+                                                "int": 1,
+                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                  "langKey": "ru",
+                                                  "value": "Будет перезаписан существующий вариант отчета.\nНажмите \"Далее\" для размещения варианта отчета в разделах приложения."
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "dataPath": "",
+                                          "items": []
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "PAGE",
+                                      "id": 201,
+                                      "name": "ПерезаписьНевозможна",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Перезапись невозможна"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        {
+                                          "type": "LABEL_DECORATION",
+                                          "id": 203,
+                                          "name": "ДекорацияЧтоБудетДальшеПерезаписьНевозможна",
+                                          "title": {
+                                            "content": [
+                                              {
+                                                "default": {
+                                                  "tag": 2
+                                                },
+                                                "int": 1,
+                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                  "langKey": "ru",
+                                                  "value": "Наименование занято другим вариантом отчета.\nВведите другое наименование или выберите вариант из списка."
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "dataPath": "",
+                                          "items": []
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  []
+                                ]
+                              }
+                            ]
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "PAGE",
+                      "id": 26,
+                      "name": "Дополнительно",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Дополнительно"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 261,
+                            "name": "ГруппаШапка",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Шапка"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "CHECK_BOX_FIELD",
+                                  "id": 225,
+                                  "name": "СброситьНастройки",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Сбросить настройки"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "СброситьНастройки",
+                                  "items": []
+                                },
+                                {
+                                  "type": "COMMAND_BAR",
+                                  "id": 263,
+                                  "name": "КоманднаяПанельДеревоПодсистем",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Командная панель дерево подсистем"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    {
+                                      "type": "SEARCH_STRING_ADDITION",
+                                      "id": 265,
+                                      "name": "СтрокаПоискаДеревоПодсистем",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                      },
+                                      "dataPath": "",
+                                      "items": []
+                                    }
+                                  ]
+                                }
+                              ],
+                              []
+                            ]
+                          },
+                          {
+                            "type": "TABLE",
+                            "id": 74,
+                            "name": "ДеревоПодсистем",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Дерево подсистем"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "ДеревоПодсистем",
+                            "items": [
+                              [
+                                {
+                                  "type": "COLUMN_GROUP",
+                                  "id": 77,
+                                  "name": "ГруппаКолонок",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Колонок"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "CHECK_BOX_FIELD",
+                                        "id": 78,
+                                        "name": "ДеревоПодсистемИспользование",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                        },
+                                        "dataPath": "ДеревоПодсистем.Использование",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "INPUT_FIELD",
+                                        "id": 80,
+                                        "name": "ДеревоПодсистемПредставление",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Раздел, Группа"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "ДеревоПодсистем.Представление",
+                                        "items": []
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                },
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 82,
+                                  "name": "ДеревоПодсистемВажность",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Важность"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "ДеревоПодсистем.Важность",
+                                  "items": []
+                                },
+                                {
+                                  "type": "LABEL_FIELD",
+                                  "id": 137,
+                                  "name": "ДеревоПодсистемПользователиПредставление",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Видимость по умолчанию"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "ДеревоПодсистем.ПользователиПредставление",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          }
+                        ],
+                        []
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 145,
+                "name": "ГруппаКоманднаяПанель",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "COMMAND_BAR",
+                      "id": 147,
+                      "name": "ГруппаКоманднаяПанельЛевая",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Командная панель левая"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        {
+                          "type": "COMMAND_BAR_BUTTON",
+                          "id": 23,
+                          "name": "Назад",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "<  Назад"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": []
+                        }
+                      ]
+                    },
+                    {
+                      "type": "COMMAND_BAR",
+                      "id": 149,
+                      "name": "ГруппаКоманднаяПанельПравая",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Командная панель правая"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "COMMAND_BAR_BUTTON",
+                            "id": 15,
+                            "name": "Далее",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Далее  >"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "COMMAND_BAR_BUTTON",
+                            "id": 55,
+                            "name": "Сохранить",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Сохранить"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "COMMAND_BAR_BUTTON",
+                            "id": 16,
+                            "name": "Отмена",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "BUTTON_GROUP",
+                            "id": 151,
+                            "name": "ГруппаКоманднаяПанельСправка",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Командная панель справка"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "ПрототипКлюч",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 3,
+                "name": "ВариантыОтчета",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 9,
+                "name": "ВариантСсылка",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[8]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 5,
+                "name": "ВариантКлючВарианта",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 11,
+                "name": "ПрототипСсылка",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[8]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 16,
+                "name": "ИдентификаторТекущейСтроки",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[8]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[7]/type"
+                }
+              },
+              {
+                "id": 15,
+                "name": "Доступен",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[9]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 13,
+                "name": "ДеревоПодсистем",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Размещение в панелях отчетов"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 19,
+                "name": "Контекст",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 20,
+                "name": "СброситьНастройки",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[9]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 21,
+                "name": "ОписаниеМодифицировано",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 22,
+                "name": "НаименованиеМодифицировано",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 23,
+                "name": "ПрототипПредопределенный",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 24,
+                "name": "Объект",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "СправочникОбъект.ВариантыОтчетов",
+                          "nameEn": "CatalogObject.ВариантыОтчетов"
+                        },
+                        "variant": "METADATA",
+                        "kind": "CATALOG"
+                      }
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 2,
+                "name": "ПользователиВарианта",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Пользователи варианта"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 6,
+                "name": "ИспользоватьВнешнихПользователей",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 7,
+                "name": "ИспользоватьГруппыПользователей",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 4,
+                "name": "ЭтоКонтекстныйВариантОтчета",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 8,
+                "name": "ВариантыКонтекста",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 10,
+                "name": "УведомитьПользователей",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[9]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "7433b2a9-f634-4af7-ac85-6aa1280ea239",
+        "name": "СохранениеВариантаОтчетаВФайл",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "SettingsStorage.ХранилищеВариантовОтчетов.Form.СохранениеВариантаОтчетаВФайл",
+          "mdoRefRu": "ХранилищеНастроек.ХранилищеВариантовОтчетов.Форма.СохранениеВариантаОтчетаВФайл"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Сохранение варианта отчета в файл"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/SettingsStorages/ХранилищеВариантовОтчетов/Forms/СохранениеВариантаОтчетаВФа_л/Ext/Form/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[10]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+          },
+          "handlers": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[2]"
+              }
+            ],
+            []
+          ],
+          "items": [
+            {
+              "type": "PAGES",
+              "id": 29,
+              "name": "ВариантыСохранения",
+              "title": {
+                "content": [
+                  {
+                    "default": {
+                      "tag": 2
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                      "langKey": "ru",
+                      "value": "Варианты сохранения"
+                    }
+                  }
+                ]
+              },
+              "dataPath": "",
+              "items": [
+                [
+                  {
+                    "type": "PAGE",
+                    "id": 31,
+                    "name": "ОдинВариантОтчета",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Один вариант отчета"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "INPUT_FIELD",
+                          "id": 1,
+                          "name": "ИмяФайла",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Имя файла"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "ИмяФайла",
+                          "items": []
+                        },
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 80,
+                          "name": "ГруппаПерсональныеНастройки",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Персональные настройки"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "LABEL_DECORATION",
+                                "id": 77,
+                                "name": "ПерсональныеНастройкиНадпись",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Персональные настройки:"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": []
+                              },
+                              {
+                                "type": "COMMAND_BAR",
+                                "id": 82,
+                                "name": "КоманднаяПанельПерсональныеНастройки",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Командная панель персональные настройки"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  {
+                                    "type": "BUTTON_GROUP",
+                                    "id": 75,
+                                    "name": "ПользовательскиеНастройкиГруппаИзменитьФлажки",
+                                    "title": {
+                                      "content": [
+                                        {
+                                          "default": {
+                                            "tag": 2
+                                          },
+                                          "int": 1,
+                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                            "langKey": "ru",
+                                            "value": "Изменить флажки"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    "dataPath": "",
+                                    "items": [
+                                      [
+                                        {
+                                          "type": "COMMAND_BAR_BUTTON",
+                                          "id": 23,
+                                          "name": "ПользовательскиеНастройкиУстановитьФлажки",
+                                          "title": {
+                                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                          },
+                                          "dataPath": "",
+                                          "items": []
+                                        },
+                                        {
+                                          "type": "COMMAND_BAR_BUTTON",
+                                          "id": 25,
+                                          "name": "ПользовательскиеНастройкиСнятьФлажки",
+                                          "title": {
+                                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                          },
+                                          "dataPath": "",
+                                          "items": []
+                                        }
+                                      ],
+                                      []
+                                    ]
+                                  }
+                                ]
+                              }
+                            ],
+                            []
+                          ]
+                        },
+                        {
+                          "type": "TABLE",
+                          "id": 4,
+                          "name": "ПерсональныеНастройки",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[10]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                          },
+                          "dataPath": "ПерсональныеНастройки",
+                          "items": [
+                            [
+                              {
+                                "type": "CHECK_BOX_FIELD",
+                                "id": 20,
+                                "name": "ПользовательскиеНастройкиПометка",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                },
+                                "dataPath": "ПерсональныеНастройки.Check",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 17,
+                                "name": "ПользовательскиеНастройкиЗначение",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                },
+                                "dataPath": "ПерсональныеНастройки.Value",
+                                "items": []
+                              }
+                            ],
+                            []
+                          ]
+                        }
+                      ],
+                      []
+                    ]
+                  },
+                  {
+                    "type": "PAGE",
+                    "id": 33,
+                    "name": "НесколькоВариантовОтчетов",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Несколько вариантов отчетов"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "INPUT_FIELD",
+                          "id": 35,
+                          "name": "ИмяКаталога",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Каталог"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "ИмяКаталога",
+                          "items": []
+                        },
+                        {
+                          "type": "TABLE",
+                          "id": 38,
+                          "name": "ОписаниеВариантовОтчетов",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Описание вариантов отчетов"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "ОписаниеВариантовОтчетов",
+                          "items": [
+                            [
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 51,
+                                "name": "ОписаниеВариантовОтчетовСсылка",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Вариант отчета"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "ОписаниеВариантовОтчетов.Ссылка",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 72,
+                                "name": "ОписаниеВариантовОтчетовИмяФайлаКраткое",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[10]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                },
+                                "dataPath": "ОписаниеВариантовОтчетов.ИмяФайлаКраткое",
+                                "items": []
+                              }
+                            ],
+                            []
+                          ]
+                        }
+                      ],
+                      []
+                    ]
+                  }
+                ],
+                []
+              ]
+            }
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "ИмяФайла",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[10]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 2,
+                "name": "ПерсональныеНастройки",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[10]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 3,
+                "name": "ХранилищеПользовательскихНастроек",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 11,
+                "name": "ИмяКаталога",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[10]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 13,
+                "name": "ОписаниеВариантовОтчетов",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[10]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 14,
+                "name": "ИмяФайлаБезРасширения",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 15,
+                "name": "РасширениеАрхива",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "9f32e85c-2ed6-41db-b0ec-6d8596940e80",
+        "name": "УсловияОтборовОтчета",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "SettingsStorage.ХранилищеВариантовОтчетов.Form.УсловияОтборовОтчета",
+          "mdoRefRu": "ХранилищеНастроек.ХранилищеВариантовОтчетов.Форма.УсловияОтборовОтчета"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Условия отборов отчета"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/SettingsStorages/ХранилищеВариантовОтчетов/Forms/УсловияОтборовОтчета/Ext/Form/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[11]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "content": [
+              {
+                "default": {
+                  "tag": 2
+                },
+                "int": 1,
+                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                  "langKey": "ru",
+                  "value": "Условия фильтров отчета"
+                }
+              }
+            ]
+          },
+          "handlers": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[2]"
+            }
+          ],
+          "items": [
+            [
+              {
+                "type": "TABLE",
+                "id": 28,
+                "name": "Отборы",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Фильтры"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "Отборы",
+                "items": [
+                  [
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 41,
+                      "name": "ОтборыПредставлениеПользовательскойНастройки",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                      },
+                      "dataPath": "Отборы.ПредставлениеПользовательскойНастройки",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 44,
+                      "name": "ОтборыВидСравнения",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                      },
+                      "dataPath": "Отборы.ВидСравнения",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "COMMAND_BAR",
+                "id": 47,
+                "name": "ГруппаКоманднаяПанель",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "COMMAND_BAR_BUTTON",
+                      "id": 26,
+                      "name": "ФормаВыбрать",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "ОК"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "COMMAND_BAR_BUTTON",
+                      "id": 49,
+                      "name": "Отмена",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "COMMAND_BAR_BUTTON",
+                      "id": 51,
+                      "name": "Справка",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "КомпоновщикНастроек",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[2]/type"
+                }
+              },
+              {
+                "id": 3,
+                "name": "НастройкиОтчета",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 4,
+                "name": "ИмяТаблицы",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 5,
+                "name": "ИдентификаторЭлементаСтруктурыНастроек",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 6,
+                "name": "Картинки",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 7,
+                "name": "Режим",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 8,
+                "name": "Отборы",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[11]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "7adced5f-3a5f-419a-926c-0452aad86c86",
+        "name": "ФильтроватьПоПолю",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "SettingsStorage.ХранилищеВариантовОтчетов.Form.ФильтроватьПоПолю",
+          "mdoRefRu": "ХранилищеНастроек.ХранилищеВариантовОтчетов.Форма.ФильтроватьПоПолю"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Фильтровать по полю"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/SettingsStorages/ХранилищеВариантовОтчетов/Forms/ФильтроватьПоПолю/Ext/Form/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[12]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+          },
+          "handlers": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[2]"
+              }
+            ],
+            []
+          ],
+          "items": [
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 1,
+                "name": "ЭлементОтбора1",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Элемент отбора 1"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "CHECK_BOX_FIELD",
+                      "id": 44,
+                      "name": "Использование1",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Использование 1"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "Использование1",
+                      "items": []
+                    },
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 58,
+                      "name": "ГруппаЛевоеЗначение1",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Левое значение 1"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 24,
+                            "name": "ЛевоеЗначение1",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[12]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                            },
+                            "dataPath": "ЛевоеЗначение1",
+                            "items": []
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 60,
+                            "name": "ПредставлениеЛевогоЗначения1",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Представление левого значения 1"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "ПредставлениеЛевогоЗначения1",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 5,
+                      "name": "ВидСравнения1",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Вид сравнения 1"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "ВидСравнения1",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 8,
+                      "name": "ПравоеЗначение1",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Правое значение 1"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "ПравоеЗначение1",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 30,
+                "name": "Дополнительно",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "CHECK_BOX_FIELD",
+                      "id": 47,
+                      "name": "ИспользованиеГруппы",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Использование группы"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "ИспользованиеГруппы",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 17,
+                      "name": "ТипГруппыЭлементовФильтра",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                      },
+                      "dataPath": "ТипГруппыЭлементовФильтра",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 3,
+                "name": "ЭлементОтбора2",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Элемент отбора 2"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 63,
+                      "name": "ГруппаЛевоеЗначение2",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Левое значение 2"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 27,
+                            "name": "ЛевоеЗначение2",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[12]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                            },
+                            "dataPath": "ЛевоеЗначение2",
+                            "items": []
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 65,
+                            "name": "ПредставлениеЛевогоЗначения2",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Представление левого значения 2"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "ПредставлениеЛевогоЗначения2",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 11,
+                      "name": "ВидСравнения2",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Вид сравнения 2"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "ВидСравнения2",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 14,
+                      "name": "ПравоеЗначение2",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Правое значение 2"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "ПравоеЗначение2",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 68,
+                "name": "КоманднаяПанель",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "HYPERLINK",
+                      "id": 72,
+                      "name": "ПерейтиКРасширеннымНастройкам",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "COMMAND_BAR",
+                      "id": 70,
+                      "name": "КомандыОсновные",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "COMMAND_BAR_BUTTON",
+                            "id": 56,
+                            "name": "ПрименитьИСформировать",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "COMMAND_BAR_BUTTON",
+                            "id": 54,
+                            "name": "Применить",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "COMMAND_BAR_BUTTON",
+                            "id": 52,
+                            "name": "Отмена",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "ВидСравнения1",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[12]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 2,
+                "name": "ПравоеЗначение1",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[12]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 3,
+                "name": "ВидСравнения2",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[12]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 4,
+                "name": "ПравоеЗначение2",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[12]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 5,
+                "name": "ТипГруппыЭлементовФильтра",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Тип группы элементов фильтра"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                        "length": 50,
+                        "allowedLength": 0,
+                        "description": {
+                          "value": {
+                            "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                            "nameRu": "КвалификаторыСтроки (50, Переменная)",
+                            "nameEn": "StringQualifiers (50, Variable)"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 6,
+                "name": "ЛевоеЗначение1",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[12]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 7,
+                "name": "ЛевоеЗначение2",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[12]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 8,
+                "name": "Использование1",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[12]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 9,
+                "name": "Использование2",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 10,
+                "name": "КомпоновщикНастроек",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[2]/type"
+                }
+              },
+              {
+                "id": 11,
+                "name": "СвойстваЗаголовка",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 12,
+                "name": "ПредставлениеЛевогоЗначения1",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[12]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 13,
+                "name": "ПредставлениеЛевогоЗначения2",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[12]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 14,
+                "name": "ТипЗначенияФильтра",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "TYPE_DESCRIPTION"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 15,
+                "name": "ДоступныеЗначения",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 16,
+                "name": "НастройкиОтчета",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 17,
+                "name": "КлючТекущегоВарианта",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 18,
+                "name": "ИспользованиеГруппы",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[12]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "f259b6b4-d582-429f-a16f-027a6bcb7438",
+        "name": "ЭлементУсловногоОформленияОтчета",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "SettingsStorage.ХранилищеВариантовОтчетов.Form.ЭлементУсловногоОформленияОтчета",
+          "mdoRefRu": "ХранилищеНастроек.ХранилищеВариантовОтчетов.Форма.ЭлементУсловногоОформленияОтчета"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Элемент условного оформления отчета"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/SettingsStorages/ХранилищеВариантовОтчетов/Forms/ЭлементУсловногоОформленияОтчета/Ext/Form/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+          },
+          "handlers": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[2]"
+            }
+          ],
+          "items": [
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 337,
+                "name": "ГруппаОформляемыеПоля",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Оформляемые поля"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 354,
+                      "name": "ГруппаОформляемыеПоляВариантыВыбора",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Варианты выбора"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "CHECK_BOX_FIELD",
+                            "id": 372,
+                            "name": "Использование",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Используется для"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "Использование",
+                            "items": []
+                          },
+                          {
+                            "type": "RADIO_BUTTON_FIELD",
+                            "id": 356,
+                            "name": "ВариантВыбораОформляемыхПолей",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Вариант выбора оформляемых полей"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "ВариантВыбораОформляемыхПолей",
+                            "items": []
+                          },
+                          {
+                            "type": "PAGES",
+                            "id": 362,
+                            "name": "ОформляемыеПоляСтраницы",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "PAGE",
+                                  "id": 364,
+                                  "name": "СтраницаОформляемоеПоле",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Оформляемое поле"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 359,
+                                      "name": "ОформляемоеПоле",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                      },
+                                      "dataPath": "ОформляемоеПоле",
+                                      "items": []
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "PAGE",
+                                  "id": 366,
+                                  "name": "СтраницаКоманднаяПанель",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    {
+                                      "type": "COMMAND_BAR",
+                                      "id": 368,
+                                      "name": "ОформляемыеПоляКомандыОсновные",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        [
+                                          {
+                                            "type": "COMMAND_BAR_BUTTON",
+                                            "id": 265,
+                                            "name": "ОформляемыеПоляДобавить",
+                                            "title": {
+                                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                            },
+                                            "dataPath": "",
+                                            "items": []
+                                          },
+                                          {
+                                            "type": "BUTTON_GROUP",
+                                            "id": 257,
+                                            "name": "ОформляемыеПоляГруппаИзменитьФлажки",
+                                            "title": {
+                                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[10]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                            },
+                                            "dataPath": "",
+                                            "items": [
+                                              [
+                                                {
+                                                  "type": "COMMAND_BAR_BUTTON",
+                                                  "id": 259,
+                                                  "name": "ОформляемыеПоляУстановитьФлажки",
+                                                  "title": {
+                                                    "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                                  },
+                                                  "dataPath": "",
+                                                  "items": []
+                                                },
+                                                {
+                                                  "type": "COMMAND_BAR_BUTTON",
+                                                  "id": 261,
+                                                  "name": "ОформляемыеПоляСнятьФлажки",
+                                                  "title": {
+                                                    "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                                  },
+                                                  "dataPath": "",
+                                                  "items": []
+                                                }
+                                              ],
+                                              []
+                                            ]
+                                          },
+                                          {
+                                            "type": "BUTTON_GROUP",
+                                            "id": 275,
+                                            "name": "ОформляемыеПоляГруппаПереместить",
+                                            "title": {
+                                              "content": [
+                                                {
+                                                  "default": {
+                                                    "tag": 2
+                                                  },
+                                                  "int": 1,
+                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                    "langKey": "ru",
+                                                    "value": "Переместить"
+                                                  }
+                                                }
+                                              ]
+                                            },
+                                            "dataPath": "",
+                                            "items": [
+                                              [
+                                                {
+                                                  "type": "COMMAND_BAR_BUTTON",
+                                                  "id": 277,
+                                                  "name": "ОформляемыеПоляПереместитьВверх",
+                                                  "title": {
+                                                    "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                                  },
+                                                  "dataPath": "",
+                                                  "items": []
+                                                },
+                                                {
+                                                  "type": "COMMAND_BAR_BUTTON",
+                                                  "id": 279,
+                                                  "name": "ОформляемыеПоляПереместитьВниз",
+                                                  "title": {
+                                                    "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                                  },
+                                                  "dataPath": "",
+                                                  "items": []
+                                                }
+                                              ],
+                                              []
+                                            ]
+                                          }
+                                        ],
+                                        []
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ],
+                              []
+                            ]
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "TABLE",
+                      "id": 30,
+                      "name": "ОформляемыеПоля",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                      },
+                      "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Fields",
+                      "items": [
+                        {
+                          "type": "COLUMN_GROUP",
+                          "id": 206,
+                          "name": "ОформляемыеПоляГруппаКолонокПоле",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "CHECK_BOX_FIELD",
+                                "id": 203,
+                                "name": "ОформляемыеПоляИспользование",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                },
+                                "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Fields.Use",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 211,
+                                "name": "ОформляемыеПоляПоле",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                },
+                                "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Fields.Field",
+                                "items": []
+                              }
+                            ],
+                            []
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 333,
+                "name": "ГруппаОформление",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                },
+                "dataPath": "",
+                "items": [
+                  {
+                    "type": "TABLE",
+                    "id": 72,
+                    "name": "Оформление",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                    },
+                    "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Appearance",
+                    "items": [
+                      [
+                        {
+                          "type": "COLUMN_GROUP",
+                          "id": 201,
+                          "name": "ОформлениеГруппаИспользованиеПараметра",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Использование параметра"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "CHECK_BOX_FIELD",
+                                "id": 96,
+                                "name": "ОформлениеИспользование",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                },
+                                "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Appearance.Use",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 105,
+                                "name": "ОформлениеПараметр",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                },
+                                "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Appearance.Parameter",
+                                "items": []
+                              }
+                            ],
+                            []
+                          ]
+                        },
+                        {
+                          "type": "COLUMN_GROUP",
+                          "id": 108,
+                          "name": "ОформлениеГруппаКолонокЗначениеПараметра",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "PICTURE_FIELD",
+                                "id": 110,
+                                "name": "ОформлениеКартинкаЗначения",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                },
+                                "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Appearance.ValuePicture",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 113,
+                                "name": "ОформлениеЗначение",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                },
+                                "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Appearance.Value",
+                                "items": []
+                              }
+                            ],
+                            []
+                          ]
+                        }
+                      ],
+                      []
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 335,
+                "name": "ГруппаОтбор",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[11]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 345,
+                      "name": "ОтборКоманднаяПанель1",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "LABEL_DECORATION",
+                            "id": 347,
+                            "name": "ОтборЗаголовок",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Условие:"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "COMMAND_BAR",
+                            "id": 350,
+                            "name": "ОтборКомандыОсновные",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "COMMAND_BAR_BUTTON",
+                                  "id": 293,
+                                  "name": "ОтборДобавитьЭлементОтбора",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Добавить"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "BUTTON_GROUP",
+                                  "id": 285,
+                                  "name": "ОтборГруппаИзменитьФлажки",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[10]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "COMMAND_BAR_BUTTON",
+                                        "id": 295,
+                                        "name": "ОтборУстановитьФлажки",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "COMMAND_BAR_BUTTON",
+                                        "id": 297,
+                                        "name": "ОтборСнятьФлажки",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                },
+                                {
+                                  "type": "BUTTON_GROUP",
+                                  "id": 291,
+                                  "name": "ОтборГруппаПереместить",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "COMMAND_BAR_BUTTON",
+                                        "id": 299,
+                                        "name": "ОтборПереместитьВверх",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "COMMAND_BAR_BUTTON",
+                                        "id": 301,
+                                        "name": "ОтборПереместитьВниз",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                }
+                              ],
+                              []
+                            ]
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "TABLE",
+                      "id": 51,
+                      "name": "Отбор",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[11]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                      },
+                      "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter",
+                      "items": [
+                        [
+                          {
+                            "type": "CHECK_BOX_FIELD",
+                            "id": 214,
+                            "name": "ОтборИспользование",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                            },
+                            "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.Use",
+                            "items": []
+                          },
+                          {
+                            "type": "COLUMN_GROUP",
+                            "id": 217,
+                            "name": "ОтборГруппаКолонокОтбор",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Фильтр"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "COLUMN_GROUP",
+                                  "id": 224,
+                                  "name": "ОтборГруппаКолонокОсновныеЭлементыОтбора",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Основные элементы фильтра"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "COLUMN_GROUP",
+                                        "id": 229,
+                                        "name": "ОтборГруппаКолонокЛевоеЗначение",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Левое значение"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": [
+                                          [
+                                            {
+                                              "type": "PICTURE_FIELD",
+                                              "id": 231,
+                                              "name": "ОтборКартинкаЛевогоЗначения",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                              },
+                                              "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.LeftValuePicture",
+                                              "items": []
+                                            },
+                                            {
+                                              "type": "INPUT_FIELD",
+                                              "id": 234,
+                                              "name": "ОтборЛевоеЗначение",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                              },
+                                              "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.LeftValue",
+                                              "items": []
+                                            }
+                                          ],
+                                          []
+                                        ]
+                                      },
+                                      {
+                                        "type": "INPUT_FIELD",
+                                        "id": 237,
+                                        "name": "ОтборВидСравнения",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                        },
+                                        "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.ComparisonType",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "COLUMN_GROUP",
+                                        "id": 240,
+                                        "name": "ОтборГруппаКолонокПравоеЗначение",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                        },
+                                        "dataPath": "",
+                                        "items": [
+                                          [
+                                            {
+                                              "type": "PICTURE_FIELD",
+                                              "id": 242,
+                                              "name": "ОтборКартинкаПравогоЗначения",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                              },
+                                              "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.RightValuePicture",
+                                              "items": []
+                                            },
+                                            {
+                                              "type": "INPUT_FIELD",
+                                              "id": 245,
+                                              "name": "ОтборПравоеЗначение",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                              },
+                                              "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.RightValue",
+                                              "items": []
+                                            }
+                                          ],
+                                          []
+                                        ]
+                                      },
+                                      {
+                                        "type": "INPUT_FIELD",
+                                        "id": 248,
+                                        "name": "ОтборДата",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                        },
+                                        "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.Date",
+                                        "items": []
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                },
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 226,
+                                  "name": "ОтборТипГруппы",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                  },
+                                  "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.GroupType",
+                                  "items": []
+                                },
+                                {
+                                  "type": "COLUMN_GROUP",
+                                  "id": 329,
+                                  "name": "ОтборГруппа6",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[11]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "COLUMN_GROUP",
+                                        "id": 219,
+                                        "name": "ОтборГруппаКолонокПрименение",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Применение"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": [
+                                          [
+                                            {
+                                              "type": "INPUT_FIELD",
+                                              "id": 251,
+                                              "name": "ОтборПрименение",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                              },
+                                              "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.Application",
+                                              "items": []
+                                            },
+                                            {
+                                              "type": "INPUT_FIELD",
+                                              "id": 254,
+                                              "name": "ОтборРежимОтображения",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                              },
+                                              "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.ViewMode",
+                                              "items": []
+                                            }
+                                          ],
+                                          []
+                                        ]
+                                      },
+                                      {
+                                        "type": "INPUT_FIELD",
+                                        "id": 221,
+                                        "name": "ОтборПредставление",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                        },
+                                        "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.Presentation",
+                                        "items": []
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                }
+                              ],
+                              []
+                            ]
+                          }
+                        ],
+                        []
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "INPUT_FIELD",
+                "id": 93,
+                "name": "Наименование",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "dataPath": "Наименование",
+                "items": []
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 339,
+                "name": "КоманднаяПанель",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 341,
+                      "name": "ВариантыИспользования",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 156,
+                            "name": "ВариантыИспользованияКоманды",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Варианты использования (команды)"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "LABEL_DECORATION",
+                                  "id": 153,
+                                  "name": "ДекорацияПоказывать",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Показывать:                 "
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "COMMAND_BAR",
+                                  "id": 199,
+                                  "name": "КомандыИзменитьФлажки",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[10]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    {
+                                      "type": "BUTTON_GROUP",
+                                      "id": 343,
+                                      "name": "ГруппаИзменитьФлажки",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[10]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        [
+                                          {
+                                            "type": "COMMAND_BAR_BUTTON",
+                                            "id": 190,
+                                            "name": "Показывать_УстановитьПометки",
+                                            "title": {
+                                              "content": [
+                                                {
+                                                  "default": {
+                                                    "tag": 2
+                                                  },
+                                                  "int": 1,
+                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                    "langKey": "ru",
+                                                    "value": "Установить пометки"
+                                                  }
+                                                }
+                                              ]
+                                            },
+                                            "dataPath": "",
+                                            "items": []
+                                          },
+                                          {
+                                            "type": "COMMAND_BAR_BUTTON",
+                                            "id": 188,
+                                            "name": "Показывать_СнятьПометки",
+                                            "title": {
+                                              "content": [
+                                                {
+                                                  "default": {
+                                                    "tag": 2
+                                                  },
+                                                  "int": 1,
+                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                    "langKey": "ru",
+                                                    "value": "Снять пометки"
+                                                  }
+                                                }
+                                              ]
+                                            },
+                                            "dataPath": "",
+                                            "items": []
+                                          }
+                                        ],
+                                        []
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ],
+                              []
+                            ]
+                          },
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 160,
+                            "name": "ВариантыИспользованияПометки",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Варианты использования (пометки)"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "CHECK_BOX_FIELD",
+                                  "id": 185,
+                                  "name": "ИспользоватьВГруппировке",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "В группировке"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "ИспользоватьВГруппировке",
+                                  "items": []
+                                },
+                                {
+                                  "type": "CHECK_BOX_FIELD",
+                                  "id": 176,
+                                  "name": "ИспользоватьВИерархическойГруппировке",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "В иерархической группировке"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "ИспользоватьВИерархическойГруппировке",
+                                  "items": []
+                                },
+                                {
+                                  "type": "CHECK_BOX_FIELD",
+                                  "id": 173,
+                                  "name": "ИспользоватьВОбщемИтоге",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "В общем итоге"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "ИспользоватьВОбщемИтоге",
+                                  "items": []
+                                },
+                                {
+                                  "type": "CHECK_BOX_FIELD",
+                                  "id": 179,
+                                  "name": "ИспользоватьВЗаголовкеПолей",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "В заголовке полей"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "ИспользоватьВЗаголовкеПолей",
+                                  "items": []
+                                },
+                                {
+                                  "type": "CHECK_BOX_FIELD",
+                                  "id": 182,
+                                  "name": "ИспользоватьВЗаголовке",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "В заголовке"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "ИспользоватьВЗаголовке",
+                                  "items": []
+                                },
+                                {
+                                  "type": "CHECK_BOX_FIELD",
+                                  "id": 167,
+                                  "name": "ИспользоватьВПараметрах",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "В параметрах"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "ИспользоватьВПараметрах",
+                                  "items": []
+                                },
+                                {
+                                  "type": "CHECK_BOX_FIELD",
+                                  "id": 170,
+                                  "name": "ИспользоватьВОтборе",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "В фильтрах"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "ИспользоватьВОтборе",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "COMMAND_BAR",
+                      "id": 323,
+                      "name": "КомандыОсновные",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "COMMAND_BAR_BUTTON",
+                            "id": 26,
+                            "name": "ФормаВыбрать",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[11]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "COMMAND_BAR_BUTTON",
+                            "id": 325,
+                            "name": "Отмена",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "COMMAND_BAR_BUTTON",
+                            "id": 327,
+                            "name": "Справка",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "КомпоновщикНастроек",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[2]/type"
+                }
+              },
+              {
+                "id": 3,
+                "name": "НастройкиОтчета",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 5,
+                "name": "ИдентификаторЭлементаСтруктурыНастроек",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 2,
+                "name": "ИдентификаторКД",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 6,
+                "name": "НаименованиеПоУмолчанию",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 8,
+                "name": "Наименование",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 9,
+                "name": "ИспользоватьВГруппировке",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 10,
+                "name": "ИспользоватьВПараметрах",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[6]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 11,
+                "name": "ИспользоватьВОтборе",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[7]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 12,
+                "name": "ИспользоватьВОбщемИтоге",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 13,
+                "name": "ИспользоватьВИерархическойГруппировке",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 14,
+                "name": "ИспользоватьВЗаголовкеПолей",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 15,
+                "name": "ИспользоватьВЗаголовке",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 16,
+                "name": "ФлажкиОбластиОтображения",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 17,
+                "name": "ТребуетсяОбновлениеНаименованияПоУмолчанию",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 18,
+                "name": "ЭтоНовый",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 4,
+                "name": "ВариантВыбораОформляемыхПолей",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 7,
+                "name": "ОформляемоеПоле",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 19,
+                "name": "Использование",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      }
+    ],
+    []
+  ],
+  "mdoReference": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/owner"
+  },
+  "mdoType": "SETTINGS_STORAGE",
+  "moduleTypes": [
+    [
+      "ManagerModule",
+      [
+        "src/test/resources/ext/designer/ssl_3_2/src/cf/SettingsStorages/ХранилищеВариантовОтчетов/Ext/ManagerModule.bsl"
+      ]
+    ]
+  ],
+  "modules": [
+    {
+      "moduleType": "ManagerModule",
+      "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/SettingsStorages/ХранилищеВариантовОтчетов/Ext/ManagerModule.bsl",
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/owner"
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "isProtected": false
+    }
+  ],
+  "name": "ХранилищеВариантовОтчетов",
+  "objectBelonging": "OWN",
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "content": [
+      {
+        "default": {
+          "tag": 2
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+          "langKey": "ru",
+          "value": "Хранилище вариантов отчетов"
+        }
+      }
+    ]
+  },
+  "templates": [],
+  "uuid": "14512818-58b0-44cc-b00d-d37913c57aad"
+}}

--- a/src/test/resources/fixtures/ssl_3_2/SettingsStorages.ХранилищеВариантовОтчетов.json
+++ b/src/test/resources/fixtures/ssl_3_2/SettingsStorages.ХранилищеВариантовОтчетов.json
@@ -192,130 +192,6 @@
                 },
                 "dataPath": "ВыводитьЗаголовкиНастроек",
                 "items": []
-              },
-              {
-                "type": "USUAL_GROUP",
-                "id": 96,
-                "name": "КоманднаяПанель",
-                "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Командная панель"
-                      }
-                    }
-                  ]
-                },
-                "dataPath": "",
-                "items": [
-                  [
-                    {
-                      "type": "USUAL_GROUP",
-                      "id": 109,
-                      "name": "ДополнительныеВозможности",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Дополнительные возможности"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
-                        {
-                          "type": "HYPERLINK",
-                          "id": 104,
-                          "name": "ПерейтиКРасширеннымНастройкам",
-                          "title": {
-                            "content": [
-                              {
-                                "default": {
-                                  "tag": 2
-                                },
-                                "int": 1,
-                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                  "langKey": "ru",
-                                  "value": "Больше возможностей..."
-                                }
-                              }
-                            ]
-                          },
-                          "dataPath": "",
-                          "items": []
-                        }
-                      ]
-                    },
-                    {
-                      "type": "COMMAND_BAR",
-                      "id": 98,
-                      "name": "КомандыОсновные",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Команды основные"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "COMMAND_BAR_BUTTON",
-                            "id": 100,
-                            "name": "Применить",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Применить"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "COMMAND_BAR_BUTTON",
-                            "id": 102,
-                            "name": "Отмена",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                            },
-                            "dataPath": "",
-                            "items": []
-                          }
-                        ],
-                        []
-                      ]
-                    }
-                  ],
-                  []
-                ]
               }
             ],
             []
@@ -570,146 +446,6 @@
                 ]
               },
               {
-                "type": "COMMAND_BAR",
-                "id": 27,
-                "name": "ОсновнаяКоманднаяПанель",
-                "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Основная командная панель"
-                      }
-                    }
-                  ]
-                },
-                "dataPath": "",
-                "items": [
-                  [
-                    {
-                      "type": "COMMAND_BAR_BUTTON",
-                      "id": 6,
-                      "name": "Выбрать",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "COMMAND_BAR_BUTTON",
-                      "id": 7,
-                      "name": "Изменить",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "COMMAND_BAR_BUTTON",
-                      "id": 15,
-                      "name": "Удалить",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Пометить на удаление / Снять пометку"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "COMMAND_BAR_BUTTON",
-                      "id": 13,
-                      "name": "ПоказыватьЛичныеВариантыОтчетовДругихАвторов",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Показывать личные варианты отчетов других авторов"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "COMMAND_BAR_BUTTON",
-                      "id": 28,
-                      "name": "ФормаОбновить",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Обновить"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "BUTTON_GROUP",
-                      "id": 8,
-                      "name": "КоманднаяПанельДерева",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Командная панель дерева"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
-                        {
-                          "type": "SEARCH_STRING_ADDITION",
-                          "id": 59,
-                          "name": "СтрокаПоиска",
-                          "title": {
-                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                          },
-                          "dataPath": "",
-                          "items": []
-                        }
-                      ]
-                    }
-                  ],
-                  []
-                ]
-              },
-              {
                 "type": "TABLE",
                 "id": 1,
                 "name": "ДеревоВариантовОтчета",
@@ -837,7 +573,7 @@
                 "id": 1,
                 "name": "ДеревоВариантовОтчета",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                 },
                 "type": {
                   "types": [
@@ -904,7 +640,7 @@
                 "id": 6,
                 "name": "ВариантОписание",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
@@ -1906,7 +1642,7 @@
               },
               {
                 "type": "USUAL_GROUP",
-                "id": 193,
+                "id": 198,
                 "name": "ГруппаОчиститьПериод",
                 "title": {
                   "content": [
@@ -2257,51 +1993,73 @@
             }
           ],
           "items": [
-            [
-              {
-                "type": "INPUT_FIELD",
-                "id": 1,
-                "name": "ЗаголовокГруппы",
-                "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Заголовок"
-                      }
+            {
+              "type": "USUAL_GROUP",
+              "id": 13,
+              "name": "Основное",
+              "title": {
+                "content": [
+                  {
+                    "default": {
+                      "tag": 2
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                      "langKey": "ru",
+                      "value": "Основное"
                     }
-                  ]
-                },
-                "dataPath": "ЗаголовокГруппы",
-                "items": []
+                  }
+                ]
               },
-              {
-                "type": "RADIO_BUTTON_FIELD",
-                "id": 4,
-                "name": "Расположение",
-                "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Расположение"
-                      }
-                    }
-                  ]
-                },
-                "dataPath": "РасположениеГруппы",
-                "items": []
-              }
-            ],
-            []
+              "dataPath": "",
+              "items": [
+                [
+                  {
+                    "type": "INPUT_FIELD",
+                    "id": 1,
+                    "name": "ЗаголовокГруппы",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Заголовок"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "ЗаголовокГруппы",
+                    "items": []
+                  },
+                  {
+                    "type": "RADIO_BUTTON_FIELD",
+                    "id": 4,
+                    "name": "Расположение",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Расположение"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "РасположениеГруппы",
+                    "items": []
+                  }
+                ],
+                []
+              ]
+            }
           ],
           "attributes": [
             [
@@ -2309,7 +2067,7 @@
                 "id": 1,
                 "name": "ЗаголовокГруппы",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
@@ -2319,7 +2077,7 @@
                 "id": 2,
                 "name": "РасположениеГруппы",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
@@ -2394,108 +2152,41 @@
             []
           ],
           "items": [
-            [
-              {
-                "type": "USUAL_GROUP",
-                "id": 266,
-                "name": "Сортировка",
-                "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Сортировка"
-                      }
-                    }
-                  ]
-                },
-                "dataPath": "",
-                "items": [
-                  [
-                    {
-                      "type": "USUAL_BUTTON",
-                      "id": 1,
-                      "name": "СортироватьПоВозрастанию",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Сортировать по возрастанию"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": []
+            {
+              "type": "PAGES",
+              "id": 482,
+              "name": "Страницы",
+              "title": {
+                "content": [
+                  {
+                    "default": {
+                      "tag": 2
                     },
-                    {
-                      "type": "USUAL_BUTTON",
-                      "id": 3,
-                      "name": "СортироватьПоУбыванию",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Сортировать по убыванию"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": []
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                      "langKey": "ru",
+                      "value": "Страницы"
                     }
-                  ],
-                  []
+                  }
                 ]
               },
-              {
-                "type": "USUAL_GROUP",
-                "id": 16,
-                "name": "ФильтрПоЗначению",
-                "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Фильтр по значению"
-                      }
-                    }
-                  ]
-                },
-                "dataPath": "",
-                "items": [
+              "dataPath": "",
+              "items": [
+                [
                   {
-                    "type": "PAGES",
-                    "id": 404,
-                    "name": "ФильтрПоЗначениюСтраницы",
+                    "type": "PAGE",
+                    "id": 484,
+                    "name": "БыстрыеНастройки",
                     "title": {
-                      "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/synonym"
                     },
                     "dataPath": "",
                     "items": [
                       [
                         {
-                          "type": "PAGE",
-                          "id": 406,
-                          "name": "ЗначенияФильтра",
+                          "type": "USUAL_GROUP",
+                          "id": 488,
+                          "name": "БыстрыеНастройкиКолонка1",
                           "title": {
                             "content": [
                               {
@@ -2505,7 +2196,7 @@
                                 "int": 1,
                                 "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                                   "langKey": "ru",
-                                  "value": "Значения"
+                                  "value": "Быстрые настройки колонка 1"
                                 }
                               }
                             ]
@@ -2514,54 +2205,9 @@
                           "items": [
                             [
                               {
-                                "type": "TABLE",
-                                "id": 18,
-                                "name": "Значения",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                },
-                                "dataPath": "Значения",
-                                "items": [
-                                  [
-                                    {
-                                      "type": "CHECK_BOX_FIELD",
-                                      "id": 34,
-                                      "name": "ЗначенияПометка",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                      },
-                                      "dataPath": "Значения.Check",
-                                      "items": []
-                                    },
-                                    {
-                                      "type": "INPUT_FIELD",
-                                      "id": 31,
-                                      "name": "ЗначенияЗначение",
-                                      "title": {
-                                        "content": [
-                                          {
-                                            "default": {
-                                              "tag": 2
-                                            },
-                                            "int": 1,
-                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                              "langKey": "ru",
-                                              "value": "Значение"
-                                            }
-                                          }
-                                        ]
-                                      },
-                                      "dataPath": "Значения.Value",
-                                      "items": []
-                                    }
-                                  ],
-                                  []
-                                ]
-                              },
-                              {
                                 "type": "USUAL_GROUP",
-                                "id": 435,
-                                "name": "ОпцииЗаполненияФильтраПоЗначению",
+                                "id": 266,
+                                "name": "Сортировка",
                                 "title": {
                                   "content": [
                                     {
@@ -2571,7 +2217,7 @@
                                       "int": 1,
                                       "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                                         "langKey": "ru",
-                                        "value": "Опции заполнения фильтра по значению"
+                                        "value": "Сортировать"
                                       }
                                     }
                                   ]
@@ -2580,19 +2226,9 @@
                                 "items": [
                                   [
                                     {
-                                      "type": "LABEL_DECORATION",
-                                      "id": 415,
-                                      "name": "СтатистикаФильтраПоЗначению",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                      },
-                                      "dataPath": "",
-                                      "items": []
-                                    },
-                                    {
-                                      "type": "LABEL_DECORATION",
-                                      "id": 437,
-                                      "name": "ВывестиВсеЗначенияРазделаОтчета",
+                                      "type": "USUAL_BUTTON",
+                                      "id": 1,
+                                      "name": "СортироватьПоВозрастанию",
                                       "title": {
                                         "content": [
                                           {
@@ -2602,7 +2238,747 @@
                                             "int": 1,
                                             "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                                               "langKey": "ru",
-                                              "value": "Вывести все"
+                                              "value": "По возрастанию"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": []
+                                    },
+                                    {
+                                      "type": "USUAL_BUTTON",
+                                      "id": 3,
+                                      "name": "СортироватьПоУбыванию",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "По убыванию"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": []
+                                    }
+                                  ],
+                                  []
+                                ]
+                              },
+                              {
+                                "type": "USUAL_GROUP",
+                                "id": 494,
+                                "name": "Сгруппировать",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Сгруппировать"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  {
+                                    "type": "USUAL_BUTTON",
+                                    "id": 440,
+                                    "name": "СгруппироватьПоВыбранномуПолю",
+                                    "title": {
+                                      "content": [
+                                        {
+                                          "default": {
+                                            "tag": 2
+                                          },
+                                          "int": 1,
+                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                            "langKey": "ru",
+                                            "value": "По полю"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    "dataPath": "",
+                                    "items": []
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "USUAL_GROUP",
+                                "id": 200,
+                                "name": "Перемещение",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Переместить"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "USUAL_BUTTON",
+                                      "id": 186,
+                                      "name": "ПереместитьПолеВлево",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Влево"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": []
+                                    },
+                                    {
+                                      "type": "USUAL_BUTTON",
+                                      "id": 188,
+                                      "name": "ПереместитьПолеВправо",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Вправо"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": []
+                                    },
+                                    {
+                                      "type": "USUAL_BUTTON",
+                                      "id": 192,
+                                      "name": "ПереместитьПолеНиже",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Ниже"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": []
+                                    },
+                                    {
+                                      "type": "USUAL_BUTTON",
+                                      "id": 190,
+                                      "name": "ПереместитьПолеВыше",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Выше"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": []
+                                    }
+                                  ],
+                                  []
+                                ]
+                              },
+                              {
+                                "type": "USUAL_GROUP",
+                                "id": 206,
+                                "name": "УстановкаШириныВысоты",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Установить"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "USUAL_GROUP",
+                                      "id": 308,
+                                      "name": "УстановкаВысотыСтроки",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Установка высоты строки"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        [
+                                          {
+                                            "type": "INPUT_FIELD",
+                                            "id": 310,
+                                            "name": "ВысотаСтроки",
+                                            "title": {
+                                              "content": [
+                                                {
+                                                  "default": {
+                                                    "tag": 2
+                                                  },
+                                                  "int": 1,
+                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                    "langKey": "ru",
+                                                    "value": "Высота строки"
+                                                  }
+                                                }
+                                              ]
+                                            },
+                                            "dataPath": "ВысотаСтроки",
+                                            "items": []
+                                          },
+                                          {
+                                            "type": "USUAL_BUTTON",
+                                            "id": 389,
+                                            "name": "УстановитьВысотуСтроки",
+                                            "title": {
+                                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                            },
+                                            "dataPath": "",
+                                            "items": []
+                                          }
+                                        ],
+                                        []
+                                      ]
+                                    },
+                                    {
+                                      "type": "USUAL_GROUP",
+                                      "id": 313,
+                                      "name": "УстановкаШириныКолонки",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Установка ширины колонки"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        [
+                                          {
+                                            "type": "INPUT_FIELD",
+                                            "id": 315,
+                                            "name": "ШиринаКолонки",
+                                            "title": {
+                                              "content": [
+                                                {
+                                                  "default": {
+                                                    "tag": 2
+                                                  },
+                                                  "int": 1,
+                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                    "langKey": "ru",
+                                                    "value": "Ширина колонки"
+                                                  }
+                                                }
+                                              ]
+                                            },
+                                            "dataPath": "ШиринаКолонки",
+                                            "items": []
+                                          },
+                                          {
+                                            "type": "USUAL_BUTTON",
+                                            "id": 391,
+                                            "name": "УстановитьШиринуКолонки",
+                                            "title": {
+                                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                            },
+                                            "dataPath": "",
+                                            "items": []
+                                          }
+                                        ],
+                                        []
+                                      ]
+                                    }
+                                  ],
+                                  []
+                                ]
+                              }
+                            ],
+                            []
+                          ]
+                        },
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 491,
+                          "name": "БыстрыеНастройкиКолонка2",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Быстрые настройки колонка1"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "USUAL_GROUP",
+                                "id": 198,
+                                "name": "Вставка",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Вставка"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  {
+                                    "type": "USUAL_GROUP",
+                                    "id": 445,
+                                    "name": "ВставкаКолонки",
+                                    "title": {
+                                      "content": [
+                                        {
+                                          "default": {
+                                            "tag": 2
+                                          },
+                                          "int": 1,
+                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                            "langKey": "ru",
+                                            "value": "Вставить"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    "dataPath": "",
+                                    "items": [
+                                      [
+                                        {
+                                          "type": "USUAL_GROUP",
+                                          "id": 447,
+                                          "name": "ВставкаКолонка1",
+                                          "title": {
+                                            "content": [
+                                              {
+                                                "default": {
+                                                  "tag": 2
+                                                },
+                                                "int": 1,
+                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                  "langKey": "ru",
+                                                  "value": "Вставка колонка 1"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "dataPath": "",
+                                          "items": [
+                                            [
+                                              {
+                                                "type": "USUAL_BUTTON",
+                                                "id": 156,
+                                                "name": "ВставитьПолеСлева",
+                                                "title": {
+                                                  "content": [
+                                                    {
+                                                      "default": {
+                                                        "tag": 2
+                                                      },
+                                                      "int": 1,
+                                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                        "langKey": "ru",
+                                                        "value": "Поле слева"
+                                                      }
+                                                    }
+                                                  ]
+                                                },
+                                                "dataPath": "",
+                                                "items": []
+                                              },
+                                              {
+                                                "type": "USUAL_BUTTON",
+                                                "id": 160,
+                                                "name": "ВставитьГруппировкуВыше",
+                                                "title": {
+                                                  "content": [
+                                                    {
+                                                      "default": {
+                                                        "tag": 2
+                                                      },
+                                                      "int": 1,
+                                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                        "langKey": "ru",
+                                                        "value": "Группировку выше"
+                                                      }
+                                                    }
+                                                  ]
+                                                },
+                                                "dataPath": "",
+                                                "items": []
+                                              }
+                                            ],
+                                            []
+                                          ]
+                                        },
+                                        {
+                                          "type": "USUAL_GROUP",
+                                          "id": 449,
+                                          "name": "ВставкаКолонка2",
+                                          "title": {
+                                            "content": [
+                                              {
+                                                "default": {
+                                                  "tag": 2
+                                                },
+                                                "int": 1,
+                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                  "langKey": "ru",
+                                                  "value": "Вставка колонка 2"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "dataPath": "",
+                                          "items": [
+                                            [
+                                              {
+                                                "type": "USUAL_BUTTON",
+                                                "id": 158,
+                                                "name": "ВставитьПолеСправа",
+                                                "title": {
+                                                  "content": [
+                                                    {
+                                                      "default": {
+                                                        "tag": 2
+                                                      },
+                                                      "int": 1,
+                                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                        "langKey": "ru",
+                                                        "value": "Поле справа"
+                                                      }
+                                                    }
+                                                  ]
+                                                },
+                                                "dataPath": "",
+                                                "items": []
+                                              },
+                                              {
+                                                "type": "USUAL_BUTTON",
+                                                "id": 162,
+                                                "name": "ВставитьГруппировкуНиже",
+                                                "title": {
+                                                  "content": [
+                                                    {
+                                                      "default": {
+                                                        "tag": 2
+                                                      },
+                                                      "int": 1,
+                                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                        "langKey": "ru",
+                                                        "value": "Группировку ниже"
+                                                      }
+                                                    }
+                                                  ]
+                                                },
+                                                "dataPath": "",
+                                                "items": []
+                                              }
+                                            ],
+                                            []
+                                          ]
+                                        }
+                                      ],
+                                      []
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "USUAL_GROUP",
+                                "id": 457,
+                                "name": "УстановкаЦветаКолонки",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Выделить"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "USUAL_GROUP",
+                                      "id": 459,
+                                      "name": "УстановкаЦветаКолонка1",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Установка цвета колонка 1"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        {
+                                          "type": "USUAL_BUTTON",
+                                          "id": 172,
+                                          "name": "ОформитьОтрицательные",
+                                          "title": {
+                                            "content": [
+                                              {
+                                                "default": {
+                                                  "tag": 2
+                                                },
+                                                "int": 1,
+                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                  "langKey": "ru",
+                                                  "value": "Отрицательные красным"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "dataPath": "",
+                                          "items": []
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "USUAL_GROUP",
+                                      "id": 461,
+                                      "name": "УстановкаЦветаКолонка2",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Установка цвета колонка 2"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        {
+                                          "type": "USUAL_BUTTON",
+                                          "id": 174,
+                                          "name": "ОформитьПоложительные",
+                                          "title": {
+                                            "content": [
+                                              {
+                                                "default": {
+                                                  "tag": 2
+                                                },
+                                                "int": 1,
+                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                  "langKey": "ru",
+                                                  "value": "Положительные зеленым"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "dataPath": "",
+                                          "items": []
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  []
+                                ]
+                              },
+                              {
+                                "type": "USUAL_GROUP",
+                                "id": 496,
+                                "name": "Изменить",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Изменить"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "USUAL_GROUP",
+                                      "id": 303,
+                                      "name": "Переименование",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Переименование"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        [
+                                          {
+                                            "type": "INPUT_FIELD",
+                                            "id": 305,
+                                            "name": "ПредставлениеПоля",
+                                            "title": {
+                                              "content": [
+                                                {
+                                                  "default": {
+                                                    "tag": 2
+                                                  },
+                                                  "int": 1,
+                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                    "langKey": "ru",
+                                                    "value": "Имя поля"
+                                                  }
+                                                }
+                                              ]
+                                            },
+                                            "dataPath": "ПредставлениеПоля",
+                                            "items": []
+                                          },
+                                          {
+                                            "type": "USUAL_BUTTON",
+                                            "id": 393,
+                                            "name": "ПереименоватьПоле",
+                                            "title": {
+                                              "content": [
+                                                {
+                                                  "default": {
+                                                    "tag": 2
+                                                  },
+                                                  "int": 1,
+                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                    "langKey": "ru",
+                                                    "value": "Переименовать"
+                                                  }
+                                                }
+                                              ]
+                                            },
+                                            "dataPath": "",
+                                            "items": []
+                                          }
+                                        ],
+                                        []
+                                      ]
+                                    },
+                                    {
+                                      "type": "USUAL_BUTTON",
+                                      "id": 164,
+                                      "name": "СкрытьПоле",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Скрыть поле"
                                             }
                                           }
                                         ]
@@ -2617,11 +2993,36 @@
                             ],
                             []
                           ]
-                        },
+                        }
+                      ],
+                      []
+                    ]
+                  },
+                  {
+                    "type": "PAGE",
+                    "id": 486,
+                    "name": "Фильтры",
+                    "title": {
+                      "content": [
                         {
-                          "type": "PAGE",
-                          "id": 408,
-                          "name": "Ожидание",
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Фильтры"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 8,
+                          "name": "ФильтрПоУсловию",
                           "title": {
                             "content": [
                               {
@@ -2631,7 +3032,142 @@
                                 "int": 1,
                                 "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                                   "langKey": "ru",
-                                  "value": "Ожидание"
+                                  "value": "По условию"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "USUAL_GROUP",
+                                "id": 376,
+                                "name": "СвойстваФильтраПоУсловиюСлева",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Свойства фильтра по условию слева"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "CHECK_BOX_FIELD",
+                                      "id": 373,
+                                      "name": "Использование",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Использование"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "Использование",
+                                      "items": []
+                                    },
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 10,
+                                      "name": "ВидСравнения",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Вид сравнения"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "ВидСравнения",
+                                      "items": []
+                                    }
+                                  ],
+                                  []
+                                ]
+                              },
+                              {
+                                "type": "USUAL_GROUP",
+                                "id": 378,
+                                "name": "СвойстваФильтраПоУсловиюСправа",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Свойства фильтра по условию справа"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  {
+                                    "type": "INPUT_FIELD",
+                                    "id": 13,
+                                    "name": "ПравоеЗначение",
+                                    "title": {
+                                      "content": [
+                                        {
+                                          "default": {
+                                            "tag": 2
+                                          },
+                                          "int": 1,
+                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                            "langKey": "ru",
+                                            "value": "Правое значение"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    "dataPath": "ПравоеЗначение",
+                                    "items": []
+                                  }
+                                ]
+                              }
+                            ],
+                            []
+                          ]
+                        },
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 16,
+                          "name": "ФильтрПоЗначению",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "По значению"
                                 }
                               }
                             ]
@@ -2640,8 +3176,8 @@
                           "items": [
                             {
                               "type": "PAGES",
-                              "id": 423,
-                              "name": "СтатусыОжидания",
+                              "id": 404,
+                              "name": "ФильтрПоЗначениюСтраницы",
                               "title": {
                                 "content": [
                                   {
@@ -2651,7 +3187,7 @@
                                     "int": 1,
                                     "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                                       "langKey": "ru",
-                                      "value": "Статусы ожидания"
+                                      "value": "Фильтр по значению"
                                     }
                                   }
                                 ]
@@ -2661,8 +3197,8 @@
                                 [
                                   {
                                     "type": "PAGE",
-                                    "id": 421,
-                                    "name": "ОжиданиеЗаполнения",
+                                    "id": 406,
+                                    "name": "ЗначенияФильтра",
                                     "title": {
                                       "content": [
                                         {
@@ -2672,7 +3208,7 @@
                                           "int": 1,
                                           "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                                             "langKey": "ru",
-                                            "value": "Ожидание заполнения"
+                                            "value": "Значения"
                                           }
                                         }
                                       ]
@@ -2681,30 +3217,54 @@
                                     "items": [
                                       [
                                         {
-                                          "type": "PICTURE_DECORATION",
-                                          "id": 410,
-                                          "name": "ИндикаторДлительнойОперации",
+                                          "type": "TABLE",
+                                          "id": 18,
+                                          "name": "Значения",
                                           "title": {
-                                            "content": [
-                                              {
-                                                "default": {
-                                                  "tag": 2
-                                                },
-                                                "int": 1,
-                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                  "langKey": "ru",
-                                                  "value": "Индикатор длительной операции"
-                                                }
-                                              }
-                                            ]
+                                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                                           },
-                                          "dataPath": "",
-                                          "items": []
+                                          "dataPath": "Значения",
+                                          "items": [
+                                            [
+                                              {
+                                                "type": "CHECK_BOX_FIELD",
+                                                "id": 34,
+                                                "name": "ЗначенияПометка",
+                                                "title": {
+                                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                                },
+                                                "dataPath": "Значения.Check",
+                                                "items": []
+                                              },
+                                              {
+                                                "type": "INPUT_FIELD",
+                                                "id": 31,
+                                                "name": "ЗначенияЗначение",
+                                                "title": {
+                                                  "content": [
+                                                    {
+                                                      "default": {
+                                                        "tag": 2
+                                                      },
+                                                      "int": 1,
+                                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                        "langKey": "ru",
+                                                        "value": "Значение"
+                                                      }
+                                                    }
+                                                  ]
+                                                },
+                                                "dataPath": "Значения.Value",
+                                                "items": []
+                                              }
+                                            ],
+                                            []
+                                          ]
                                         },
                                         {
-                                          "type": "LABEL_DECORATION",
-                                          "id": 418,
-                                          "name": "ПредставлениеДлительнойОперации",
+                                          "type": "USUAL_GROUP",
+                                          "id": 435,
+                                          "name": "ОпцииЗаполненияФильтраПоЗначению",
                                           "title": {
                                             "content": [
                                               {
@@ -2714,13 +3274,48 @@
                                                 "int": 1,
                                                 "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                                                   "langKey": "ru",
-                                                  "value": "Выполняется чтение строк поля"
+                                                  "value": "Опции заполнения фильтра по значению"
                                                 }
                                               }
                                             ]
                                           },
                                           "dataPath": "",
-                                          "items": []
+                                          "items": [
+                                            [
+                                              {
+                                                "type": "LABEL_DECORATION",
+                                                "id": 415,
+                                                "name": "СтатистикаФильтраПоЗначению",
+                                                "title": {
+                                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                                },
+                                                "dataPath": "",
+                                                "items": []
+                                              },
+                                              {
+                                                "type": "LABEL_DECORATION",
+                                                "id": 437,
+                                                "name": "ВывестиВсеЗначенияРазделаОтчета",
+                                                "title": {
+                                                  "content": [
+                                                    {
+                                                      "default": {
+                                                        "tag": 2
+                                                      },
+                                                      "int": 1,
+                                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                        "langKey": "ru",
+                                                        "value": "Вывести все"
+                                                      }
+                                                    }
+                                                  ]
+                                                },
+                                                "dataPath": "",
+                                                "items": []
+                                              }
+                                            ],
+                                            []
+                                          ]
                                         }
                                       ],
                                       []
@@ -2728,8 +3323,8 @@
                                   },
                                   {
                                     "type": "PAGE",
-                                    "id": 425,
-                                    "name": "ОшибкаЗаполнения",
+                                    "id": 408,
+                                    "name": "Ожидание",
                                     "title": {
                                       "content": [
                                         {
@@ -2739,47 +3334,126 @@
                                           "int": 1,
                                           "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                                             "langKey": "ru",
-                                            "value": "Ошибка заполнения"
+                                            "value": "Ожидание"
                                           }
                                         }
                                       ]
                                     },
                                     "dataPath": "",
                                     "items": [
-                                      [
-                                        {
-                                          "type": "PICTURE_DECORATION",
-                                          "id": 430,
-                                          "name": "ИндикаторОшибки",
-                                          "title": {
-                                            "content": [
-                                              {
-                                                "default": {
-                                                  "tag": 2
-                                                },
-                                                "int": 1,
-                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                  "langKey": "ru",
-                                                  "value": "Индикатор ошибки"
-                                                }
+                                      {
+                                        "type": "PAGES",
+                                        "id": 423,
+                                        "name": "СтатусыОжидания",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Статусы ожидания"
                                               }
-                                            ]
-                                          },
-                                          "dataPath": "",
-                                          "items": []
+                                            }
+                                          ]
                                         },
-                                        {
-                                          "type": "LABEL_DECORATION",
-                                          "id": 427,
-                                          "name": "ОписаниеОшибкиЗаполнения",
-                                          "title": {
-                                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                          },
-                                          "dataPath": "",
-                                          "items": []
-                                        }
-                                      ],
-                                      []
+                                        "dataPath": "",
+                                        "items": [
+                                          [
+                                            {
+                                              "type": "PAGE",
+                                              "id": 421,
+                                              "name": "ОжиданиеЗаполнения",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Ожидание заполнения"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "",
+                                              "items": [
+                                                [
+                                                  {
+                                                    "type": "PICTURE_DECORATION",
+                                                    "id": 410,
+                                                    "name": "ИндикаторДлительнойОперации",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "Индикатор длительной операции"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": []
+                                                  },
+                                                  {
+                                                    "type": "LABEL_DECORATION",
+                                                    "id": 418,
+                                                    "name": "ПредставлениеДлительнойОперации",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "Выполняется чтение строк поля"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": []
+                                                  }
+                                                ],
+                                                []
+                                              ]
+                                            },
+                                            {
+                                              "type": "PAGE",
+                                              "id": 425,
+                                              "name": "ОшибкаЗаполнения",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Ошибка заполнения"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "",
+                                              "items": []
+                                            }
+                                          ],
+                                          []
+                                        ]
+                                      }
                                     ]
                                   }
                                 ],
@@ -2792,1245 +3466,10 @@
                       []
                     ]
                   }
-                ]
-              },
-              {
-                "type": "USUAL_GROUP",
-                "id": 8,
-                "name": "ФильтрПоУсловию",
-                "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Фильтр по условию"
-                      }
-                    }
-                  ]
-                },
-                "dataPath": "",
-                "items": [
-                  [
-                    {
-                      "type": "USUAL_GROUP",
-                      "id": 376,
-                      "name": "СвойстваФильтраПоУсловиюСлева",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Свойства фильтра по условию слева"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
-                        {
-                          "type": "CHECK_BOX_FIELD",
-                          "id": 373,
-                          "name": "Использование",
-                          "title": {
-                            "content": [
-                              {
-                                "default": {
-                                  "tag": 2
-                                },
-                                "int": 1,
-                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                  "langKey": "ru",
-                                  "value": "Использование"
-                                }
-                              }
-                            ]
-                          },
-                          "dataPath": "Использование",
-                          "items": []
-                        }
-                      ]
-                    },
-                    {
-                      "type": "USUAL_GROUP",
-                      "id": 378,
-                      "name": "СвойстваФильтраПоУсловиюСправа",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Свойства фильтра по условию справа"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "INPUT_FIELD",
-                            "id": 10,
-                            "name": "ВидСравнения",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Вид сравнения"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "ВидСравнения",
-                            "items": []
-                          },
-                          {
-                            "type": "INPUT_FIELD",
-                            "id": 13,
-                            "name": "ПравоеЗначение",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Правое значение"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "ПравоеЗначение",
-                            "items": []
-                          }
-                        ],
-                        []
-                      ]
-                    }
-                  ],
-                  []
-                ]
-              },
-              {
-                "type": "USUAL_GROUP",
-                "id": 299,
-                "name": "КоманднаяПанель",
-                "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
-                },
-                "dataPath": "",
-                "items": [
-                  [
-                    {
-                      "type": "USUAL_GROUP",
-                      "id": 212,
-                      "name": "ДополнительныеВозможности",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Еще"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "LABEL_DECORATION",
-                            "id": 294,
-                            "name": "ДополнительныеВозможностиОтступ",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "USUAL_GROUP",
-                            "id": 292,
-                            "name": "КомандыДополнительныхВозможностей",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Команды дополнительных возможностей"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": [
-                              [
-                                {
-                                  "type": "USUAL_BUTTON",
-                                  "id": 440,
-                                  "name": "СгруппироватьПоВыбранномуПолю",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Сгруппировать по полю"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": []
-                                },
-                                {
-                                  "type": "LABEL_DECORATION",
-                                  "id": 442,
-                                  "name": "СгруппироватьГраницаГруппы",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                  },
-                                  "dataPath": "",
-                                  "items": []
-                                },
-                                {
-                                  "type": "USUAL_GROUP",
-                                  "id": 196,
-                                  "name": "Поле",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Поле"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": [
-                                    [
-                                      {
-                                        "type": "USUAL_GROUP",
-                                        "id": 198,
-                                        "name": "Вставка",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Вставка"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "",
-                                        "items": [
-                                          [
-                                            {
-                                              "type": "USUAL_GROUP",
-                                              "id": 445,
-                                              "name": "ВставкаКолонки",
-                                              "title": {
-                                                "content": [
-                                                  {
-                                                    "default": {
-                                                      "tag": 2
-                                                    },
-                                                    "int": 1,
-                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                      "langKey": "ru",
-                                                      "value": "Вставка колонки"
-                                                    }
-                                                  }
-                                                ]
-                                              },
-                                              "dataPath": "",
-                                              "items": [
-                                                [
-                                                  {
-                                                    "type": "USUAL_GROUP",
-                                                    "id": 447,
-                                                    "name": "ВставкаКолонка1",
-                                                    "title": {
-                                                      "content": [
-                                                        {
-                                                          "default": {
-                                                            "tag": 2
-                                                          },
-                                                          "int": 1,
-                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                            "langKey": "ru",
-                                                            "value": "Вставка колонка 1"
-                                                          }
-                                                        }
-                                                      ]
-                                                    },
-                                                    "dataPath": "",
-                                                    "items": [
-                                                      [
-                                                        {
-                                                          "type": "USUAL_BUTTON",
-                                                          "id": 156,
-                                                          "name": "ВставитьПолеСлева",
-                                                          "title": {
-                                                            "content": [
-                                                              {
-                                                                "default": {
-                                                                  "tag": 2
-                                                                },
-                                                                "int": 1,
-                                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                                  "langKey": "ru",
-                                                                  "value": "Вставить поле слева"
-                                                                }
-                                                              }
-                                                            ]
-                                                          },
-                                                          "dataPath": "",
-                                                          "items": []
-                                                        },
-                                                        {
-                                                          "type": "USUAL_BUTTON",
-                                                          "id": 160,
-                                                          "name": "ВставитьГруппировкуВыше",
-                                                          "title": {
-                                                            "content": [
-                                                              {
-                                                                "default": {
-                                                                  "tag": 2
-                                                                },
-                                                                "int": 1,
-                                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                                  "langKey": "ru",
-                                                                  "value": "Вставить группировку выше"
-                                                                }
-                                                              }
-                                                            ]
-                                                          },
-                                                          "dataPath": "",
-                                                          "items": []
-                                                        }
-                                                      ],
-                                                      []
-                                                    ]
-                                                  },
-                                                  {
-                                                    "type": "USUAL_GROUP",
-                                                    "id": 449,
-                                                    "name": "ВставкаКолонка2",
-                                                    "title": {
-                                                      "content": [
-                                                        {
-                                                          "default": {
-                                                            "tag": 2
-                                                          },
-                                                          "int": 1,
-                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                            "langKey": "ru",
-                                                            "value": "Вставка колонка 2"
-                                                          }
-                                                        }
-                                                      ]
-                                                    },
-                                                    "dataPath": "",
-                                                    "items": [
-                                                      [
-                                                        {
-                                                          "type": "USUAL_BUTTON",
-                                                          "id": 158,
-                                                          "name": "ВставитьПолеСправа",
-                                                          "title": {
-                                                            "content": [
-                                                              {
-                                                                "default": {
-                                                                  "tag": 2
-                                                                },
-                                                                "int": 1,
-                                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                                  "langKey": "ru",
-                                                                  "value": "Вставить поле справа"
-                                                                }
-                                                              }
-                                                            ]
-                                                          },
-                                                          "dataPath": "",
-                                                          "items": []
-                                                        },
-                                                        {
-                                                          "type": "USUAL_BUTTON",
-                                                          "id": 162,
-                                                          "name": "ВставитьГруппировкуНиже",
-                                                          "title": {
-                                                            "content": [
-                                                              {
-                                                                "default": {
-                                                                  "tag": 2
-                                                                },
-                                                                "int": 1,
-                                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                                  "langKey": "ru",
-                                                                  "value": "Вставить группировку ниже"
-                                                                }
-                                                              }
-                                                            ]
-                                                          },
-                                                          "dataPath": "",
-                                                          "items": []
-                                                        }
-                                                      ],
-                                                      []
-                                                    ]
-                                                  }
-                                                ],
-                                                []
-                                              ]
-                                            },
-                                            {
-                                              "type": "LABEL_DECORATION",
-                                              "id": 356,
-                                              "name": "ВставкаГраницаГруппы",
-                                              "title": {
-                                                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                              },
-                                              "dataPath": "",
-                                              "items": []
-                                            }
-                                          ],
-                                          []
-                                        ]
-                                      },
-                                      {
-                                        "type": "USUAL_GROUP",
-                                        "id": 200,
-                                        "name": "Перемещение",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Перемещение"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "",
-                                        "items": [
-                                          [
-                                            {
-                                              "type": "USUAL_GROUP",
-                                              "id": 451,
-                                              "name": "ПеремещениеКолонки",
-                                              "title": {
-                                                "content": [
-                                                  {
-                                                    "default": {
-                                                      "tag": 2
-                                                    },
-                                                    "int": 1,
-                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                      "langKey": "ru",
-                                                      "value": "Перемещение колонки"
-                                                    }
-                                                  }
-                                                ]
-                                              },
-                                              "dataPath": "",
-                                              "items": [
-                                                [
-                                                  {
-                                                    "type": "USUAL_GROUP",
-                                                    "id": 453,
-                                                    "name": "ПеремещениеКолонка1",
-                                                    "title": {
-                                                      "content": [
-                                                        {
-                                                          "default": {
-                                                            "tag": 2
-                                                          },
-                                                          "int": 1,
-                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                            "langKey": "ru",
-                                                            "value": "Перемещение колонка 1"
-                                                          }
-                                                        }
-                                                      ]
-                                                    },
-                                                    "dataPath": "",
-                                                    "items": [
-                                                      [
-                                                        {
-                                                          "type": "USUAL_BUTTON",
-                                                          "id": 186,
-                                                          "name": "ПереместитьПолеВлево",
-                                                          "title": {
-                                                            "content": [
-                                                              {
-                                                                "default": {
-                                                                  "tag": 2
-                                                                },
-                                                                "int": 1,
-                                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                                  "langKey": "ru",
-                                                                  "value": "Переместить влево"
-                                                                }
-                                                              }
-                                                            ]
-                                                          },
-                                                          "dataPath": "",
-                                                          "items": []
-                                                        },
-                                                        {
-                                                          "type": "USUAL_BUTTON",
-                                                          "id": 190,
-                                                          "name": "ПереместитьПолеВыше",
-                                                          "title": {
-                                                            "content": [
-                                                              {
-                                                                "default": {
-                                                                  "tag": 2
-                                                                },
-                                                                "int": 1,
-                                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                                  "langKey": "ru",
-                                                                  "value": "Переместить выше"
-                                                                }
-                                                              }
-                                                            ]
-                                                          },
-                                                          "dataPath": "",
-                                                          "items": []
-                                                        }
-                                                      ],
-                                                      []
-                                                    ]
-                                                  },
-                                                  {
-                                                    "type": "USUAL_GROUP",
-                                                    "id": 455,
-                                                    "name": "ПеремещениеКолонка2",
-                                                    "title": {
-                                                      "content": [
-                                                        {
-                                                          "default": {
-                                                            "tag": 2
-                                                          },
-                                                          "int": 1,
-                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                            "langKey": "ru",
-                                                            "value": "Перемещение колонка 2"
-                                                          }
-                                                        }
-                                                      ]
-                                                    },
-                                                    "dataPath": "",
-                                                    "items": [
-                                                      [
-                                                        {
-                                                          "type": "USUAL_BUTTON",
-                                                          "id": 188,
-                                                          "name": "ПереместитьПолеВправо",
-                                                          "title": {
-                                                            "content": [
-                                                              {
-                                                                "default": {
-                                                                  "tag": 2
-                                                                },
-                                                                "int": 1,
-                                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                                  "langKey": "ru",
-                                                                  "value": "Переместить вправо"
-                                                                }
-                                                              }
-                                                            ]
-                                                          },
-                                                          "dataPath": "",
-                                                          "items": []
-                                                        },
-                                                        {
-                                                          "type": "USUAL_BUTTON",
-                                                          "id": 192,
-                                                          "name": "ПереместитьПолеНиже",
-                                                          "title": {
-                                                            "content": [
-                                                              {
-                                                                "default": {
-                                                                  "tag": 2
-                                                                },
-                                                                "int": 1,
-                                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                                  "langKey": "ru",
-                                                                  "value": "Переместить ниже"
-                                                                }
-                                                              }
-                                                            ]
-                                                          },
-                                                          "dataPath": "",
-                                                          "items": []
-                                                        }
-                                                      ],
-                                                      []
-                                                    ]
-                                                  }
-                                                ],
-                                                []
-                                              ]
-                                            },
-                                            {
-                                              "type": "LABEL_DECORATION",
-                                              "id": 359,
-                                              "name": "ПеремещениеГраницаГруппы",
-                                              "title": {
-                                                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                              },
-                                              "dataPath": "",
-                                              "items": []
-                                            }
-                                          ],
-                                          []
-                                        ]
-                                      },
-                                      {
-                                        "type": "USUAL_GROUP",
-                                        "id": 248,
-                                        "name": "СкрытиеПереименование",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Скрытие, переименование"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "",
-                                        "items": [
-                                          [
-                                            {
-                                              "type": "USUAL_BUTTON",
-                                              "id": 164,
-                                              "name": "СкрытьПоле",
-                                              "title": {
-                                                "content": [
-                                                  {
-                                                    "default": {
-                                                      "tag": 2
-                                                    },
-                                                    "int": 1,
-                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                      "langKey": "ru",
-                                                      "value": "Скрыть"
-                                                    }
-                                                  }
-                                                ]
-                                              },
-                                              "dataPath": "",
-                                              "items": []
-                                            },
-                                            {
-                                              "type": "USUAL_GROUP",
-                                              "id": 303,
-                                              "name": "Переименование",
-                                              "title": {
-                                                "content": [
-                                                  {
-                                                    "default": {
-                                                      "tag": 2
-                                                    },
-                                                    "int": 1,
-                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                      "langKey": "ru",
-                                                      "value": "Переименование"
-                                                    }
-                                                  }
-                                                ]
-                                              },
-                                              "dataPath": "",
-                                              "items": [
-                                                [
-                                                  {
-                                                    "type": "USUAL_BUTTON",
-                                                    "id": 166,
-                                                    "name": "ПереименоватьПоле",
-                                                    "title": {
-                                                      "content": [
-                                                        {
-                                                          "default": {
-                                                            "tag": 2
-                                                          },
-                                                          "int": 1,
-                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                            "langKey": "ru",
-                                                            "value": "Переименовать"
-                                                          }
-                                                        }
-                                                      ]
-                                                    },
-                                                    "dataPath": "",
-                                                    "items": []
-                                                  },
-                                                  {
-                                                    "type": "INPUT_FIELD",
-                                                    "id": 305,
-                                                    "name": "ПредставлениеПоля",
-                                                    "title": {
-                                                      "content": [
-                                                        {
-                                                          "default": {
-                                                            "tag": 2
-                                                          },
-                                                          "int": 1,
-                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                            "langKey": "ru",
-                                                            "value": "Представление поля"
-                                                          }
-                                                        }
-                                                      ]
-                                                    },
-                                                    "dataPath": "ПредставлениеПоля",
-                                                    "items": []
-                                                  },
-                                                  {
-                                                    "type": "USUAL_BUTTON",
-                                                    "id": 393,
-                                                    "name": "ПереименоватьПолеЕще",
-                                                    "title": {
-                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                                    },
-                                                    "dataPath": "",
-                                                    "items": []
-                                                  }
-                                                ],
-                                                []
-                                              ]
-                                            },
-                                            {
-                                              "type": "LABEL_DECORATION",
-                                              "id": 362,
-                                              "name": "СкрытиеПереименованиеГраницаГруппы",
-                                              "title": {
-                                                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                              },
-                                              "dataPath": "",
-                                              "items": []
-                                            }
-                                          ],
-                                          []
-                                        ]
-                                      }
-                                    ],
-                                    []
-                                  ]
-                                },
-                                {
-                                  "type": "USUAL_GROUP",
-                                  "id": 202,
-                                  "name": "Оформление",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Оформление"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": [
-                                    [
-                                      {
-                                        "type": "USUAL_GROUP",
-                                        "id": 204,
-                                        "name": "УстановкаЦвета",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Установка цвета"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "",
-                                        "items": [
-                                          [
-                                            {
-                                              "type": "USUAL_GROUP",
-                                              "id": 457,
-                                              "name": "УстановкаЦветаКолонки",
-                                              "title": {
-                                                "content": [
-                                                  {
-                                                    "default": {
-                                                      "tag": 2
-                                                    },
-                                                    "int": 1,
-                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                      "langKey": "ru",
-                                                      "value": "Установка цвета колонки"
-                                                    }
-                                                  }
-                                                ]
-                                              },
-                                              "dataPath": "",
-                                              "items": [
-                                                [
-                                                  {
-                                                    "type": "USUAL_GROUP",
-                                                    "id": 459,
-                                                    "name": "УстановкаЦветаКолонка1",
-                                                    "title": {
-                                                      "content": [
-                                                        {
-                                                          "default": {
-                                                            "tag": 2
-                                                          },
-                                                          "int": 1,
-                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                            "langKey": "ru",
-                                                            "value": "Установка цвета колонка 1"
-                                                          }
-                                                        }
-                                                      ]
-                                                    },
-                                                    "dataPath": "",
-                                                    "items": [
-                                                      {
-                                                        "type": "USUAL_BUTTON",
-                                                        "id": 172,
-                                                        "name": "ОформитьОтрицательные",
-                                                        "title": {
-                                                          "content": [
-                                                            {
-                                                              "default": {
-                                                                "tag": 2
-                                                              },
-                                                              "int": 1,
-                                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                                "langKey": "ru",
-                                                                "value": "Отрицательные красным"
-                                                              }
-                                                            }
-                                                          ]
-                                                        },
-                                                        "dataPath": "",
-                                                        "items": []
-                                                      }
-                                                    ]
-                                                  },
-                                                  {
-                                                    "type": "USUAL_GROUP",
-                                                    "id": 461,
-                                                    "name": "УстановкаЦветаКолонка2",
-                                                    "title": {
-                                                      "content": [
-                                                        {
-                                                          "default": {
-                                                            "tag": 2
-                                                          },
-                                                          "int": 1,
-                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                            "langKey": "ru",
-                                                            "value": "Установка цвета колонка 2"
-                                                          }
-                                                        }
-                                                      ]
-                                                    },
-                                                    "dataPath": "",
-                                                    "items": [
-                                                      {
-                                                        "type": "USUAL_BUTTON",
-                                                        "id": 174,
-                                                        "name": "ОформитьПоложительные",
-                                                        "title": {
-                                                          "content": [
-                                                            {
-                                                              "default": {
-                                                                "tag": 2
-                                                              },
-                                                              "int": 1,
-                                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                                "langKey": "ru",
-                                                                "value": "Положительные зеленым"
-                                                              }
-                                                            }
-                                                          ]
-                                                        },
-                                                        "dataPath": "",
-                                                        "items": []
-                                                      }
-                                                    ]
-                                                  }
-                                                ],
-                                                []
-                                              ]
-                                            },
-                                            {
-                                              "type": "LABEL_DECORATION",
-                                              "id": 365,
-                                              "name": "УстановкаЦветаГраницаГруппы",
-                                              "title": {
-                                                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                              },
-                                              "dataPath": "",
-                                              "items": []
-                                            }
-                                          ],
-                                          []
-                                        ]
-                                      },
-                                      {
-                                        "type": "USUAL_GROUP",
-                                        "id": 384,
-                                        "name": "ГруппаШиринаВысота",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Ширина высота"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "",
-                                        "items": [
-                                          [
-                                            {
-                                              "type": "USUAL_GROUP",
-                                              "id": 206,
-                                              "name": "УстановкаШириныВысоты",
-                                              "title": {
-                                                "content": [
-                                                  {
-                                                    "default": {
-                                                      "tag": 2
-                                                    },
-                                                    "int": 1,
-                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                      "langKey": "ru",
-                                                      "value": "Установка ширины, высоты"
-                                                    }
-                                                  }
-                                                ]
-                                              },
-                                              "dataPath": "",
-                                              "items": [
-                                                [
-                                                  {
-                                                    "type": "USUAL_GROUP",
-                                                    "id": 308,
-                                                    "name": "УстановкаВысотыСтроки",
-                                                    "title": {
-                                                      "content": [
-                                                        {
-                                                          "default": {
-                                                            "tag": 2
-                                                          },
-                                                          "int": 1,
-                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                            "langKey": "ru",
-                                                            "value": "Установка высоты строки"
-                                                          }
-                                                        }
-                                                      ]
-                                                    },
-                                                    "dataPath": "",
-                                                    "items": [
-                                                      [
-                                                        {
-                                                          "type": "USUAL_BUTTON",
-                                                          "id": 380,
-                                                          "name": "УстановитьВысотуСтроки",
-                                                          "title": {
-                                                            "content": [
-                                                              {
-                                                                "default": {
-                                                                  "tag": 2
-                                                                },
-                                                                "int": 1,
-                                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                                  "langKey": "ru",
-                                                                  "value": "Высота строки"
-                                                                }
-                                                              }
-                                                            ]
-                                                          },
-                                                          "dataPath": "",
-                                                          "items": []
-                                                        },
-                                                        {
-                                                          "type": "INPUT_FIELD",
-                                                          "id": 310,
-                                                          "name": "ВысотаСтроки",
-                                                          "title": {
-                                                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                                          },
-                                                          "dataPath": "ВысотаСтроки",
-                                                          "items": []
-                                                        },
-                                                        {
-                                                          "type": "USUAL_BUTTON",
-                                                          "id": 389,
-                                                          "name": "УстановитьВысотуСтрокиЕще",
-                                                          "title": {
-                                                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                                          },
-                                                          "dataPath": "",
-                                                          "items": []
-                                                        }
-                                                      ],
-                                                      []
-                                                    ]
-                                                  },
-                                                  {
-                                                    "type": "USUAL_GROUP",
-                                                    "id": 313,
-                                                    "name": "УстановкаШириныКолонки",
-                                                    "title": {
-                                                      "content": [
-                                                        {
-                                                          "default": {
-                                                            "tag": 2
-                                                          },
-                                                          "int": 1,
-                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                            "langKey": "ru",
-                                                            "value": "Установка ширины колонки"
-                                                          }
-                                                        }
-                                                      ]
-                                                    },
-                                                    "dataPath": "",
-                                                    "items": [
-                                                      [
-                                                        {
-                                                          "type": "USUAL_BUTTON",
-                                                          "id": 382,
-                                                          "name": "УстановитьШиринуКолонки",
-                                                          "title": {
-                                                            "content": [
-                                                              {
-                                                                "default": {
-                                                                  "tag": 2
-                                                                },
-                                                                "int": 1,
-                                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                                  "langKey": "ru",
-                                                                  "value": "Ширина колонки"
-                                                                }
-                                                              }
-                                                            ]
-                                                          },
-                                                          "dataPath": "",
-                                                          "items": []
-                                                        },
-                                                        {
-                                                          "type": "INPUT_FIELD",
-                                                          "id": 315,
-                                                          "name": "ШиринаКолонки",
-                                                          "title": {
-                                                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                                          },
-                                                          "dataPath": "ШиринаКолонки",
-                                                          "items": []
-                                                        },
-                                                        {
-                                                          "type": "USUAL_BUTTON",
-                                                          "id": 391,
-                                                          "name": "УстановитьШиринуКолонкиЕще",
-                                                          "title": {
-                                                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                                          },
-                                                          "dataPath": "",
-                                                          "items": []
-                                                        }
-                                                      ],
-                                                      []
-                                                    ]
-                                                  }
-                                                ],
-                                                []
-                                              ]
-                                            },
-                                            {
-                                              "type": "LABEL_DECORATION",
-                                              "id": 386,
-                                              "name": "Отступ",
-                                              "title": {
-                                                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                              },
-                                              "dataPath": "",
-                                              "items": []
-                                            }
-                                          ],
-                                          []
-                                        ]
-                                      },
-                                      {
-                                        "type": "LABEL_DECORATION",
-                                        "id": 368,
-                                        "name": "УстановкаШириныВысотыГраницаГруппы",
-                                        "title": {
-                                          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                        },
-                                        "dataPath": "",
-                                        "items": []
-                                      },
-                                      {
-                                        "type": "USUAL_BUTTON",
-                                        "id": 182,
-                                        "name": "ОформитьЕще",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Оформление..."
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "",
-                                        "items": []
-                                      }
-                                    ],
-                                    []
-                                  ]
-                                }
-                              ],
-                              []
-                            ]
-                          }
-                        ],
-                        []
-                      ]
-                    },
-                    {
-                      "type": "COMMAND_BAR",
-                      "id": 301,
-                      "name": "КомандыОсновные",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "COMMAND_BAR_BUTTON",
-                            "id": 318,
-                            "name": "ПрименитьИСформировать",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Применить и сформировать"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "COMMAND_BAR_BUTTON",
-                            "id": 320,
-                            "name": "Применить",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "COMMAND_BAR_BUTTON",
-                            "id": 284,
-                            "name": "Отмена",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                            },
-                            "dataPath": "",
-                            "items": []
-                          }
-                        ],
-                        []
-                      ]
-                    }
-                  ],
-                  []
-                ]
-              }
-            ],
-            []
+                ],
+                []
+              ]
+            }
           ],
           "attributes": [
             [
@@ -4038,7 +3477,7 @@
                 "id": 1,
                 "name": "ВидСравнения",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
@@ -4048,7 +3487,7 @@
                 "id": 2,
                 "name": "ПравоеЗначение",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
@@ -4058,7 +3497,7 @@
                 "id": 3,
                 "name": "Значения",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "types": [
@@ -4078,7 +3517,7 @@
                 "id": 4,
                 "name": "Использование",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
@@ -4098,7 +3537,18 @@
                 "id": 8,
                 "name": "ПредставлениеПоля",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Представление поля"
+                      }
+                    }
+                  ]
                 },
                 "type": {
                   "types": [
@@ -4130,7 +3580,7 @@
                 "id": 9,
                 "name": "ВысотаСтроки",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "types": [
@@ -4163,7 +3613,7 @@
                 "id": 10,
                 "name": "ШиринаКолонки",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[7]/type"
@@ -4432,62 +3882,6 @@
               },
               {
                 "type": "USUAL_GROUP",
-                "id": 19,
-                "name": "ГруппаДругихОтчетовНет",
-                "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Других отчетов нет"
-                      }
-                    }
-                  ]
-                },
-                "dataPath": "",
-                "items": [
-                  [
-                    {
-                      "type": "PICTURE_DECORATION",
-                      "id": 21,
-                      "name": "КартинкаДругихОтчетовНет",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Картинка других отчетов нет"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "LABEL_DECORATION",
-                      "id": 16,
-                      "name": "НадписьДругихОтчетовНет",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[8]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    }
-                  ],
-                  []
-                ]
-              },
-              {
-                "type": "USUAL_GROUP",
                 "id": 5,
                 "name": "ГруппаПодвал",
                 "title": {
@@ -4506,64 +3900,27 @@
                 },
                 "dataPath": "",
                 "items": [
-                  [
-                    {
-                      "type": "CHECK_BOX_FIELD",
-                      "id": 7,
-                      "name": "ЗакрыватьПослеВыбора",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Закрывать это окно после перехода к отчету"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "ЗакрыватьПослеВыбора",
-                      "items": []
-                    },
-                    {
-                      "type": "COMMAND_BAR",
-                      "id": 10,
-                      "name": "ГруппаКоманднаяПанель",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "COMMAND_BAR_BUTTON",
-                            "id": 12,
-                            "name": "Закрыть",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                            },
-                            "dataPath": "",
-                            "items": []
+                  {
+                    "type": "CHECK_BOX_FIELD",
+                    "id": 7,
+                    "name": "ЗакрыватьПослеВыбора",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
                           },
-                          {
-                            "type": "COMMAND_BAR_BUTTON",
-                            "id": 14,
-                            "name": "ФормаСправка",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                            },
-                            "dataPath": "",
-                            "items": []
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Закрывать это окно после перехода к отчету"
                           }
-                        ],
-                        []
+                        }
                       ]
-                    }
-                  ],
-                  []
+                    },
+                    "dataPath": "ЗакрыватьПослеВыбора",
+                    "items": []
+                  }
                 ]
               }
             ],
@@ -4749,7 +4106,7 @@
                 "id": 11,
                 "name": "ЗакрыватьПослеВыбора",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[8]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[8]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
@@ -4851,646 +4208,40 @@
             []
           ],
           "items": [
-            [
-              {
-                "type": "PAGES",
-                "id": 24,
-                "name": "Страницы",
-                "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Страницы"
-                      }
-                    }
-                  ]
-                },
-                "dataPath": "",
-                "items": [
-                  [
-                    {
-                      "type": "PAGE",
-                      "id": 25,
-                      "name": "Основное",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Основное"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "INPUT_FIELD",
-                            "id": 52,
-                            "name": "Наименование",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                            },
-                            "dataPath": "Объект.Description",
-                            "items": []
-                          },
-                          {
-                            "type": "INPUT_FIELD",
-                            "id": 252,
-                            "name": "Назначение",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                            },
-                            "dataPath": "Объект.Назначение",
-                            "items": []
-                          },
-                          {
-                            "type": "USUAL_GROUP",
-                            "id": 268,
-                            "name": "ГруппаДоступность",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Доступность"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": [
-                              [
-                                {
-                                  "type": "RADIO_BUTTON_FIELD",
-                                  "id": 98,
-                                  "name": "Доступен",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Доступен"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "Доступен",
-                                  "items": []
-                                },
-                                {
-                                  "type": "TABLE",
-                                  "id": 206,
-                                  "name": "ПользователиВарианта",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Показать в панелях отчетов пользователей (начальная настройка)"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "ПользователиВарианта",
-                                  "items": [
-                                    [
-                                      {
-                                        "type": "CHECK_BOX_FIELD",
-                                        "id": 236,
-                                        "name": "ПользователиВариантаПометка",
-                                        "title": {
-                                          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                        },
-                                        "dataPath": "ПользователиВарианта.Check",
-                                        "items": []
-                                      },
-                                      {
-                                        "type": "INPUT_FIELD",
-                                        "id": 219,
-                                        "name": "ПользователиВариантаЗначение",
-                                        "title": {
-                                          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                                        },
-                                        "dataPath": "ПользователиВарианта.Value",
-                                        "items": []
-                                      }
-                                    ],
-                                    []
-                                  ]
-                                },
-                                {
-                                  "type": "CHECK_BOX_FIELD",
-                                  "id": 247,
-                                  "name": "УведомитьПользователей",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Уведомить в чате об этом варианте отчета"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "УведомитьПользователей",
-                                  "items": []
-                                }
-                              ],
-                              []
-                            ]
-                          },
-                          {
-                            "type": "USUAL_GROUP",
-                            "id": 250,
-                            "name": "ГруппаОписание",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
-                            },
-                            "dataPath": "",
-                            "items": [
-                              {
-                                "type": "INPUT_FIELD",
-                                "id": 8,
-                                "name": "Описание",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                },
-                                "dataPath": "Объект.Описание",
-                                "items": []
-                              }
-                            ]
-                          },
-                          {
-                            "type": "USUAL_GROUP",
-                            "id": 190,
-                            "name": "Страница1Подвал",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Страница 1 подвал"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": [
-                              {
-                                "type": "PAGES",
-                                "id": 86,
-                                "name": "ЧтоБудетДальше",
-                                "title": {
-                                  "content": [
-                                    {
-                                      "default": {
-                                        "tag": 2
-                                      },
-                                      "int": 1,
-                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                        "langKey": "ru",
-                                        "value": "Что будет дальше"
-                                      }
-                                    }
-                                  ]
-                                },
-                                "dataPath": "",
-                                "items": [
-                                  [
-                                    {
-                                      "type": "PAGE",
-                                      "id": 88,
-                                      "name": "Новый",
-                                      "title": {
-                                        "content": [
-                                          {
-                                            "default": {
-                                              "tag": 2
-                                            },
-                                            "int": 1,
-                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                              "langKey": "ru",
-                                              "value": "Новый"
-                                            }
-                                          }
-                                        ]
-                                      },
-                                      "dataPath": "",
-                                      "items": [
-                                        {
-                                          "type": "LABEL_DECORATION",
-                                          "id": 187,
-                                          "name": "ДекорацияЧтоБудетДальшеНовый",
-                                          "title": {
-                                            "content": [
-                                              {
-                                                "default": {
-                                                  "tag": 2
-                                                },
-                                                "int": 1,
-                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                  "langKey": "ru",
-                                                  "value": "Будет сохранен новый вариант отчета.\nНажмите \"Далее\" для размещения варианта отчета в разделах приложения."
-                                                }
-                                              }
-                                            ]
-                                          },
-                                          "dataPath": "",
-                                          "items": []
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "PAGE",
-                                      "id": 87,
-                                      "name": "Перезапись",
-                                      "title": {
-                                        "content": [
-                                          {
-                                            "default": {
-                                              "tag": 2
-                                            },
-                                            "int": 1,
-                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                              "langKey": "ru",
-                                              "value": "Перезапись"
-                                            }
-                                          }
-                                        ]
-                                      },
-                                      "dataPath": "",
-                                      "items": [
-                                        {
-                                          "type": "LABEL_DECORATION",
-                                          "id": 184,
-                                          "name": "ДекорацияЧтоБудетДальшеПерезапись",
-                                          "title": {
-                                            "content": [
-                                              {
-                                                "default": {
-                                                  "tag": 2
-                                                },
-                                                "int": 1,
-                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                  "langKey": "ru",
-                                                  "value": "Будет перезаписан существующий вариант отчета.\nНажмите \"Далее\" для размещения варианта отчета в разделах приложения."
-                                                }
-                                              }
-                                            ]
-                                          },
-                                          "dataPath": "",
-                                          "items": []
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "PAGE",
-                                      "id": 201,
-                                      "name": "ПерезаписьНевозможна",
-                                      "title": {
-                                        "content": [
-                                          {
-                                            "default": {
-                                              "tag": 2
-                                            },
-                                            "int": 1,
-                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                              "langKey": "ru",
-                                              "value": "Перезапись невозможна"
-                                            }
-                                          }
-                                        ]
-                                      },
-                                      "dataPath": "",
-                                      "items": [
-                                        {
-                                          "type": "LABEL_DECORATION",
-                                          "id": 203,
-                                          "name": "ДекорацияЧтоБудетДальшеПерезаписьНевозможна",
-                                          "title": {
-                                            "content": [
-                                              {
-                                                "default": {
-                                                  "tag": 2
-                                                },
-                                                "int": 1,
-                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                  "langKey": "ru",
-                                                  "value": "Наименование занято другим вариантом отчета.\nВведите другое наименование или выберите вариант из списка."
-                                                }
-                                              }
-                                            ]
-                                          },
-                                          "dataPath": "",
-                                          "items": []
-                                        }
-                                      ]
-                                    }
-                                  ],
-                                  []
-                                ]
-                              }
-                            ]
-                          }
-                        ],
-                        []
-                      ]
-                    },
-                    {
-                      "type": "PAGE",
-                      "id": 26,
-                      "name": "Дополнительно",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Дополнительно"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "USUAL_GROUP",
-                            "id": 261,
-                            "name": "ГруппаШапка",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Шапка"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": [
-                              [
-                                {
-                                  "type": "CHECK_BOX_FIELD",
-                                  "id": 225,
-                                  "name": "СброситьНастройки",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Сбросить настройки"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "СброситьНастройки",
-                                  "items": []
-                                },
-                                {
-                                  "type": "COMMAND_BAR",
-                                  "id": 263,
-                                  "name": "КоманднаяПанельДеревоПодсистем",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Командная панель дерево подсистем"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": [
-                                    {
-                                      "type": "SEARCH_STRING_ADDITION",
-                                      "id": 265,
-                                      "name": "СтрокаПоискаДеревоПодсистем",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                      },
-                                      "dataPath": "",
-                                      "items": []
-                                    }
-                                  ]
-                                }
-                              ],
-                              []
-                            ]
-                          },
-                          {
-                            "type": "TABLE",
-                            "id": 74,
-                            "name": "ДеревоПодсистем",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Дерево подсистем"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "ДеревоПодсистем",
-                            "items": [
-                              [
-                                {
-                                  "type": "COLUMN_GROUP",
-                                  "id": 77,
-                                  "name": "ГруппаКолонок",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Колонок"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": [
-                                    [
-                                      {
-                                        "type": "CHECK_BOX_FIELD",
-                                        "id": 78,
-                                        "name": "ДеревоПодсистемИспользование",
-                                        "title": {
-                                          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                        },
-                                        "dataPath": "ДеревоПодсистем.Использование",
-                                        "items": []
-                                      },
-                                      {
-                                        "type": "INPUT_FIELD",
-                                        "id": 80,
-                                        "name": "ДеревоПодсистемПредставление",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Раздел, Группа"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "ДеревоПодсистем.Представление",
-                                        "items": []
-                                      }
-                                    ],
-                                    []
-                                  ]
-                                },
-                                {
-                                  "type": "INPUT_FIELD",
-                                  "id": 82,
-                                  "name": "ДеревоПодсистемВажность",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Важность"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "ДеревоПодсистем.Важность",
-                                  "items": []
-                                },
-                                {
-                                  "type": "LABEL_FIELD",
-                                  "id": 137,
-                                  "name": "ДеревоПодсистемПользователиПредставление",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Видимость по умолчанию"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "ДеревоПодсистем.ПользователиПредставление",
-                                  "items": []
-                                }
-                              ],
-                              []
-                            ]
-                          }
-                        ],
-                        []
-                      ]
-                    }
-                  ],
-                  []
-                ]
+            {
+              "type": "PAGES",
+              "id": 24,
+              "name": "Страницы",
+              "title": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
               },
-              {
-                "type": "USUAL_GROUP",
-                "id": 145,
-                "name": "ГруппаКоманднаяПанель",
-                "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
-                },
-                "dataPath": "",
-                "items": [
-                  [
-                    {
-                      "type": "COMMAND_BAR",
-                      "id": 147,
-                      "name": "ГруппаКоманднаяПанельЛевая",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Командная панель левая"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
+              "dataPath": "",
+              "items": [
+                [
+                  {
+                    "type": "PAGE",
+                    "id": 25,
+                    "name": "Основное",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
                         {
-                          "type": "COMMAND_BAR_BUTTON",
-                          "id": 23,
-                          "name": "Назад",
+                          "type": "INPUT_FIELD",
+                          "id": 52,
+                          "name": "Наименование",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                          },
+                          "dataPath": "Объект.Description",
+                          "items": []
+                        },
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 294,
+                          "name": "ГруппаДоступенНазначение",
                           "title": {
                             "content": [
                               {
@@ -5500,120 +4251,571 @@
                                 "int": 1,
                                 "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                                   "langKey": "ru",
-                                  "value": "<  Назад"
+                                  "value": "Доступен назначение"
                                 }
                               }
                             ]
                           },
                           "dataPath": "",
-                          "items": []
+                          "items": [
+                            [
+                              {
+                                "type": "RADIO_BUTTON_FIELD",
+                                "id": 98,
+                                "name": "Доступен",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Доступен"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "Доступен",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 252,
+                                "name": "Назначение",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                },
+                                "dataPath": "Объект.Назначение",
+                                "items": []
+                              }
+                            ],
+                            []
+                          ]
+                        },
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 268,
+                          "name": "ГруппаДоступность",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Доступность"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "TABLE",
+                                "id": 206,
+                                "name": "ПользователиВарианта",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Показать в панелях отчетов пользователей (начальная настройка)"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "ПользователиВарианта",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "CHECK_BOX_FIELD",
+                                      "id": 236,
+                                      "name": "ПользователиВариантаПометка",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                      },
+                                      "dataPath": "ПользователиВарианта.Check",
+                                      "items": []
+                                    },
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 219,
+                                      "name": "ПользователиВариантаЗначение",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                      },
+                                      "dataPath": "ПользователиВарианта.Value",
+                                      "items": []
+                                    }
+                                  ],
+                                  []
+                                ]
+                              },
+                              {
+                                "type": "CHECK_BOX_FIELD",
+                                "id": 247,
+                                "name": "УведомитьПользователей",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Уведомить в чате об этом варианте отчета"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "УведомитьПользователей",
+                                "items": []
+                              }
+                            ],
+                            []
+                          ]
+                        },
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 250,
+                          "name": "ГруппаОписание",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                          },
+                          "dataPath": "",
+                          "items": [
+                            {
+                              "type": "INPUT_FIELD",
+                              "id": 8,
+                              "name": "Описание",
+                              "title": {
+                                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                              },
+                              "dataPath": "Объект.Описание",
+                              "items": []
+                            }
+                          ]
+                        },
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 190,
+                          "name": "Страница1Подвал",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Страница 1 подвал"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            {
+                              "type": "PAGES",
+                              "id": 86,
+                              "name": "ЧтоБудетДальше",
+                              "title": {
+                                "content": [
+                                  {
+                                    "default": {
+                                      "tag": 2
+                                    },
+                                    "int": 1,
+                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                      "langKey": "ru",
+                                      "value": "Что будет дальше"
+                                    }
+                                  }
+                                ]
+                              },
+                              "dataPath": "",
+                              "items": [
+                                [
+                                  {
+                                    "type": "PAGE",
+                                    "id": 88,
+                                    "name": "Новый",
+                                    "title": {
+                                      "content": [
+                                        {
+                                          "default": {
+                                            "tag": 2
+                                          },
+                                          "int": 1,
+                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                            "langKey": "ru",
+                                            "value": "Новый"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    "dataPath": "",
+                                    "items": [
+                                      {
+                                        "type": "LABEL_DECORATION",
+                                        "id": 187,
+                                        "name": "ДекорацияЧтоБудетДальшеНовый",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Будет сохранен новый вариант отчета.\nНажмите \"Далее\" для размещения варианта отчета в разделах приложения."
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PAGE",
+                                    "id": 87,
+                                    "name": "Перезапись",
+                                    "title": {
+                                      "content": [
+                                        {
+                                          "default": {
+                                            "tag": 2
+                                          },
+                                          "int": 1,
+                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                            "langKey": "ru",
+                                            "value": "Перезапись"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    "dataPath": "",
+                                    "items": [
+                                      {
+                                        "type": "LABEL_DECORATION",
+                                        "id": 184,
+                                        "name": "ДекорацияЧтоБудетДальшеПерезапись",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Будет перезаписан существующий вариант отчета.\nНажмите \"Далее\" для размещения варианта отчета в разделах приложения."
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PAGE",
+                                    "id": 201,
+                                    "name": "ПерезаписьНевозможна",
+                                    "title": {
+                                      "content": [
+                                        {
+                                          "default": {
+                                            "tag": 2
+                                          },
+                                          "int": 1,
+                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                            "langKey": "ru",
+                                            "value": "Перезапись невозможна"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    "dataPath": "",
+                                    "items": [
+                                      {
+                                        "type": "LABEL_DECORATION",
+                                        "id": 203,
+                                        "name": "ДекорацияЧтоБудетДальшеПерезаписьНевозможна",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Наименование занято другим вариантом отчета.\nВведите другое наименование или выберите вариант из списка."
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      }
+                                    ]
+                                  }
+                                ],
+                                []
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      []
+                    ]
+                  },
+                  {
+                    "type": "PAGE",
+                    "id": 26,
+                    "name": "Дополнительно",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Дополнительно"
+                          }
                         }
                       ]
                     },
-                    {
-                      "type": "COMMAND_BAR",
-                      "id": 149,
-                      "name": "ГруппаКоманднаяПанельПравая",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Командная панель правая"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "COMMAND_BAR_BUTTON",
-                            "id": 15,
-                            "name": "Далее",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Далее  >"
-                                  }
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 261,
+                          "name": "ГруппаШапка",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Шапка"
                                 }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": []
+                              }
+                            ]
                           },
-                          {
-                            "type": "COMMAND_BAR_BUTTON",
-                            "id": 55,
-                            "name": "Сохранить",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Сохранить"
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "CHECK_BOX_FIELD",
+                                "id": 225,
+                                "name": "СброситьНастройки",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Сбросить настройки"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "СброситьНастройки",
+                                "items": []
+                              },
+                              {
+                                "type": "COMMAND_BAR",
+                                "id": 263,
+                                "name": "КоманднаяПанельДеревоПодсистем",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Командная панель дерево подсистем"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  {
+                                    "type": "SEARCH_STRING_ADDITION",
+                                    "id": 265,
+                                    "name": "СтрокаПоискаДеревоПодсистем",
+                                    "title": {
+                                      "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                    },
+                                    "dataPath": "",
+                                    "items": []
                                   }
+                                ]
+                              }
+                            ],
+                            []
+                          ]
+                        },
+                        {
+                          "type": "TABLE",
+                          "id": 74,
+                          "name": "ДеревоПодсистем",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Дерево подсистем"
                                 }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": []
+                              }
+                            ]
                           },
-                          {
-                            "type": "COMMAND_BAR_BUTTON",
-                            "id": 16,
-                            "name": "Отмена",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "BUTTON_GROUP",
-                            "id": 151,
-                            "name": "ГруппаКоманднаяПанельСправка",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Командная панель справка"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": []
-                          }
-                        ],
-                        []
-                      ]
-                    }
-                  ],
-                  []
-                ]
-              }
-            ],
-            []
+                          "dataPath": "ДеревоПодсистем",
+                          "items": [
+                            [
+                              {
+                                "type": "COLUMN_GROUP",
+                                "id": 77,
+                                "name": "ГруппаКолонок",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Колонок"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "CHECK_BOX_FIELD",
+                                      "id": 78,
+                                      "name": "ДеревоПодсистемИспользование",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                      },
+                                      "dataPath": "ДеревоПодсистем.Использование",
+                                      "items": []
+                                    },
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 80,
+                                      "name": "ДеревоПодсистемПредставление",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Раздел, Группа"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "ДеревоПодсистем.Представление",
+                                      "items": []
+                                    }
+                                  ],
+                                  []
+                                ]
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 82,
+                                "name": "ДеревоПодсистемВажность",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Важность"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "ДеревоПодсистем.Важность",
+                                "items": []
+                              },
+                              {
+                                "type": "LABEL_FIELD",
+                                "id": 137,
+                                "name": "ДеревоПодсистемПользователиПредставление",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Видимость по умолчанию"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "ДеревоПодсистем.ПользователиПредставление",
+                                "items": []
+                              }
+                            ],
+                            []
+                          ]
+                        }
+                      ],
+                      []
+                    ]
+                  }
+                ],
+                []
+              ]
+            }
           ],
           "attributes": [
             [
@@ -5681,7 +4883,7 @@
                 "id": 15,
                 "name": "Доступен",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[9]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[9]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
@@ -5722,7 +4924,7 @@
                 "id": 20,
                 "name": "СброситьНастройки",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[9]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[9]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
@@ -5850,7 +5052,7 @@
                 "id": 10,
                 "name": "УведомитьПользователей",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[9]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[9]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
@@ -5989,9 +5191,9 @@
                           "items": []
                         },
                         {
-                          "type": "USUAL_GROUP",
-                          "id": 80,
-                          "name": "ГруппаПерсональныеНастройки",
+                          "type": "TABLE",
+                          "id": 4,
+                          "name": "ПерсональныеНастройки",
                           "title": {
                             "content": [
                               {
@@ -6005,108 +5207,6 @@
                                 }
                               }
                             ]
-                          },
-                          "dataPath": "",
-                          "items": [
-                            [
-                              {
-                                "type": "LABEL_DECORATION",
-                                "id": 77,
-                                "name": "ПерсональныеНастройкиНадпись",
-                                "title": {
-                                  "content": [
-                                    {
-                                      "default": {
-                                        "tag": 2
-                                      },
-                                      "int": 1,
-                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                        "langKey": "ru",
-                                        "value": "Персональные настройки:"
-                                      }
-                                    }
-                                  ]
-                                },
-                                "dataPath": "",
-                                "items": []
-                              },
-                              {
-                                "type": "COMMAND_BAR",
-                                "id": 82,
-                                "name": "КоманднаяПанельПерсональныеНастройки",
-                                "title": {
-                                  "content": [
-                                    {
-                                      "default": {
-                                        "tag": 2
-                                      },
-                                      "int": 1,
-                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                        "langKey": "ru",
-                                        "value": "Командная панель персональные настройки"
-                                      }
-                                    }
-                                  ]
-                                },
-                                "dataPath": "",
-                                "items": [
-                                  {
-                                    "type": "BUTTON_GROUP",
-                                    "id": 75,
-                                    "name": "ПользовательскиеНастройкиГруппаИзменитьФлажки",
-                                    "title": {
-                                      "content": [
-                                        {
-                                          "default": {
-                                            "tag": 2
-                                          },
-                                          "int": 1,
-                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                            "langKey": "ru",
-                                            "value": "Изменить флажки"
-                                          }
-                                        }
-                                      ]
-                                    },
-                                    "dataPath": "",
-                                    "items": [
-                                      [
-                                        {
-                                          "type": "COMMAND_BAR_BUTTON",
-                                          "id": 23,
-                                          "name": "ПользовательскиеНастройкиУстановитьФлажки",
-                                          "title": {
-                                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                          },
-                                          "dataPath": "",
-                                          "items": []
-                                        },
-                                        {
-                                          "type": "COMMAND_BAR_BUTTON",
-                                          "id": 25,
-                                          "name": "ПользовательскиеНастройкиСнятьФлажки",
-                                          "title": {
-                                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                          },
-                                          "dataPath": "",
-                                          "items": []
-                                        }
-                                      ],
-                                      []
-                                    ]
-                                  }
-                                ]
-                              }
-                            ],
-                            []
-                          ]
-                        },
-                        {
-                          "type": "TABLE",
-                          "id": 4,
-                          "name": "ПерсональныеНастройки",
-                          "title": {
-                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[10]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                           },
                           "dataPath": "ПерсональныеНастройки",
                           "items": [
@@ -6126,7 +5226,7 @@
                                 "id": 17,
                                 "name": "ПользовательскиеНастройкиЗначение",
                                 "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                                 },
                                 "dataPath": "ПерсональныеНастройки.Value",
                                 "items": []
@@ -6392,109 +5492,51 @@
             }
           ],
           "items": [
-            [
-              {
-                "type": "TABLE",
-                "id": 28,
-                "name": "Отборы",
-                "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Фильтры"
-                      }
-                    }
-                  ]
-                },
-                "dataPath": "Отборы",
-                "items": [
-                  [
-                    {
-                      "type": "INPUT_FIELD",
-                      "id": 41,
-                      "name": "ОтборыПредставлениеПользовательскойНастройки",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
-                      },
-                      "dataPath": "Отборы.ПредставлениеПользовательскойНастройки",
-                      "items": []
-                    },
-                    {
-                      "type": "INPUT_FIELD",
-                      "id": 44,
-                      "name": "ОтборыВидСравнения",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                      },
-                      "dataPath": "Отборы.ВидСравнения",
-                      "items": []
-                    }
-                  ],
-                  []
-                ]
+            {
+              "type": "TABLE",
+              "id": 28,
+              "name": "Отборы",
+              "title": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
               },
-              {
-                "type": "COMMAND_BAR",
-                "id": 47,
-                "name": "ГруппаКоманднаяПанель",
-                "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
-                },
-                "dataPath": "",
-                "items": [
-                  [
-                    {
-                      "type": "COMMAND_BAR_BUTTON",
-                      "id": 26,
-                      "name": "ФормаВыбрать",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "ОК"
-                            }
+              "dataPath": "Отборы",
+              "items": [
+                [
+                  {
+                    "type": "INPUT_FIELD",
+                    "id": 41,
+                    "name": "ОтборыПредставлениеПользовательскойНастройки",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Поле"
                           }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": []
+                        }
+                      ]
                     },
-                    {
-                      "type": "COMMAND_BAR_BUTTON",
-                      "id": 49,
-                      "name": "Отмена",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                      },
-                      "dataPath": "",
-                      "items": []
+                    "dataPath": "Отборы.ПредставлениеПользовательскойНастройки",
+                    "items": []
+                  },
+                  {
+                    "type": "INPUT_FIELD",
+                    "id": 44,
+                    "name": "ОтборыВидСравнения",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                     },
-                    {
-                      "type": "COMMAND_BAR_BUTTON",
-                      "id": 51,
-                      "name": "Справка",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    }
-                  ],
-                  []
-                ]
-              }
-            ],
-            []
+                    "dataPath": "Отборы.ВидСравнения",
+                    "items": []
+                  }
+                ],
+                []
+              ]
+            }
           ],
           "attributes": [
             [
@@ -6562,7 +5604,7 @@
                 "id": 8,
                 "name": "Отборы",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[11]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
@@ -6787,7 +5829,18 @@
                 "id": 30,
                 "name": "Дополнительно",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Еще"
+                      }
+                    }
+                  ]
                 },
                 "dataPath": "",
                 "items": [
@@ -6949,74 +6002,6 @@
                   ],
                   []
                 ]
-              },
-              {
-                "type": "USUAL_GROUP",
-                "id": 68,
-                "name": "КоманднаяПанель",
-                "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
-                },
-                "dataPath": "",
-                "items": [
-                  [
-                    {
-                      "type": "HYPERLINK",
-                      "id": 72,
-                      "name": "ПерейтиКРасширеннымНастройкам",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "COMMAND_BAR",
-                      "id": 70,
-                      "name": "КомандыОсновные",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "COMMAND_BAR_BUTTON",
-                            "id": 56,
-                            "name": "ПрименитьИСформировать",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "COMMAND_BAR_BUTTON",
-                            "id": 54,
-                            "name": "Применить",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "COMMAND_BAR_BUTTON",
-                            "id": 52,
-                            "name": "Отмена",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                            },
-                            "dataPath": "",
-                            "items": []
-                          }
-                        ],
-                        []
-                      ]
-                    }
-                  ],
-                  []
-                ]
               }
             ],
             []
@@ -7098,15 +6083,9 @@
                       },
                       "int": 1,
                       "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
-                        "length": 50,
+                        "length": 20,
                         "allowedLength": 0,
-                        "description": {
-                          "value": {
-                            "@class": "com.github._1c_syntax.bsl.types.MultiName",
-                            "nameRu": "КвалификаторыСтроки (50, Переменная)",
-                            "nameEn": "StringQualifiers (50, Variable)"
-                          }
-                        }
+                        "description": {}
                       }
                     }
                   ]
@@ -7315,105 +6294,189 @@
             }
           ],
           "items": [
-            [
-              {
-                "type": "USUAL_GROUP",
-                "id": 337,
-                "name": "ГруппаОформляемыеПоля",
-                "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Оформляемые поля"
-                      }
-                    }
-                  ]
-                },
-                "dataPath": "",
-                "items": [
-                  [
-                    {
-                      "type": "USUAL_GROUP",
-                      "id": 354,
-                      "name": "ГруппаОформляемыеПоляВариантыВыбора",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Варианты выбора"
+            {
+              "type": "PAGES",
+              "id": 412,
+              "name": "Страницы",
+              "title": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+              },
+              "dataPath": "",
+              "items": [
+                [
+                  {
+                    "type": "PAGE",
+                    "id": 419,
+                    "name": "ГруппаОсновное",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                    },
+                    "dataPath": "",
+                    "items": [
+                      {
+                        "type": "USUAL_GROUP",
+                        "id": 447,
+                        "name": "ГруппаОсновноеКолонки",
+                        "title": {
+                          "content": [
+                            {
+                              "default": {
+                                "tag": 2
+                              },
+                              "int": 1,
+                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                "langKey": "ru",
+                                "value": "Основное колонки"
+                              }
                             }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "CHECK_BOX_FIELD",
-                            "id": 372,
-                            "name": "Использование",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Используется для"
+                          ]
+                        },
+                        "dataPath": "",
+                        "items": [
+                          [
+                            {
+                              "type": "USUAL_GROUP",
+                              "id": 443,
+                              "name": "ГруппаОсновноеЛеваяКолонка",
+                              "title": {
+                                "content": [
+                                  {
+                                    "default": {
+                                      "tag": 2
+                                    },
+                                    "int": 1,
+                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                      "langKey": "ru",
+                                      "value": "Основное левая колонка"
+                                    }
                                   }
-                                }
+                                ]
+                              },
+                              "dataPath": "",
+                              "items": [
+                                [
+                                  {
+                                    "type": "CHECK_BOX_FIELD",
+                                    "id": 372,
+                                    "name": "Использование",
+                                    "title": {
+                                      "content": [
+                                        {
+                                          "default": {
+                                            "tag": 2
+                                          },
+                                          "int": 1,
+                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                            "langKey": "ru",
+                                            "value": "Используется"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    "dataPath": "Использование",
+                                    "items": []
+                                  },
+                                  {
+                                    "type": "INPUT_FIELD",
+                                    "id": 93,
+                                    "name": "Наименование",
+                                    "title": {
+                                      "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                    },
+                                    "dataPath": "Наименование",
+                                    "items": []
+                                  },
+                                  {
+                                    "type": "INPUT_FIELD",
+                                    "id": 436,
+                                    "name": "РежимОтображения",
+                                    "title": {
+                                      "content": [
+                                        {
+                                          "default": {
+                                            "tag": 2
+                                          },
+                                          "int": 1,
+                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                            "langKey": "ru",
+                                            "value": "Режим отображения"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    "dataPath": "РежимОтображения",
+                                    "items": []
+                                  },
+                                  {
+                                    "type": "RADIO_BUTTON_FIELD",
+                                    "id": 356,
+                                    "name": "ВариантВыбораОформляемыхПолей",
+                                    "title": {
+                                      "content": [
+                                        {
+                                          "default": {
+                                            "tag": 2
+                                          },
+                                          "int": 1,
+                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                            "langKey": "ru",
+                                            "value": "Оформлять"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    "dataPath": "ВариантВыбораОформляемыхПолей",
+                                    "items": []
+                                  },
+                                  {
+                                    "type": "INPUT_FIELD",
+                                    "id": 359,
+                                    "name": "ОформляемоеПоле",
+                                    "title": {
+                                      "content": [
+                                        {
+                                          "default": {
+                                            "tag": 2
+                                          },
+                                          "int": 1,
+                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                            "langKey": "ru",
+                                            "value": "Оформляемое поле"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    "dataPath": "ОформляемоеПоле",
+                                    "items": []
+                                  }
+                                ],
+                                []
                               ]
                             },
-                            "dataPath": "Использование",
-                            "items": []
-                          },
-                          {
-                            "type": "RADIO_BUTTON_FIELD",
-                            "id": 356,
-                            "name": "ВариантВыбораОформляемыхПолей",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Вариант выбора оформляемых полей"
+                            {
+                              "type": "USUAL_GROUP",
+                              "id": 445,
+                              "name": "ГруппаОсновноеПраваяКолонка",
+                              "title": {
+                                "content": [
+                                  {
+                                    "default": {
+                                      "tag": 2
+                                    },
+                                    "int": 1,
+                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                      "langKey": "ru",
+                                      "value": "Основное правая колонка"
+                                    }
                                   }
-                                }
-                              ]
-                            },
-                            "dataPath": "ВариантВыбораОформляемыхПолей",
-                            "items": []
-                          },
-                          {
-                            "type": "PAGES",
-                            "id": 362,
-                            "name": "ОформляемыеПоляСтраницы",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                            },
-                            "dataPath": "",
-                            "items": [
-                              [
+                                ]
+                              },
+                              "dataPath": "",
+                              "items": [
                                 {
-                                  "type": "PAGE",
-                                  "id": 364,
-                                  "name": "СтраницаОформляемоеПоле",
+                                  "type": "TABLE",
+                                  "id": 30,
+                                  "name": "ОформляемыеПоля",
                                   "title": {
                                     "content": [
                                       {
@@ -7423,132 +6486,42 @@
                                         "int": 1,
                                         "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                                           "langKey": "ru",
-                                          "value": "Оформляемое поле"
+                                          "value": "Оформляемые поля"
                                         }
                                       }
                                     ]
                                   },
-                                  "dataPath": "",
+                                  "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Fields",
                                   "items": [
                                     {
-                                      "type": "INPUT_FIELD",
-                                      "id": 359,
-                                      "name": "ОформляемоеПоле",
+                                      "type": "COLUMN_GROUP",
+                                      "id": 206,
+                                      "name": "ОформляемыеПоляГруппаКолонокПоле",
                                       "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                      },
-                                      "dataPath": "ОформляемоеПоле",
-                                      "items": []
-                                    }
-                                  ]
-                                },
-                                {
-                                  "type": "PAGE",
-                                  "id": 366,
-                                  "name": "СтраницаКоманднаяПанель",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
-                                  },
-                                  "dataPath": "",
-                                  "items": [
-                                    {
-                                      "type": "COMMAND_BAR",
-                                      "id": 368,
-                                      "name": "ОформляемыеПоляКомандыОсновные",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[11]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                                       },
                                       "dataPath": "",
                                       "items": [
                                         [
                                           {
-                                            "type": "COMMAND_BAR_BUTTON",
-                                            "id": 265,
-                                            "name": "ОформляемыеПоляДобавить",
+                                            "type": "CHECK_BOX_FIELD",
+                                            "id": 203,
+                                            "name": "ОформляемыеПоляИспользование",
                                             "title": {
                                               "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
                                             },
-                                            "dataPath": "",
+                                            "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Fields.Use",
                                             "items": []
                                           },
                                           {
-                                            "type": "BUTTON_GROUP",
-                                            "id": 257,
-                                            "name": "ОформляемыеПоляГруппаИзменитьФлажки",
+                                            "type": "INPUT_FIELD",
+                                            "id": 211,
+                                            "name": "ОформляемыеПоляПоле",
                                             "title": {
-                                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[10]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
                                             },
-                                            "dataPath": "",
-                                            "items": [
-                                              [
-                                                {
-                                                  "type": "COMMAND_BAR_BUTTON",
-                                                  "id": 259,
-                                                  "name": "ОформляемыеПоляУстановитьФлажки",
-                                                  "title": {
-                                                    "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                                  },
-                                                  "dataPath": "",
-                                                  "items": []
-                                                },
-                                                {
-                                                  "type": "COMMAND_BAR_BUTTON",
-                                                  "id": 261,
-                                                  "name": "ОформляемыеПоляСнятьФлажки",
-                                                  "title": {
-                                                    "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                                  },
-                                                  "dataPath": "",
-                                                  "items": []
-                                                }
-                                              ],
-                                              []
-                                            ]
-                                          },
-                                          {
-                                            "type": "BUTTON_GROUP",
-                                            "id": 275,
-                                            "name": "ОформляемыеПоляГруппаПереместить",
-                                            "title": {
-                                              "content": [
-                                                {
-                                                  "default": {
-                                                    "tag": 2
-                                                  },
-                                                  "int": 1,
-                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                    "langKey": "ru",
-                                                    "value": "Переместить"
-                                                  }
-                                                }
-                                              ]
-                                            },
-                                            "dataPath": "",
-                                            "items": [
-                                              [
-                                                {
-                                                  "type": "COMMAND_BAR_BUTTON",
-                                                  "id": 277,
-                                                  "name": "ОформляемыеПоляПереместитьВверх",
-                                                  "title": {
-                                                    "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                                  },
-                                                  "dataPath": "",
-                                                  "items": []
-                                                },
-                                                {
-                                                  "type": "COMMAND_BAR_BUTTON",
-                                                  "id": 279,
-                                                  "name": "ОформляемыеПоляПереместитьВниз",
-                                                  "title": {
-                                                    "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                                  },
-                                                  "dataPath": "",
-                                                  "items": []
-                                                }
-                                              ],
-                                              []
-                                            ]
+                                            "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Fields.Field",
+                                            "items": []
                                           }
                                         ],
                                         []
@@ -7556,86 +6529,417 @@
                                     }
                                   ]
                                 }
-                              ],
-                              []
-                            ]
-                          }
-                        ],
-                        []
-                      ]
-                    },
-                    {
-                      "type": "TABLE",
-                      "id": 30,
-                      "name": "ОформляемыеПоля",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                      },
-                      "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Fields",
-                      "items": [
+                              ]
+                            }
+                          ],
+                          []
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "PAGE",
+                    "id": 333,
+                    "name": "ГруппаОформление",
+                    "title": {
+                      "content": [
                         {
-                          "type": "COLUMN_GROUP",
-                          "id": 206,
-                          "name": "ОформляемыеПоляГруппаКолонокПоле",
-                          "title": {
-                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                          "default": {
+                            "tag": 2
                           },
-                          "dataPath": "",
-                          "items": [
-                            [
-                              {
-                                "type": "CHECK_BOX_FIELD",
-                                "id": 203,
-                                "name": "ОформляемыеПоляИспользование",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                },
-                                "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Fields.Use",
-                                "items": []
-                              },
-                              {
-                                "type": "INPUT_FIELD",
-                                "id": 211,
-                                "name": "ОформляемыеПоляПоле",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                },
-                                "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Fields.Field",
-                                "items": []
-                              }
-                            ],
-                            []
-                          ]
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Оформление"
+                          }
                         }
                       ]
-                    }
-                  ],
-                  []
-                ]
-              },
-              {
-                "type": "USUAL_GROUP",
-                "id": 333,
-                "name": "ГруппаОформление",
-                "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
-                },
-                "dataPath": "",
-                "items": [
-                  {
-                    "type": "TABLE",
-                    "id": 72,
-                    "name": "Оформление",
-                    "title": {
-                      "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
                     },
-                    "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Appearance",
+                    "dataPath": "",
+                    "items": [
+                      {
+                        "type": "TABLE",
+                        "id": 72,
+                        "name": "Оформление",
+                        "title": {
+                          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                        },
+                        "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Appearance",
+                        "items": [
+                          [
+                            {
+                              "type": "COLUMN_GROUP",
+                              "id": 201,
+                              "name": "ОформлениеГруппаИспользованиеПараметра",
+                              "title": {
+                                "content": [
+                                  {
+                                    "default": {
+                                      "tag": 2
+                                    },
+                                    "int": 1,
+                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                      "langKey": "ru",
+                                      "value": "Использование параметра"
+                                    }
+                                  }
+                                ]
+                              },
+                              "dataPath": "",
+                              "items": [
+                                [
+                                  {
+                                    "type": "CHECK_BOX_FIELD",
+                                    "id": 96,
+                                    "name": "ОформлениеИспользование",
+                                    "title": {
+                                      "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                    },
+                                    "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Appearance.Use",
+                                    "items": []
+                                  },
+                                  {
+                                    "type": "INPUT_FIELD",
+                                    "id": 105,
+                                    "name": "ОформлениеПараметр",
+                                    "title": {
+                                      "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                    },
+                                    "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Appearance.Parameter",
+                                    "items": []
+                                  }
+                                ],
+                                []
+                              ]
+                            },
+                            {
+                              "type": "COLUMN_GROUP",
+                              "id": 108,
+                              "name": "ОформлениеГруппаКолонокЗначениеПараметра",
+                              "title": {
+                                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                              },
+                              "dataPath": "",
+                              "items": [
+                                [
+                                  {
+                                    "type": "PICTURE_FIELD",
+                                    "id": 110,
+                                    "name": "ОформлениеКартинкаЗначения",
+                                    "title": {
+                                      "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                    },
+                                    "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Appearance.ValuePicture",
+                                    "items": []
+                                  },
+                                  {
+                                    "type": "INPUT_FIELD",
+                                    "id": 113,
+                                    "name": "ОформлениеЗначение",
+                                    "title": {
+                                      "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                    },
+                                    "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Appearance.Value",
+                                    "items": []
+                                  }
+                                ],
+                                []
+                              ]
+                            }
+                          ],
+                          []
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "PAGE",
+                    "id": 335,
+                    "name": "ГруппаОтбор",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                    },
+                    "dataPath": "",
+                    "items": [
+                      {
+                        "type": "TABLE",
+                        "id": 51,
+                        "name": "Отбор",
+                        "title": {
+                          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                        },
+                        "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter",
+                        "items": [
+                          [
+                            {
+                              "type": "CHECK_BOX_FIELD",
+                              "id": 214,
+                              "name": "ОтборИспользование",
+                              "title": {
+                                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                              },
+                              "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.Use",
+                              "items": []
+                            },
+                            {
+                              "type": "COLUMN_GROUP",
+                              "id": 217,
+                              "name": "ОтборГруппаКолонокОтбор",
+                              "title": {
+                                "content": [
+                                  {
+                                    "default": {
+                                      "tag": 2
+                                    },
+                                    "int": 1,
+                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                      "langKey": "ru",
+                                      "value": "Фильтр"
+                                    }
+                                  }
+                                ]
+                              },
+                              "dataPath": "",
+                              "items": [
+                                [
+                                  {
+                                    "type": "COLUMN_GROUP",
+                                    "id": 224,
+                                    "name": "ОтборГруппаКолонокОсновныеЭлементыОтбора",
+                                    "title": {
+                                      "content": [
+                                        {
+                                          "default": {
+                                            "tag": 2
+                                          },
+                                          "int": 1,
+                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                            "langKey": "ru",
+                                            "value": "Основные элементы фильтра"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    "dataPath": "",
+                                    "items": [
+                                      [
+                                        {
+                                          "type": "COLUMN_GROUP",
+                                          "id": 229,
+                                          "name": "ОтборГруппаКолонокЛевоеЗначение",
+                                          "title": {
+                                            "content": [
+                                              {
+                                                "default": {
+                                                  "tag": 2
+                                                },
+                                                "int": 1,
+                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                  "langKey": "ru",
+                                                  "value": "Левое значение"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "dataPath": "",
+                                          "items": [
+                                            [
+                                              {
+                                                "type": "PICTURE_FIELD",
+                                                "id": 231,
+                                                "name": "ОтборКартинкаЛевогоЗначения",
+                                                "title": {
+                                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                                },
+                                                "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.LeftValuePicture",
+                                                "items": []
+                                              },
+                                              {
+                                                "type": "INPUT_FIELD",
+                                                "id": 234,
+                                                "name": "ОтборЛевоеЗначение",
+                                                "title": {
+                                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                                },
+                                                "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.LeftValue",
+                                                "items": []
+                                              }
+                                            ],
+                                            []
+                                          ]
+                                        },
+                                        {
+                                          "type": "INPUT_FIELD",
+                                          "id": 237,
+                                          "name": "ОтборВидСравнения",
+                                          "title": {
+                                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                          },
+                                          "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.ComparisonType",
+                                          "items": []
+                                        },
+                                        {
+                                          "type": "COLUMN_GROUP",
+                                          "id": 240,
+                                          "name": "ОтборГруппаКолонокПравоеЗначение",
+                                          "title": {
+                                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                          },
+                                          "dataPath": "",
+                                          "items": [
+                                            [
+                                              {
+                                                "type": "PICTURE_FIELD",
+                                                "id": 242,
+                                                "name": "ОтборКартинкаПравогоЗначения",
+                                                "title": {
+                                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                                },
+                                                "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.RightValuePicture",
+                                                "items": []
+                                              },
+                                              {
+                                                "type": "INPUT_FIELD",
+                                                "id": 245,
+                                                "name": "ОтборПравоеЗначение",
+                                                "title": {
+                                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                                },
+                                                "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.RightValue",
+                                                "items": []
+                                              }
+                                            ],
+                                            []
+                                          ]
+                                        },
+                                        {
+                                          "type": "INPUT_FIELD",
+                                          "id": 248,
+                                          "name": "ОтборДата",
+                                          "title": {
+                                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                          },
+                                          "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.Date",
+                                          "items": []
+                                        }
+                                      ],
+                                      []
+                                    ]
+                                  },
+                                  {
+                                    "type": "INPUT_FIELD",
+                                    "id": 226,
+                                    "name": "ОтборТипГруппы",
+                                    "title": {
+                                      "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                    },
+                                    "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.GroupType",
+                                    "items": []
+                                  },
+                                  {
+                                    "type": "COLUMN_GROUP",
+                                    "id": 329,
+                                    "name": "ОтборГруппа6",
+                                    "title": {
+                                      "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                    },
+                                    "dataPath": "",
+                                    "items": [
+                                      [
+                                        {
+                                          "type": "COLUMN_GROUP",
+                                          "id": 219,
+                                          "name": "ОтборГруппаКолонокПрименение",
+                                          "title": {
+                                            "content": [
+                                              {
+                                                "default": {
+                                                  "tag": 2
+                                                },
+                                                "int": 1,
+                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                  "langKey": "ru",
+                                                  "value": "Применение"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "dataPath": "",
+                                          "items": [
+                                            [
+                                              {
+                                                "type": "INPUT_FIELD",
+                                                "id": 251,
+                                                "name": "ОтборПрименение",
+                                                "title": {
+                                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                                },
+                                                "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.Application",
+                                                "items": []
+                                              },
+                                              {
+                                                "type": "INPUT_FIELD",
+                                                "id": 254,
+                                                "name": "ОтборРежимОтображения",
+                                                "title": {
+                                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                                },
+                                                "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.ViewMode",
+                                                "items": []
+                                              }
+                                            ],
+                                            []
+                                          ]
+                                        },
+                                        {
+                                          "type": "INPUT_FIELD",
+                                          "id": 221,
+                                          "name": "ОтборПредставление",
+                                          "title": {
+                                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                          },
+                                          "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.Presentation",
+                                          "items": []
+                                        }
+                                      ],
+                                      []
+                                    ]
+                                  }
+                                ],
+                                []
+                              ]
+                            }
+                          ],
+                          []
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "PAGE",
+                    "id": 417,
+                    "name": "ГруппаВариантыИспользования",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Область использования"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "",
                     "items": [
                       [
                         {
-                          "type": "COLUMN_GROUP",
-                          "id": 201,
-                          "name": "ОформлениеГруппаИспользованиеПараметра",
+                          "type": "USUAL_GROUP",
+                          "id": 156,
+                          "name": "ВариантыИспользованияКоманды",
                           "title": {
                             "content": [
                               {
@@ -7645,7 +6949,107 @@
                                 "int": 1,
                                 "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                                   "langKey": "ru",
-                                  "value": "Использование параметра"
+                                  "value": "Варианты использования (команды)"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            {
+                              "type": "COMMAND_BAR",
+                              "id": 199,
+                              "name": "КомандыИзменитьФлажки",
+                              "title": {
+                                "content": [
+                                  {
+                                    "default": {
+                                      "tag": 2
+                                    },
+                                    "int": 1,
+                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                      "langKey": "ru",
+                                      "value": "Изменить флажки"
+                                    }
+                                  }
+                                ]
+                              },
+                              "dataPath": "",
+                              "items": [
+                                {
+                                  "type": "BUTTON_GROUP",
+                                  "id": 343,
+                                  "name": "ГруппаИзменитьФлажки",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "COMMAND_BAR_BUTTON",
+                                        "id": 190,
+                                        "name": "Показывать_УстановитьПометки",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Включить все"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "COMMAND_BAR_BUTTON",
+                                        "id": 188,
+                                        "name": "Показывать_СнятьПометки",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Выключить все"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 160,
+                          "name": "ВариантыИспользованияПометки",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Варианты использования (пометки)"
                                 }
                               }
                             ]
@@ -7655,56 +7059,149 @@
                             [
                               {
                                 "type": "CHECK_BOX_FIELD",
-                                "id": 96,
-                                "name": "ОформлениеИспользование",
+                                "id": 185,
+                                "name": "ИспользоватьВГруппировке",
                                 "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "В группировке"
+                                      }
+                                    }
+                                  ]
                                 },
-                                "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Appearance.Use",
+                                "dataPath": "ИспользоватьВГруппировке",
                                 "items": []
                               },
                               {
-                                "type": "INPUT_FIELD",
-                                "id": 105,
-                                "name": "ОформлениеПараметр",
+                                "type": "CHECK_BOX_FIELD",
+                                "id": 176,
+                                "name": "ИспользоватьВИерархическойГруппировке",
                                 "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "В иерархической группировке"
+                                      }
+                                    }
+                                  ]
                                 },
-                                "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Appearance.Parameter",
-                                "items": []
-                              }
-                            ],
-                            []
-                          ]
-                        },
-                        {
-                          "type": "COLUMN_GROUP",
-                          "id": 108,
-                          "name": "ОформлениеГруппаКолонокЗначениеПараметра",
-                          "title": {
-                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                          },
-                          "dataPath": "",
-                          "items": [
-                            [
-                              {
-                                "type": "PICTURE_FIELD",
-                                "id": 110,
-                                "name": "ОформлениеКартинкаЗначения",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                },
-                                "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Appearance.ValuePicture",
+                                "dataPath": "ИспользоватьВИерархическойГруппировке",
                                 "items": []
                               },
                               {
-                                "type": "INPUT_FIELD",
-                                "id": 113,
-                                "name": "ОформлениеЗначение",
+                                "type": "CHECK_BOX_FIELD",
+                                "id": 173,
+                                "name": "ИспользоватьВОбщемИтоге",
                                 "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "В общем итоге"
+                                      }
+                                    }
+                                  ]
                                 },
-                                "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Appearance.Value",
+                                "dataPath": "ИспользоватьВОбщемИтоге",
+                                "items": []
+                              },
+                              {
+                                "type": "CHECK_BOX_FIELD",
+                                "id": 179,
+                                "name": "ИспользоватьВЗаголовкеПолей",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "В заголовке полей"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "ИспользоватьВЗаголовкеПолей",
+                                "items": []
+                              },
+                              {
+                                "type": "CHECK_BOX_FIELD",
+                                "id": 182,
+                                "name": "ИспользоватьВЗаголовке",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "В заголовке"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "ИспользоватьВЗаголовке",
+                                "items": []
+                              },
+                              {
+                                "type": "CHECK_BOX_FIELD",
+                                "id": 167,
+                                "name": "ИспользоватьВПараметрах",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "В параметрах"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "ИспользоватьВПараметрах",
+                                "items": []
+                              },
+                              {
+                                "type": "CHECK_BOX_FIELD",
+                                "id": 170,
+                                "name": "ИспользоватьВОтборе",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "В фильтрах"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "ИспользоватьВОтборе",
                                 "items": []
                               }
                             ],
@@ -7715,781 +7212,10 @@
                       []
                     ]
                   }
-                ]
-              },
-              {
-                "type": "USUAL_GROUP",
-                "id": 335,
-                "name": "ГруппаОтбор",
-                "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[11]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                },
-                "dataPath": "",
-                "items": [
-                  [
-                    {
-                      "type": "USUAL_GROUP",
-                      "id": 345,
-                      "name": "ОтборКоманднаяПанель1",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "LABEL_DECORATION",
-                            "id": 347,
-                            "name": "ОтборЗаголовок",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Условие:"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "COMMAND_BAR",
-                            "id": 350,
-                            "name": "ОтборКомандыОсновные",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                            },
-                            "dataPath": "",
-                            "items": [
-                              [
-                                {
-                                  "type": "COMMAND_BAR_BUTTON",
-                                  "id": 293,
-                                  "name": "ОтборДобавитьЭлементОтбора",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Добавить"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": []
-                                },
-                                {
-                                  "type": "BUTTON_GROUP",
-                                  "id": 285,
-                                  "name": "ОтборГруппаИзменитьФлажки",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[10]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                  },
-                                  "dataPath": "",
-                                  "items": [
-                                    [
-                                      {
-                                        "type": "COMMAND_BAR_BUTTON",
-                                        "id": 295,
-                                        "name": "ОтборУстановитьФлажки",
-                                        "title": {
-                                          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                        },
-                                        "dataPath": "",
-                                        "items": []
-                                      },
-                                      {
-                                        "type": "COMMAND_BAR_BUTTON",
-                                        "id": 297,
-                                        "name": "ОтборСнятьФлажки",
-                                        "title": {
-                                          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                        },
-                                        "dataPath": "",
-                                        "items": []
-                                      }
-                                    ],
-                                    []
-                                  ]
-                                },
-                                {
-                                  "type": "BUTTON_GROUP",
-                                  "id": 291,
-                                  "name": "ОтборГруппаПереместить",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
-                                  },
-                                  "dataPath": "",
-                                  "items": [
-                                    [
-                                      {
-                                        "type": "COMMAND_BAR_BUTTON",
-                                        "id": 299,
-                                        "name": "ОтборПереместитьВверх",
-                                        "title": {
-                                          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                        },
-                                        "dataPath": "",
-                                        "items": []
-                                      },
-                                      {
-                                        "type": "COMMAND_BAR_BUTTON",
-                                        "id": 301,
-                                        "name": "ОтборПереместитьВниз",
-                                        "title": {
-                                          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                        },
-                                        "dataPath": "",
-                                        "items": []
-                                      }
-                                    ],
-                                    []
-                                  ]
-                                }
-                              ],
-                              []
-                            ]
-                          }
-                        ],
-                        []
-                      ]
-                    },
-                    {
-                      "type": "TABLE",
-                      "id": 51,
-                      "name": "Отбор",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[11]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                      },
-                      "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter",
-                      "items": [
-                        [
-                          {
-                            "type": "CHECK_BOX_FIELD",
-                            "id": 214,
-                            "name": "ОтборИспользование",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                            },
-                            "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.Use",
-                            "items": []
-                          },
-                          {
-                            "type": "COLUMN_GROUP",
-                            "id": 217,
-                            "name": "ОтборГруппаКолонокОтбор",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Фильтр"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": [
-                              [
-                                {
-                                  "type": "COLUMN_GROUP",
-                                  "id": 224,
-                                  "name": "ОтборГруппаКолонокОсновныеЭлементыОтбора",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Основные элементы фильтра"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": [
-                                    [
-                                      {
-                                        "type": "COLUMN_GROUP",
-                                        "id": 229,
-                                        "name": "ОтборГруппаКолонокЛевоеЗначение",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Левое значение"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "",
-                                        "items": [
-                                          [
-                                            {
-                                              "type": "PICTURE_FIELD",
-                                              "id": 231,
-                                              "name": "ОтборКартинкаЛевогоЗначения",
-                                              "title": {
-                                                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                              },
-                                              "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.LeftValuePicture",
-                                              "items": []
-                                            },
-                                            {
-                                              "type": "INPUT_FIELD",
-                                              "id": 234,
-                                              "name": "ОтборЛевоеЗначение",
-                                              "title": {
-                                                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                              },
-                                              "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.LeftValue",
-                                              "items": []
-                                            }
-                                          ],
-                                          []
-                                        ]
-                                      },
-                                      {
-                                        "type": "INPUT_FIELD",
-                                        "id": 237,
-                                        "name": "ОтборВидСравнения",
-                                        "title": {
-                                          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                        },
-                                        "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.ComparisonType",
-                                        "items": []
-                                      },
-                                      {
-                                        "type": "COLUMN_GROUP",
-                                        "id": 240,
-                                        "name": "ОтборГруппаКолонокПравоеЗначение",
-                                        "title": {
-                                          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                                        },
-                                        "dataPath": "",
-                                        "items": [
-                                          [
-                                            {
-                                              "type": "PICTURE_FIELD",
-                                              "id": 242,
-                                              "name": "ОтборКартинкаПравогоЗначения",
-                                              "title": {
-                                                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                              },
-                                              "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.RightValuePicture",
-                                              "items": []
-                                            },
-                                            {
-                                              "type": "INPUT_FIELD",
-                                              "id": 245,
-                                              "name": "ОтборПравоеЗначение",
-                                              "title": {
-                                                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                              },
-                                              "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.RightValue",
-                                              "items": []
-                                            }
-                                          ],
-                                          []
-                                        ]
-                                      },
-                                      {
-                                        "type": "INPUT_FIELD",
-                                        "id": 248,
-                                        "name": "ОтборДата",
-                                        "title": {
-                                          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                        },
-                                        "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.Date",
-                                        "items": []
-                                      }
-                                    ],
-                                    []
-                                  ]
-                                },
-                                {
-                                  "type": "INPUT_FIELD",
-                                  "id": 226,
-                                  "name": "ОтборТипГруппы",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                  },
-                                  "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.GroupType",
-                                  "items": []
-                                },
-                                {
-                                  "type": "COLUMN_GROUP",
-                                  "id": 329,
-                                  "name": "ОтборГруппа6",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[11]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                  },
-                                  "dataPath": "",
-                                  "items": [
-                                    [
-                                      {
-                                        "type": "COLUMN_GROUP",
-                                        "id": 219,
-                                        "name": "ОтборГруппаКолонокПрименение",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Применение"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "",
-                                        "items": [
-                                          [
-                                            {
-                                              "type": "INPUT_FIELD",
-                                              "id": 251,
-                                              "name": "ОтборПрименение",
-                                              "title": {
-                                                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                              },
-                                              "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.Application",
-                                              "items": []
-                                            },
-                                            {
-                                              "type": "INPUT_FIELD",
-                                              "id": 254,
-                                              "name": "ОтборРежимОтображения",
-                                              "title": {
-                                                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                              },
-                                              "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.ViewMode",
-                                              "items": []
-                                            }
-                                          ],
-                                          []
-                                        ]
-                                      },
-                                      {
-                                        "type": "INPUT_FIELD",
-                                        "id": 221,
-                                        "name": "ОтборПредставление",
-                                        "title": {
-                                          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                        },
-                                        "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.Presentation",
-                                        "items": []
-                                      }
-                                    ],
-                                    []
-                                  ]
-                                }
-                              ],
-                              []
-                            ]
-                          }
-                        ],
-                        []
-                      ]
-                    }
-                  ],
-                  []
-                ]
-              },
-              {
-                "type": "INPUT_FIELD",
-                "id": 93,
-                "name": "Наименование",
-                "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                },
-                "dataPath": "Наименование",
-                "items": []
-              },
-              {
-                "type": "USUAL_GROUP",
-                "id": 339,
-                "name": "КоманднаяПанель",
-                "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
-                },
-                "dataPath": "",
-                "items": [
-                  [
-                    {
-                      "type": "USUAL_GROUP",
-                      "id": 341,
-                      "name": "ВариантыИспользования",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "USUAL_GROUP",
-                            "id": 156,
-                            "name": "ВариантыИспользованияКоманды",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Варианты использования (команды)"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": [
-                              [
-                                {
-                                  "type": "LABEL_DECORATION",
-                                  "id": 153,
-                                  "name": "ДекорацияПоказывать",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Показывать:                 "
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": []
-                                },
-                                {
-                                  "type": "COMMAND_BAR",
-                                  "id": 199,
-                                  "name": "КомандыИзменитьФлажки",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[10]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                  },
-                                  "dataPath": "",
-                                  "items": [
-                                    {
-                                      "type": "BUTTON_GROUP",
-                                      "id": 343,
-                                      "name": "ГруппаИзменитьФлажки",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[10]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                      },
-                                      "dataPath": "",
-                                      "items": [
-                                        [
-                                          {
-                                            "type": "COMMAND_BAR_BUTTON",
-                                            "id": 190,
-                                            "name": "Показывать_УстановитьПометки",
-                                            "title": {
-                                              "content": [
-                                                {
-                                                  "default": {
-                                                    "tag": 2
-                                                  },
-                                                  "int": 1,
-                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                    "langKey": "ru",
-                                                    "value": "Установить пометки"
-                                                  }
-                                                }
-                                              ]
-                                            },
-                                            "dataPath": "",
-                                            "items": []
-                                          },
-                                          {
-                                            "type": "COMMAND_BAR_BUTTON",
-                                            "id": 188,
-                                            "name": "Показывать_СнятьПометки",
-                                            "title": {
-                                              "content": [
-                                                {
-                                                  "default": {
-                                                    "tag": 2
-                                                  },
-                                                  "int": 1,
-                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                    "langKey": "ru",
-                                                    "value": "Снять пометки"
-                                                  }
-                                                }
-                                              ]
-                                            },
-                                            "dataPath": "",
-                                            "items": []
-                                          }
-                                        ],
-                                        []
-                                      ]
-                                    }
-                                  ]
-                                }
-                              ],
-                              []
-                            ]
-                          },
-                          {
-                            "type": "USUAL_GROUP",
-                            "id": 160,
-                            "name": "ВариантыИспользованияПометки",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Варианты использования (пометки)"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": [
-                              [
-                                {
-                                  "type": "CHECK_BOX_FIELD",
-                                  "id": 185,
-                                  "name": "ИспользоватьВГруппировке",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "В группировке"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "ИспользоватьВГруппировке",
-                                  "items": []
-                                },
-                                {
-                                  "type": "CHECK_BOX_FIELD",
-                                  "id": 176,
-                                  "name": "ИспользоватьВИерархическойГруппировке",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "В иерархической группировке"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "ИспользоватьВИерархическойГруппировке",
-                                  "items": []
-                                },
-                                {
-                                  "type": "CHECK_BOX_FIELD",
-                                  "id": 173,
-                                  "name": "ИспользоватьВОбщемИтоге",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "В общем итоге"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "ИспользоватьВОбщемИтоге",
-                                  "items": []
-                                },
-                                {
-                                  "type": "CHECK_BOX_FIELD",
-                                  "id": 179,
-                                  "name": "ИспользоватьВЗаголовкеПолей",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "В заголовке полей"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "ИспользоватьВЗаголовкеПолей",
-                                  "items": []
-                                },
-                                {
-                                  "type": "CHECK_BOX_FIELD",
-                                  "id": 182,
-                                  "name": "ИспользоватьВЗаголовке",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "В заголовке"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "ИспользоватьВЗаголовке",
-                                  "items": []
-                                },
-                                {
-                                  "type": "CHECK_BOX_FIELD",
-                                  "id": 167,
-                                  "name": "ИспользоватьВПараметрах",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "В параметрах"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "ИспользоватьВПараметрах",
-                                  "items": []
-                                },
-                                {
-                                  "type": "CHECK_BOX_FIELD",
-                                  "id": 170,
-                                  "name": "ИспользоватьВОтборе",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "В фильтрах"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "ИспользоватьВОтборе",
-                                  "items": []
-                                }
-                              ],
-                              []
-                            ]
-                          }
-                        ],
-                        []
-                      ]
-                    },
-                    {
-                      "type": "COMMAND_BAR",
-                      "id": 323,
-                      "name": "КомандыОсновные",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "COMMAND_BAR_BUTTON",
-                            "id": 26,
-                            "name": "ФормаВыбрать",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[11]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "COMMAND_BAR_BUTTON",
-                            "id": 325,
-                            "name": "Отмена",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "COMMAND_BAR_BUTTON",
-                            "id": 327,
-                            "name": "Справка",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                            },
-                            "dataPath": "",
-                            "items": []
-                          }
-                        ],
-                        []
-                      ]
-                    }
-                  ],
-                  []
-                ]
-              }
-            ],
-            []
+                ],
+                []
+              ]
+            }
           ],
           "attributes": [
             [
@@ -8547,7 +7273,7 @@
                 "id": 8,
                 "name": "Наименование",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
@@ -8557,7 +7283,7 @@
                 "id": 9,
                 "name": "ИспользоватьВГруппировке",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
@@ -8567,7 +7293,7 @@
                 "id": 10,
                 "name": "ИспользоватьВПараметрах",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[6]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[6]/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
@@ -8577,7 +7303,7 @@
                 "id": 11,
                 "name": "ИспользоватьВОтборе",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[7]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[7]/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
@@ -8587,7 +7313,7 @@
                 "id": 12,
                 "name": "ИспользоватьВОбщемИтоге",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
@@ -8597,7 +7323,7 @@
                 "id": 13,
                 "name": "ИспользоватьВИерархическойГруппировке",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
@@ -8607,7 +7333,7 @@
                 "id": 14,
                 "name": "ИспользоватьВЗаголовкеПолей",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
@@ -8617,7 +7343,7 @@
                 "id": 15,
                 "name": "ИспользоватьВЗаголовке",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
@@ -8657,7 +7383,18 @@
                 "id": 4,
                 "name": "ВариантВыбораОформляемыхПолей",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Вариант выбора оформляемых полей"
+                      }
+                    }
+                  ]
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
@@ -8667,7 +7404,7 @@
                 "id": 7,
                 "name": "ОформляемоеПоле",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
@@ -8677,10 +7414,20 @@
                 "id": 19,
                 "name": "Использование",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 20,
+                "name": "РежимОтображения",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[15]/type"
                 }
               }
             ],

--- a/src/test/resources/fixtures/ssl_3_2/SettingsStorages.ХранилищеВариантовОтчетов_edt.json
+++ b/src/test/resources/fixtures/ssl_3_2/SettingsStorages.ХранилищеВариантовОтчетов_edt.json
@@ -192,130 +192,6 @@
                 },
                 "dataPath": "ВыводитьЗаголовкиНастроек",
                 "items": []
-              },
-              {
-                "type": "USUAL_GROUP",
-                "id": 96,
-                "name": "КоманднаяПанель",
-                "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Командная панель"
-                      }
-                    }
-                  ]
-                },
-                "dataPath": "",
-                "items": [
-                  [
-                    {
-                      "type": "USUAL_GROUP",
-                      "id": 109,
-                      "name": "ДополнительныеВозможности",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Дополнительные возможности"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
-                        {
-                          "type": "HYPERLINK",
-                          "id": 104,
-                          "name": "ПерейтиКРасширеннымНастройкам",
-                          "title": {
-                            "content": [
-                              {
-                                "default": {
-                                  "tag": 2
-                                },
-                                "int": 1,
-                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                  "langKey": "ru",
-                                  "value": "Больше возможностей..."
-                                }
-                              }
-                            ]
-                          },
-                          "dataPath": "",
-                          "items": []
-                        }
-                      ]
-                    },
-                    {
-                      "type": "COMMAND_BAR",
-                      "id": 98,
-                      "name": "КомандыОсновные",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Команды основные"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "BUTTON",
-                            "id": 100,
-                            "name": "Применить",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Применить"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "BUTTON",
-                            "id": 102,
-                            "name": "Отмена",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                            },
-                            "dataPath": "",
-                            "items": []
-                          }
-                        ],
-                        []
-                      ]
-                    }
-                  ],
-                  []
-                ]
               }
             ],
             []
@@ -570,146 +446,6 @@
                 ]
               },
               {
-                "type": "COMMAND_BAR",
-                "id": 27,
-                "name": "ОсновнаяКоманднаяПанель",
-                "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Основная командная панель"
-                      }
-                    }
-                  ]
-                },
-                "dataPath": "",
-                "items": [
-                  [
-                    {
-                      "type": "BUTTON",
-                      "id": 6,
-                      "name": "Выбрать",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "BUTTON",
-                      "id": 7,
-                      "name": "Изменить",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "BUTTON",
-                      "id": 15,
-                      "name": "Удалить",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Пометить на удаление / Снять пометку"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "BUTTON",
-                      "id": 13,
-                      "name": "ПоказыватьЛичныеВариантыОтчетовДругихАвторов",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Показывать личные варианты отчетов других авторов"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "BUTTON",
-                      "id": 28,
-                      "name": "ФормаОбновить",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Обновить"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "FORM_GROUP",
-                      "id": 8,
-                      "name": "КоманднаяПанельДерева",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Командная панель дерева"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
-                        {
-                          "type": "ADDITION",
-                          "id": 59,
-                          "name": "СтрокаПоиска",
-                          "title": {
-                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                          },
-                          "dataPath": "",
-                          "items": []
-                        }
-                      ]
-                    }
-                  ],
-                  []
-                ]
-              },
-              {
                 "type": "TABLE",
                 "id": 1,
                 "name": "ДеревоВариантовОтчета",
@@ -837,7 +573,7 @@
                 "id": 1,
                 "name": "ДеревоВариантовОтчета",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                 },
                 "type": {
                   "types": [
@@ -904,7 +640,7 @@
                 "id": 6,
                 "name": "ВариантОписание",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
@@ -1906,7 +1642,7 @@
               },
               {
                 "type": "USUAL_GROUP",
-                "id": 193,
+                "id": 198,
                 "name": "ГруппаОчиститьПериод",
                 "title": {
                   "content": [
@@ -2257,51 +1993,73 @@
             }
           ],
           "items": [
-            [
-              {
-                "type": "INPUT_FIELD",
-                "id": 1,
-                "name": "ЗаголовокГруппы",
-                "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Заголовок"
-                      }
+            {
+              "type": "USUAL_GROUP",
+              "id": 13,
+              "name": "Основное",
+              "title": {
+                "content": [
+                  {
+                    "default": {
+                      "tag": 2
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                      "langKey": "ru",
+                      "value": "Основное"
                     }
-                  ]
-                },
-                "dataPath": "ЗаголовокГруппы",
-                "items": []
+                  }
+                ]
               },
-              {
-                "type": "RADIO_BUTTON_FIELD",
-                "id": 4,
-                "name": "Расположение",
-                "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Расположение"
-                      }
-                    }
-                  ]
-                },
-                "dataPath": "РасположениеГруппы",
-                "items": []
-              }
-            ],
-            []
+              "dataPath": "",
+              "items": [
+                [
+                  {
+                    "type": "INPUT_FIELD",
+                    "id": 1,
+                    "name": "ЗаголовокГруппы",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Заголовок"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "ЗаголовокГруппы",
+                    "items": []
+                  },
+                  {
+                    "type": "RADIO_BUTTON_FIELD",
+                    "id": 4,
+                    "name": "Расположение",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Расположение"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "РасположениеГруппы",
+                    "items": []
+                  }
+                ],
+                []
+              ]
+            }
           ],
           "attributes": [
             [
@@ -2309,7 +2067,7 @@
                 "id": 1,
                 "name": "ЗаголовокГруппы",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
@@ -2319,7 +2077,7 @@
                 "id": 2,
                 "name": "РасположениеГруппы",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
@@ -2394,108 +2152,41 @@
             []
           ],
           "items": [
-            [
-              {
-                "type": "USUAL_GROUP",
-                "id": 266,
-                "name": "Сортировка",
-                "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Сортировка"
-                      }
-                    }
-                  ]
-                },
-                "dataPath": "",
-                "items": [
-                  [
-                    {
-                      "type": "USUAL_BUTTON",
-                      "id": 1,
-                      "name": "СортироватьПоВозрастанию",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Сортировать по возрастанию"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": []
+            {
+              "type": "PAGES",
+              "id": 482,
+              "name": "Страницы",
+              "title": {
+                "content": [
+                  {
+                    "default": {
+                      "tag": 2
                     },
-                    {
-                      "type": "USUAL_BUTTON",
-                      "id": 3,
-                      "name": "СортироватьПоУбыванию",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Сортировать по убыванию"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": []
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                      "langKey": "ru",
+                      "value": "Страницы"
                     }
-                  ],
-                  []
+                  }
                 ]
               },
-              {
-                "type": "USUAL_GROUP",
-                "id": 16,
-                "name": "ФильтрПоЗначению",
-                "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Фильтр по значению"
-                      }
-                    }
-                  ]
-                },
-                "dataPath": "",
-                "items": [
+              "dataPath": "",
+              "items": [
+                [
                   {
-                    "type": "PAGES",
-                    "id": 404,
-                    "name": "ФильтрПоЗначениюСтраницы",
+                    "type": "PAGE",
+                    "id": 484,
+                    "name": "БыстрыеНастройки",
                     "title": {
-                      "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/synonym"
                     },
                     "dataPath": "",
                     "items": [
                       [
                         {
-                          "type": "PAGE",
-                          "id": 406,
-                          "name": "ЗначенияФильтра",
+                          "type": "USUAL_GROUP",
+                          "id": 488,
+                          "name": "БыстрыеНастройкиКолонка1",
                           "title": {
                             "content": [
                               {
@@ -2505,7 +2196,7 @@
                                 "int": 1,
                                 "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                                   "langKey": "ru",
-                                  "value": "Значения"
+                                  "value": "Быстрые настройки колонка 1"
                                 }
                               }
                             ]
@@ -2514,54 +2205,9 @@
                           "items": [
                             [
                               {
-                                "type": "TABLE",
-                                "id": 18,
-                                "name": "Значения",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                },
-                                "dataPath": "Значения",
-                                "items": [
-                                  [
-                                    {
-                                      "type": "CHECK_BOX_FIELD",
-                                      "id": 34,
-                                      "name": "ЗначенияПометка",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                      },
-                                      "dataPath": "Значения.Check",
-                                      "items": []
-                                    },
-                                    {
-                                      "type": "INPUT_FIELD",
-                                      "id": 31,
-                                      "name": "ЗначенияЗначение",
-                                      "title": {
-                                        "content": [
-                                          {
-                                            "default": {
-                                              "tag": 2
-                                            },
-                                            "int": 1,
-                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                              "langKey": "ru",
-                                              "value": "Значение"
-                                            }
-                                          }
-                                        ]
-                                      },
-                                      "dataPath": "Значения.Value",
-                                      "items": []
-                                    }
-                                  ],
-                                  []
-                                ]
-                              },
-                              {
                                 "type": "USUAL_GROUP",
-                                "id": 435,
-                                "name": "ОпцииЗаполненияФильтраПоЗначению",
+                                "id": 266,
+                                "name": "Сортировка",
                                 "title": {
                                   "content": [
                                     {
@@ -2571,7 +2217,7 @@
                                       "int": 1,
                                       "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                                         "langKey": "ru",
-                                        "value": "Опции заполнения фильтра по значению"
+                                        "value": "Сортировать"
                                       }
                                     }
                                   ]
@@ -2580,19 +2226,9 @@
                                 "items": [
                                   [
                                     {
-                                      "type": "LABEL",
-                                      "id": 415,
-                                      "name": "СтатистикаФильтраПоЗначению",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                      },
-                                      "dataPath": "",
-                                      "items": []
-                                    },
-                                    {
-                                      "type": "LABEL",
-                                      "id": 437,
-                                      "name": "ВывестиВсеЗначенияРазделаОтчета",
+                                      "type": "USUAL_BUTTON",
+                                      "id": 1,
+                                      "name": "СортироватьПоВозрастанию",
                                       "title": {
                                         "content": [
                                           {
@@ -2602,7 +2238,747 @@
                                             "int": 1,
                                             "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                                               "langKey": "ru",
-                                              "value": "Вывести все"
+                                              "value": "По возрастанию"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": []
+                                    },
+                                    {
+                                      "type": "USUAL_BUTTON",
+                                      "id": 3,
+                                      "name": "СортироватьПоУбыванию",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "По убыванию"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": []
+                                    }
+                                  ],
+                                  []
+                                ]
+                              },
+                              {
+                                "type": "USUAL_GROUP",
+                                "id": 494,
+                                "name": "Сгруппировать",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Сгруппировать"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  {
+                                    "type": "USUAL_BUTTON",
+                                    "id": 440,
+                                    "name": "СгруппироватьПоВыбранномуПолю",
+                                    "title": {
+                                      "content": [
+                                        {
+                                          "default": {
+                                            "tag": 2
+                                          },
+                                          "int": 1,
+                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                            "langKey": "ru",
+                                            "value": "По полю"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    "dataPath": "",
+                                    "items": []
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "USUAL_GROUP",
+                                "id": 200,
+                                "name": "Перемещение",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Переместить"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "USUAL_BUTTON",
+                                      "id": 186,
+                                      "name": "ПереместитьПолеВлево",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Влево"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": []
+                                    },
+                                    {
+                                      "type": "USUAL_BUTTON",
+                                      "id": 188,
+                                      "name": "ПереместитьПолеВправо",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Вправо"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": []
+                                    },
+                                    {
+                                      "type": "USUAL_BUTTON",
+                                      "id": 192,
+                                      "name": "ПереместитьПолеНиже",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Ниже"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": []
+                                    },
+                                    {
+                                      "type": "USUAL_BUTTON",
+                                      "id": 190,
+                                      "name": "ПереместитьПолеВыше",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Выше"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": []
+                                    }
+                                  ],
+                                  []
+                                ]
+                              },
+                              {
+                                "type": "USUAL_GROUP",
+                                "id": 206,
+                                "name": "УстановкаШириныВысоты",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Установить"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "USUAL_GROUP",
+                                      "id": 308,
+                                      "name": "УстановкаВысотыСтроки",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Установка высоты строки"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        [
+                                          {
+                                            "type": "INPUT_FIELD",
+                                            "id": 310,
+                                            "name": "ВысотаСтроки",
+                                            "title": {
+                                              "content": [
+                                                {
+                                                  "default": {
+                                                    "tag": 2
+                                                  },
+                                                  "int": 1,
+                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                    "langKey": "ru",
+                                                    "value": "Высота строки"
+                                                  }
+                                                }
+                                              ]
+                                            },
+                                            "dataPath": "ВысотаСтроки",
+                                            "items": []
+                                          },
+                                          {
+                                            "type": "USUAL_BUTTON",
+                                            "id": 389,
+                                            "name": "УстановитьВысотуСтроки",
+                                            "title": {
+                                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                            },
+                                            "dataPath": "",
+                                            "items": []
+                                          }
+                                        ],
+                                        []
+                                      ]
+                                    },
+                                    {
+                                      "type": "USUAL_GROUP",
+                                      "id": 313,
+                                      "name": "УстановкаШириныКолонки",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Установка ширины колонки"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        [
+                                          {
+                                            "type": "INPUT_FIELD",
+                                            "id": 315,
+                                            "name": "ШиринаКолонки",
+                                            "title": {
+                                              "content": [
+                                                {
+                                                  "default": {
+                                                    "tag": 2
+                                                  },
+                                                  "int": 1,
+                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                    "langKey": "ru",
+                                                    "value": "Ширина колонки"
+                                                  }
+                                                }
+                                              ]
+                                            },
+                                            "dataPath": "ШиринаКолонки",
+                                            "items": []
+                                          },
+                                          {
+                                            "type": "USUAL_BUTTON",
+                                            "id": 391,
+                                            "name": "УстановитьШиринуКолонки",
+                                            "title": {
+                                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                            },
+                                            "dataPath": "",
+                                            "items": []
+                                          }
+                                        ],
+                                        []
+                                      ]
+                                    }
+                                  ],
+                                  []
+                                ]
+                              }
+                            ],
+                            []
+                          ]
+                        },
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 491,
+                          "name": "БыстрыеНастройкиКолонка2",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Быстрые настройки колонка1"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "USUAL_GROUP",
+                                "id": 198,
+                                "name": "Вставка",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Вставка"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  {
+                                    "type": "USUAL_GROUP",
+                                    "id": 445,
+                                    "name": "ВставкаКолонки",
+                                    "title": {
+                                      "content": [
+                                        {
+                                          "default": {
+                                            "tag": 2
+                                          },
+                                          "int": 1,
+                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                            "langKey": "ru",
+                                            "value": "Вставить"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    "dataPath": "",
+                                    "items": [
+                                      [
+                                        {
+                                          "type": "USUAL_GROUP",
+                                          "id": 447,
+                                          "name": "ВставкаКолонка1",
+                                          "title": {
+                                            "content": [
+                                              {
+                                                "default": {
+                                                  "tag": 2
+                                                },
+                                                "int": 1,
+                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                  "langKey": "ru",
+                                                  "value": "Вставка колонка 1"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "dataPath": "",
+                                          "items": [
+                                            [
+                                              {
+                                                "type": "USUAL_BUTTON",
+                                                "id": 156,
+                                                "name": "ВставитьПолеСлева",
+                                                "title": {
+                                                  "content": [
+                                                    {
+                                                      "default": {
+                                                        "tag": 2
+                                                      },
+                                                      "int": 1,
+                                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                        "langKey": "ru",
+                                                        "value": "Поле слева"
+                                                      }
+                                                    }
+                                                  ]
+                                                },
+                                                "dataPath": "",
+                                                "items": []
+                                              },
+                                              {
+                                                "type": "USUAL_BUTTON",
+                                                "id": 160,
+                                                "name": "ВставитьГруппировкуВыше",
+                                                "title": {
+                                                  "content": [
+                                                    {
+                                                      "default": {
+                                                        "tag": 2
+                                                      },
+                                                      "int": 1,
+                                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                        "langKey": "ru",
+                                                        "value": "Группировку выше"
+                                                      }
+                                                    }
+                                                  ]
+                                                },
+                                                "dataPath": "",
+                                                "items": []
+                                              }
+                                            ],
+                                            []
+                                          ]
+                                        },
+                                        {
+                                          "type": "USUAL_GROUP",
+                                          "id": 449,
+                                          "name": "ВставкаКолонка2",
+                                          "title": {
+                                            "content": [
+                                              {
+                                                "default": {
+                                                  "tag": 2
+                                                },
+                                                "int": 1,
+                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                  "langKey": "ru",
+                                                  "value": "Вставка колонка 2"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "dataPath": "",
+                                          "items": [
+                                            [
+                                              {
+                                                "type": "USUAL_BUTTON",
+                                                "id": 158,
+                                                "name": "ВставитьПолеСправа",
+                                                "title": {
+                                                  "content": [
+                                                    {
+                                                      "default": {
+                                                        "tag": 2
+                                                      },
+                                                      "int": 1,
+                                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                        "langKey": "ru",
+                                                        "value": "Поле справа"
+                                                      }
+                                                    }
+                                                  ]
+                                                },
+                                                "dataPath": "",
+                                                "items": []
+                                              },
+                                              {
+                                                "type": "USUAL_BUTTON",
+                                                "id": 162,
+                                                "name": "ВставитьГруппировкуНиже",
+                                                "title": {
+                                                  "content": [
+                                                    {
+                                                      "default": {
+                                                        "tag": 2
+                                                      },
+                                                      "int": 1,
+                                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                        "langKey": "ru",
+                                                        "value": "Группировку ниже"
+                                                      }
+                                                    }
+                                                  ]
+                                                },
+                                                "dataPath": "",
+                                                "items": []
+                                              }
+                                            ],
+                                            []
+                                          ]
+                                        }
+                                      ],
+                                      []
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "USUAL_GROUP",
+                                "id": 457,
+                                "name": "УстановкаЦветаКолонки",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Выделить"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "USUAL_GROUP",
+                                      "id": 459,
+                                      "name": "УстановкаЦветаКолонка1",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Установка цвета колонка 1"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        {
+                                          "type": "USUAL_BUTTON",
+                                          "id": 172,
+                                          "name": "ОформитьОтрицательные",
+                                          "title": {
+                                            "content": [
+                                              {
+                                                "default": {
+                                                  "tag": 2
+                                                },
+                                                "int": 1,
+                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                  "langKey": "ru",
+                                                  "value": "Отрицательные красным"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "dataPath": "",
+                                          "items": []
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "USUAL_GROUP",
+                                      "id": 461,
+                                      "name": "УстановкаЦветаКолонка2",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Установка цвета колонка 2"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        {
+                                          "type": "USUAL_BUTTON",
+                                          "id": 174,
+                                          "name": "ОформитьПоложительные",
+                                          "title": {
+                                            "content": [
+                                              {
+                                                "default": {
+                                                  "tag": 2
+                                                },
+                                                "int": 1,
+                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                  "langKey": "ru",
+                                                  "value": "Положительные зеленым"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "dataPath": "",
+                                          "items": []
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  []
+                                ]
+                              },
+                              {
+                                "type": "USUAL_GROUP",
+                                "id": 496,
+                                "name": "Изменить",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Изменить"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "USUAL_GROUP",
+                                      "id": 303,
+                                      "name": "Переименование",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Переименование"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        [
+                                          {
+                                            "type": "INPUT_FIELD",
+                                            "id": 305,
+                                            "name": "ПредставлениеПоля",
+                                            "title": {
+                                              "content": [
+                                                {
+                                                  "default": {
+                                                    "tag": 2
+                                                  },
+                                                  "int": 1,
+                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                    "langKey": "ru",
+                                                    "value": "Имя поля"
+                                                  }
+                                                }
+                                              ]
+                                            },
+                                            "dataPath": "ПредставлениеПоля",
+                                            "items": []
+                                          },
+                                          {
+                                            "type": "USUAL_BUTTON",
+                                            "id": 393,
+                                            "name": "ПереименоватьПоле",
+                                            "title": {
+                                              "content": [
+                                                {
+                                                  "default": {
+                                                    "tag": 2
+                                                  },
+                                                  "int": 1,
+                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                    "langKey": "ru",
+                                                    "value": "Переименовать"
+                                                  }
+                                                }
+                                              ]
+                                            },
+                                            "dataPath": "",
+                                            "items": []
+                                          }
+                                        ],
+                                        []
+                                      ]
+                                    },
+                                    {
+                                      "type": "USUAL_BUTTON",
+                                      "id": 164,
+                                      "name": "СкрытьПоле",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Скрыть поле"
                                             }
                                           }
                                         ]
@@ -2617,11 +2993,36 @@
                             ],
                             []
                           ]
-                        },
+                        }
+                      ],
+                      []
+                    ]
+                  },
+                  {
+                    "type": "PAGE",
+                    "id": 486,
+                    "name": "Фильтры",
+                    "title": {
+                      "content": [
                         {
-                          "type": "PAGE",
-                          "id": 408,
-                          "name": "Ожидание",
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Фильтры"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 8,
+                          "name": "ФильтрПоУсловию",
                           "title": {
                             "content": [
                               {
@@ -2631,7 +3032,142 @@
                                 "int": 1,
                                 "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                                   "langKey": "ru",
-                                  "value": "Ожидание"
+                                  "value": "По условию"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "USUAL_GROUP",
+                                "id": 376,
+                                "name": "СвойстваФильтраПоУсловиюСлева",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Свойства фильтра по условию слева"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "CHECK_BOX_FIELD",
+                                      "id": 373,
+                                      "name": "Использование",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Использование"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "Использование",
+                                      "items": []
+                                    },
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 10,
+                                      "name": "ВидСравнения",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Вид сравнения"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "ВидСравнения",
+                                      "items": []
+                                    }
+                                  ],
+                                  []
+                                ]
+                              },
+                              {
+                                "type": "USUAL_GROUP",
+                                "id": 378,
+                                "name": "СвойстваФильтраПоУсловиюСправа",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Свойства фильтра по условию справа"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  {
+                                    "type": "INPUT_FIELD",
+                                    "id": 13,
+                                    "name": "ПравоеЗначение",
+                                    "title": {
+                                      "content": [
+                                        {
+                                          "default": {
+                                            "tag": 2
+                                          },
+                                          "int": 1,
+                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                            "langKey": "ru",
+                                            "value": "Правое значение"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    "dataPath": "ПравоеЗначение",
+                                    "items": []
+                                  }
+                                ]
+                              }
+                            ],
+                            []
+                          ]
+                        },
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 16,
+                          "name": "ФильтрПоЗначению",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "По значению"
                                 }
                               }
                             ]
@@ -2640,8 +3176,8 @@
                           "items": [
                             {
                               "type": "PAGES",
-                              "id": 423,
-                              "name": "СтатусыОжидания",
+                              "id": 404,
+                              "name": "ФильтрПоЗначениюСтраницы",
                               "title": {
                                 "content": [
                                   {
@@ -2651,7 +3187,7 @@
                                     "int": 1,
                                     "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                                       "langKey": "ru",
-                                      "value": "Статусы ожидания"
+                                      "value": "Фильтр по значению"
                                     }
                                   }
                                 ]
@@ -2661,8 +3197,8 @@
                                 [
                                   {
                                     "type": "PAGE",
-                                    "id": 421,
-                                    "name": "ОжиданиеЗаполнения",
+                                    "id": 406,
+                                    "name": "ЗначенияФильтра",
                                     "title": {
                                       "content": [
                                         {
@@ -2672,7 +3208,7 @@
                                           "int": 1,
                                           "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                                             "langKey": "ru",
-                                            "value": "Ожидание заполнения"
+                                            "value": "Значения"
                                           }
                                         }
                                       ]
@@ -2681,30 +3217,54 @@
                                     "items": [
                                       [
                                         {
-                                          "type": "DECORATION",
-                                          "id": 410,
-                                          "name": "ИндикаторДлительнойОперации",
+                                          "type": "TABLE",
+                                          "id": 18,
+                                          "name": "Значения",
                                           "title": {
-                                            "content": [
-                                              {
-                                                "default": {
-                                                  "tag": 2
-                                                },
-                                                "int": 1,
-                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                  "langKey": "ru",
-                                                  "value": "Индикатор длительной операции"
-                                                }
-                                              }
-                                            ]
+                                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                                           },
-                                          "dataPath": "",
-                                          "items": []
+                                          "dataPath": "Значения",
+                                          "items": [
+                                            [
+                                              {
+                                                "type": "CHECK_BOX_FIELD",
+                                                "id": 34,
+                                                "name": "ЗначенияПометка",
+                                                "title": {
+                                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                                },
+                                                "dataPath": "Значения.Check",
+                                                "items": []
+                                              },
+                                              {
+                                                "type": "INPUT_FIELD",
+                                                "id": 31,
+                                                "name": "ЗначенияЗначение",
+                                                "title": {
+                                                  "content": [
+                                                    {
+                                                      "default": {
+                                                        "tag": 2
+                                                      },
+                                                      "int": 1,
+                                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                        "langKey": "ru",
+                                                        "value": "Значение"
+                                                      }
+                                                    }
+                                                  ]
+                                                },
+                                                "dataPath": "Значения.Value",
+                                                "items": []
+                                              }
+                                            ],
+                                            []
+                                          ]
                                         },
                                         {
-                                          "type": "LABEL",
-                                          "id": 418,
-                                          "name": "ПредставлениеДлительнойОперации",
+                                          "type": "USUAL_GROUP",
+                                          "id": 435,
+                                          "name": "ОпцииЗаполненияФильтраПоЗначению",
                                           "title": {
                                             "content": [
                                               {
@@ -2714,13 +3274,48 @@
                                                 "int": 1,
                                                 "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                                                   "langKey": "ru",
-                                                  "value": "Выполняется чтение строк поля"
+                                                  "value": "Опции заполнения фильтра по значению"
                                                 }
                                               }
                                             ]
                                           },
                                           "dataPath": "",
-                                          "items": []
+                                          "items": [
+                                            [
+                                              {
+                                                "type": "LABEL",
+                                                "id": 415,
+                                                "name": "СтатистикаФильтраПоЗначению",
+                                                "title": {
+                                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                                },
+                                                "dataPath": "",
+                                                "items": []
+                                              },
+                                              {
+                                                "type": "LABEL",
+                                                "id": 437,
+                                                "name": "ВывестиВсеЗначенияРазделаОтчета",
+                                                "title": {
+                                                  "content": [
+                                                    {
+                                                      "default": {
+                                                        "tag": 2
+                                                      },
+                                                      "int": 1,
+                                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                        "langKey": "ru",
+                                                        "value": "Вывести все"
+                                                      }
+                                                    }
+                                                  ]
+                                                },
+                                                "dataPath": "",
+                                                "items": []
+                                              }
+                                            ],
+                                            []
+                                          ]
                                         }
                                       ],
                                       []
@@ -2728,8 +3323,8 @@
                                   },
                                   {
                                     "type": "PAGE",
-                                    "id": 425,
-                                    "name": "ОшибкаЗаполнения",
+                                    "id": 408,
+                                    "name": "Ожидание",
                                     "title": {
                                       "content": [
                                         {
@@ -2739,47 +3334,126 @@
                                           "int": 1,
                                           "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                                             "langKey": "ru",
-                                            "value": "Ошибка заполнения"
+                                            "value": "Ожидание"
                                           }
                                         }
                                       ]
                                     },
                                     "dataPath": "",
                                     "items": [
-                                      [
-                                        {
-                                          "type": "DECORATION",
-                                          "id": 430,
-                                          "name": "ИндикаторОшибки",
-                                          "title": {
-                                            "content": [
-                                              {
-                                                "default": {
-                                                  "tag": 2
-                                                },
-                                                "int": 1,
-                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                  "langKey": "ru",
-                                                  "value": "Индикатор ошибки"
-                                                }
+                                      {
+                                        "type": "PAGES",
+                                        "id": 423,
+                                        "name": "СтатусыОжидания",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Статусы ожидания"
                                               }
-                                            ]
-                                          },
-                                          "dataPath": "",
-                                          "items": []
+                                            }
+                                          ]
                                         },
-                                        {
-                                          "type": "LABEL",
-                                          "id": 427,
-                                          "name": "ОписаниеОшибкиЗаполнения",
-                                          "title": {
-                                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                          },
-                                          "dataPath": "",
-                                          "items": []
-                                        }
-                                      ],
-                                      []
+                                        "dataPath": "",
+                                        "items": [
+                                          [
+                                            {
+                                              "type": "PAGE",
+                                              "id": 421,
+                                              "name": "ОжиданиеЗаполнения",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Ожидание заполнения"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "",
+                                              "items": [
+                                                [
+                                                  {
+                                                    "type": "DECORATION",
+                                                    "id": 410,
+                                                    "name": "ИндикаторДлительнойОперации",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "Индикатор длительной операции"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": []
+                                                  },
+                                                  {
+                                                    "type": "LABEL",
+                                                    "id": 418,
+                                                    "name": "ПредставлениеДлительнойОперации",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "Выполняется чтение строк поля"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": []
+                                                  }
+                                                ],
+                                                []
+                                              ]
+                                            },
+                                            {
+                                              "type": "PAGE",
+                                              "id": 425,
+                                              "name": "ОшибкаЗаполнения",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Ошибка заполнения"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "",
+                                              "items": []
+                                            }
+                                          ],
+                                          []
+                                        ]
+                                      }
                                     ]
                                   }
                                 ],
@@ -2792,1245 +3466,10 @@
                       []
                     ]
                   }
-                ]
-              },
-              {
-                "type": "USUAL_GROUP",
-                "id": 8,
-                "name": "ФильтрПоУсловию",
-                "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Фильтр по условию"
-                      }
-                    }
-                  ]
-                },
-                "dataPath": "",
-                "items": [
-                  [
-                    {
-                      "type": "USUAL_GROUP",
-                      "id": 376,
-                      "name": "СвойстваФильтраПоУсловиюСлева",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Свойства фильтра по условию слева"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
-                        {
-                          "type": "CHECK_BOX_FIELD",
-                          "id": 373,
-                          "name": "Использование",
-                          "title": {
-                            "content": [
-                              {
-                                "default": {
-                                  "tag": 2
-                                },
-                                "int": 1,
-                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                  "langKey": "ru",
-                                  "value": "Использование"
-                                }
-                              }
-                            ]
-                          },
-                          "dataPath": "Использование",
-                          "items": []
-                        }
-                      ]
-                    },
-                    {
-                      "type": "USUAL_GROUP",
-                      "id": 378,
-                      "name": "СвойстваФильтраПоУсловиюСправа",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Свойства фильтра по условию справа"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "INPUT_FIELD",
-                            "id": 10,
-                            "name": "ВидСравнения",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Вид сравнения"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "ВидСравнения",
-                            "items": []
-                          },
-                          {
-                            "type": "INPUT_FIELD",
-                            "id": 13,
-                            "name": "ПравоеЗначение",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Правое значение"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "ПравоеЗначение",
-                            "items": []
-                          }
-                        ],
-                        []
-                      ]
-                    }
-                  ],
-                  []
-                ]
-              },
-              {
-                "type": "USUAL_GROUP",
-                "id": 299,
-                "name": "КоманднаяПанель",
-                "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
-                },
-                "dataPath": "",
-                "items": [
-                  [
-                    {
-                      "type": "USUAL_GROUP",
-                      "id": 212,
-                      "name": "ДополнительныеВозможности",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Еще"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "LABEL",
-                            "id": 294,
-                            "name": "ДополнительныеВозможностиОтступ",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "USUAL_GROUP",
-                            "id": 292,
-                            "name": "КомандыДополнительныхВозможностей",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Команды дополнительных возможностей"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": [
-                              [
-                                {
-                                  "type": "USUAL_BUTTON",
-                                  "id": 440,
-                                  "name": "СгруппироватьПоВыбранномуПолю",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Сгруппировать по полю"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": []
-                                },
-                                {
-                                  "type": "LABEL",
-                                  "id": 442,
-                                  "name": "СгруппироватьГраницаГруппы",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                  },
-                                  "dataPath": "",
-                                  "items": []
-                                },
-                                {
-                                  "type": "USUAL_GROUP",
-                                  "id": 196,
-                                  "name": "Поле",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Поле"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": [
-                                    [
-                                      {
-                                        "type": "USUAL_GROUP",
-                                        "id": 198,
-                                        "name": "Вставка",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Вставка"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "",
-                                        "items": [
-                                          [
-                                            {
-                                              "type": "USUAL_GROUP",
-                                              "id": 445,
-                                              "name": "ВставкаКолонки",
-                                              "title": {
-                                                "content": [
-                                                  {
-                                                    "default": {
-                                                      "tag": 2
-                                                    },
-                                                    "int": 1,
-                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                      "langKey": "ru",
-                                                      "value": "Вставка колонки"
-                                                    }
-                                                  }
-                                                ]
-                                              },
-                                              "dataPath": "",
-                                              "items": [
-                                                [
-                                                  {
-                                                    "type": "USUAL_GROUP",
-                                                    "id": 447,
-                                                    "name": "ВставкаКолонка1",
-                                                    "title": {
-                                                      "content": [
-                                                        {
-                                                          "default": {
-                                                            "tag": 2
-                                                          },
-                                                          "int": 1,
-                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                            "langKey": "ru",
-                                                            "value": "Вставка колонка 1"
-                                                          }
-                                                        }
-                                                      ]
-                                                    },
-                                                    "dataPath": "",
-                                                    "items": [
-                                                      [
-                                                        {
-                                                          "type": "USUAL_BUTTON",
-                                                          "id": 156,
-                                                          "name": "ВставитьПолеСлева",
-                                                          "title": {
-                                                            "content": [
-                                                              {
-                                                                "default": {
-                                                                  "tag": 2
-                                                                },
-                                                                "int": 1,
-                                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                                  "langKey": "ru",
-                                                                  "value": "Вставить поле слева"
-                                                                }
-                                                              }
-                                                            ]
-                                                          },
-                                                          "dataPath": "",
-                                                          "items": []
-                                                        },
-                                                        {
-                                                          "type": "USUAL_BUTTON",
-                                                          "id": 160,
-                                                          "name": "ВставитьГруппировкуВыше",
-                                                          "title": {
-                                                            "content": [
-                                                              {
-                                                                "default": {
-                                                                  "tag": 2
-                                                                },
-                                                                "int": 1,
-                                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                                  "langKey": "ru",
-                                                                  "value": "Вставить группировку выше"
-                                                                }
-                                                              }
-                                                            ]
-                                                          },
-                                                          "dataPath": "",
-                                                          "items": []
-                                                        }
-                                                      ],
-                                                      []
-                                                    ]
-                                                  },
-                                                  {
-                                                    "type": "USUAL_GROUP",
-                                                    "id": 449,
-                                                    "name": "ВставкаКолонка2",
-                                                    "title": {
-                                                      "content": [
-                                                        {
-                                                          "default": {
-                                                            "tag": 2
-                                                          },
-                                                          "int": 1,
-                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                            "langKey": "ru",
-                                                            "value": "Вставка колонка 2"
-                                                          }
-                                                        }
-                                                      ]
-                                                    },
-                                                    "dataPath": "",
-                                                    "items": [
-                                                      [
-                                                        {
-                                                          "type": "USUAL_BUTTON",
-                                                          "id": 158,
-                                                          "name": "ВставитьПолеСправа",
-                                                          "title": {
-                                                            "content": [
-                                                              {
-                                                                "default": {
-                                                                  "tag": 2
-                                                                },
-                                                                "int": 1,
-                                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                                  "langKey": "ru",
-                                                                  "value": "Вставить поле справа"
-                                                                }
-                                                              }
-                                                            ]
-                                                          },
-                                                          "dataPath": "",
-                                                          "items": []
-                                                        },
-                                                        {
-                                                          "type": "USUAL_BUTTON",
-                                                          "id": 162,
-                                                          "name": "ВставитьГруппировкуНиже",
-                                                          "title": {
-                                                            "content": [
-                                                              {
-                                                                "default": {
-                                                                  "tag": 2
-                                                                },
-                                                                "int": 1,
-                                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                                  "langKey": "ru",
-                                                                  "value": "Вставить группировку ниже"
-                                                                }
-                                                              }
-                                                            ]
-                                                          },
-                                                          "dataPath": "",
-                                                          "items": []
-                                                        }
-                                                      ],
-                                                      []
-                                                    ]
-                                                  }
-                                                ],
-                                                []
-                                              ]
-                                            },
-                                            {
-                                              "type": "LABEL",
-                                              "id": 356,
-                                              "name": "ВставкаГраницаГруппы",
-                                              "title": {
-                                                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                              },
-                                              "dataPath": "",
-                                              "items": []
-                                            }
-                                          ],
-                                          []
-                                        ]
-                                      },
-                                      {
-                                        "type": "USUAL_GROUP",
-                                        "id": 200,
-                                        "name": "Перемещение",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Перемещение"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "",
-                                        "items": [
-                                          [
-                                            {
-                                              "type": "USUAL_GROUP",
-                                              "id": 451,
-                                              "name": "ПеремещениеКолонки",
-                                              "title": {
-                                                "content": [
-                                                  {
-                                                    "default": {
-                                                      "tag": 2
-                                                    },
-                                                    "int": 1,
-                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                      "langKey": "ru",
-                                                      "value": "Перемещение колонки"
-                                                    }
-                                                  }
-                                                ]
-                                              },
-                                              "dataPath": "",
-                                              "items": [
-                                                [
-                                                  {
-                                                    "type": "USUAL_GROUP",
-                                                    "id": 453,
-                                                    "name": "ПеремещениеКолонка1",
-                                                    "title": {
-                                                      "content": [
-                                                        {
-                                                          "default": {
-                                                            "tag": 2
-                                                          },
-                                                          "int": 1,
-                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                            "langKey": "ru",
-                                                            "value": "Перемещение колонка 1"
-                                                          }
-                                                        }
-                                                      ]
-                                                    },
-                                                    "dataPath": "",
-                                                    "items": [
-                                                      [
-                                                        {
-                                                          "type": "USUAL_BUTTON",
-                                                          "id": 186,
-                                                          "name": "ПереместитьПолеВлево",
-                                                          "title": {
-                                                            "content": [
-                                                              {
-                                                                "default": {
-                                                                  "tag": 2
-                                                                },
-                                                                "int": 1,
-                                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                                  "langKey": "ru",
-                                                                  "value": "Переместить влево"
-                                                                }
-                                                              }
-                                                            ]
-                                                          },
-                                                          "dataPath": "",
-                                                          "items": []
-                                                        },
-                                                        {
-                                                          "type": "USUAL_BUTTON",
-                                                          "id": 190,
-                                                          "name": "ПереместитьПолеВыше",
-                                                          "title": {
-                                                            "content": [
-                                                              {
-                                                                "default": {
-                                                                  "tag": 2
-                                                                },
-                                                                "int": 1,
-                                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                                  "langKey": "ru",
-                                                                  "value": "Переместить выше"
-                                                                }
-                                                              }
-                                                            ]
-                                                          },
-                                                          "dataPath": "",
-                                                          "items": []
-                                                        }
-                                                      ],
-                                                      []
-                                                    ]
-                                                  },
-                                                  {
-                                                    "type": "USUAL_GROUP",
-                                                    "id": 455,
-                                                    "name": "ПеремещениеКолонка2",
-                                                    "title": {
-                                                      "content": [
-                                                        {
-                                                          "default": {
-                                                            "tag": 2
-                                                          },
-                                                          "int": 1,
-                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                            "langKey": "ru",
-                                                            "value": "Перемещение колонка 2"
-                                                          }
-                                                        }
-                                                      ]
-                                                    },
-                                                    "dataPath": "",
-                                                    "items": [
-                                                      [
-                                                        {
-                                                          "type": "USUAL_BUTTON",
-                                                          "id": 188,
-                                                          "name": "ПереместитьПолеВправо",
-                                                          "title": {
-                                                            "content": [
-                                                              {
-                                                                "default": {
-                                                                  "tag": 2
-                                                                },
-                                                                "int": 1,
-                                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                                  "langKey": "ru",
-                                                                  "value": "Переместить вправо"
-                                                                }
-                                                              }
-                                                            ]
-                                                          },
-                                                          "dataPath": "",
-                                                          "items": []
-                                                        },
-                                                        {
-                                                          "type": "USUAL_BUTTON",
-                                                          "id": 192,
-                                                          "name": "ПереместитьПолеНиже",
-                                                          "title": {
-                                                            "content": [
-                                                              {
-                                                                "default": {
-                                                                  "tag": 2
-                                                                },
-                                                                "int": 1,
-                                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                                  "langKey": "ru",
-                                                                  "value": "Переместить ниже"
-                                                                }
-                                                              }
-                                                            ]
-                                                          },
-                                                          "dataPath": "",
-                                                          "items": []
-                                                        }
-                                                      ],
-                                                      []
-                                                    ]
-                                                  }
-                                                ],
-                                                []
-                                              ]
-                                            },
-                                            {
-                                              "type": "LABEL",
-                                              "id": 359,
-                                              "name": "ПеремещениеГраницаГруппы",
-                                              "title": {
-                                                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                              },
-                                              "dataPath": "",
-                                              "items": []
-                                            }
-                                          ],
-                                          []
-                                        ]
-                                      },
-                                      {
-                                        "type": "USUAL_GROUP",
-                                        "id": 248,
-                                        "name": "СкрытиеПереименование",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Скрытие, переименование"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "",
-                                        "items": [
-                                          [
-                                            {
-                                              "type": "USUAL_BUTTON",
-                                              "id": 164,
-                                              "name": "СкрытьПоле",
-                                              "title": {
-                                                "content": [
-                                                  {
-                                                    "default": {
-                                                      "tag": 2
-                                                    },
-                                                    "int": 1,
-                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                      "langKey": "ru",
-                                                      "value": "Скрыть"
-                                                    }
-                                                  }
-                                                ]
-                                              },
-                                              "dataPath": "",
-                                              "items": []
-                                            },
-                                            {
-                                              "type": "USUAL_GROUP",
-                                              "id": 303,
-                                              "name": "Переименование",
-                                              "title": {
-                                                "content": [
-                                                  {
-                                                    "default": {
-                                                      "tag": 2
-                                                    },
-                                                    "int": 1,
-                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                      "langKey": "ru",
-                                                      "value": "Переименование"
-                                                    }
-                                                  }
-                                                ]
-                                              },
-                                              "dataPath": "",
-                                              "items": [
-                                                [
-                                                  {
-                                                    "type": "USUAL_BUTTON",
-                                                    "id": 166,
-                                                    "name": "ПереименоватьПоле",
-                                                    "title": {
-                                                      "content": [
-                                                        {
-                                                          "default": {
-                                                            "tag": 2
-                                                          },
-                                                          "int": 1,
-                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                            "langKey": "ru",
-                                                            "value": "Переименовать"
-                                                          }
-                                                        }
-                                                      ]
-                                                    },
-                                                    "dataPath": "",
-                                                    "items": []
-                                                  },
-                                                  {
-                                                    "type": "INPUT_FIELD",
-                                                    "id": 305,
-                                                    "name": "ПредставлениеПоля",
-                                                    "title": {
-                                                      "content": [
-                                                        {
-                                                          "default": {
-                                                            "tag": 2
-                                                          },
-                                                          "int": 1,
-                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                            "langKey": "ru",
-                                                            "value": "Представление поля"
-                                                          }
-                                                        }
-                                                      ]
-                                                    },
-                                                    "dataPath": "ПредставлениеПоля",
-                                                    "items": []
-                                                  },
-                                                  {
-                                                    "type": "USUAL_BUTTON",
-                                                    "id": 393,
-                                                    "name": "ПереименоватьПолеЕще",
-                                                    "title": {
-                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                                    },
-                                                    "dataPath": "",
-                                                    "items": []
-                                                  }
-                                                ],
-                                                []
-                                              ]
-                                            },
-                                            {
-                                              "type": "LABEL",
-                                              "id": 362,
-                                              "name": "СкрытиеПереименованиеГраницаГруппы",
-                                              "title": {
-                                                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                              },
-                                              "dataPath": "",
-                                              "items": []
-                                            }
-                                          ],
-                                          []
-                                        ]
-                                      }
-                                    ],
-                                    []
-                                  ]
-                                },
-                                {
-                                  "type": "USUAL_GROUP",
-                                  "id": 202,
-                                  "name": "Оформление",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Оформление"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": [
-                                    [
-                                      {
-                                        "type": "USUAL_GROUP",
-                                        "id": 204,
-                                        "name": "УстановкаЦвета",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Установка цвета"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "",
-                                        "items": [
-                                          [
-                                            {
-                                              "type": "USUAL_GROUP",
-                                              "id": 457,
-                                              "name": "УстановкаЦветаКолонки",
-                                              "title": {
-                                                "content": [
-                                                  {
-                                                    "default": {
-                                                      "tag": 2
-                                                    },
-                                                    "int": 1,
-                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                      "langKey": "ru",
-                                                      "value": "Установка цвета колонки"
-                                                    }
-                                                  }
-                                                ]
-                                              },
-                                              "dataPath": "",
-                                              "items": [
-                                                [
-                                                  {
-                                                    "type": "USUAL_GROUP",
-                                                    "id": 459,
-                                                    "name": "УстановкаЦветаКолонка1",
-                                                    "title": {
-                                                      "content": [
-                                                        {
-                                                          "default": {
-                                                            "tag": 2
-                                                          },
-                                                          "int": 1,
-                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                            "langKey": "ru",
-                                                            "value": "Установка цвета колонка 1"
-                                                          }
-                                                        }
-                                                      ]
-                                                    },
-                                                    "dataPath": "",
-                                                    "items": [
-                                                      {
-                                                        "type": "USUAL_BUTTON",
-                                                        "id": 172,
-                                                        "name": "ОформитьОтрицательные",
-                                                        "title": {
-                                                          "content": [
-                                                            {
-                                                              "default": {
-                                                                "tag": 2
-                                                              },
-                                                              "int": 1,
-                                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                                "langKey": "ru",
-                                                                "value": "Отрицательные красным"
-                                                              }
-                                                            }
-                                                          ]
-                                                        },
-                                                        "dataPath": "",
-                                                        "items": []
-                                                      }
-                                                    ]
-                                                  },
-                                                  {
-                                                    "type": "USUAL_GROUP",
-                                                    "id": 461,
-                                                    "name": "УстановкаЦветаКолонка2",
-                                                    "title": {
-                                                      "content": [
-                                                        {
-                                                          "default": {
-                                                            "tag": 2
-                                                          },
-                                                          "int": 1,
-                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                            "langKey": "ru",
-                                                            "value": "Установка цвета колонка 2"
-                                                          }
-                                                        }
-                                                      ]
-                                                    },
-                                                    "dataPath": "",
-                                                    "items": [
-                                                      {
-                                                        "type": "USUAL_BUTTON",
-                                                        "id": 174,
-                                                        "name": "ОформитьПоложительные",
-                                                        "title": {
-                                                          "content": [
-                                                            {
-                                                              "default": {
-                                                                "tag": 2
-                                                              },
-                                                              "int": 1,
-                                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                                "langKey": "ru",
-                                                                "value": "Положительные зеленым"
-                                                              }
-                                                            }
-                                                          ]
-                                                        },
-                                                        "dataPath": "",
-                                                        "items": []
-                                                      }
-                                                    ]
-                                                  }
-                                                ],
-                                                []
-                                              ]
-                                            },
-                                            {
-                                              "type": "LABEL",
-                                              "id": 365,
-                                              "name": "УстановкаЦветаГраницаГруппы",
-                                              "title": {
-                                                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                              },
-                                              "dataPath": "",
-                                              "items": []
-                                            }
-                                          ],
-                                          []
-                                        ]
-                                      },
-                                      {
-                                        "type": "USUAL_GROUP",
-                                        "id": 384,
-                                        "name": "ГруппаШиринаВысота",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Ширина высота"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "",
-                                        "items": [
-                                          [
-                                            {
-                                              "type": "USUAL_GROUP",
-                                              "id": 206,
-                                              "name": "УстановкаШириныВысоты",
-                                              "title": {
-                                                "content": [
-                                                  {
-                                                    "default": {
-                                                      "tag": 2
-                                                    },
-                                                    "int": 1,
-                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                      "langKey": "ru",
-                                                      "value": "Установка ширины, высоты"
-                                                    }
-                                                  }
-                                                ]
-                                              },
-                                              "dataPath": "",
-                                              "items": [
-                                                [
-                                                  {
-                                                    "type": "USUAL_GROUP",
-                                                    "id": 308,
-                                                    "name": "УстановкаВысотыСтроки",
-                                                    "title": {
-                                                      "content": [
-                                                        {
-                                                          "default": {
-                                                            "tag": 2
-                                                          },
-                                                          "int": 1,
-                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                            "langKey": "ru",
-                                                            "value": "Установка высоты строки"
-                                                          }
-                                                        }
-                                                      ]
-                                                    },
-                                                    "dataPath": "",
-                                                    "items": [
-                                                      [
-                                                        {
-                                                          "type": "USUAL_BUTTON",
-                                                          "id": 380,
-                                                          "name": "УстановитьВысотуСтроки",
-                                                          "title": {
-                                                            "content": [
-                                                              {
-                                                                "default": {
-                                                                  "tag": 2
-                                                                },
-                                                                "int": 1,
-                                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                                  "langKey": "ru",
-                                                                  "value": "Высота строки"
-                                                                }
-                                                              }
-                                                            ]
-                                                          },
-                                                          "dataPath": "",
-                                                          "items": []
-                                                        },
-                                                        {
-                                                          "type": "INPUT_FIELD",
-                                                          "id": 310,
-                                                          "name": "ВысотаСтроки",
-                                                          "title": {
-                                                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                                          },
-                                                          "dataPath": "ВысотаСтроки",
-                                                          "items": []
-                                                        },
-                                                        {
-                                                          "type": "USUAL_BUTTON",
-                                                          "id": 389,
-                                                          "name": "УстановитьВысотуСтрокиЕще",
-                                                          "title": {
-                                                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                                          },
-                                                          "dataPath": "",
-                                                          "items": []
-                                                        }
-                                                      ],
-                                                      []
-                                                    ]
-                                                  },
-                                                  {
-                                                    "type": "USUAL_GROUP",
-                                                    "id": 313,
-                                                    "name": "УстановкаШириныКолонки",
-                                                    "title": {
-                                                      "content": [
-                                                        {
-                                                          "default": {
-                                                            "tag": 2
-                                                          },
-                                                          "int": 1,
-                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                            "langKey": "ru",
-                                                            "value": "Установка ширины колонки"
-                                                          }
-                                                        }
-                                                      ]
-                                                    },
-                                                    "dataPath": "",
-                                                    "items": [
-                                                      [
-                                                        {
-                                                          "type": "USUAL_BUTTON",
-                                                          "id": 382,
-                                                          "name": "УстановитьШиринуКолонки",
-                                                          "title": {
-                                                            "content": [
-                                                              {
-                                                                "default": {
-                                                                  "tag": 2
-                                                                },
-                                                                "int": 1,
-                                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                                  "langKey": "ru",
-                                                                  "value": "Ширина колонки"
-                                                                }
-                                                              }
-                                                            ]
-                                                          },
-                                                          "dataPath": "",
-                                                          "items": []
-                                                        },
-                                                        {
-                                                          "type": "INPUT_FIELD",
-                                                          "id": 315,
-                                                          "name": "ШиринаКолонки",
-                                                          "title": {
-                                                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                                          },
-                                                          "dataPath": "ШиринаКолонки",
-                                                          "items": []
-                                                        },
-                                                        {
-                                                          "type": "USUAL_BUTTON",
-                                                          "id": 391,
-                                                          "name": "УстановитьШиринуКолонкиЕще",
-                                                          "title": {
-                                                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                                          },
-                                                          "dataPath": "",
-                                                          "items": []
-                                                        }
-                                                      ],
-                                                      []
-                                                    ]
-                                                  }
-                                                ],
-                                                []
-                                              ]
-                                            },
-                                            {
-                                              "type": "LABEL",
-                                              "id": 386,
-                                              "name": "Отступ",
-                                              "title": {
-                                                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                              },
-                                              "dataPath": "",
-                                              "items": []
-                                            }
-                                          ],
-                                          []
-                                        ]
-                                      },
-                                      {
-                                        "type": "LABEL",
-                                        "id": 368,
-                                        "name": "УстановкаШириныВысотыГраницаГруппы",
-                                        "title": {
-                                          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                        },
-                                        "dataPath": "",
-                                        "items": []
-                                      },
-                                      {
-                                        "type": "USUAL_BUTTON",
-                                        "id": 182,
-                                        "name": "ОформитьЕще",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Оформление..."
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "",
-                                        "items": []
-                                      }
-                                    ],
-                                    []
-                                  ]
-                                }
-                              ],
-                              []
-                            ]
-                          }
-                        ],
-                        []
-                      ]
-                    },
-                    {
-                      "type": "COMMAND_BAR",
-                      "id": 301,
-                      "name": "КомандыОсновные",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "BUTTON",
-                            "id": 318,
-                            "name": "ПрименитьИСформировать",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Применить и сформировать"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "BUTTON",
-                            "id": 320,
-                            "name": "Применить",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "BUTTON",
-                            "id": 284,
-                            "name": "Отмена",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                            },
-                            "dataPath": "",
-                            "items": []
-                          }
-                        ],
-                        []
-                      ]
-                    }
-                  ],
-                  []
-                ]
-              }
-            ],
-            []
+                ],
+                []
+              ]
+            }
           ],
           "attributes": [
             [
@@ -4038,7 +3477,7 @@
                 "id": 1,
                 "name": "ВидСравнения",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
@@ -4048,7 +3487,7 @@
                 "id": 2,
                 "name": "ПравоеЗначение",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
@@ -4058,7 +3497,7 @@
                 "id": 3,
                 "name": "Значения",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "types": [
@@ -4078,7 +3517,7 @@
                 "id": 4,
                 "name": "Использование",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
@@ -4098,7 +3537,18 @@
                 "id": 8,
                 "name": "ПредставлениеПоля",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Представление поля"
+                      }
+                    }
+                  ]
                 },
                 "type": {
                   "types": [
@@ -4130,7 +3580,7 @@
                 "id": 9,
                 "name": "ВысотаСтроки",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "types": [
@@ -4163,7 +3613,7 @@
                 "id": 10,
                 "name": "ШиринаКолонки",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[7]/type"
@@ -4432,62 +3882,6 @@
               },
               {
                 "type": "USUAL_GROUP",
-                "id": 19,
-                "name": "ГруппаДругихОтчетовНет",
-                "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Других отчетов нет"
-                      }
-                    }
-                  ]
-                },
-                "dataPath": "",
-                "items": [
-                  [
-                    {
-                      "type": "DECORATION",
-                      "id": 21,
-                      "name": "КартинкаДругихОтчетовНет",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Картинка других отчетов нет"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "LABEL",
-                      "id": 16,
-                      "name": "НадписьДругихОтчетовНет",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[8]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    }
-                  ],
-                  []
-                ]
-              },
-              {
-                "type": "USUAL_GROUP",
                 "id": 5,
                 "name": "ГруппаПодвал",
                 "title": {
@@ -4506,64 +3900,27 @@
                 },
                 "dataPath": "",
                 "items": [
-                  [
-                    {
-                      "type": "CHECK_BOX_FIELD",
-                      "id": 7,
-                      "name": "ЗакрыватьПослеВыбора",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Закрывать это окно после перехода к отчету"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "ЗакрыватьПослеВыбора",
-                      "items": []
-                    },
-                    {
-                      "type": "COMMAND_BAR",
-                      "id": 10,
-                      "name": "ГруппаКоманднаяПанель",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "BUTTON",
-                            "id": 12,
-                            "name": "Закрыть",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                            },
-                            "dataPath": "",
-                            "items": []
+                  {
+                    "type": "CHECK_BOX_FIELD",
+                    "id": 7,
+                    "name": "ЗакрыватьПослеВыбора",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
                           },
-                          {
-                            "type": "BUTTON",
-                            "id": 14,
-                            "name": "ФормаСправка",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                            },
-                            "dataPath": "",
-                            "items": []
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Закрывать это окно после перехода к отчету"
                           }
-                        ],
-                        []
+                        }
                       ]
-                    }
-                  ],
-                  []
+                    },
+                    "dataPath": "ЗакрыватьПослеВыбора",
+                    "items": []
+                  }
                 ]
               }
             ],
@@ -4749,7 +4106,7 @@
                 "id": 11,
                 "name": "ЗакрыватьПослеВыбора",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[8]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[8]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
@@ -4851,646 +4208,40 @@
             []
           ],
           "items": [
-            [
-              {
-                "type": "PAGES",
-                "id": 24,
-                "name": "Страницы",
-                "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Страницы"
-                      }
-                    }
-                  ]
-                },
-                "dataPath": "",
-                "items": [
-                  [
-                    {
-                      "type": "PAGE",
-                      "id": 25,
-                      "name": "Основное",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Основное"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "INPUT_FIELD",
-                            "id": 52,
-                            "name": "Наименование",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                            },
-                            "dataPath": "Объект.Description",
-                            "items": []
-                          },
-                          {
-                            "type": "INPUT_FIELD",
-                            "id": 252,
-                            "name": "Назначение",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                            },
-                            "dataPath": "Объект.Назначение",
-                            "items": []
-                          },
-                          {
-                            "type": "USUAL_GROUP",
-                            "id": 268,
-                            "name": "ГруппаДоступность",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Доступность"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": [
-                              [
-                                {
-                                  "type": "RADIO_BUTTON_FIELD",
-                                  "id": 98,
-                                  "name": "Доступен",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Доступен"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "Доступен",
-                                  "items": []
-                                },
-                                {
-                                  "type": "TABLE",
-                                  "id": 206,
-                                  "name": "ПользователиВарианта",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Показать в панелях отчетов пользователей (начальная настройка)"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "ПользователиВарианта",
-                                  "items": [
-                                    [
-                                      {
-                                        "type": "CHECK_BOX_FIELD",
-                                        "id": 236,
-                                        "name": "ПользователиВариантаПометка",
-                                        "title": {
-                                          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                        },
-                                        "dataPath": "ПользователиВарианта.Check",
-                                        "items": []
-                                      },
-                                      {
-                                        "type": "INPUT_FIELD",
-                                        "id": 219,
-                                        "name": "ПользователиВариантаЗначение",
-                                        "title": {
-                                          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                                        },
-                                        "dataPath": "ПользователиВарианта.Value",
-                                        "items": []
-                                      }
-                                    ],
-                                    []
-                                  ]
-                                },
-                                {
-                                  "type": "CHECK_BOX_FIELD",
-                                  "id": 247,
-                                  "name": "УведомитьПользователей",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Уведомить в чате об этом варианте отчета"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "УведомитьПользователей",
-                                  "items": []
-                                }
-                              ],
-                              []
-                            ]
-                          },
-                          {
-                            "type": "USUAL_GROUP",
-                            "id": 250,
-                            "name": "ГруппаОписание",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
-                            },
-                            "dataPath": "",
-                            "items": [
-                              {
-                                "type": "INPUT_FIELD",
-                                "id": 8,
-                                "name": "Описание",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                },
-                                "dataPath": "Объект.Описание",
-                                "items": []
-                              }
-                            ]
-                          },
-                          {
-                            "type": "USUAL_GROUP",
-                            "id": 190,
-                            "name": "Страница1Подвал",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Страница 1 подвал"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": [
-                              {
-                                "type": "PAGES",
-                                "id": 86,
-                                "name": "ЧтоБудетДальше",
-                                "title": {
-                                  "content": [
-                                    {
-                                      "default": {
-                                        "tag": 2
-                                      },
-                                      "int": 1,
-                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                        "langKey": "ru",
-                                        "value": "Что будет дальше"
-                                      }
-                                    }
-                                  ]
-                                },
-                                "dataPath": "",
-                                "items": [
-                                  [
-                                    {
-                                      "type": "PAGE",
-                                      "id": 88,
-                                      "name": "Новый",
-                                      "title": {
-                                        "content": [
-                                          {
-                                            "default": {
-                                              "tag": 2
-                                            },
-                                            "int": 1,
-                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                              "langKey": "ru",
-                                              "value": "Новый"
-                                            }
-                                          }
-                                        ]
-                                      },
-                                      "dataPath": "",
-                                      "items": [
-                                        {
-                                          "type": "LABEL",
-                                          "id": 187,
-                                          "name": "ДекорацияЧтоБудетДальшеНовый",
-                                          "title": {
-                                            "content": [
-                                              {
-                                                "default": {
-                                                  "tag": 2
-                                                },
-                                                "int": 1,
-                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                  "langKey": "ru",
-                                                  "value": "Будет сохранен новый вариант отчета.\nНажмите \"Далее\" для размещения варианта отчета в разделах приложения."
-                                                }
-                                              }
-                                            ]
-                                          },
-                                          "dataPath": "",
-                                          "items": []
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "PAGE",
-                                      "id": 87,
-                                      "name": "Перезапись",
-                                      "title": {
-                                        "content": [
-                                          {
-                                            "default": {
-                                              "tag": 2
-                                            },
-                                            "int": 1,
-                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                              "langKey": "ru",
-                                              "value": "Перезапись"
-                                            }
-                                          }
-                                        ]
-                                      },
-                                      "dataPath": "",
-                                      "items": [
-                                        {
-                                          "type": "LABEL",
-                                          "id": 184,
-                                          "name": "ДекорацияЧтоБудетДальшеПерезапись",
-                                          "title": {
-                                            "content": [
-                                              {
-                                                "default": {
-                                                  "tag": 2
-                                                },
-                                                "int": 1,
-                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                  "langKey": "ru",
-                                                  "value": "Будет перезаписан существующий вариант отчета.\nНажмите \"Далее\" для размещения варианта отчета в разделах приложения."
-                                                }
-                                              }
-                                            ]
-                                          },
-                                          "dataPath": "",
-                                          "items": []
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "PAGE",
-                                      "id": 201,
-                                      "name": "ПерезаписьНевозможна",
-                                      "title": {
-                                        "content": [
-                                          {
-                                            "default": {
-                                              "tag": 2
-                                            },
-                                            "int": 1,
-                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                              "langKey": "ru",
-                                              "value": "Перезапись невозможна"
-                                            }
-                                          }
-                                        ]
-                                      },
-                                      "dataPath": "",
-                                      "items": [
-                                        {
-                                          "type": "LABEL",
-                                          "id": 203,
-                                          "name": "ДекорацияЧтоБудетДальшеПерезаписьНевозможна",
-                                          "title": {
-                                            "content": [
-                                              {
-                                                "default": {
-                                                  "tag": 2
-                                                },
-                                                "int": 1,
-                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                  "langKey": "ru",
-                                                  "value": "Наименование занято другим вариантом отчета.\nВведите другое наименование или выберите вариант из списка."
-                                                }
-                                              }
-                                            ]
-                                          },
-                                          "dataPath": "",
-                                          "items": []
-                                        }
-                                      ]
-                                    }
-                                  ],
-                                  []
-                                ]
-                              }
-                            ]
-                          }
-                        ],
-                        []
-                      ]
-                    },
-                    {
-                      "type": "PAGE",
-                      "id": 26,
-                      "name": "Дополнительно",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Дополнительно"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "USUAL_GROUP",
-                            "id": 261,
-                            "name": "ГруппаШапка",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Шапка"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": [
-                              [
-                                {
-                                  "type": "CHECK_BOX_FIELD",
-                                  "id": 225,
-                                  "name": "СброситьНастройки",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Сбросить настройки"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "СброситьНастройки",
-                                  "items": []
-                                },
-                                {
-                                  "type": "COMMAND_BAR",
-                                  "id": 263,
-                                  "name": "КоманднаяПанельДеревоПодсистем",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Командная панель дерево подсистем"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": [
-                                    {
-                                      "type": "ADDITION",
-                                      "id": 265,
-                                      "name": "СтрокаПоискаДеревоПодсистем",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                      },
-                                      "dataPath": "",
-                                      "items": []
-                                    }
-                                  ]
-                                }
-                              ],
-                              []
-                            ]
-                          },
-                          {
-                            "type": "TABLE",
-                            "id": 74,
-                            "name": "ДеревоПодсистем",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Дерево подсистем"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "ДеревоПодсистем",
-                            "items": [
-                              [
-                                {
-                                  "type": "COLUMN_GROUP",
-                                  "id": 77,
-                                  "name": "ГруппаКолонок",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Колонок"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": [
-                                    [
-                                      {
-                                        "type": "CHECK_BOX_FIELD",
-                                        "id": 78,
-                                        "name": "ДеревоПодсистемИспользование",
-                                        "title": {
-                                          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                        },
-                                        "dataPath": "ДеревоПодсистем.Использование",
-                                        "items": []
-                                      },
-                                      {
-                                        "type": "INPUT_FIELD",
-                                        "id": 80,
-                                        "name": "ДеревоПодсистемПредставление",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Раздел, Группа"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "ДеревоПодсистем.Представление",
-                                        "items": []
-                                      }
-                                    ],
-                                    []
-                                  ]
-                                },
-                                {
-                                  "type": "INPUT_FIELD",
-                                  "id": 82,
-                                  "name": "ДеревоПодсистемВажность",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Важность"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "ДеревоПодсистем.Важность",
-                                  "items": []
-                                },
-                                {
-                                  "type": "LABEL_FIELD",
-                                  "id": 137,
-                                  "name": "ДеревоПодсистемПользователиПредставление",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Видимость по умолчанию"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "ДеревоПодсистем.ПользователиПредставление",
-                                  "items": []
-                                }
-                              ],
-                              []
-                            ]
-                          }
-                        ],
-                        []
-                      ]
-                    }
-                  ],
-                  []
-                ]
+            {
+              "type": "PAGES",
+              "id": 24,
+              "name": "Страницы",
+              "title": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
               },
-              {
-                "type": "USUAL_GROUP",
-                "id": 145,
-                "name": "ГруппаКоманднаяПанель",
-                "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
-                },
-                "dataPath": "",
-                "items": [
-                  [
-                    {
-                      "type": "COMMAND_BAR",
-                      "id": 147,
-                      "name": "ГруппаКоманднаяПанельЛевая",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Командная панель левая"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
+              "dataPath": "",
+              "items": [
+                [
+                  {
+                    "type": "PAGE",
+                    "id": 25,
+                    "name": "Основное",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
                         {
-                          "type": "BUTTON",
-                          "id": 23,
-                          "name": "Назад",
+                          "type": "INPUT_FIELD",
+                          "id": 52,
+                          "name": "Наименование",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                          },
+                          "dataPath": "Объект.Description",
+                          "items": []
+                        },
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 294,
+                          "name": "ГруппаДоступенНазначение",
                           "title": {
                             "content": [
                               {
@@ -5500,120 +4251,571 @@
                                 "int": 1,
                                 "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                                   "langKey": "ru",
-                                  "value": "<  Назад"
+                                  "value": "Доступен назначение"
                                 }
                               }
                             ]
                           },
                           "dataPath": "",
-                          "items": []
+                          "items": [
+                            [
+                              {
+                                "type": "RADIO_BUTTON_FIELD",
+                                "id": 98,
+                                "name": "Доступен",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Доступен"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "Доступен",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 252,
+                                "name": "Назначение",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                },
+                                "dataPath": "Объект.Назначение",
+                                "items": []
+                              }
+                            ],
+                            []
+                          ]
+                        },
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 268,
+                          "name": "ГруппаДоступность",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Доступность"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "TABLE",
+                                "id": 206,
+                                "name": "ПользователиВарианта",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Показать в панелях отчетов пользователей (начальная настройка)"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "ПользователиВарианта",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "CHECK_BOX_FIELD",
+                                      "id": 236,
+                                      "name": "ПользователиВариантаПометка",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                      },
+                                      "dataPath": "ПользователиВарианта.Check",
+                                      "items": []
+                                    },
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 219,
+                                      "name": "ПользователиВариантаЗначение",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                      },
+                                      "dataPath": "ПользователиВарианта.Value",
+                                      "items": []
+                                    }
+                                  ],
+                                  []
+                                ]
+                              },
+                              {
+                                "type": "CHECK_BOX_FIELD",
+                                "id": 247,
+                                "name": "УведомитьПользователей",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Уведомить в чате об этом варианте отчета"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "УведомитьПользователей",
+                                "items": []
+                              }
+                            ],
+                            []
+                          ]
+                        },
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 250,
+                          "name": "ГруппаОписание",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                          },
+                          "dataPath": "",
+                          "items": [
+                            {
+                              "type": "INPUT_FIELD",
+                              "id": 8,
+                              "name": "Описание",
+                              "title": {
+                                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                              },
+                              "dataPath": "Объект.Описание",
+                              "items": []
+                            }
+                          ]
+                        },
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 190,
+                          "name": "Страница1Подвал",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Страница 1 подвал"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            {
+                              "type": "PAGES",
+                              "id": 86,
+                              "name": "ЧтоБудетДальше",
+                              "title": {
+                                "content": [
+                                  {
+                                    "default": {
+                                      "tag": 2
+                                    },
+                                    "int": 1,
+                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                      "langKey": "ru",
+                                      "value": "Что будет дальше"
+                                    }
+                                  }
+                                ]
+                              },
+                              "dataPath": "",
+                              "items": [
+                                [
+                                  {
+                                    "type": "PAGE",
+                                    "id": 88,
+                                    "name": "Новый",
+                                    "title": {
+                                      "content": [
+                                        {
+                                          "default": {
+                                            "tag": 2
+                                          },
+                                          "int": 1,
+                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                            "langKey": "ru",
+                                            "value": "Новый"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    "dataPath": "",
+                                    "items": [
+                                      {
+                                        "type": "LABEL",
+                                        "id": 187,
+                                        "name": "ДекорацияЧтоБудетДальшеНовый",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Будет сохранен новый вариант отчета.\nНажмите \"Далее\" для размещения варианта отчета в разделах приложения."
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PAGE",
+                                    "id": 87,
+                                    "name": "Перезапись",
+                                    "title": {
+                                      "content": [
+                                        {
+                                          "default": {
+                                            "tag": 2
+                                          },
+                                          "int": 1,
+                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                            "langKey": "ru",
+                                            "value": "Перезапись"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    "dataPath": "",
+                                    "items": [
+                                      {
+                                        "type": "LABEL",
+                                        "id": 184,
+                                        "name": "ДекорацияЧтоБудетДальшеПерезапись",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Будет перезаписан существующий вариант отчета.\nНажмите \"Далее\" для размещения варианта отчета в разделах приложения."
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PAGE",
+                                    "id": 201,
+                                    "name": "ПерезаписьНевозможна",
+                                    "title": {
+                                      "content": [
+                                        {
+                                          "default": {
+                                            "tag": 2
+                                          },
+                                          "int": 1,
+                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                            "langKey": "ru",
+                                            "value": "Перезапись невозможна"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    "dataPath": "",
+                                    "items": [
+                                      {
+                                        "type": "LABEL",
+                                        "id": 203,
+                                        "name": "ДекорацияЧтоБудетДальшеПерезаписьНевозможна",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Наименование занято другим вариантом отчета.\nВведите другое наименование или выберите вариант из списка."
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      }
+                                    ]
+                                  }
+                                ],
+                                []
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      []
+                    ]
+                  },
+                  {
+                    "type": "PAGE",
+                    "id": 26,
+                    "name": "Дополнительно",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Дополнительно"
+                          }
                         }
                       ]
                     },
-                    {
-                      "type": "COMMAND_BAR",
-                      "id": 149,
-                      "name": "ГруппаКоманднаяПанельПравая",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Командная панель правая"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "BUTTON",
-                            "id": 15,
-                            "name": "Далее",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Далее  >"
-                                  }
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 261,
+                          "name": "ГруппаШапка",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Шапка"
                                 }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": []
+                              }
+                            ]
                           },
-                          {
-                            "type": "BUTTON",
-                            "id": 55,
-                            "name": "Сохранить",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Сохранить"
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "CHECK_BOX_FIELD",
+                                "id": 225,
+                                "name": "СброситьНастройки",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Сбросить настройки"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "СброситьНастройки",
+                                "items": []
+                              },
+                              {
+                                "type": "COMMAND_BAR",
+                                "id": 263,
+                                "name": "КоманднаяПанельДеревоПодсистем",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Командная панель дерево подсистем"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  {
+                                    "type": "ADDITION",
+                                    "id": 265,
+                                    "name": "СтрокаПоискаДеревоПодсистем",
+                                    "title": {
+                                      "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                    },
+                                    "dataPath": "",
+                                    "items": []
                                   }
+                                ]
+                              }
+                            ],
+                            []
+                          ]
+                        },
+                        {
+                          "type": "TABLE",
+                          "id": 74,
+                          "name": "ДеревоПодсистем",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Дерево подсистем"
                                 }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": []
+                              }
+                            ]
                           },
-                          {
-                            "type": "BUTTON",
-                            "id": 16,
-                            "name": "Отмена",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "FORM_GROUP",
-                            "id": 151,
-                            "name": "ГруппаКоманднаяПанельСправка",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Командная панель справка"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": []
-                          }
-                        ],
-                        []
-                      ]
-                    }
-                  ],
-                  []
-                ]
-              }
-            ],
-            []
+                          "dataPath": "ДеревоПодсистем",
+                          "items": [
+                            [
+                              {
+                                "type": "COLUMN_GROUP",
+                                "id": 77,
+                                "name": "ГруппаКолонок",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Колонок"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "CHECK_BOX_FIELD",
+                                      "id": 78,
+                                      "name": "ДеревоПодсистемИспользование",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                      },
+                                      "dataPath": "ДеревоПодсистем.Использование",
+                                      "items": []
+                                    },
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 80,
+                                      "name": "ДеревоПодсистемПредставление",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Раздел, Группа"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "ДеревоПодсистем.Представление",
+                                      "items": []
+                                    }
+                                  ],
+                                  []
+                                ]
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 82,
+                                "name": "ДеревоПодсистемВажность",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Важность"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "ДеревоПодсистем.Важность",
+                                "items": []
+                              },
+                              {
+                                "type": "LABEL_FIELD",
+                                "id": 137,
+                                "name": "ДеревоПодсистемПользователиПредставление",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Видимость по умолчанию"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "ДеревоПодсистем.ПользователиПредставление",
+                                "items": []
+                              }
+                            ],
+                            []
+                          ]
+                        }
+                      ],
+                      []
+                    ]
+                  }
+                ],
+                []
+              ]
+            }
           ],
           "attributes": [
             [
@@ -5681,7 +4883,7 @@
                 "id": 15,
                 "name": "Доступен",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[9]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[9]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
@@ -5722,7 +4924,7 @@
                 "id": 20,
                 "name": "СброситьНастройки",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[9]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[9]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
@@ -5850,7 +5052,7 @@
                 "id": 10,
                 "name": "УведомитьПользователей",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[9]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[9]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
@@ -5989,9 +5191,9 @@
                           "items": []
                         },
                         {
-                          "type": "USUAL_GROUP",
-                          "id": 80,
-                          "name": "ГруппаПерсональныеНастройки",
+                          "type": "TABLE",
+                          "id": 4,
+                          "name": "ПерсональныеНастройки",
                           "title": {
                             "content": [
                               {
@@ -6005,108 +5207,6 @@
                                 }
                               }
                             ]
-                          },
-                          "dataPath": "",
-                          "items": [
-                            [
-                              {
-                                "type": "LABEL",
-                                "id": 77,
-                                "name": "ПерсональныеНастройкиНадпись",
-                                "title": {
-                                  "content": [
-                                    {
-                                      "default": {
-                                        "tag": 2
-                                      },
-                                      "int": 1,
-                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                        "langKey": "ru",
-                                        "value": "Персональные настройки:"
-                                      }
-                                    }
-                                  ]
-                                },
-                                "dataPath": "",
-                                "items": []
-                              },
-                              {
-                                "type": "COMMAND_BAR",
-                                "id": 82,
-                                "name": "КоманднаяПанельПерсональныеНастройки",
-                                "title": {
-                                  "content": [
-                                    {
-                                      "default": {
-                                        "tag": 2
-                                      },
-                                      "int": 1,
-                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                        "langKey": "ru",
-                                        "value": "Командная панель персональные настройки"
-                                      }
-                                    }
-                                  ]
-                                },
-                                "dataPath": "",
-                                "items": [
-                                  {
-                                    "type": "FORM_GROUP",
-                                    "id": 75,
-                                    "name": "ПользовательскиеНастройкиГруппаИзменитьФлажки",
-                                    "title": {
-                                      "content": [
-                                        {
-                                          "default": {
-                                            "tag": 2
-                                          },
-                                          "int": 1,
-                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                            "langKey": "ru",
-                                            "value": "Изменить флажки"
-                                          }
-                                        }
-                                      ]
-                                    },
-                                    "dataPath": "",
-                                    "items": [
-                                      [
-                                        {
-                                          "type": "BUTTON",
-                                          "id": 23,
-                                          "name": "ПользовательскиеНастройкиУстановитьФлажки",
-                                          "title": {
-                                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                          },
-                                          "dataPath": "",
-                                          "items": []
-                                        },
-                                        {
-                                          "type": "BUTTON",
-                                          "id": 25,
-                                          "name": "ПользовательскиеНастройкиСнятьФлажки",
-                                          "title": {
-                                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                          },
-                                          "dataPath": "",
-                                          "items": []
-                                        }
-                                      ],
-                                      []
-                                    ]
-                                  }
-                                ]
-                              }
-                            ],
-                            []
-                          ]
-                        },
-                        {
-                          "type": "TABLE",
-                          "id": 4,
-                          "name": "ПерсональныеНастройки",
-                          "title": {
-                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[10]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                           },
                           "dataPath": "ПерсональныеНастройки",
                           "items": [
@@ -6126,7 +5226,7 @@
                                 "id": 17,
                                 "name": "ПользовательскиеНастройкиЗначение",
                                 "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                                 },
                                 "dataPath": "ПерсональныеНастройки.Value",
                                 "items": []
@@ -6392,109 +5492,51 @@
             }
           ],
           "items": [
-            [
-              {
-                "type": "TABLE",
-                "id": 28,
-                "name": "Отборы",
-                "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Фильтры"
-                      }
-                    }
-                  ]
-                },
-                "dataPath": "Отборы",
-                "items": [
-                  [
-                    {
-                      "type": "INPUT_FIELD",
-                      "id": 41,
-                      "name": "ОтборыПредставлениеПользовательскойНастройки",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
-                      },
-                      "dataPath": "Отборы.ПредставлениеПользовательскойНастройки",
-                      "items": []
-                    },
-                    {
-                      "type": "INPUT_FIELD",
-                      "id": 44,
-                      "name": "ОтборыВидСравнения",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                      },
-                      "dataPath": "Отборы.ВидСравнения",
-                      "items": []
-                    }
-                  ],
-                  []
-                ]
+            {
+              "type": "TABLE",
+              "id": 28,
+              "name": "Отборы",
+              "title": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
               },
-              {
-                "type": "COMMAND_BAR",
-                "id": 47,
-                "name": "ГруппаКоманднаяПанель",
-                "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
-                },
-                "dataPath": "",
-                "items": [
-                  [
-                    {
-                      "type": "BUTTON",
-                      "id": 26,
-                      "name": "ФормаВыбрать",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "ОК"
-                            }
+              "dataPath": "Отборы",
+              "items": [
+                [
+                  {
+                    "type": "INPUT_FIELD",
+                    "id": 41,
+                    "name": "ОтборыПредставлениеПользовательскойНастройки",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Поле"
                           }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": []
+                        }
+                      ]
                     },
-                    {
-                      "type": "BUTTON",
-                      "id": 49,
-                      "name": "Отмена",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                      },
-                      "dataPath": "",
-                      "items": []
+                    "dataPath": "Отборы.ПредставлениеПользовательскойНастройки",
+                    "items": []
+                  },
+                  {
+                    "type": "INPUT_FIELD",
+                    "id": 44,
+                    "name": "ОтборыВидСравнения",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                     },
-                    {
-                      "type": "BUTTON",
-                      "id": 51,
-                      "name": "Справка",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    }
-                  ],
-                  []
-                ]
-              }
-            ],
-            []
+                    "dataPath": "Отборы.ВидСравнения",
+                    "items": []
+                  }
+                ],
+                []
+              ]
+            }
           ],
           "attributes": [
             [
@@ -6562,7 +5604,7 @@
                 "id": 8,
                 "name": "Отборы",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[11]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
@@ -6787,7 +5829,18 @@
                 "id": 30,
                 "name": "Дополнительно",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Еще"
+                      }
+                    }
+                  ]
                 },
                 "dataPath": "",
                 "items": [
@@ -6949,74 +6002,6 @@
                   ],
                   []
                 ]
-              },
-              {
-                "type": "USUAL_GROUP",
-                "id": 68,
-                "name": "КоманднаяПанель",
-                "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
-                },
-                "dataPath": "",
-                "items": [
-                  [
-                    {
-                      "type": "HYPERLINK",
-                      "id": 72,
-                      "name": "ПерейтиКРасширеннымНастройкам",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "COMMAND_BAR",
-                      "id": 70,
-                      "name": "КомандыОсновные",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "BUTTON",
-                            "id": 56,
-                            "name": "ПрименитьИСформировать",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "BUTTON",
-                            "id": 54,
-                            "name": "Применить",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "BUTTON",
-                            "id": 52,
-                            "name": "Отмена",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                            },
-                            "dataPath": "",
-                            "items": []
-                          }
-                        ],
-                        []
-                      ]
-                    }
-                  ],
-                  []
-                ]
               }
             ],
             []
@@ -7098,15 +6083,9 @@
                       },
                       "int": 1,
                       "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
-                        "length": 50,
+                        "length": 20,
                         "allowedLength": 0,
-                        "description": {
-                          "value": {
-                            "@class": "com.github._1c_syntax.bsl.types.MultiName",
-                            "nameRu": "КвалификаторыСтроки (50, Переменная)",
-                            "nameEn": "StringQualifiers (50, Variable)"
-                          }
-                        }
+                        "description": {}
                       }
                     }
                   ]
@@ -7315,105 +6294,189 @@
             }
           ],
           "items": [
-            [
-              {
-                "type": "USUAL_GROUP",
-                "id": 337,
-                "name": "ГруппаОформляемыеПоля",
-                "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Оформляемые поля"
-                      }
-                    }
-                  ]
-                },
-                "dataPath": "",
-                "items": [
-                  [
-                    {
-                      "type": "USUAL_GROUP",
-                      "id": 354,
-                      "name": "ГруппаОформляемыеПоляВариантыВыбора",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Варианты выбора"
+            {
+              "type": "PAGES",
+              "id": 412,
+              "name": "Страницы",
+              "title": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+              },
+              "dataPath": "",
+              "items": [
+                [
+                  {
+                    "type": "PAGE",
+                    "id": 419,
+                    "name": "ГруппаОсновное",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                    },
+                    "dataPath": "",
+                    "items": [
+                      {
+                        "type": "USUAL_GROUP",
+                        "id": 447,
+                        "name": "ГруппаОсновноеКолонки",
+                        "title": {
+                          "content": [
+                            {
+                              "default": {
+                                "tag": 2
+                              },
+                              "int": 1,
+                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                "langKey": "ru",
+                                "value": "Основное колонки"
+                              }
                             }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "CHECK_BOX_FIELD",
-                            "id": 372,
-                            "name": "Использование",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Используется для"
+                          ]
+                        },
+                        "dataPath": "",
+                        "items": [
+                          [
+                            {
+                              "type": "USUAL_GROUP",
+                              "id": 443,
+                              "name": "ГруппаОсновноеЛеваяКолонка",
+                              "title": {
+                                "content": [
+                                  {
+                                    "default": {
+                                      "tag": 2
+                                    },
+                                    "int": 1,
+                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                      "langKey": "ru",
+                                      "value": "Основное левая колонка"
+                                    }
                                   }
-                                }
+                                ]
+                              },
+                              "dataPath": "",
+                              "items": [
+                                [
+                                  {
+                                    "type": "CHECK_BOX_FIELD",
+                                    "id": 372,
+                                    "name": "Использование",
+                                    "title": {
+                                      "content": [
+                                        {
+                                          "default": {
+                                            "tag": 2
+                                          },
+                                          "int": 1,
+                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                            "langKey": "ru",
+                                            "value": "Используется"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    "dataPath": "Использование",
+                                    "items": []
+                                  },
+                                  {
+                                    "type": "INPUT_FIELD",
+                                    "id": 93,
+                                    "name": "Наименование",
+                                    "title": {
+                                      "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                    },
+                                    "dataPath": "Наименование",
+                                    "items": []
+                                  },
+                                  {
+                                    "type": "INPUT_FIELD",
+                                    "id": 436,
+                                    "name": "РежимОтображения",
+                                    "title": {
+                                      "content": [
+                                        {
+                                          "default": {
+                                            "tag": 2
+                                          },
+                                          "int": 1,
+                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                            "langKey": "ru",
+                                            "value": "Режим отображения"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    "dataPath": "РежимОтображения",
+                                    "items": []
+                                  },
+                                  {
+                                    "type": "RADIO_BUTTON_FIELD",
+                                    "id": 356,
+                                    "name": "ВариантВыбораОформляемыхПолей",
+                                    "title": {
+                                      "content": [
+                                        {
+                                          "default": {
+                                            "tag": 2
+                                          },
+                                          "int": 1,
+                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                            "langKey": "ru",
+                                            "value": "Оформлять"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    "dataPath": "ВариантВыбораОформляемыхПолей",
+                                    "items": []
+                                  },
+                                  {
+                                    "type": "INPUT_FIELD",
+                                    "id": 359,
+                                    "name": "ОформляемоеПоле",
+                                    "title": {
+                                      "content": [
+                                        {
+                                          "default": {
+                                            "tag": 2
+                                          },
+                                          "int": 1,
+                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                            "langKey": "ru",
+                                            "value": "Оформляемое поле"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    "dataPath": "ОформляемоеПоле",
+                                    "items": []
+                                  }
+                                ],
+                                []
                               ]
                             },
-                            "dataPath": "Использование",
-                            "items": []
-                          },
-                          {
-                            "type": "RADIO_BUTTON_FIELD",
-                            "id": 356,
-                            "name": "ВариантВыбораОформляемыхПолей",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Вариант выбора оформляемых полей"
+                            {
+                              "type": "USUAL_GROUP",
+                              "id": 445,
+                              "name": "ГруппаОсновноеПраваяКолонка",
+                              "title": {
+                                "content": [
+                                  {
+                                    "default": {
+                                      "tag": 2
+                                    },
+                                    "int": 1,
+                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                      "langKey": "ru",
+                                      "value": "Основное правая колонка"
+                                    }
                                   }
-                                }
-                              ]
-                            },
-                            "dataPath": "ВариантВыбораОформляемыхПолей",
-                            "items": []
-                          },
-                          {
-                            "type": "PAGES",
-                            "id": 362,
-                            "name": "ОформляемыеПоляСтраницы",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                            },
-                            "dataPath": "",
-                            "items": [
-                              [
+                                ]
+                              },
+                              "dataPath": "",
+                              "items": [
                                 {
-                                  "type": "PAGE",
-                                  "id": 364,
-                                  "name": "СтраницаОформляемоеПоле",
+                                  "type": "TABLE",
+                                  "id": 30,
+                                  "name": "ОформляемыеПоля",
                                   "title": {
                                     "content": [
                                       {
@@ -7423,132 +6486,42 @@
                                         "int": 1,
                                         "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                                           "langKey": "ru",
-                                          "value": "Оформляемое поле"
+                                          "value": "Оформляемые поля"
                                         }
                                       }
                                     ]
                                   },
-                                  "dataPath": "",
+                                  "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Fields",
                                   "items": [
                                     {
-                                      "type": "INPUT_FIELD",
-                                      "id": 359,
-                                      "name": "ОформляемоеПоле",
+                                      "type": "COLUMN_GROUP",
+                                      "id": 206,
+                                      "name": "ОформляемыеПоляГруппаКолонокПоле",
                                       "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                      },
-                                      "dataPath": "ОформляемоеПоле",
-                                      "items": []
-                                    }
-                                  ]
-                                },
-                                {
-                                  "type": "PAGE",
-                                  "id": 366,
-                                  "name": "СтраницаКоманднаяПанель",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
-                                  },
-                                  "dataPath": "",
-                                  "items": [
-                                    {
-                                      "type": "COMMAND_BAR",
-                                      "id": 368,
-                                      "name": "ОформляемыеПоляКомандыОсновные",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[11]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                                       },
                                       "dataPath": "",
                                       "items": [
                                         [
                                           {
-                                            "type": "BUTTON",
-                                            "id": 265,
-                                            "name": "ОформляемыеПоляДобавить",
+                                            "type": "CHECK_BOX_FIELD",
+                                            "id": 203,
+                                            "name": "ОформляемыеПоляИспользование",
                                             "title": {
                                               "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
                                             },
-                                            "dataPath": "",
+                                            "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Fields.Use",
                                             "items": []
                                           },
                                           {
-                                            "type": "FORM_GROUP",
-                                            "id": 257,
-                                            "name": "ОформляемыеПоляГруппаИзменитьФлажки",
+                                            "type": "INPUT_FIELD",
+                                            "id": 211,
+                                            "name": "ОформляемыеПоляПоле",
                                             "title": {
-                                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[10]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
                                             },
-                                            "dataPath": "",
-                                            "items": [
-                                              [
-                                                {
-                                                  "type": "BUTTON",
-                                                  "id": 259,
-                                                  "name": "ОформляемыеПоляУстановитьФлажки",
-                                                  "title": {
-                                                    "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                                  },
-                                                  "dataPath": "",
-                                                  "items": []
-                                                },
-                                                {
-                                                  "type": "BUTTON",
-                                                  "id": 261,
-                                                  "name": "ОформляемыеПоляСнятьФлажки",
-                                                  "title": {
-                                                    "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                                  },
-                                                  "dataPath": "",
-                                                  "items": []
-                                                }
-                                              ],
-                                              []
-                                            ]
-                                          },
-                                          {
-                                            "type": "FORM_GROUP",
-                                            "id": 275,
-                                            "name": "ОформляемыеПоляГруппаПереместить",
-                                            "title": {
-                                              "content": [
-                                                {
-                                                  "default": {
-                                                    "tag": 2
-                                                  },
-                                                  "int": 1,
-                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                    "langKey": "ru",
-                                                    "value": "Переместить"
-                                                  }
-                                                }
-                                              ]
-                                            },
-                                            "dataPath": "",
-                                            "items": [
-                                              [
-                                                {
-                                                  "type": "BUTTON",
-                                                  "id": 277,
-                                                  "name": "ОформляемыеПоляПереместитьВверх",
-                                                  "title": {
-                                                    "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                                  },
-                                                  "dataPath": "",
-                                                  "items": []
-                                                },
-                                                {
-                                                  "type": "BUTTON",
-                                                  "id": 279,
-                                                  "name": "ОформляемыеПоляПереместитьВниз",
-                                                  "title": {
-                                                    "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                                  },
-                                                  "dataPath": "",
-                                                  "items": []
-                                                }
-                                              ],
-                                              []
-                                            ]
+                                            "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Fields.Field",
+                                            "items": []
                                           }
                                         ],
                                         []
@@ -7556,86 +6529,417 @@
                                     }
                                   ]
                                 }
-                              ],
-                              []
-                            ]
-                          }
-                        ],
-                        []
-                      ]
-                    },
-                    {
-                      "type": "TABLE",
-                      "id": 30,
-                      "name": "ОформляемыеПоля",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                      },
-                      "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Fields",
-                      "items": [
+                              ]
+                            }
+                          ],
+                          []
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "PAGE",
+                    "id": 333,
+                    "name": "ГруппаОформление",
+                    "title": {
+                      "content": [
                         {
-                          "type": "COLUMN_GROUP",
-                          "id": 206,
-                          "name": "ОформляемыеПоляГруппаКолонокПоле",
-                          "title": {
-                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                          "default": {
+                            "tag": 2
                           },
-                          "dataPath": "",
-                          "items": [
-                            [
-                              {
-                                "type": "CHECK_BOX_FIELD",
-                                "id": 203,
-                                "name": "ОформляемыеПоляИспользование",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                },
-                                "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Fields.Use",
-                                "items": []
-                              },
-                              {
-                                "type": "INPUT_FIELD",
-                                "id": 211,
-                                "name": "ОформляемыеПоляПоле",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                },
-                                "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Fields.Field",
-                                "items": []
-                              }
-                            ],
-                            []
-                          ]
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Оформление"
+                          }
                         }
                       ]
-                    }
-                  ],
-                  []
-                ]
-              },
-              {
-                "type": "USUAL_GROUP",
-                "id": 333,
-                "name": "ГруппаОформление",
-                "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
-                },
-                "dataPath": "",
-                "items": [
-                  {
-                    "type": "TABLE",
-                    "id": 72,
-                    "name": "Оформление",
-                    "title": {
-                      "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
                     },
-                    "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Appearance",
+                    "dataPath": "",
+                    "items": [
+                      {
+                        "type": "TABLE",
+                        "id": 72,
+                        "name": "Оформление",
+                        "title": {
+                          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                        },
+                        "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Appearance",
+                        "items": [
+                          [
+                            {
+                              "type": "COLUMN_GROUP",
+                              "id": 201,
+                              "name": "ОформлениеГруппаИспользованиеПараметра",
+                              "title": {
+                                "content": [
+                                  {
+                                    "default": {
+                                      "tag": 2
+                                    },
+                                    "int": 1,
+                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                      "langKey": "ru",
+                                      "value": "Использование параметра"
+                                    }
+                                  }
+                                ]
+                              },
+                              "dataPath": "",
+                              "items": [
+                                [
+                                  {
+                                    "type": "CHECK_BOX_FIELD",
+                                    "id": 96,
+                                    "name": "ОформлениеИспользование",
+                                    "title": {
+                                      "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                    },
+                                    "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Appearance.Use",
+                                    "items": []
+                                  },
+                                  {
+                                    "type": "INPUT_FIELD",
+                                    "id": 105,
+                                    "name": "ОформлениеПараметр",
+                                    "title": {
+                                      "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                    },
+                                    "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Appearance.Parameter",
+                                    "items": []
+                                  }
+                                ],
+                                []
+                              ]
+                            },
+                            {
+                              "type": "COLUMN_GROUP",
+                              "id": 108,
+                              "name": "ОформлениеГруппаКолонокЗначениеПараметра",
+                              "title": {
+                                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                              },
+                              "dataPath": "",
+                              "items": [
+                                [
+                                  {
+                                    "type": "PICTURE_FIELD",
+                                    "id": 110,
+                                    "name": "ОформлениеКартинкаЗначения",
+                                    "title": {
+                                      "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                    },
+                                    "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Appearance.ValuePicture",
+                                    "items": []
+                                  },
+                                  {
+                                    "type": "INPUT_FIELD",
+                                    "id": 113,
+                                    "name": "ОформлениеЗначение",
+                                    "title": {
+                                      "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                    },
+                                    "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Appearance.Value",
+                                    "items": []
+                                  }
+                                ],
+                                []
+                              ]
+                            }
+                          ],
+                          []
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "PAGE",
+                    "id": 335,
+                    "name": "ГруппаОтбор",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                    },
+                    "dataPath": "",
+                    "items": [
+                      {
+                        "type": "TABLE",
+                        "id": 51,
+                        "name": "Отбор",
+                        "title": {
+                          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                        },
+                        "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter",
+                        "items": [
+                          [
+                            {
+                              "type": "CHECK_BOX_FIELD",
+                              "id": 214,
+                              "name": "ОтборИспользование",
+                              "title": {
+                                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                              },
+                              "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.Use",
+                              "items": []
+                            },
+                            {
+                              "type": "COLUMN_GROUP",
+                              "id": 217,
+                              "name": "ОтборГруппаКолонокОтбор",
+                              "title": {
+                                "content": [
+                                  {
+                                    "default": {
+                                      "tag": 2
+                                    },
+                                    "int": 1,
+                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                      "langKey": "ru",
+                                      "value": "Фильтр"
+                                    }
+                                  }
+                                ]
+                              },
+                              "dataPath": "",
+                              "items": [
+                                [
+                                  {
+                                    "type": "COLUMN_GROUP",
+                                    "id": 224,
+                                    "name": "ОтборГруппаКолонокОсновныеЭлементыОтбора",
+                                    "title": {
+                                      "content": [
+                                        {
+                                          "default": {
+                                            "tag": 2
+                                          },
+                                          "int": 1,
+                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                            "langKey": "ru",
+                                            "value": "Основные элементы фильтра"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    "dataPath": "",
+                                    "items": [
+                                      [
+                                        {
+                                          "type": "COLUMN_GROUP",
+                                          "id": 229,
+                                          "name": "ОтборГруппаКолонокЛевоеЗначение",
+                                          "title": {
+                                            "content": [
+                                              {
+                                                "default": {
+                                                  "tag": 2
+                                                },
+                                                "int": 1,
+                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                  "langKey": "ru",
+                                                  "value": "Левое значение"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "dataPath": "",
+                                          "items": [
+                                            [
+                                              {
+                                                "type": "PICTURE_FIELD",
+                                                "id": 231,
+                                                "name": "ОтборКартинкаЛевогоЗначения",
+                                                "title": {
+                                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                                },
+                                                "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.LeftValuePicture",
+                                                "items": []
+                                              },
+                                              {
+                                                "type": "INPUT_FIELD",
+                                                "id": 234,
+                                                "name": "ОтборЛевоеЗначение",
+                                                "title": {
+                                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                                },
+                                                "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.LeftValue",
+                                                "items": []
+                                              }
+                                            ],
+                                            []
+                                          ]
+                                        },
+                                        {
+                                          "type": "INPUT_FIELD",
+                                          "id": 237,
+                                          "name": "ОтборВидСравнения",
+                                          "title": {
+                                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                          },
+                                          "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.ComparisonType",
+                                          "items": []
+                                        },
+                                        {
+                                          "type": "COLUMN_GROUP",
+                                          "id": 240,
+                                          "name": "ОтборГруппаКолонокПравоеЗначение",
+                                          "title": {
+                                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                          },
+                                          "dataPath": "",
+                                          "items": [
+                                            [
+                                              {
+                                                "type": "PICTURE_FIELD",
+                                                "id": 242,
+                                                "name": "ОтборКартинкаПравогоЗначения",
+                                                "title": {
+                                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                                },
+                                                "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.RightValuePicture",
+                                                "items": []
+                                              },
+                                              {
+                                                "type": "INPUT_FIELD",
+                                                "id": 245,
+                                                "name": "ОтборПравоеЗначение",
+                                                "title": {
+                                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                                },
+                                                "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.RightValue",
+                                                "items": []
+                                              }
+                                            ],
+                                            []
+                                          ]
+                                        },
+                                        {
+                                          "type": "INPUT_FIELD",
+                                          "id": 248,
+                                          "name": "ОтборДата",
+                                          "title": {
+                                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                          },
+                                          "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.Date",
+                                          "items": []
+                                        }
+                                      ],
+                                      []
+                                    ]
+                                  },
+                                  {
+                                    "type": "INPUT_FIELD",
+                                    "id": 226,
+                                    "name": "ОтборТипГруппы",
+                                    "title": {
+                                      "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                    },
+                                    "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.GroupType",
+                                    "items": []
+                                  },
+                                  {
+                                    "type": "COLUMN_GROUP",
+                                    "id": 329,
+                                    "name": "ОтборГруппа6",
+                                    "title": {
+                                      "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                    },
+                                    "dataPath": "",
+                                    "items": [
+                                      [
+                                        {
+                                          "type": "COLUMN_GROUP",
+                                          "id": 219,
+                                          "name": "ОтборГруппаКолонокПрименение",
+                                          "title": {
+                                            "content": [
+                                              {
+                                                "default": {
+                                                  "tag": 2
+                                                },
+                                                "int": 1,
+                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                  "langKey": "ru",
+                                                  "value": "Применение"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "dataPath": "",
+                                          "items": [
+                                            [
+                                              {
+                                                "type": "INPUT_FIELD",
+                                                "id": 251,
+                                                "name": "ОтборПрименение",
+                                                "title": {
+                                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                                },
+                                                "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.Application",
+                                                "items": []
+                                              },
+                                              {
+                                                "type": "INPUT_FIELD",
+                                                "id": 254,
+                                                "name": "ОтборРежимОтображения",
+                                                "title": {
+                                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                                },
+                                                "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.ViewMode",
+                                                "items": []
+                                              }
+                                            ],
+                                            []
+                                          ]
+                                        },
+                                        {
+                                          "type": "INPUT_FIELD",
+                                          "id": 221,
+                                          "name": "ОтборПредставление",
+                                          "title": {
+                                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                          },
+                                          "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.Presentation",
+                                          "items": []
+                                        }
+                                      ],
+                                      []
+                                    ]
+                                  }
+                                ],
+                                []
+                              ]
+                            }
+                          ],
+                          []
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "PAGE",
+                    "id": 417,
+                    "name": "ГруппаВариантыИспользования",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Область использования"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "",
                     "items": [
                       [
                         {
-                          "type": "COLUMN_GROUP",
-                          "id": 201,
-                          "name": "ОформлениеГруппаИспользованиеПараметра",
+                          "type": "USUAL_GROUP",
+                          "id": 156,
+                          "name": "ВариантыИспользованияКоманды",
                           "title": {
                             "content": [
                               {
@@ -7645,7 +6949,107 @@
                                 "int": 1,
                                 "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                                   "langKey": "ru",
-                                  "value": "Использование параметра"
+                                  "value": "Варианты использования (команды)"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            {
+                              "type": "COMMAND_BAR",
+                              "id": 199,
+                              "name": "КомандыИзменитьФлажки",
+                              "title": {
+                                "content": [
+                                  {
+                                    "default": {
+                                      "tag": 2
+                                    },
+                                    "int": 1,
+                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                      "langKey": "ru",
+                                      "value": "Изменить флажки"
+                                    }
+                                  }
+                                ]
+                              },
+                              "dataPath": "",
+                              "items": [
+                                {
+                                  "type": "FORM_GROUP",
+                                  "id": 343,
+                                  "name": "ГруппаИзменитьФлажки",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "BUTTON",
+                                        "id": 190,
+                                        "name": "Показывать_УстановитьПометки",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Включить все"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "BUTTON",
+                                        "id": 188,
+                                        "name": "Показывать_СнятьПометки",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Выключить все"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 160,
+                          "name": "ВариантыИспользованияПометки",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Варианты использования (пометки)"
                                 }
                               }
                             ]
@@ -7655,56 +7059,149 @@
                             [
                               {
                                 "type": "CHECK_BOX_FIELD",
-                                "id": 96,
-                                "name": "ОформлениеИспользование",
+                                "id": 185,
+                                "name": "ИспользоватьВГруппировке",
                                 "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "В группировке"
+                                      }
+                                    }
+                                  ]
                                 },
-                                "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Appearance.Use",
+                                "dataPath": "ИспользоватьВГруппировке",
                                 "items": []
                               },
                               {
-                                "type": "INPUT_FIELD",
-                                "id": 105,
-                                "name": "ОформлениеПараметр",
+                                "type": "CHECK_BOX_FIELD",
+                                "id": 176,
+                                "name": "ИспользоватьВИерархическойГруппировке",
                                 "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "В иерархической группировке"
+                                      }
+                                    }
+                                  ]
                                 },
-                                "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Appearance.Parameter",
-                                "items": []
-                              }
-                            ],
-                            []
-                          ]
-                        },
-                        {
-                          "type": "COLUMN_GROUP",
-                          "id": 108,
-                          "name": "ОформлениеГруппаКолонокЗначениеПараметра",
-                          "title": {
-                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                          },
-                          "dataPath": "",
-                          "items": [
-                            [
-                              {
-                                "type": "PICTURE_FIELD",
-                                "id": 110,
-                                "name": "ОформлениеКартинкаЗначения",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                },
-                                "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Appearance.ValuePicture",
+                                "dataPath": "ИспользоватьВИерархическойГруппировке",
                                 "items": []
                               },
                               {
-                                "type": "INPUT_FIELD",
-                                "id": 113,
-                                "name": "ОформлениеЗначение",
+                                "type": "CHECK_BOX_FIELD",
+                                "id": 173,
+                                "name": "ИспользоватьВОбщемИтоге",
                                 "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "В общем итоге"
+                                      }
+                                    }
+                                  ]
                                 },
-                                "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Appearance.Value",
+                                "dataPath": "ИспользоватьВОбщемИтоге",
+                                "items": []
+                              },
+                              {
+                                "type": "CHECK_BOX_FIELD",
+                                "id": 179,
+                                "name": "ИспользоватьВЗаголовкеПолей",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "В заголовке полей"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "ИспользоватьВЗаголовкеПолей",
+                                "items": []
+                              },
+                              {
+                                "type": "CHECK_BOX_FIELD",
+                                "id": 182,
+                                "name": "ИспользоватьВЗаголовке",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "В заголовке"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "ИспользоватьВЗаголовке",
+                                "items": []
+                              },
+                              {
+                                "type": "CHECK_BOX_FIELD",
+                                "id": 167,
+                                "name": "ИспользоватьВПараметрах",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "В параметрах"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "ИспользоватьВПараметрах",
+                                "items": []
+                              },
+                              {
+                                "type": "CHECK_BOX_FIELD",
+                                "id": 170,
+                                "name": "ИспользоватьВОтборе",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "В фильтрах"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "ИспользоватьВОтборе",
                                 "items": []
                               }
                             ],
@@ -7715,781 +7212,10 @@
                       []
                     ]
                   }
-                ]
-              },
-              {
-                "type": "USUAL_GROUP",
-                "id": 335,
-                "name": "ГруппаОтбор",
-                "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[11]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                },
-                "dataPath": "",
-                "items": [
-                  [
-                    {
-                      "type": "USUAL_GROUP",
-                      "id": 345,
-                      "name": "ОтборКоманднаяПанель1",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "LABEL",
-                            "id": 347,
-                            "name": "ОтборЗаголовок",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Условие:"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "COMMAND_BAR",
-                            "id": 350,
-                            "name": "ОтборКомандыОсновные",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                            },
-                            "dataPath": "",
-                            "items": [
-                              [
-                                {
-                                  "type": "BUTTON",
-                                  "id": 293,
-                                  "name": "ОтборДобавитьЭлементОтбора",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Добавить"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": []
-                                },
-                                {
-                                  "type": "FORM_GROUP",
-                                  "id": 285,
-                                  "name": "ОтборГруппаИзменитьФлажки",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[10]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                  },
-                                  "dataPath": "",
-                                  "items": [
-                                    [
-                                      {
-                                        "type": "BUTTON",
-                                        "id": 295,
-                                        "name": "ОтборУстановитьФлажки",
-                                        "title": {
-                                          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                        },
-                                        "dataPath": "",
-                                        "items": []
-                                      },
-                                      {
-                                        "type": "BUTTON",
-                                        "id": 297,
-                                        "name": "ОтборСнятьФлажки",
-                                        "title": {
-                                          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                        },
-                                        "dataPath": "",
-                                        "items": []
-                                      }
-                                    ],
-                                    []
-                                  ]
-                                },
-                                {
-                                  "type": "FORM_GROUP",
-                                  "id": 291,
-                                  "name": "ОтборГруппаПереместить",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
-                                  },
-                                  "dataPath": "",
-                                  "items": [
-                                    [
-                                      {
-                                        "type": "BUTTON",
-                                        "id": 299,
-                                        "name": "ОтборПереместитьВверх",
-                                        "title": {
-                                          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                        },
-                                        "dataPath": "",
-                                        "items": []
-                                      },
-                                      {
-                                        "type": "BUTTON",
-                                        "id": 301,
-                                        "name": "ОтборПереместитьВниз",
-                                        "title": {
-                                          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                        },
-                                        "dataPath": "",
-                                        "items": []
-                                      }
-                                    ],
-                                    []
-                                  ]
-                                }
-                              ],
-                              []
-                            ]
-                          }
-                        ],
-                        []
-                      ]
-                    },
-                    {
-                      "type": "TABLE",
-                      "id": 51,
-                      "name": "Отбор",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[11]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                      },
-                      "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter",
-                      "items": [
-                        [
-                          {
-                            "type": "CHECK_BOX_FIELD",
-                            "id": 214,
-                            "name": "ОтборИспользование",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                            },
-                            "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.Use",
-                            "items": []
-                          },
-                          {
-                            "type": "COLUMN_GROUP",
-                            "id": 217,
-                            "name": "ОтборГруппаКолонокОтбор",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Фильтр"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": [
-                              [
-                                {
-                                  "type": "COLUMN_GROUP",
-                                  "id": 224,
-                                  "name": "ОтборГруппаКолонокОсновныеЭлементыОтбора",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Основные элементы фильтра"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": [
-                                    [
-                                      {
-                                        "type": "COLUMN_GROUP",
-                                        "id": 229,
-                                        "name": "ОтборГруппаКолонокЛевоеЗначение",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Левое значение"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "",
-                                        "items": [
-                                          [
-                                            {
-                                              "type": "PICTURE_FIELD",
-                                              "id": 231,
-                                              "name": "ОтборКартинкаЛевогоЗначения",
-                                              "title": {
-                                                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                              },
-                                              "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.LeftValuePicture",
-                                              "items": []
-                                            },
-                                            {
-                                              "type": "INPUT_FIELD",
-                                              "id": 234,
-                                              "name": "ОтборЛевоеЗначение",
-                                              "title": {
-                                                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                              },
-                                              "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.LeftValue",
-                                              "items": []
-                                            }
-                                          ],
-                                          []
-                                        ]
-                                      },
-                                      {
-                                        "type": "INPUT_FIELD",
-                                        "id": 237,
-                                        "name": "ОтборВидСравнения",
-                                        "title": {
-                                          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                        },
-                                        "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.ComparisonType",
-                                        "items": []
-                                      },
-                                      {
-                                        "type": "COLUMN_GROUP",
-                                        "id": 240,
-                                        "name": "ОтборГруппаКолонокПравоеЗначение",
-                                        "title": {
-                                          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                                        },
-                                        "dataPath": "",
-                                        "items": [
-                                          [
-                                            {
-                                              "type": "PICTURE_FIELD",
-                                              "id": 242,
-                                              "name": "ОтборКартинкаПравогоЗначения",
-                                              "title": {
-                                                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                              },
-                                              "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.RightValuePicture",
-                                              "items": []
-                                            },
-                                            {
-                                              "type": "INPUT_FIELD",
-                                              "id": 245,
-                                              "name": "ОтборПравоеЗначение",
-                                              "title": {
-                                                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                              },
-                                              "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.RightValue",
-                                              "items": []
-                                            }
-                                          ],
-                                          []
-                                        ]
-                                      },
-                                      {
-                                        "type": "INPUT_FIELD",
-                                        "id": 248,
-                                        "name": "ОтборДата",
-                                        "title": {
-                                          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                        },
-                                        "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.Date",
-                                        "items": []
-                                      }
-                                    ],
-                                    []
-                                  ]
-                                },
-                                {
-                                  "type": "INPUT_FIELD",
-                                  "id": 226,
-                                  "name": "ОтборТипГруппы",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                  },
-                                  "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.GroupType",
-                                  "items": []
-                                },
-                                {
-                                  "type": "COLUMN_GROUP",
-                                  "id": 329,
-                                  "name": "ОтборГруппа6",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[11]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                  },
-                                  "dataPath": "",
-                                  "items": [
-                                    [
-                                      {
-                                        "type": "COLUMN_GROUP",
-                                        "id": 219,
-                                        "name": "ОтборГруппаКолонокПрименение",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Применение"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "",
-                                        "items": [
-                                          [
-                                            {
-                                              "type": "INPUT_FIELD",
-                                              "id": 251,
-                                              "name": "ОтборПрименение",
-                                              "title": {
-                                                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                              },
-                                              "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.Application",
-                                              "items": []
-                                            },
-                                            {
-                                              "type": "INPUT_FIELD",
-                                              "id": 254,
-                                              "name": "ОтборРежимОтображения",
-                                              "title": {
-                                                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                              },
-                                              "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.ViewMode",
-                                              "items": []
-                                            }
-                                          ],
-                                          []
-                                        ]
-                                      },
-                                      {
-                                        "type": "INPUT_FIELD",
-                                        "id": 221,
-                                        "name": "ОтборПредставление",
-                                        "title": {
-                                          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                                        },
-                                        "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.Presentation",
-                                        "items": []
-                                      }
-                                    ],
-                                    []
-                                  ]
-                                }
-                              ],
-                              []
-                            ]
-                          }
-                        ],
-                        []
-                      ]
-                    }
-                  ],
-                  []
-                ]
-              },
-              {
-                "type": "INPUT_FIELD",
-                "id": 93,
-                "name": "Наименование",
-                "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                },
-                "dataPath": "Наименование",
-                "items": []
-              },
-              {
-                "type": "USUAL_GROUP",
-                "id": 339,
-                "name": "КоманднаяПанель",
-                "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
-                },
-                "dataPath": "",
-                "items": [
-                  [
-                    {
-                      "type": "USUAL_GROUP",
-                      "id": 341,
-                      "name": "ВариантыИспользования",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "USUAL_GROUP",
-                            "id": 156,
-                            "name": "ВариантыИспользованияКоманды",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Варианты использования (команды)"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": [
-                              [
-                                {
-                                  "type": "LABEL",
-                                  "id": 153,
-                                  "name": "ДекорацияПоказывать",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Показывать:                 "
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "",
-                                  "items": []
-                                },
-                                {
-                                  "type": "COMMAND_BAR",
-                                  "id": 199,
-                                  "name": "КомандыИзменитьФлажки",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[10]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                  },
-                                  "dataPath": "",
-                                  "items": [
-                                    {
-                                      "type": "FORM_GROUP",
-                                      "id": 343,
-                                      "name": "ГруппаИзменитьФлажки",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[10]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                                      },
-                                      "dataPath": "",
-                                      "items": [
-                                        [
-                                          {
-                                            "type": "BUTTON",
-                                            "id": 190,
-                                            "name": "Показывать_УстановитьПометки",
-                                            "title": {
-                                              "content": [
-                                                {
-                                                  "default": {
-                                                    "tag": 2
-                                                  },
-                                                  "int": 1,
-                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                    "langKey": "ru",
-                                                    "value": "Установить пометки"
-                                                  }
-                                                }
-                                              ]
-                                            },
-                                            "dataPath": "",
-                                            "items": []
-                                          },
-                                          {
-                                            "type": "BUTTON",
-                                            "id": 188,
-                                            "name": "Показывать_СнятьПометки",
-                                            "title": {
-                                              "content": [
-                                                {
-                                                  "default": {
-                                                    "tag": 2
-                                                  },
-                                                  "int": 1,
-                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                    "langKey": "ru",
-                                                    "value": "Снять пометки"
-                                                  }
-                                                }
-                                              ]
-                                            },
-                                            "dataPath": "",
-                                            "items": []
-                                          }
-                                        ],
-                                        []
-                                      ]
-                                    }
-                                  ]
-                                }
-                              ],
-                              []
-                            ]
-                          },
-                          {
-                            "type": "USUAL_GROUP",
-                            "id": 160,
-                            "name": "ВариантыИспользованияПометки",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Варианты использования (пометки)"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": [
-                              [
-                                {
-                                  "type": "CHECK_BOX_FIELD",
-                                  "id": 185,
-                                  "name": "ИспользоватьВГруппировке",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "В группировке"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "ИспользоватьВГруппировке",
-                                  "items": []
-                                },
-                                {
-                                  "type": "CHECK_BOX_FIELD",
-                                  "id": 176,
-                                  "name": "ИспользоватьВИерархическойГруппировке",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "В иерархической группировке"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "ИспользоватьВИерархическойГруппировке",
-                                  "items": []
-                                },
-                                {
-                                  "type": "CHECK_BOX_FIELD",
-                                  "id": 173,
-                                  "name": "ИспользоватьВОбщемИтоге",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "В общем итоге"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "ИспользоватьВОбщемИтоге",
-                                  "items": []
-                                },
-                                {
-                                  "type": "CHECK_BOX_FIELD",
-                                  "id": 179,
-                                  "name": "ИспользоватьВЗаголовкеПолей",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "В заголовке полей"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "ИспользоватьВЗаголовкеПолей",
-                                  "items": []
-                                },
-                                {
-                                  "type": "CHECK_BOX_FIELD",
-                                  "id": 182,
-                                  "name": "ИспользоватьВЗаголовке",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "В заголовке"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "ИспользоватьВЗаголовке",
-                                  "items": []
-                                },
-                                {
-                                  "type": "CHECK_BOX_FIELD",
-                                  "id": 167,
-                                  "name": "ИспользоватьВПараметрах",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "В параметрах"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "ИспользоватьВПараметрах",
-                                  "items": []
-                                },
-                                {
-                                  "type": "CHECK_BOX_FIELD",
-                                  "id": 170,
-                                  "name": "ИспользоватьВОтборе",
-                                  "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "В фильтрах"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  "dataPath": "ИспользоватьВОтборе",
-                                  "items": []
-                                }
-                              ],
-                              []
-                            ]
-                          }
-                        ],
-                        []
-                      ]
-                    },
-                    {
-                      "type": "COMMAND_BAR",
-                      "id": 323,
-                      "name": "КомандыОсновные",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "BUTTON",
-                            "id": 26,
-                            "name": "ФормаВыбрать",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[11]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "BUTTON",
-                            "id": 325,
-                            "name": "Отмена",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "BUTTON",
-                            "id": 327,
-                            "name": "Справка",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
-                            },
-                            "dataPath": "",
-                            "items": []
-                          }
-                        ],
-                        []
-                      ]
-                    }
-                  ],
-                  []
-                ]
-              }
-            ],
-            []
+                ],
+                []
+              ]
+            }
           ],
           "attributes": [
             [
@@ -8547,7 +7273,7 @@
                 "id": 8,
                 "name": "Наименование",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
@@ -8557,7 +7283,7 @@
                 "id": 9,
                 "name": "ИспользоватьВГруппировке",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
@@ -8567,7 +7293,7 @@
                 "id": 10,
                 "name": "ИспользоватьВПараметрах",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[6]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[6]/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
@@ -8577,7 +7303,7 @@
                 "id": 11,
                 "name": "ИспользоватьВОтборе",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[7]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[7]/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
@@ -8587,7 +7313,7 @@
                 "id": 12,
                 "name": "ИспользоватьВОбщемИтоге",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
@@ -8597,7 +7323,7 @@
                 "id": 13,
                 "name": "ИспользоватьВИерархическойГруппировке",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
@@ -8607,7 +7333,7 @@
                 "id": 14,
                 "name": "ИспользоватьВЗаголовкеПолей",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
@@ -8617,7 +7343,7 @@
                 "id": 15,
                 "name": "ИспользоватьВЗаголовке",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
@@ -8657,7 +7383,18 @@
                 "id": 4,
                 "name": "ВариантВыбораОформляемыхПолей",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Вариант выбора оформляемых полей"
+                      }
+                    }
+                  ]
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
@@ -8667,7 +7404,7 @@
                 "id": 7,
                 "name": "ОформляемоеПоле",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
@@ -8677,10 +7414,20 @@
                 "id": 19,
                 "name": "Использование",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 20,
+                "name": "РежимОтображения",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[15]/type"
                 }
               }
             ],

--- a/src/test/resources/fixtures/ssl_3_2/SettingsStorages.ХранилищеВариантовОтчетов_edt.json
+++ b/src/test/resources/fixtures/ssl_3_2/SettingsStorages.ХранилищеВариантовОтчетов_edt.json
@@ -1,0 +1,8746 @@
+{"com.github._1c_syntax.bsl.mdo.SettingsStorage": {
+  "comment": "",
+  "description": "Хранилище вариантов отчетов",
+  "forms": [
+    [
+      {
+        "uuid": "077e2c42-bc3b-48bf-bbc2-41effe20f613",
+        "name": "БыстрыеНастройкиОтчета",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "SettingsStorage.ХранилищеВариантовОтчетов.Form.БыстрыеНастройкиОтчета",
+          "mdoRefRu": "ХранилищеНастроек.ХранилищеВариантовОтчетов.Форма.БыстрыеНастройкиОтчета"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Быстрые настройки"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/SettingsStorages/ХранилищеВариантовОтчетов/Forms/БыстрыеНастро_киОтчета/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "content": []
+          },
+          "handlers": [
+            [
+              {
+                "event": "OnOpen",
+                "name": "ПриОткрытии"
+              },
+              {
+                "event": "OnCreateAtServer",
+                "name": "ПриСозданииНаСервере"
+              }
+            ],
+            []
+          ],
+          "items": [
+            [
+              {
+                "type": "TABLE",
+                "id": 1,
+                "name": "БыстрыеНастройки",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/synonym"
+                },
+                "dataPath": "БыстрыеНастройки",
+                "items": [
+                  [
+                    {
+                      "type": "COLUMN_GROUP",
+                      "id": 38,
+                      "name": "БыстрыеНастройкиГруппаНастройка",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Настройка"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "CHECK_BOX_FIELD",
+                            "id": 14,
+                            "name": "БыстрыеНастройкиПометка",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Пометка"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "БыстрыеНастройки.Пометка",
+                            "items": []
+                          },
+                          {
+                            "type": "PICTURE_FIELD",
+                            "id": 56,
+                            "name": "БыстрыеНастройкиКартинкаНастройки",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Картинка настройки"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "БыстрыеНастройки.КартинкаНастройки",
+                            "items": []
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 20,
+                            "name": "БыстрыеНастройкиЗаголовок",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                            },
+                            "dataPath": "БыстрыеНастройки.Заголовок",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 93,
+                      "name": "БыстрыеНастройкиВидСравнения",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Условие"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "БыстрыеНастройки.ВидСравнения",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "CHECK_BOX_FIELD",
+                "id": 106,
+                "name": "ВыводитьЗаголовкиНастроек",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Выводить заголовки настроек"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "ВыводитьЗаголовкиНастроек",
+                "items": []
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 96,
+                "name": "КоманднаяПанель",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Командная панель"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 109,
+                      "name": "ДополнительныеВозможности",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Дополнительные возможности"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        {
+                          "type": "HYPERLINK",
+                          "id": 104,
+                          "name": "ПерейтиКРасширеннымНастройкам",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Больше возможностей..."
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": []
+                        }
+                      ]
+                    },
+                    {
+                      "type": "COMMAND_BAR",
+                      "id": 98,
+                      "name": "КомандыОсновные",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Команды основные"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "BUTTON",
+                            "id": 100,
+                            "name": "Применить",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Применить"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "BUTTON",
+                            "id": 102,
+                            "name": "Отмена",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "БыстрыеНастройки",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/synonym"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "VALUE_TABLE"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 0
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 2,
+                "name": "КомпоновщикНастроек",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "DATA_COMPOSITION_SETTINGS_COMPOSER"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 3,
+                "name": "НастройкиОтчета",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "types": [],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 4,
+                "name": "ВариантМодифицирован",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "BOOLEAN"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 5,
+                "name": "КлючТекущегоВарианта",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                        "length": 0,
+                        "allowedLength": 0,
+                        "description": {
+                          "value": {
+                            "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                            "nameRu": "КвалификаторыСтроки (0, Переменная)",
+                            "nameEn": "StringQualifiers (0, Variable)"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 6,
+                "name": "ВыводитьЗаголовкиНастроек",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "type": "SETTINGS_STORAGE",
+          "mdoRef": "SettingsStorage.ХранилищеВариантовОтчетов",
+          "mdoRefRu": "ХранилищеНастроек.ХранилищеВариантовОтчетов"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "57964dd6-4b0b-4590-bc44-de744cc423af",
+        "name": "ВыборВариантаОтчета",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "SettingsStorage.ХранилищеВариантовОтчетов.Form.ВыборВариантаОтчета",
+          "mdoRefRu": "ХранилищеНастроек.ХранилищеВариантовОтчетов.Форма.ВыборВариантаОтчета"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Выбор варианта отчета"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/SettingsStorages/ХранилищеВариантовОтчетов/Forms/ВыборВариантаОтчета/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+          },
+          "handlers": [
+            [
+              {
+                "event": "NotificationProcessing",
+                "name": "ОбработкаОповещения"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[2]"
+              },
+              {
+                "event": "BeforeLoadDataFromSettingsAtServer",
+                "name": "ПередЗагрузкойДанныхИзНастроекНаСервере"
+              }
+            ],
+            []
+          ],
+          "items": [
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 22,
+                "name": "БыстрыеОтборы",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Быстрые фильтры"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  {
+                    "type": "INPUT_FIELD",
+                    "id": 56,
+                    "name": "ОтборАвтор",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Автор"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "ОтборАвтор",
+                    "items": []
+                  }
+                ]
+              },
+              {
+                "type": "COMMAND_BAR",
+                "id": 27,
+                "name": "ОсновнаяКоманднаяПанель",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Основная командная панель"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "BUTTON",
+                      "id": 6,
+                      "name": "Выбрать",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "BUTTON",
+                      "id": 7,
+                      "name": "Изменить",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "BUTTON",
+                      "id": 15,
+                      "name": "Удалить",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Пометить на удаление / Снять пометку"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "BUTTON",
+                      "id": 13,
+                      "name": "ПоказыватьЛичныеВариантыОтчетовДругихАвторов",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Показывать личные варианты отчетов других авторов"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "BUTTON",
+                      "id": 28,
+                      "name": "ФормаОбновить",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Обновить"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "FORM_GROUP",
+                      "id": 8,
+                      "name": "КоманднаяПанельДерева",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Командная панель дерева"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        {
+                          "type": "ADDITION",
+                          "id": 59,
+                          "name": "СтрокаПоиска",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                          },
+                          "dataPath": "",
+                          "items": []
+                        }
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "TABLE",
+                "id": 1,
+                "name": "ДеревоВариантовОтчета",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Дерево вариантов отчета"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "ДеревоВариантовОтчета",
+                "items": [
+                  [
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 4,
+                      "name": "ДеревоВариантовОтчетаПредставление",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Наименование"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "ДеревоВариантовОтчета.Наименование",
+                      "items": []
+                    },
+                    {
+                      "type": "PICTURE_FIELD",
+                      "id": 29,
+                      "name": "ДеревоВариантовОтчетаКартинкаАвтора",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Картинка автора"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "ДеревоВариантовОтчета.КартинкаАвтора",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 18,
+                      "name": "ДеревоВариантовОтчетаАвтор",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                      },
+                      "dataPath": "ДеревоВариантовОтчета.Автор",
+                      "items": []
+                    },
+                    {
+                      "type": "PICTURE_FIELD",
+                      "id": 62,
+                      "name": "ДеревоВариантовОтчетаКартинкаНазначение",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Картинка назначение"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "ДеревоВариантовОтчета.КартинкаНазначение",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "INPUT_FIELD",
+                "id": 11,
+                "name": "ВариантОписание",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Описание"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "ВариантОписание",
+                "items": []
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "ДеревоВариантовОтчета",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "VALUE_TREE"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 4,
+                "name": "ТекущийПользователь",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "СправочникСсылка.Пользователи",
+                          "nameEn": "CatalogRef.Пользователи"
+                        },
+                        "variant": "METADATA",
+                        "kind": "CATALOG"
+                      }
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 2,
+                "name": "ОтчетИнформация",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 3,
+                "name": "ПолныеПраваНаВарианты",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 6,
+                "name": "ВариантОписание",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 7,
+                "name": "ПоказыватьЛичныеВариантыОтчетовДругихАвторов",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 8,
+                "name": "КлючВарианта",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 9,
+                "name": "ОтборАвтор",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 2,
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "СправочникСсылка.ВнешниеПользователи",
+                          "nameEn": "CatalogRef.ВнешниеПользователи"
+                        },
+                        "variant": "METADATA",
+                        "kind": "CATALOG"
+                      },
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[2]/type/types/java.util.CollSer/com.github._1c_syntax.bsl.types.value.CustomValueType"
+                      }
+                    }
+                  ],
+                  "composite": true,
+                  "qualifiers": []
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "f5bb88eb-c239-4ae3-a297-dfbbd679e008",
+        "name": "ВыборПоляОтчета",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "SettingsStorage.ХранилищеВариантовОтчетов.Form.ВыборПоляОтчета",
+          "mdoRefRu": "ХранилищеНастроек.ХранилищеВариантовОтчетов.Форма.ВыборПоляОтчета"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Выбор поля отчета"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/SettingsStorages/ХранилищеВариантовОтчетов/Forms/ВыборПоляОтчета/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/synonym"
+          },
+          "handlers": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[2]"
+            }
+          ],
+          "items": [
+            {
+              "type": "USUAL_GROUP",
+              "id": 94,
+              "name": "ГруппаДоступныеПоля",
+              "title": {
+                "content": [
+                  {
+                    "default": {
+                      "tag": 2
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                      "langKey": "ru",
+                      "value": "Доступные поля"
+                    }
+                  }
+                ]
+              },
+              "dataPath": "",
+              "items": []
+            }
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "КомпоновщикНастроек",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[2]/type"
+                }
+              },
+              {
+                "id": 3,
+                "name": "НастройкиОтчета",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 4,
+                "name": "ИмяКоллекцииПолей",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 5,
+                "name": "ИдентификаторЭлементаСтруктурыНастроек",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 7,
+                "name": "Режим",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "c888ccc1-9116-4b88-b950-aeabd54191c0",
+        "name": "ВыборФинансовогоПериода",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "SettingsStorage.ХранилищеВариантовОтчетов.Form.ВыборФинансовогоПериода",
+          "mdoRefRu": "ХранилищеНастроек.ХранилищеВариантовОтчетов.Форма.ВыборФинансовогоПериода"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Выбор финансового периода"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/SettingsStorages/ХранилищеВариантовОтчетов/Forms/ВыборФинансовогоПериода/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "content": [
+              {
+                "default": {
+                  "tag": 2
+                },
+                "int": 1,
+                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                  "langKey": "ru",
+                  "value": "Выбор периода"
+                }
+              }
+            ]
+          },
+          "handlers": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[2]"
+            }
+          ],
+          "items": [
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 99,
+                "name": "ГруппаВыборГода",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Выбор года"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 187,
+                      "name": "ПерейтиНаГодНазадВарианты",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Перейти на год назад (варианты)"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "USUAL_BUTTON",
+                            "id": 90,
+                            "name": "ПерейтиНаГодНазадДоступно",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "<"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "LABEL",
+                            "id": 184,
+                            "name": "ПерейтиНаГодНазадНедоступно",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 92,
+                      "name": "ДатаНачалаГода",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Дата начала года"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "ДатаНачалаГода",
+                      "items": []
+                    },
+                    {
+                      "type": "USUAL_BUTTON",
+                      "id": 95,
+                      "name": "ПерейтиНаГодВперед",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": ">"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 176,
+                "name": "ГруппаВыборПериода",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/title"
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 178,
+                      "name": "Месяцы",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Месяцы"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 150,
+                            "name": "Квартал1",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Квартал 1"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "USUAL_BUTTON",
+                                  "id": 101,
+                                  "name": "ВыбратьМесяц1",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "январь"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "USUAL_BUTTON",
+                                  "id": 103,
+                                  "name": "ВыбратьМесяц2",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "февраль"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "USUAL_BUTTON",
+                                  "id": 105,
+                                  "name": "ВыбратьМесяц3",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "март"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          },
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 154,
+                            "name": "Квартал2",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Квартал 2"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "USUAL_BUTTON",
+                                  "id": 109,
+                                  "name": "ВыбратьМесяц4",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "апрель"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "USUAL_BUTTON",
+                                  "id": 111,
+                                  "name": "ВыбратьМесяц5",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "май"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "USUAL_BUTTON",
+                                  "id": 113,
+                                  "name": "ВыбратьМесяц6",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "июнь"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          },
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 158,
+                            "name": "Квартал3",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Квартал 3"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "USUAL_BUTTON",
+                                  "id": 117,
+                                  "name": "ВыбратьМесяц7",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "июль"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "USUAL_BUTTON",
+                                  "id": 119,
+                                  "name": "ВыбратьМесяц8",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "август"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "USUAL_BUTTON",
+                                  "id": 121,
+                                  "name": "ВыбратьМесяц9",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "сентябрь"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          },
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 162,
+                            "name": "Квартал4",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Квартал 4"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "USUAL_BUTTON",
+                                  "id": 125,
+                                  "name": "ВыбратьМесяц10",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "октябрь"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "USUAL_BUTTON",
+                                  "id": 127,
+                                  "name": "ВыбратьМесяц11",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "ноябрь"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "USUAL_BUTTON",
+                                  "id": 129,
+                                  "name": "ВыбратьМесяц12",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "декабрь"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 180,
+                      "name": "Кварталы",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Кварталы"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "USUAL_BUTTON",
+                            "id": 107,
+                            "name": "ВыбратьКвартал1",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "1 квартал"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "USUAL_BUTTON",
+                            "id": 115,
+                            "name": "ВыбратьКвартал2",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "2 квартал"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "USUAL_BUTTON",
+                            "id": 123,
+                            "name": "ВыбратьКвартал3",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "3 квартал"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "USUAL_BUTTON",
+                            "id": 131,
+                            "name": "ВыбратьКвартал4",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "4 квартал"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 182,
+                      "name": "НарастающимИтогом",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Нарастающим итогом"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "USUAL_BUTTON",
+                            "id": 174,
+                            "name": "ВыбратьДень",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "день..."
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "USUAL_BUTTON",
+                            "id": 133,
+                            "name": "ВыбратьПолугодие",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "полугодие"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "USUAL_BUTTON",
+                            "id": 137,
+                            "name": "Выбрать9Месяцев",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "9 месяцев"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "USUAL_BUTTON",
+                            "id": 139,
+                            "name": "ВыбратьГод",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "год"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 193,
+                "name": "ГруппаОчиститьПериод",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Очистить период"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "USUAL_BUTTON",
+                      "id": 189,
+                      "name": "ОчиститьПериод",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "за все время"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "USUAL_BUTTON",
+                      "id": 195,
+                      "name": "ПерейтиКСтандартномуВариантуПериода",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Стандартный вариант"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 2,
+                "name": "НачалоПериода",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "DATE"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.qualifiers.DateQualifiers": {
+                        "dateFractions": 1,
+                        "description": {
+                          "value": {
+                            "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                            "nameRu": "КвалификаторыДаты (Дата)",
+                            "nameEn": "DateQualifiers (Date)"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 3,
+                "name": "КонецПериода",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 4,
+                "name": "ДатаНачалаГода",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 5,
+                "name": "ИмяТекущегоЭлемента",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 1,
+                "name": "ОграничениеСнизу",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 6,
+                "name": "ВыбранныйГодОграничен",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 7,
+                "name": "Период",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "STANDARD_PERIOD"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 8,
+                "name": "ИмяКоманды",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/owner"
+        },
+        "usePurposes": [
+          "PLATFORM_APPLICATION"
+        ]
+      },
+      {
+        "uuid": "ff4d92a7-5fa3-4a46-a6f5-47c3952edb22",
+        "name": "ВыборФинансовогоПериодаДень",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "SettingsStorage.ХранилищеВариантовОтчетов.Form.ВыборФинансовогоПериодаДень",
+          "mdoRefRu": "ХранилищеНастроек.ХранилищеВариантовОтчетов.Форма.ВыборФинансовогоПериодаДень"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Выбор финансового периода день"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/SettingsStorages/ХранилищеВариантовОтчетов/Forms/ВыборФинансовогоПериодаДень/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[5]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "content": [
+              {
+                "default": {
+                  "tag": 2
+                },
+                "int": 1,
+                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                  "langKey": "ru",
+                  "value": "Выбор дня"
+                }
+              }
+            ]
+          },
+          "handlers": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[2]"
+            }
+          ],
+          "items": [
+            {
+              "type": "CALENDAR_FIELD",
+              "id": 1,
+              "name": "День",
+              "title": {
+                "content": [
+                  {
+                    "default": {
+                      "tag": 2
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                      "langKey": "ru",
+                      "value": "День"
+                    }
+                  }
+                ]
+              },
+              "dataPath": "День",
+              "items": []
+            }
+          ],
+          "attributes": [
+            {
+              "id": 1,
+              "name": "День",
+              "title": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[5]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+              },
+              "type": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+              }
+            }
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "bb350b39-1f4d-460a-98c9-8d2308cf22f0",
+        "name": "ГруппаВыбранныхПолей",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "SettingsStorage.ХранилищеВариантовОтчетов.Form.ГруппаВыбранныхПолей",
+          "mdoRefRu": "ХранилищеНастроек.ХранилищеВариантовОтчетов.Форма.ГруппаВыбранныхПолей"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Группа выбранных полей"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/SettingsStorages/ХранилищеВариантовОтчетов/Forms/ГруппаВыбранныхПоле_/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+          },
+          "handlers": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[2]"
+            }
+          ],
+          "items": [
+            [
+              {
+                "type": "INPUT_FIELD",
+                "id": 1,
+                "name": "ЗаголовокГруппы",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Заголовок"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "ЗаголовокГруппы",
+                "items": []
+              },
+              {
+                "type": "RADIO_BUTTON_FIELD",
+                "id": 4,
+                "name": "Расположение",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Расположение"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "РасположениеГруппы",
+                "items": []
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "ЗаголовокГруппы",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 2,
+                "name": "РасположениеГруппы",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "eaeb5aa8-8edf-4f74-8011-2d476f543bf6",
+        "name": "НастройкаПоля",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "SettingsStorage.ХранилищеВариантовОтчетов.Form.НастройкаПоля",
+          "mdoRefRu": "ХранилищеНастроек.ХранилищеВариантовОтчетов.Форма.НастройкаПоля"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Настройка поля"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/SettingsStorages/ХранилищеВариантовОтчетов/Forms/Настро_каПоля/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+          },
+          "handlers": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[2]"
+              }
+            ],
+            []
+          ],
+          "items": [
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 266,
+                "name": "Сортировка",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Сортировка"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "USUAL_BUTTON",
+                      "id": 1,
+                      "name": "СортироватьПоВозрастанию",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Сортировать по возрастанию"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "USUAL_BUTTON",
+                      "id": 3,
+                      "name": "СортироватьПоУбыванию",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Сортировать по убыванию"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 16,
+                "name": "ФильтрПоЗначению",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Фильтр по значению"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  {
+                    "type": "PAGES",
+                    "id": 404,
+                    "name": "ФильтрПоЗначениюСтраницы",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "PAGE",
+                          "id": 406,
+                          "name": "ЗначенияФильтра",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Значения"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "TABLE",
+                                "id": 18,
+                                "name": "Значения",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                },
+                                "dataPath": "Значения",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "CHECK_BOX_FIELD",
+                                      "id": 34,
+                                      "name": "ЗначенияПометка",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                      },
+                                      "dataPath": "Значения.Check",
+                                      "items": []
+                                    },
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 31,
+                                      "name": "ЗначенияЗначение",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Значение"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "Значения.Value",
+                                      "items": []
+                                    }
+                                  ],
+                                  []
+                                ]
+                              },
+                              {
+                                "type": "USUAL_GROUP",
+                                "id": 435,
+                                "name": "ОпцииЗаполненияФильтраПоЗначению",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Опции заполнения фильтра по значению"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "LABEL",
+                                      "id": 415,
+                                      "name": "СтатистикаФильтраПоЗначению",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                      },
+                                      "dataPath": "",
+                                      "items": []
+                                    },
+                                    {
+                                      "type": "LABEL",
+                                      "id": 437,
+                                      "name": "ВывестиВсеЗначенияРазделаОтчета",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Вывести все"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": []
+                                    }
+                                  ],
+                                  []
+                                ]
+                              }
+                            ],
+                            []
+                          ]
+                        },
+                        {
+                          "type": "PAGE",
+                          "id": 408,
+                          "name": "Ожидание",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Ожидание"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            {
+                              "type": "PAGES",
+                              "id": 423,
+                              "name": "СтатусыОжидания",
+                              "title": {
+                                "content": [
+                                  {
+                                    "default": {
+                                      "tag": 2
+                                    },
+                                    "int": 1,
+                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                      "langKey": "ru",
+                                      "value": "Статусы ожидания"
+                                    }
+                                  }
+                                ]
+                              },
+                              "dataPath": "",
+                              "items": [
+                                [
+                                  {
+                                    "type": "PAGE",
+                                    "id": 421,
+                                    "name": "ОжиданиеЗаполнения",
+                                    "title": {
+                                      "content": [
+                                        {
+                                          "default": {
+                                            "tag": 2
+                                          },
+                                          "int": 1,
+                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                            "langKey": "ru",
+                                            "value": "Ожидание заполнения"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    "dataPath": "",
+                                    "items": [
+                                      [
+                                        {
+                                          "type": "DECORATION",
+                                          "id": 410,
+                                          "name": "ИндикаторДлительнойОперации",
+                                          "title": {
+                                            "content": [
+                                              {
+                                                "default": {
+                                                  "tag": 2
+                                                },
+                                                "int": 1,
+                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                  "langKey": "ru",
+                                                  "value": "Индикатор длительной операции"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "dataPath": "",
+                                          "items": []
+                                        },
+                                        {
+                                          "type": "LABEL",
+                                          "id": 418,
+                                          "name": "ПредставлениеДлительнойОперации",
+                                          "title": {
+                                            "content": [
+                                              {
+                                                "default": {
+                                                  "tag": 2
+                                                },
+                                                "int": 1,
+                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                  "langKey": "ru",
+                                                  "value": "Выполняется чтение строк поля"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "dataPath": "",
+                                          "items": []
+                                        }
+                                      ],
+                                      []
+                                    ]
+                                  },
+                                  {
+                                    "type": "PAGE",
+                                    "id": 425,
+                                    "name": "ОшибкаЗаполнения",
+                                    "title": {
+                                      "content": [
+                                        {
+                                          "default": {
+                                            "tag": 2
+                                          },
+                                          "int": 1,
+                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                            "langKey": "ru",
+                                            "value": "Ошибка заполнения"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    "dataPath": "",
+                                    "items": [
+                                      [
+                                        {
+                                          "type": "DECORATION",
+                                          "id": 430,
+                                          "name": "ИндикаторОшибки",
+                                          "title": {
+                                            "content": [
+                                              {
+                                                "default": {
+                                                  "tag": 2
+                                                },
+                                                "int": 1,
+                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                  "langKey": "ru",
+                                                  "value": "Индикатор ошибки"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "dataPath": "",
+                                          "items": []
+                                        },
+                                        {
+                                          "type": "LABEL",
+                                          "id": 427,
+                                          "name": "ОписаниеОшибкиЗаполнения",
+                                          "title": {
+                                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                          },
+                                          "dataPath": "",
+                                          "items": []
+                                        }
+                                      ],
+                                      []
+                                    ]
+                                  }
+                                ],
+                                []
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      []
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 8,
+                "name": "ФильтрПоУсловию",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Фильтр по условию"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 376,
+                      "name": "СвойстваФильтраПоУсловиюСлева",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Свойства фильтра по условию слева"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        {
+                          "type": "CHECK_BOX_FIELD",
+                          "id": 373,
+                          "name": "Использование",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Использование"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "Использование",
+                          "items": []
+                        }
+                      ]
+                    },
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 378,
+                      "name": "СвойстваФильтраПоУсловиюСправа",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Свойства фильтра по условию справа"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 10,
+                            "name": "ВидСравнения",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Вид сравнения"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "ВидСравнения",
+                            "items": []
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 13,
+                            "name": "ПравоеЗначение",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Правое значение"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "ПравоеЗначение",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 299,
+                "name": "КоманднаяПанель",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 212,
+                      "name": "ДополнительныеВозможности",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Еще"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "LABEL",
+                            "id": 294,
+                            "name": "ДополнительныеВозможностиОтступ",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 292,
+                            "name": "КомандыДополнительныхВозможностей",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Команды дополнительных возможностей"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "USUAL_BUTTON",
+                                  "id": 440,
+                                  "name": "СгруппироватьПоВыбранномуПолю",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Сгруппировать по полю"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "LABEL",
+                                  "id": 442,
+                                  "name": "СгруппироватьГраницаГруппы",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "USUAL_GROUP",
+                                  "id": 196,
+                                  "name": "Поле",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Поле"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "USUAL_GROUP",
+                                        "id": 198,
+                                        "name": "Вставка",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Вставка"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": [
+                                          [
+                                            {
+                                              "type": "USUAL_GROUP",
+                                              "id": 445,
+                                              "name": "ВставкаКолонки",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Вставка колонки"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "",
+                                              "items": [
+                                                [
+                                                  {
+                                                    "type": "USUAL_GROUP",
+                                                    "id": 447,
+                                                    "name": "ВставкаКолонка1",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "Вставка колонка 1"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": [
+                                                      [
+                                                        {
+                                                          "type": "USUAL_BUTTON",
+                                                          "id": 156,
+                                                          "name": "ВставитьПолеСлева",
+                                                          "title": {
+                                                            "content": [
+                                                              {
+                                                                "default": {
+                                                                  "tag": 2
+                                                                },
+                                                                "int": 1,
+                                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                  "langKey": "ru",
+                                                                  "value": "Вставить поле слева"
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          "dataPath": "",
+                                                          "items": []
+                                                        },
+                                                        {
+                                                          "type": "USUAL_BUTTON",
+                                                          "id": 160,
+                                                          "name": "ВставитьГруппировкуВыше",
+                                                          "title": {
+                                                            "content": [
+                                                              {
+                                                                "default": {
+                                                                  "tag": 2
+                                                                },
+                                                                "int": 1,
+                                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                  "langKey": "ru",
+                                                                  "value": "Вставить группировку выше"
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          "dataPath": "",
+                                                          "items": []
+                                                        }
+                                                      ],
+                                                      []
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "USUAL_GROUP",
+                                                    "id": 449,
+                                                    "name": "ВставкаКолонка2",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "Вставка колонка 2"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": [
+                                                      [
+                                                        {
+                                                          "type": "USUAL_BUTTON",
+                                                          "id": 158,
+                                                          "name": "ВставитьПолеСправа",
+                                                          "title": {
+                                                            "content": [
+                                                              {
+                                                                "default": {
+                                                                  "tag": 2
+                                                                },
+                                                                "int": 1,
+                                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                  "langKey": "ru",
+                                                                  "value": "Вставить поле справа"
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          "dataPath": "",
+                                                          "items": []
+                                                        },
+                                                        {
+                                                          "type": "USUAL_BUTTON",
+                                                          "id": 162,
+                                                          "name": "ВставитьГруппировкуНиже",
+                                                          "title": {
+                                                            "content": [
+                                                              {
+                                                                "default": {
+                                                                  "tag": 2
+                                                                },
+                                                                "int": 1,
+                                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                  "langKey": "ru",
+                                                                  "value": "Вставить группировку ниже"
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          "dataPath": "",
+                                                          "items": []
+                                                        }
+                                                      ],
+                                                      []
+                                                    ]
+                                                  }
+                                                ],
+                                                []
+                                              ]
+                                            },
+                                            {
+                                              "type": "LABEL",
+                                              "id": 356,
+                                              "name": "ВставкаГраницаГруппы",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                              },
+                                              "dataPath": "",
+                                              "items": []
+                                            }
+                                          ],
+                                          []
+                                        ]
+                                      },
+                                      {
+                                        "type": "USUAL_GROUP",
+                                        "id": 200,
+                                        "name": "Перемещение",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Перемещение"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": [
+                                          [
+                                            {
+                                              "type": "USUAL_GROUP",
+                                              "id": 451,
+                                              "name": "ПеремещениеКолонки",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Перемещение колонки"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "",
+                                              "items": [
+                                                [
+                                                  {
+                                                    "type": "USUAL_GROUP",
+                                                    "id": 453,
+                                                    "name": "ПеремещениеКолонка1",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "Перемещение колонка 1"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": [
+                                                      [
+                                                        {
+                                                          "type": "USUAL_BUTTON",
+                                                          "id": 186,
+                                                          "name": "ПереместитьПолеВлево",
+                                                          "title": {
+                                                            "content": [
+                                                              {
+                                                                "default": {
+                                                                  "tag": 2
+                                                                },
+                                                                "int": 1,
+                                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                  "langKey": "ru",
+                                                                  "value": "Переместить влево"
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          "dataPath": "",
+                                                          "items": []
+                                                        },
+                                                        {
+                                                          "type": "USUAL_BUTTON",
+                                                          "id": 190,
+                                                          "name": "ПереместитьПолеВыше",
+                                                          "title": {
+                                                            "content": [
+                                                              {
+                                                                "default": {
+                                                                  "tag": 2
+                                                                },
+                                                                "int": 1,
+                                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                  "langKey": "ru",
+                                                                  "value": "Переместить выше"
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          "dataPath": "",
+                                                          "items": []
+                                                        }
+                                                      ],
+                                                      []
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "USUAL_GROUP",
+                                                    "id": 455,
+                                                    "name": "ПеремещениеКолонка2",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "Перемещение колонка 2"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": [
+                                                      [
+                                                        {
+                                                          "type": "USUAL_BUTTON",
+                                                          "id": 188,
+                                                          "name": "ПереместитьПолеВправо",
+                                                          "title": {
+                                                            "content": [
+                                                              {
+                                                                "default": {
+                                                                  "tag": 2
+                                                                },
+                                                                "int": 1,
+                                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                  "langKey": "ru",
+                                                                  "value": "Переместить вправо"
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          "dataPath": "",
+                                                          "items": []
+                                                        },
+                                                        {
+                                                          "type": "USUAL_BUTTON",
+                                                          "id": 192,
+                                                          "name": "ПереместитьПолеНиже",
+                                                          "title": {
+                                                            "content": [
+                                                              {
+                                                                "default": {
+                                                                  "tag": 2
+                                                                },
+                                                                "int": 1,
+                                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                  "langKey": "ru",
+                                                                  "value": "Переместить ниже"
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          "dataPath": "",
+                                                          "items": []
+                                                        }
+                                                      ],
+                                                      []
+                                                    ]
+                                                  }
+                                                ],
+                                                []
+                                              ]
+                                            },
+                                            {
+                                              "type": "LABEL",
+                                              "id": 359,
+                                              "name": "ПеремещениеГраницаГруппы",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                              },
+                                              "dataPath": "",
+                                              "items": []
+                                            }
+                                          ],
+                                          []
+                                        ]
+                                      },
+                                      {
+                                        "type": "USUAL_GROUP",
+                                        "id": 248,
+                                        "name": "СкрытиеПереименование",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Скрытие, переименование"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": [
+                                          [
+                                            {
+                                              "type": "USUAL_BUTTON",
+                                              "id": 164,
+                                              "name": "СкрытьПоле",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Скрыть"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "",
+                                              "items": []
+                                            },
+                                            {
+                                              "type": "USUAL_GROUP",
+                                              "id": 303,
+                                              "name": "Переименование",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Переименование"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "",
+                                              "items": [
+                                                [
+                                                  {
+                                                    "type": "USUAL_BUTTON",
+                                                    "id": 166,
+                                                    "name": "ПереименоватьПоле",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "Переименовать"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": []
+                                                  },
+                                                  {
+                                                    "type": "INPUT_FIELD",
+                                                    "id": 305,
+                                                    "name": "ПредставлениеПоля",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "Представление поля"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "ПредставлениеПоля",
+                                                    "items": []
+                                                  },
+                                                  {
+                                                    "type": "USUAL_BUTTON",
+                                                    "id": 393,
+                                                    "name": "ПереименоватьПолеЕще",
+                                                    "title": {
+                                                      "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": []
+                                                  }
+                                                ],
+                                                []
+                                              ]
+                                            },
+                                            {
+                                              "type": "LABEL",
+                                              "id": 362,
+                                              "name": "СкрытиеПереименованиеГраницаГруппы",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                              },
+                                              "dataPath": "",
+                                              "items": []
+                                            }
+                                          ],
+                                          []
+                                        ]
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                },
+                                {
+                                  "type": "USUAL_GROUP",
+                                  "id": 202,
+                                  "name": "Оформление",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Оформление"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "USUAL_GROUP",
+                                        "id": 204,
+                                        "name": "УстановкаЦвета",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Установка цвета"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": [
+                                          [
+                                            {
+                                              "type": "USUAL_GROUP",
+                                              "id": 457,
+                                              "name": "УстановкаЦветаКолонки",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Установка цвета колонки"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "",
+                                              "items": [
+                                                [
+                                                  {
+                                                    "type": "USUAL_GROUP",
+                                                    "id": 459,
+                                                    "name": "УстановкаЦветаКолонка1",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "Установка цвета колонка 1"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": [
+                                                      {
+                                                        "type": "USUAL_BUTTON",
+                                                        "id": 172,
+                                                        "name": "ОформитьОтрицательные",
+                                                        "title": {
+                                                          "content": [
+                                                            {
+                                                              "default": {
+                                                                "tag": 2
+                                                              },
+                                                              "int": 1,
+                                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                "langKey": "ru",
+                                                                "value": "Отрицательные красным"
+                                                              }
+                                                            }
+                                                          ]
+                                                        },
+                                                        "dataPath": "",
+                                                        "items": []
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "USUAL_GROUP",
+                                                    "id": 461,
+                                                    "name": "УстановкаЦветаКолонка2",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "Установка цвета колонка 2"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": [
+                                                      {
+                                                        "type": "USUAL_BUTTON",
+                                                        "id": 174,
+                                                        "name": "ОформитьПоложительные",
+                                                        "title": {
+                                                          "content": [
+                                                            {
+                                                              "default": {
+                                                                "tag": 2
+                                                              },
+                                                              "int": 1,
+                                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                "langKey": "ru",
+                                                                "value": "Положительные зеленым"
+                                                              }
+                                                            }
+                                                          ]
+                                                        },
+                                                        "dataPath": "",
+                                                        "items": []
+                                                      }
+                                                    ]
+                                                  }
+                                                ],
+                                                []
+                                              ]
+                                            },
+                                            {
+                                              "type": "LABEL",
+                                              "id": 365,
+                                              "name": "УстановкаЦветаГраницаГруппы",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                              },
+                                              "dataPath": "",
+                                              "items": []
+                                            }
+                                          ],
+                                          []
+                                        ]
+                                      },
+                                      {
+                                        "type": "USUAL_GROUP",
+                                        "id": 384,
+                                        "name": "ГруппаШиринаВысота",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Ширина высота"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": [
+                                          [
+                                            {
+                                              "type": "USUAL_GROUP",
+                                              "id": 206,
+                                              "name": "УстановкаШириныВысоты",
+                                              "title": {
+                                                "content": [
+                                                  {
+                                                    "default": {
+                                                      "tag": 2
+                                                    },
+                                                    "int": 1,
+                                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                      "langKey": "ru",
+                                                      "value": "Установка ширины, высоты"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              "dataPath": "",
+                                              "items": [
+                                                [
+                                                  {
+                                                    "type": "USUAL_GROUP",
+                                                    "id": 308,
+                                                    "name": "УстановкаВысотыСтроки",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "Установка высоты строки"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": [
+                                                      [
+                                                        {
+                                                          "type": "USUAL_BUTTON",
+                                                          "id": 380,
+                                                          "name": "УстановитьВысотуСтроки",
+                                                          "title": {
+                                                            "content": [
+                                                              {
+                                                                "default": {
+                                                                  "tag": 2
+                                                                },
+                                                                "int": 1,
+                                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                  "langKey": "ru",
+                                                                  "value": "Высота строки"
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          "dataPath": "",
+                                                          "items": []
+                                                        },
+                                                        {
+                                                          "type": "INPUT_FIELD",
+                                                          "id": 310,
+                                                          "name": "ВысотаСтроки",
+                                                          "title": {
+                                                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                                          },
+                                                          "dataPath": "ВысотаСтроки",
+                                                          "items": []
+                                                        },
+                                                        {
+                                                          "type": "USUAL_BUTTON",
+                                                          "id": 389,
+                                                          "name": "УстановитьВысотуСтрокиЕще",
+                                                          "title": {
+                                                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                                          },
+                                                          "dataPath": "",
+                                                          "items": []
+                                                        }
+                                                      ],
+                                                      []
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "USUAL_GROUP",
+                                                    "id": 313,
+                                                    "name": "УстановкаШириныКолонки",
+                                                    "title": {
+                                                      "content": [
+                                                        {
+                                                          "default": {
+                                                            "tag": 2
+                                                          },
+                                                          "int": 1,
+                                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                            "langKey": "ru",
+                                                            "value": "Установка ширины колонки"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    "dataPath": "",
+                                                    "items": [
+                                                      [
+                                                        {
+                                                          "type": "USUAL_BUTTON",
+                                                          "id": 382,
+                                                          "name": "УстановитьШиринуКолонки",
+                                                          "title": {
+                                                            "content": [
+                                                              {
+                                                                "default": {
+                                                                  "tag": 2
+                                                                },
+                                                                "int": 1,
+                                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                                  "langKey": "ru",
+                                                                  "value": "Ширина колонки"
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          "dataPath": "",
+                                                          "items": []
+                                                        },
+                                                        {
+                                                          "type": "INPUT_FIELD",
+                                                          "id": 315,
+                                                          "name": "ШиринаКолонки",
+                                                          "title": {
+                                                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                                          },
+                                                          "dataPath": "ШиринаКолонки",
+                                                          "items": []
+                                                        },
+                                                        {
+                                                          "type": "USUAL_BUTTON",
+                                                          "id": 391,
+                                                          "name": "УстановитьШиринуКолонкиЕще",
+                                                          "title": {
+                                                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                                          },
+                                                          "dataPath": "",
+                                                          "items": []
+                                                        }
+                                                      ],
+                                                      []
+                                                    ]
+                                                  }
+                                                ],
+                                                []
+                                              ]
+                                            },
+                                            {
+                                              "type": "LABEL",
+                                              "id": 386,
+                                              "name": "Отступ",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                              },
+                                              "dataPath": "",
+                                              "items": []
+                                            }
+                                          ],
+                                          []
+                                        ]
+                                      },
+                                      {
+                                        "type": "LABEL",
+                                        "id": 368,
+                                        "name": "УстановкаШириныВысотыГраницаГруппы",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "USUAL_BUTTON",
+                                        "id": 182,
+                                        "name": "ОформитьЕще",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Оформление..."
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                }
+                              ],
+                              []
+                            ]
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "COMMAND_BAR",
+                      "id": 301,
+                      "name": "КомандыОсновные",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "BUTTON",
+                            "id": 318,
+                            "name": "ПрименитьИСформировать",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Применить и сформировать"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "BUTTON",
+                            "id": 320,
+                            "name": "Применить",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "BUTTON",
+                            "id": 284,
+                            "name": "Отмена",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "ВидСравнения",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 2,
+                "name": "ПравоеЗначение",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 3,
+                "name": "Значения",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "VALUE_LIST"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 4,
+                "name": "Использование",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 7,
+                "name": "КомпоновщикНастроек",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[2]/type"
+                }
+              },
+              {
+                "id": 8,
+                "name": "ПредставлениеПоля",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                        "length": 150,
+                        "allowedLength": 0,
+                        "description": {}
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 9,
+                "name": "ВысотаСтроки",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                        "precision": 5,
+                        "scale": 0,
+                        "nonNegative": true,
+                        "description": {}
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 10,
+                "name": "ШиринаКолонки",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[7]/type"
+                }
+              },
+              {
+                "id": 11,
+                "name": "НастройкиОтчета",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 12,
+                "name": "СвойстваЗаголовка",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 13,
+                "name": "ИдентификаторЭлементаСтруктурыНастроек",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 5,
+                "name": "ДоступныеЗначения",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 6,
+                "name": "СнятьФильтрПоУсловию",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 14,
+                "name": "ИндексыГруппИЭлементов",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 17,
+                "name": "КоличествоСтрокВРазделеОтчета",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                        "precision": 10,
+                        "scale": 0,
+                        "nonNegative": true,
+                        "description": {}
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 15,
+                "name": "ВыведеныВсеЗначенияРазделаОтчета",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 16,
+                "name": "КоличествоПервыхЧитаемыхСтрок",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[15]/type"
+                }
+              },
+              {
+                "id": 18,
+                "name": "АдресДанныхРасшифровки",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 19,
+                "name": "Документ",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "SPREADSHEET_DOCUMENT"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "b2f17ef1-3f6f-4029-b3e2-28d6b79c5b76",
+        "name": "ПанельДругихОтчетов",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "SettingsStorage.ХранилищеВариантовОтчетов.Form.ПанельДругихОтчетов",
+          "mdoRefRu": "ХранилищеНастроек.ХранилищеВариантовОтчетов.Форма.ПанельДругихОтчетов"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Панель других отчетов"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/SettingsStorages/ХранилищеВариантовОтчетов/Forms/ПанельДругихОтчетов/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[8]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "content": [
+              {
+                "default": {
+                  "tag": 2
+                },
+                "int": 1,
+                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                  "langKey": "ru",
+                  "value": "Другие отчеты"
+                }
+              }
+            ]
+          },
+          "handlers": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[2]"
+            }
+          ],
+          "items": [
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 1,
+                "name": "СтраницаДругиеОтчеты",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Страница другие отчеты"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  {
+                    "type": "USUAL_GROUP",
+                    "id": 3,
+                    "name": "ГруппаДругиеВариантыОтчета",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Варианты отчета"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "",
+                    "items": []
+                  }
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 19,
+                "name": "ГруппаДругихОтчетовНет",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Других отчетов нет"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "DECORATION",
+                      "id": 21,
+                      "name": "КартинкаДругихОтчетовНет",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Картинка других отчетов нет"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL",
+                      "id": 16,
+                      "name": "НадписьДругихОтчетовНет",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[8]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 5,
+                "name": "ГруппаПодвал",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Подвал"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "CHECK_BOX_FIELD",
+                      "id": 7,
+                      "name": "ЗакрыватьПослеВыбора",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Закрывать это окно после перехода к отчету"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "ЗакрыватьПослеВыбора",
+                      "items": []
+                    },
+                    {
+                      "type": "COMMAND_BAR",
+                      "id": 10,
+                      "name": "ГруппаКоманднаяПанель",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "BUTTON",
+                            "id": 12,
+                            "name": "Закрыть",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "BUTTON",
+                            "id": 14,
+                            "name": "ФормаСправка",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "ВариантСсылка",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "СправочникСсылка.ВариантыОтчетов",
+                          "nameEn": "CatalogRef.ВариантыОтчетов"
+                        },
+                        "variant": "METADATA",
+                        "kind": "CATALOG"
+                      }
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 2,
+                "name": "ПодсистемаСсылка",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 2,
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "СправочникСсылка.ИдентификаторыОбъектовМетаданных",
+                          "nameEn": "CatalogRef.ИдентификаторыОбъектовМетаданных"
+                        },
+                        "variant": "METADATA",
+                        "kind": "CATALOG"
+                      },
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "СправочникСсылка.ИдентификаторыОбъектовРасширений",
+                          "nameEn": "CatalogRef.ИдентификаторыОбъектовРасширений"
+                        },
+                        "variant": "METADATA",
+                        "kind": "CATALOG"
+                      }
+                    }
+                  ],
+                  "composite": true,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 3,
+                "name": "ОтчетСсылка",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 3,
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "СправочникСсылка.ДополнительныеОтчетыИОбработки",
+                          "nameEn": "CatalogRef.ДополнительныеОтчетыИОбработки"
+                        },
+                        "variant": "METADATA",
+                        "kind": "CATALOG"
+                      },
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[8]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[2]/type/types/java.util.CollSer/com.github._1c_syntax.bsl.types.value.CustomValueType"
+                      },
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[8]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[2]/type/types/java.util.CollSer/com.github._1c_syntax.bsl.types.value.CustomValueType[2]"
+                      }
+                    }
+                  ],
+                  "composite": true,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 4,
+                "name": "ГруппыПодсистем",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 5,
+                "name": "ЕстьДругиеОтчеты",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 8,
+                "name": "ВариантыПанели",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 9,
+                "name": "ВариантыПанелиНомерЭлемента",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                        "precision": 10,
+                        "scale": 0,
+                        "nonNegative": false,
+                        "description": {
+                          "value": {
+                            "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                            "nameRu": "КвалификаторыЧисла (10.0)",
+                            "nameEn": "NumberQualifiers (10.0)"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 10,
+                "name": "ВариантыПанелиКлючТекущегоВарианта",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 11,
+                "name": "ЗакрыватьПослеВыбора",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[8]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 12,
+                "name": "ОтчетНаименование",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 6,
+                "name": "ВидимыеВарианты",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "364cbfe2-bc44-4387-aa7e-6b4aa086c9e9",
+        "name": "СохранениеВариантаОтчета",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "SettingsStorage.ХранилищеВариантовОтчетов.Form.СохранениеВариантаОтчета",
+          "mdoRefRu": "ХранилищеНастроек.ХранилищеВариантовОтчетов.Форма.СохранениеВариантаОтчета"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Сохранение варианта отчета"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/SettingsStorages/ХранилищеВариантовОтчетов/Forms/СохранениеВариантаОтчета/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[9]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+          },
+          "handlers": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[2]"
+              },
+              {
+                "event": "FillCheckProcessingAtServer",
+                "name": "ОбработкаПроверкиЗаполненияНаСервере"
+              }
+            ],
+            []
+          ],
+          "items": [
+            [
+              {
+                "type": "PAGES",
+                "id": 24,
+                "name": "Страницы",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Страницы"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "PAGE",
+                      "id": 25,
+                      "name": "Основное",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Основное"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 52,
+                            "name": "Наименование",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                            },
+                            "dataPath": "Объект.Description",
+                            "items": []
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 252,
+                            "name": "Назначение",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                            },
+                            "dataPath": "Объект.Назначение",
+                            "items": []
+                          },
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 268,
+                            "name": "ГруппаДоступность",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Доступность"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "RADIO_BUTTON_FIELD",
+                                  "id": 98,
+                                  "name": "Доступен",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Доступен"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "Доступен",
+                                  "items": []
+                                },
+                                {
+                                  "type": "TABLE",
+                                  "id": 206,
+                                  "name": "ПользователиВарианта",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Показать в панелях отчетов пользователей (начальная настройка)"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "ПользователиВарианта",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "CHECK_BOX_FIELD",
+                                        "id": 236,
+                                        "name": "ПользователиВариантаПометка",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                        },
+                                        "dataPath": "ПользователиВарианта.Check",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "INPUT_FIELD",
+                                        "id": 219,
+                                        "name": "ПользователиВариантаЗначение",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                        },
+                                        "dataPath": "ПользователиВарианта.Value",
+                                        "items": []
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                },
+                                {
+                                  "type": "CHECK_BOX_FIELD",
+                                  "id": 247,
+                                  "name": "УведомитьПользователей",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Уведомить в чате об этом варианте отчета"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "УведомитьПользователей",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          },
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 250,
+                            "name": "ГруппаОписание",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                            },
+                            "dataPath": "",
+                            "items": [
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 8,
+                                "name": "Описание",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                },
+                                "dataPath": "Объект.Описание",
+                                "items": []
+                              }
+                            ]
+                          },
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 190,
+                            "name": "Страница1Подвал",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Страница 1 подвал"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              {
+                                "type": "PAGES",
+                                "id": 86,
+                                "name": "ЧтоБудетДальше",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Что будет дальше"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "PAGE",
+                                      "id": 88,
+                                      "name": "Новый",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Новый"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        {
+                                          "type": "LABEL",
+                                          "id": 187,
+                                          "name": "ДекорацияЧтоБудетДальшеНовый",
+                                          "title": {
+                                            "content": [
+                                              {
+                                                "default": {
+                                                  "tag": 2
+                                                },
+                                                "int": 1,
+                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                  "langKey": "ru",
+                                                  "value": "Будет сохранен новый вариант отчета.\nНажмите \"Далее\" для размещения варианта отчета в разделах приложения."
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "dataPath": "",
+                                          "items": []
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "PAGE",
+                                      "id": 87,
+                                      "name": "Перезапись",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Перезапись"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        {
+                                          "type": "LABEL",
+                                          "id": 184,
+                                          "name": "ДекорацияЧтоБудетДальшеПерезапись",
+                                          "title": {
+                                            "content": [
+                                              {
+                                                "default": {
+                                                  "tag": 2
+                                                },
+                                                "int": 1,
+                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                  "langKey": "ru",
+                                                  "value": "Будет перезаписан существующий вариант отчета.\nНажмите \"Далее\" для размещения варианта отчета в разделах приложения."
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "dataPath": "",
+                                          "items": []
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "PAGE",
+                                      "id": 201,
+                                      "name": "ПерезаписьНевозможна",
+                                      "title": {
+                                        "content": [
+                                          {
+                                            "default": {
+                                              "tag": 2
+                                            },
+                                            "int": 1,
+                                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                              "langKey": "ru",
+                                              "value": "Перезапись невозможна"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        {
+                                          "type": "LABEL",
+                                          "id": 203,
+                                          "name": "ДекорацияЧтоБудетДальшеПерезаписьНевозможна",
+                                          "title": {
+                                            "content": [
+                                              {
+                                                "default": {
+                                                  "tag": 2
+                                                },
+                                                "int": 1,
+                                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                  "langKey": "ru",
+                                                  "value": "Наименование занято другим вариантом отчета.\nВведите другое наименование или выберите вариант из списка."
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "dataPath": "",
+                                          "items": []
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  []
+                                ]
+                              }
+                            ]
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "PAGE",
+                      "id": 26,
+                      "name": "Дополнительно",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Дополнительно"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 261,
+                            "name": "ГруппаШапка",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Шапка"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "CHECK_BOX_FIELD",
+                                  "id": 225,
+                                  "name": "СброситьНастройки",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Сбросить настройки"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "СброситьНастройки",
+                                  "items": []
+                                },
+                                {
+                                  "type": "COMMAND_BAR",
+                                  "id": 263,
+                                  "name": "КоманднаяПанельДеревоПодсистем",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Командная панель дерево подсистем"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    {
+                                      "type": "ADDITION",
+                                      "id": 265,
+                                      "name": "СтрокаПоискаДеревоПодсистем",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                      },
+                                      "dataPath": "",
+                                      "items": []
+                                    }
+                                  ]
+                                }
+                              ],
+                              []
+                            ]
+                          },
+                          {
+                            "type": "TABLE",
+                            "id": 74,
+                            "name": "ДеревоПодсистем",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Дерево подсистем"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "ДеревоПодсистем",
+                            "items": [
+                              [
+                                {
+                                  "type": "COLUMN_GROUP",
+                                  "id": 77,
+                                  "name": "ГруппаКолонок",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Колонок"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "CHECK_BOX_FIELD",
+                                        "id": 78,
+                                        "name": "ДеревоПодсистемИспользование",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                        },
+                                        "dataPath": "ДеревоПодсистем.Использование",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "INPUT_FIELD",
+                                        "id": 80,
+                                        "name": "ДеревоПодсистемПредставление",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Раздел, Группа"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "ДеревоПодсистем.Представление",
+                                        "items": []
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                },
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 82,
+                                  "name": "ДеревоПодсистемВажность",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Важность"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "ДеревоПодсистем.Важность",
+                                  "items": []
+                                },
+                                {
+                                  "type": "LABEL_FIELD",
+                                  "id": 137,
+                                  "name": "ДеревоПодсистемПользователиПредставление",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Видимость по умолчанию"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "ДеревоПодсистем.ПользователиПредставление",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          }
+                        ],
+                        []
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 145,
+                "name": "ГруппаКоманднаяПанель",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "COMMAND_BAR",
+                      "id": 147,
+                      "name": "ГруппаКоманднаяПанельЛевая",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Командная панель левая"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        {
+                          "type": "BUTTON",
+                          "id": 23,
+                          "name": "Назад",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "<  Назад"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": []
+                        }
+                      ]
+                    },
+                    {
+                      "type": "COMMAND_BAR",
+                      "id": 149,
+                      "name": "ГруппаКоманднаяПанельПравая",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Командная панель правая"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "BUTTON",
+                            "id": 15,
+                            "name": "Далее",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Далее  >"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "BUTTON",
+                            "id": 55,
+                            "name": "Сохранить",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Сохранить"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "BUTTON",
+                            "id": 16,
+                            "name": "Отмена",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "FORM_GROUP",
+                            "id": 151,
+                            "name": "ГруппаКоманднаяПанельСправка",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Командная панель справка"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "ПрототипКлюч",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 3,
+                "name": "ВариантыОтчета",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 9,
+                "name": "ВариантСсылка",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[8]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 5,
+                "name": "ВариантКлючВарианта",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 11,
+                "name": "ПрототипСсылка",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[8]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 16,
+                "name": "ИдентификаторТекущейСтроки",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[8]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[7]/type"
+                }
+              },
+              {
+                "id": 15,
+                "name": "Доступен",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[9]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 13,
+                "name": "ДеревоПодсистем",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Размещение в панелях отчетов"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 19,
+                "name": "Контекст",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 20,
+                "name": "СброситьНастройки",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[9]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 21,
+                "name": "ОписаниеМодифицировано",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 22,
+                "name": "НаименованиеМодифицировано",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 23,
+                "name": "ПрототипПредопределенный",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 24,
+                "name": "Объект",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "fullName": {
+                          "nameRu": "СправочникОбъект.ВариантыОтчетов",
+                          "nameEn": "CatalogObject.ВариантыОтчетов"
+                        },
+                        "variant": "METADATA",
+                        "kind": "CATALOG"
+                      }
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 2,
+                "name": "ПользователиВарианта",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Пользователи варианта"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 6,
+                "name": "ИспользоватьВнешнихПользователей",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 7,
+                "name": "ИспользоватьГруппыПользователей",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 4,
+                "name": "ЭтоКонтекстныйВариантОтчета",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 8,
+                "name": "ВариантыКонтекста",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 10,
+                "name": "УведомитьПользователей",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[9]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "7433b2a9-f634-4af7-ac85-6aa1280ea239",
+        "name": "СохранениеВариантаОтчетаВФайл",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "SettingsStorage.ХранилищеВариантовОтчетов.Form.СохранениеВариантаОтчетаВФайл",
+          "mdoRefRu": "ХранилищеНастроек.ХранилищеВариантовОтчетов.Форма.СохранениеВариантаОтчетаВФайл"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Сохранение варианта отчета в файл"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/SettingsStorages/ХранилищеВариантовОтчетов/Forms/СохранениеВариантаОтчетаВФа_л/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[10]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+          },
+          "handlers": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[2]"
+              }
+            ],
+            []
+          ],
+          "items": [
+            {
+              "type": "PAGES",
+              "id": 29,
+              "name": "ВариантыСохранения",
+              "title": {
+                "content": [
+                  {
+                    "default": {
+                      "tag": 2
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                      "langKey": "ru",
+                      "value": "Варианты сохранения"
+                    }
+                  }
+                ]
+              },
+              "dataPath": "",
+              "items": [
+                [
+                  {
+                    "type": "PAGE",
+                    "id": 31,
+                    "name": "ОдинВариантОтчета",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Один вариант отчета"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "INPUT_FIELD",
+                          "id": 1,
+                          "name": "ИмяФайла",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Имя файла"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "ИмяФайла",
+                          "items": []
+                        },
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 80,
+                          "name": "ГруппаПерсональныеНастройки",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Персональные настройки"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "LABEL",
+                                "id": 77,
+                                "name": "ПерсональныеНастройкиНадпись",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Персональные настройки:"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": []
+                              },
+                              {
+                                "type": "COMMAND_BAR",
+                                "id": 82,
+                                "name": "КоманднаяПанельПерсональныеНастройки",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Командная панель персональные настройки"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  {
+                                    "type": "FORM_GROUP",
+                                    "id": 75,
+                                    "name": "ПользовательскиеНастройкиГруппаИзменитьФлажки",
+                                    "title": {
+                                      "content": [
+                                        {
+                                          "default": {
+                                            "tag": 2
+                                          },
+                                          "int": 1,
+                                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                            "langKey": "ru",
+                                            "value": "Изменить флажки"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    "dataPath": "",
+                                    "items": [
+                                      [
+                                        {
+                                          "type": "BUTTON",
+                                          "id": 23,
+                                          "name": "ПользовательскиеНастройкиУстановитьФлажки",
+                                          "title": {
+                                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                          },
+                                          "dataPath": "",
+                                          "items": []
+                                        },
+                                        {
+                                          "type": "BUTTON",
+                                          "id": 25,
+                                          "name": "ПользовательскиеНастройкиСнятьФлажки",
+                                          "title": {
+                                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                          },
+                                          "dataPath": "",
+                                          "items": []
+                                        }
+                                      ],
+                                      []
+                                    ]
+                                  }
+                                ]
+                              }
+                            ],
+                            []
+                          ]
+                        },
+                        {
+                          "type": "TABLE",
+                          "id": 4,
+                          "name": "ПерсональныеНастройки",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[10]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                          },
+                          "dataPath": "ПерсональныеНастройки",
+                          "items": [
+                            [
+                              {
+                                "type": "CHECK_BOX_FIELD",
+                                "id": 20,
+                                "name": "ПользовательскиеНастройкиПометка",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                },
+                                "dataPath": "ПерсональныеНастройки.Check",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 17,
+                                "name": "ПользовательскиеНастройкиЗначение",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                },
+                                "dataPath": "ПерсональныеНастройки.Value",
+                                "items": []
+                              }
+                            ],
+                            []
+                          ]
+                        }
+                      ],
+                      []
+                    ]
+                  },
+                  {
+                    "type": "PAGE",
+                    "id": 33,
+                    "name": "НесколькоВариантовОтчетов",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Несколько вариантов отчетов"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "INPUT_FIELD",
+                          "id": 35,
+                          "name": "ИмяКаталога",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Каталог"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "ИмяКаталога",
+                          "items": []
+                        },
+                        {
+                          "type": "TABLE",
+                          "id": 38,
+                          "name": "ОписаниеВариантовОтчетов",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Описание вариантов отчетов"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "ОписаниеВариантовОтчетов",
+                          "items": [
+                            [
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 51,
+                                "name": "ОписаниеВариантовОтчетовСсылка",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Вариант отчета"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "ОписаниеВариантовОтчетов.Ссылка",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 72,
+                                "name": "ОписаниеВариантовОтчетовИмяФайлаКраткое",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[10]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                },
+                                "dataPath": "ОписаниеВариантовОтчетов.ИмяФайлаКраткое",
+                                "items": []
+                              }
+                            ],
+                            []
+                          ]
+                        }
+                      ],
+                      []
+                    ]
+                  }
+                ],
+                []
+              ]
+            }
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "ИмяФайла",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[10]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 2,
+                "name": "ПерсональныеНастройки",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[10]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 3,
+                "name": "ХранилищеПользовательскихНастроек",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 11,
+                "name": "ИмяКаталога",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[10]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 13,
+                "name": "ОписаниеВариантовОтчетов",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[10]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 14,
+                "name": "ИмяФайлаБезРасширения",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 15,
+                "name": "РасширениеАрхива",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "9f32e85c-2ed6-41db-b0ec-6d8596940e80",
+        "name": "УсловияОтборовОтчета",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "SettingsStorage.ХранилищеВариантовОтчетов.Form.УсловияОтборовОтчета",
+          "mdoRefRu": "ХранилищеНастроек.ХранилищеВариантовОтчетов.Форма.УсловияОтборовОтчета"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Условия отборов отчета"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/SettingsStorages/ХранилищеВариантовОтчетов/Forms/УсловияОтборовОтчета/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[11]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "content": [
+              {
+                "default": {
+                  "tag": 2
+                },
+                "int": 1,
+                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                  "langKey": "ru",
+                  "value": "Условия фильтров отчета"
+                }
+              }
+            ]
+          },
+          "handlers": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[2]"
+            }
+          ],
+          "items": [
+            [
+              {
+                "type": "TABLE",
+                "id": 28,
+                "name": "Отборы",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Фильтры"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "Отборы",
+                "items": [
+                  [
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 41,
+                      "name": "ОтборыПредставлениеПользовательскойНастройки",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                      },
+                      "dataPath": "Отборы.ПредставлениеПользовательскойНастройки",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 44,
+                      "name": "ОтборыВидСравнения",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                      },
+                      "dataPath": "Отборы.ВидСравнения",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "COMMAND_BAR",
+                "id": 47,
+                "name": "ГруппаКоманднаяПанель",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "BUTTON",
+                      "id": 26,
+                      "name": "ФормаВыбрать",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "ОК"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "BUTTON",
+                      "id": 49,
+                      "name": "Отмена",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "BUTTON",
+                      "id": 51,
+                      "name": "Справка",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "КомпоновщикНастроек",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[2]/type"
+                }
+              },
+              {
+                "id": 3,
+                "name": "НастройкиОтчета",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 4,
+                "name": "ИмяТаблицы",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 5,
+                "name": "ИдентификаторЭлементаСтруктурыНастроек",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 6,
+                "name": "Картинки",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 7,
+                "name": "Режим",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 8,
+                "name": "Отборы",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[11]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "7adced5f-3a5f-419a-926c-0452aad86c86",
+        "name": "ФильтроватьПоПолю",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "SettingsStorage.ХранилищеВариантовОтчетов.Form.ФильтроватьПоПолю",
+          "mdoRefRu": "ХранилищеНастроек.ХранилищеВариантовОтчетов.Форма.ФильтроватьПоПолю"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Фильтровать по полю"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/SettingsStorages/ХранилищеВариантовОтчетов/Forms/ФильтроватьПоПолю/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[12]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+          },
+          "handlers": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[2]"
+              }
+            ],
+            []
+          ],
+          "items": [
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 1,
+                "name": "ЭлементОтбора1",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Элемент отбора 1"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "CHECK_BOX_FIELD",
+                      "id": 44,
+                      "name": "Использование1",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Использование 1"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "Использование1",
+                      "items": []
+                    },
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 58,
+                      "name": "ГруппаЛевоеЗначение1",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Левое значение 1"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 24,
+                            "name": "ЛевоеЗначение1",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[12]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                            },
+                            "dataPath": "ЛевоеЗначение1",
+                            "items": []
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 60,
+                            "name": "ПредставлениеЛевогоЗначения1",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Представление левого значения 1"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "ПредставлениеЛевогоЗначения1",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 5,
+                      "name": "ВидСравнения1",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Вид сравнения 1"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "ВидСравнения1",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 8,
+                      "name": "ПравоеЗначение1",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Правое значение 1"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "ПравоеЗначение1",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 30,
+                "name": "Дополнительно",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "CHECK_BOX_FIELD",
+                      "id": 47,
+                      "name": "ИспользованиеГруппы",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Использование группы"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "ИспользованиеГруппы",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 17,
+                      "name": "ТипГруппыЭлементовФильтра",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                      },
+                      "dataPath": "ТипГруппыЭлементовФильтра",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 3,
+                "name": "ЭлементОтбора2",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Элемент отбора 2"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 63,
+                      "name": "ГруппаЛевоеЗначение2",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Левое значение 2"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 27,
+                            "name": "ЛевоеЗначение2",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[12]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                            },
+                            "dataPath": "ЛевоеЗначение2",
+                            "items": []
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 65,
+                            "name": "ПредставлениеЛевогоЗначения2",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Представление левого значения 2"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "ПредставлениеЛевогоЗначения2",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 11,
+                      "name": "ВидСравнения2",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Вид сравнения 2"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "ВидСравнения2",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 14,
+                      "name": "ПравоеЗначение2",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Правое значение 2"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "ПравоеЗначение2",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 68,
+                "name": "КоманднаяПанель",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "HYPERLINK",
+                      "id": 72,
+                      "name": "ПерейтиКРасширеннымНастройкам",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "COMMAND_BAR",
+                      "id": 70,
+                      "name": "КомандыОсновные",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "BUTTON",
+                            "id": 56,
+                            "name": "ПрименитьИСформировать",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "BUTTON",
+                            "id": 54,
+                            "name": "Применить",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "BUTTON",
+                            "id": 52,
+                            "name": "Отмена",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "ВидСравнения1",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[12]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 2,
+                "name": "ПравоеЗначение1",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[12]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 3,
+                "name": "ВидСравнения2",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[12]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 4,
+                "name": "ПравоеЗначение2",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[12]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 5,
+                "name": "ТипГруппыЭлементовФильтра",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Тип группы элементов фильтра"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                        "length": 50,
+                        "allowedLength": 0,
+                        "description": {
+                          "value": {
+                            "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                            "nameRu": "КвалификаторыСтроки (50, Переменная)",
+                            "nameEn": "StringQualifiers (50, Variable)"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 6,
+                "name": "ЛевоеЗначение1",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[12]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 7,
+                "name": "ЛевоеЗначение2",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[12]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 8,
+                "name": "Использование1",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[12]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 9,
+                "name": "Использование2",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 10,
+                "name": "КомпоновщикНастроек",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[2]/type"
+                }
+              },
+              {
+                "id": 11,
+                "name": "СвойстваЗаголовка",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 12,
+                "name": "ПредставлениеЛевогоЗначения1",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[12]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 13,
+                "name": "ПредставлениеЛевогоЗначения2",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[12]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 14,
+                "name": "ТипЗначенияФильтра",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "TYPE_DESCRIPTION"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 15,
+                "name": "ДоступныеЗначения",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 16,
+                "name": "НастройкиОтчета",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 17,
+                "name": "КлючТекущегоВарианта",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 18,
+                "name": "ИспользованиеГруппы",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[12]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "f259b6b4-d582-429f-a16f-027a6bcb7438",
+        "name": "ЭлементУсловногоОформленияОтчета",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "SettingsStorage.ХранилищеВариантовОтчетов.Form.ЭлементУсловногоОформленияОтчета",
+          "mdoRefRu": "ХранилищеНастроек.ХранилищеВариантовОтчетов.Форма.ЭлементУсловногоОформленияОтчета"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Элемент условного оформления отчета"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/SettingsStorages/ХранилищеВариантовОтчетов/Forms/ЭлементУсловногоОформленияОтчета/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+          },
+          "handlers": [
+            {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[2]"
+            }
+          ],
+          "items": [
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 337,
+                "name": "ГруппаОформляемыеПоля",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Оформляемые поля"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 354,
+                      "name": "ГруппаОформляемыеПоляВариантыВыбора",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Варианты выбора"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "CHECK_BOX_FIELD",
+                            "id": 372,
+                            "name": "Использование",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Используется для"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "Использование",
+                            "items": []
+                          },
+                          {
+                            "type": "RADIO_BUTTON_FIELD",
+                            "id": 356,
+                            "name": "ВариантВыбораОформляемыхПолей",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Вариант выбора оформляемых полей"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "ВариантВыбораОформляемыхПолей",
+                            "items": []
+                          },
+                          {
+                            "type": "PAGES",
+                            "id": 362,
+                            "name": "ОформляемыеПоляСтраницы",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "PAGE",
+                                  "id": 364,
+                                  "name": "СтраницаОформляемоеПоле",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Оформляемое поле"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 359,
+                                      "name": "ОформляемоеПоле",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                      },
+                                      "dataPath": "ОформляемоеПоле",
+                                      "items": []
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "PAGE",
+                                  "id": 366,
+                                  "name": "СтраницаКоманднаяПанель",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    {
+                                      "type": "COMMAND_BAR",
+                                      "id": 368,
+                                      "name": "ОформляемыеПоляКомандыОсновные",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        [
+                                          {
+                                            "type": "BUTTON",
+                                            "id": 265,
+                                            "name": "ОформляемыеПоляДобавить",
+                                            "title": {
+                                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                            },
+                                            "dataPath": "",
+                                            "items": []
+                                          },
+                                          {
+                                            "type": "FORM_GROUP",
+                                            "id": 257,
+                                            "name": "ОформляемыеПоляГруппаИзменитьФлажки",
+                                            "title": {
+                                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[10]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                            },
+                                            "dataPath": "",
+                                            "items": [
+                                              [
+                                                {
+                                                  "type": "BUTTON",
+                                                  "id": 259,
+                                                  "name": "ОформляемыеПоляУстановитьФлажки",
+                                                  "title": {
+                                                    "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                                  },
+                                                  "dataPath": "",
+                                                  "items": []
+                                                },
+                                                {
+                                                  "type": "BUTTON",
+                                                  "id": 261,
+                                                  "name": "ОформляемыеПоляСнятьФлажки",
+                                                  "title": {
+                                                    "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                                  },
+                                                  "dataPath": "",
+                                                  "items": []
+                                                }
+                                              ],
+                                              []
+                                            ]
+                                          },
+                                          {
+                                            "type": "FORM_GROUP",
+                                            "id": 275,
+                                            "name": "ОформляемыеПоляГруппаПереместить",
+                                            "title": {
+                                              "content": [
+                                                {
+                                                  "default": {
+                                                    "tag": 2
+                                                  },
+                                                  "int": 1,
+                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                    "langKey": "ru",
+                                                    "value": "Переместить"
+                                                  }
+                                                }
+                                              ]
+                                            },
+                                            "dataPath": "",
+                                            "items": [
+                                              [
+                                                {
+                                                  "type": "BUTTON",
+                                                  "id": 277,
+                                                  "name": "ОформляемыеПоляПереместитьВверх",
+                                                  "title": {
+                                                    "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                                  },
+                                                  "dataPath": "",
+                                                  "items": []
+                                                },
+                                                {
+                                                  "type": "BUTTON",
+                                                  "id": 279,
+                                                  "name": "ОформляемыеПоляПереместитьВниз",
+                                                  "title": {
+                                                    "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                                  },
+                                                  "dataPath": "",
+                                                  "items": []
+                                                }
+                                              ],
+                                              []
+                                            ]
+                                          }
+                                        ],
+                                        []
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ],
+                              []
+                            ]
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "TABLE",
+                      "id": 30,
+                      "name": "ОформляемыеПоля",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                      },
+                      "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Fields",
+                      "items": [
+                        {
+                          "type": "COLUMN_GROUP",
+                          "id": 206,
+                          "name": "ОформляемыеПоляГруппаКолонокПоле",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "CHECK_BOX_FIELD",
+                                "id": 203,
+                                "name": "ОформляемыеПоляИспользование",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                },
+                                "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Fields.Use",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 211,
+                                "name": "ОформляемыеПоляПоле",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                },
+                                "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Fields.Field",
+                                "items": []
+                              }
+                            ],
+                            []
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 333,
+                "name": "ГруппаОформление",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                },
+                "dataPath": "",
+                "items": [
+                  {
+                    "type": "TABLE",
+                    "id": 72,
+                    "name": "Оформление",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                    },
+                    "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Appearance",
+                    "items": [
+                      [
+                        {
+                          "type": "COLUMN_GROUP",
+                          "id": 201,
+                          "name": "ОформлениеГруппаИспользованиеПараметра",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Использование параметра"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "CHECK_BOX_FIELD",
+                                "id": 96,
+                                "name": "ОформлениеИспользование",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                },
+                                "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Appearance.Use",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 105,
+                                "name": "ОформлениеПараметр",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                },
+                                "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Appearance.Parameter",
+                                "items": []
+                              }
+                            ],
+                            []
+                          ]
+                        },
+                        {
+                          "type": "COLUMN_GROUP",
+                          "id": 108,
+                          "name": "ОформлениеГруппаКолонокЗначениеПараметра",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "PICTURE_FIELD",
+                                "id": 110,
+                                "name": "ОформлениеКартинкаЗначения",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                },
+                                "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Appearance.ValuePicture",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 113,
+                                "name": "ОформлениеЗначение",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                },
+                                "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Appearance.Value",
+                                "items": []
+                              }
+                            ],
+                            []
+                          ]
+                        }
+                      ],
+                      []
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 335,
+                "name": "ГруппаОтбор",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[11]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 345,
+                      "name": "ОтборКоманднаяПанель1",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "LABEL",
+                            "id": 347,
+                            "name": "ОтборЗаголовок",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Условие:"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "COMMAND_BAR",
+                            "id": 350,
+                            "name": "ОтборКомандыОсновные",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "BUTTON",
+                                  "id": 293,
+                                  "name": "ОтборДобавитьЭлементОтбора",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Добавить"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "FORM_GROUP",
+                                  "id": 285,
+                                  "name": "ОтборГруппаИзменитьФлажки",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[10]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "BUTTON",
+                                        "id": 295,
+                                        "name": "ОтборУстановитьФлажки",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "BUTTON",
+                                        "id": 297,
+                                        "name": "ОтборСнятьФлажки",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                },
+                                {
+                                  "type": "FORM_GROUP",
+                                  "id": 291,
+                                  "name": "ОтборГруппаПереместить",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "BUTTON",
+                                        "id": 299,
+                                        "name": "ОтборПереместитьВверх",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "BUTTON",
+                                        "id": 301,
+                                        "name": "ОтборПереместитьВниз",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                        },
+                                        "dataPath": "",
+                                        "items": []
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                }
+                              ],
+                              []
+                            ]
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "TABLE",
+                      "id": 51,
+                      "name": "Отбор",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[11]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                      },
+                      "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter",
+                      "items": [
+                        [
+                          {
+                            "type": "CHECK_BOX_FIELD",
+                            "id": 214,
+                            "name": "ОтборИспользование",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                            },
+                            "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.Use",
+                            "items": []
+                          },
+                          {
+                            "type": "COLUMN_GROUP",
+                            "id": 217,
+                            "name": "ОтборГруппаКолонокОтбор",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Фильтр"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "COLUMN_GROUP",
+                                  "id": 224,
+                                  "name": "ОтборГруппаКолонокОсновныеЭлементыОтбора",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Основные элементы фильтра"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "COLUMN_GROUP",
+                                        "id": 229,
+                                        "name": "ОтборГруппаКолонокЛевоеЗначение",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Левое значение"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": [
+                                          [
+                                            {
+                                              "type": "PICTURE_FIELD",
+                                              "id": 231,
+                                              "name": "ОтборКартинкаЛевогоЗначения",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                              },
+                                              "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.LeftValuePicture",
+                                              "items": []
+                                            },
+                                            {
+                                              "type": "INPUT_FIELD",
+                                              "id": 234,
+                                              "name": "ОтборЛевоеЗначение",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                              },
+                                              "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.LeftValue",
+                                              "items": []
+                                            }
+                                          ],
+                                          []
+                                        ]
+                                      },
+                                      {
+                                        "type": "INPUT_FIELD",
+                                        "id": 237,
+                                        "name": "ОтборВидСравнения",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                        },
+                                        "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.ComparisonType",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "COLUMN_GROUP",
+                                        "id": 240,
+                                        "name": "ОтборГруппаКолонокПравоеЗначение",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                        },
+                                        "dataPath": "",
+                                        "items": [
+                                          [
+                                            {
+                                              "type": "PICTURE_FIELD",
+                                              "id": 242,
+                                              "name": "ОтборКартинкаПравогоЗначения",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                              },
+                                              "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.RightValuePicture",
+                                              "items": []
+                                            },
+                                            {
+                                              "type": "INPUT_FIELD",
+                                              "id": 245,
+                                              "name": "ОтборПравоеЗначение",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                              },
+                                              "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.RightValue",
+                                              "items": []
+                                            }
+                                          ],
+                                          []
+                                        ]
+                                      },
+                                      {
+                                        "type": "INPUT_FIELD",
+                                        "id": 248,
+                                        "name": "ОтборДата",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                        },
+                                        "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.Date",
+                                        "items": []
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                },
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 226,
+                                  "name": "ОтборТипГруппы",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                  },
+                                  "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.GroupType",
+                                  "items": []
+                                },
+                                {
+                                  "type": "COLUMN_GROUP",
+                                  "id": 329,
+                                  "name": "ОтборГруппа6",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[11]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "COLUMN_GROUP",
+                                        "id": 219,
+                                        "name": "ОтборГруппаКолонокПрименение",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Применение"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": [
+                                          [
+                                            {
+                                              "type": "INPUT_FIELD",
+                                              "id": 251,
+                                              "name": "ОтборПрименение",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                              },
+                                              "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.Application",
+                                              "items": []
+                                            },
+                                            {
+                                              "type": "INPUT_FIELD",
+                                              "id": 254,
+                                              "name": "ОтборРежимОтображения",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                              },
+                                              "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.ViewMode",
+                                              "items": []
+                                            }
+                                          ],
+                                          []
+                                        ]
+                                      },
+                                      {
+                                        "type": "INPUT_FIELD",
+                                        "id": 221,
+                                        "name": "ОтборПредставление",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                                        },
+                                        "dataPath": "КомпоновщикНастроек.Settings.ConditionalAppearance[0].Filter.Presentation",
+                                        "items": []
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                }
+                              ],
+                              []
+                            ]
+                          }
+                        ],
+                        []
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "INPUT_FIELD",
+                "id": 93,
+                "name": "Наименование",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "dataPath": "Наименование",
+                "items": []
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 339,
+                "name": "КоманднаяПанель",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 341,
+                      "name": "ВариантыИспользования",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 156,
+                            "name": "ВариантыИспользованияКоманды",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Варианты использования (команды)"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "LABEL",
+                                  "id": 153,
+                                  "name": "ДекорацияПоказывать",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Показывать:                 "
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "COMMAND_BAR",
+                                  "id": 199,
+                                  "name": "КомандыИзменитьФлажки",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[10]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    {
+                                      "type": "FORM_GROUP",
+                                      "id": 343,
+                                      "name": "ГруппаИзменитьФлажки",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[10]/data/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                      },
+                                      "dataPath": "",
+                                      "items": [
+                                        [
+                                          {
+                                            "type": "BUTTON",
+                                            "id": 190,
+                                            "name": "Показывать_УстановитьПометки",
+                                            "title": {
+                                              "content": [
+                                                {
+                                                  "default": {
+                                                    "tag": 2
+                                                  },
+                                                  "int": 1,
+                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                    "langKey": "ru",
+                                                    "value": "Установить пометки"
+                                                  }
+                                                }
+                                              ]
+                                            },
+                                            "dataPath": "",
+                                            "items": []
+                                          },
+                                          {
+                                            "type": "BUTTON",
+                                            "id": 188,
+                                            "name": "Показывать_СнятьПометки",
+                                            "title": {
+                                              "content": [
+                                                {
+                                                  "default": {
+                                                    "tag": 2
+                                                  },
+                                                  "int": 1,
+                                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                    "langKey": "ru",
+                                                    "value": "Снять пометки"
+                                                  }
+                                                }
+                                              ]
+                                            },
+                                            "dataPath": "",
+                                            "items": []
+                                          }
+                                        ],
+                                        []
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ],
+                              []
+                            ]
+                          },
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 160,
+                            "name": "ВариантыИспользованияПометки",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Варианты использования (пометки)"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "CHECK_BOX_FIELD",
+                                  "id": 185,
+                                  "name": "ИспользоватьВГруппировке",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "В группировке"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "ИспользоватьВГруппировке",
+                                  "items": []
+                                },
+                                {
+                                  "type": "CHECK_BOX_FIELD",
+                                  "id": 176,
+                                  "name": "ИспользоватьВИерархическойГруппировке",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "В иерархической группировке"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "ИспользоватьВИерархическойГруппировке",
+                                  "items": []
+                                },
+                                {
+                                  "type": "CHECK_BOX_FIELD",
+                                  "id": 173,
+                                  "name": "ИспользоватьВОбщемИтоге",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "В общем итоге"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "ИспользоватьВОбщемИтоге",
+                                  "items": []
+                                },
+                                {
+                                  "type": "CHECK_BOX_FIELD",
+                                  "id": 179,
+                                  "name": "ИспользоватьВЗаголовкеПолей",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "В заголовке полей"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "ИспользоватьВЗаголовкеПолей",
+                                  "items": []
+                                },
+                                {
+                                  "type": "CHECK_BOX_FIELD",
+                                  "id": 182,
+                                  "name": "ИспользоватьВЗаголовке",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "В заголовке"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "ИспользоватьВЗаголовке",
+                                  "items": []
+                                },
+                                {
+                                  "type": "CHECK_BOX_FIELD",
+                                  "id": 167,
+                                  "name": "ИспользоватьВПараметрах",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "В параметрах"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "ИспользоватьВПараметрах",
+                                  "items": []
+                                },
+                                {
+                                  "type": "CHECK_BOX_FIELD",
+                                  "id": 170,
+                                  "name": "ИспользоватьВОтборе",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "В фильтрах"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "ИспользоватьВОтборе",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "COMMAND_BAR",
+                      "id": 323,
+                      "name": "КомандыОсновные",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "BUTTON",
+                            "id": 26,
+                            "name": "ФормаВыбрать",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[11]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "BUTTON",
+                            "id": 325,
+                            "name": "Отмена",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "BUTTON",
+                            "id": 327,
+                            "name": "Справка",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "КомпоновщикНастроек",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[2]/type"
+                }
+              },
+              {
+                "id": 3,
+                "name": "НастройкиОтчета",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 5,
+                "name": "ИдентификаторЭлементаСтруктурыНастроек",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 2,
+                "name": "ИдентификаторКД",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 6,
+                "name": "НаименованиеПоУмолчанию",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 8,
+                "name": "Наименование",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 9,
+                "name": "ИспользоватьВГруппировке",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 10,
+                "name": "ИспользоватьВПараметрах",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[6]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 11,
+                "name": "ИспользоватьВОтборе",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[7]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 12,
+                "name": "ИспользоватьВОбщемИтоге",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 13,
+                "name": "ИспользоватьВИерархическойГруппировке",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 14,
+                "name": "ИспользоватьВЗаголовкеПолей",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 15,
+                "name": "ИспользоватьВЗаголовке",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 16,
+                "name": "ФлажкиОбластиОтображения",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              },
+              {
+                "id": 17,
+                "name": "ТребуетсяОбновлениеНаименованияПоУмолчанию",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 18,
+                "name": "ЭтоНовый",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              },
+              {
+                "id": 4,
+                "name": "ВариантВыбораОформляемыхПолей",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 7,
+                "name": "ОформляемоеПоле",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[13]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              },
+              {
+                "id": 19,
+                "name": "Использование",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[4]/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      }
+    ],
+    []
+  ],
+  "mdoReference": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/owner"
+  },
+  "mdoType": "SETTINGS_STORAGE",
+  "moduleTypes": [
+    [
+      "ManagerModule",
+      [
+        "src/test/resources/ext/edt/ssl_3_2/configuration/src/SettingsStorages/ХранилищеВариантовОтчетов/ManagerModule.bsl"
+      ]
+    ]
+  ],
+  "modules": [
+    {
+      "moduleType": "ManagerModule",
+      "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/SettingsStorages/ХранилищеВариантовОтчетов/ManagerModule.bsl",
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.SettingsStorage/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/owner"
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "isProtected": false
+    }
+  ],
+  "name": "ХранилищеВариантовОтчетов",
+  "objectBelonging": "OWN",
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "content": [
+      {
+        "default": {
+          "tag": 2
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+          "langKey": "ru",
+          "value": "Хранилище вариантов отчетов"
+        }
+      }
+    ]
+  },
+  "templates": [],
+  "uuid": "14512818-58b0-44cc-b00d-d37913c57aad"
+}}

--- a/src/test/resources/fixtures/ssl_3_2/StyleItems.ВажнаяНадписьШрифт.json
+++ b/src/test/resources/fixtures/ssl_3_2/StyleItems.ВажнаяНадписьШрифт.json
@@ -1,0 +1,28 @@
+{"com.github._1c_syntax.bsl.mdo.StyleItem": {
+  "comment": "",
+  "description": "Важная надпись шрифт",
+  "mdoReference": {
+    "type": "STYLE_ITEM",
+    "mdoRef": "StyleItem.ВажнаяНадписьШрифт",
+    "mdoRefRu": "ЭлементСтиля.ВажнаяНадписьШрифт"
+  },
+  "mdoType": "STYLE_ITEM",
+  "name": "ВажнаяНадписьШрифт",
+  "objectBelonging": "OWN",
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "content": [
+      {
+        "default": {
+          "tag": 2
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+          "langKey": "ru",
+          "value": "Важная надпись шрифт"
+        }
+      }
+    ]
+  },
+  "uuid": "fa2a9ef2-00a1-44f4-a82c-6c7288dd62dc"
+}}

--- a/src/test/resources/fixtures/ssl_3_2/StyleItems.ВидДняПроизводственногоКалендаряВоскресеньеЦвет.json
+++ b/src/test/resources/fixtures/ssl_3_2/StyleItems.ВидДняПроизводственногоКалендаряВоскресеньеЦвет.json
@@ -1,0 +1,28 @@
+{"com.github._1c_syntax.bsl.mdo.StyleItem": {
+  "comment": "",
+  "description": "Вид дня производственного календаря \"Воскресенье\"",
+  "mdoReference": {
+    "type": "STYLE_ITEM",
+    "mdoRef": "StyleItem.ВидДняПроизводственногоКалендаряВоскресеньеЦвет",
+    "mdoRefRu": "ЭлементСтиля.ВидДняПроизводственногоКалендаряВоскресеньеЦвет"
+  },
+  "mdoType": "STYLE_ITEM",
+  "name": "ВидДняПроизводственногоКалендаряВоскресеньеЦвет",
+  "objectBelonging": "OWN",
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "content": [
+      {
+        "default": {
+          "tag": 2
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+          "langKey": "ru",
+          "value": "Вид дня производственного календаря \"Воскресенье\""
+        }
+      }
+    ]
+  },
+  "uuid": "b7e435a9-6107-4d02-a949-cff793462e31"
+}}

--- a/src/test/resources/fixtures/ssl_3_2/Subsystems.Администрирование.json
+++ b/src/test/resources/fixtures/ssl_3_2/Subsystems.Администрирование.json
@@ -1,0 +1,633 @@
+{"com.github._1c_syntax.bsl.mdo.Subsystem": {
+  "comment": "",
+  "content": [
+    [
+      {
+        "type": "COMMON_COMMAND",
+        "mdoRef": "CommonCommand.НастройкаСистемнойУчетнойЗаписиЭлектроннойПочты",
+        "mdoRefRu": "ОбщаяКоманда.НастройкаСистемнойУчетнойЗаписиЭлектроннойПочты"
+      },
+      {
+        "type": "DATA_PROCESSOR",
+        "mdoRef": "DataProcessor.АктивныеПользователи",
+        "mdoRefRu": "Обработка.АктивныеПользователи"
+      },
+      {
+        "type": "DATA_PROCESSOR",
+        "mdoRef": "DataProcessor.БлокировкаРаботыПользователей",
+        "mdoRefRu": "Обработка.БлокировкаРаботыПользователей"
+      },
+      {
+        "type": "DATA_PROCESSOR",
+        "mdoRef": "DataProcessor.ЖурналРегистрации",
+        "mdoRefRu": "Обработка.ЖурналРегистрации"
+      },
+      {
+        "type": "DATA_PROCESSOR",
+        "mdoRef": "DataProcessor.РегламентныеИФоновыеЗадания",
+        "mdoRefRu": "Обработка.РегламентныеИФоновыеЗадания"
+      },
+      {
+        "type": "DATA_PROCESSOR",
+        "mdoRef": "DataProcessor.УдалениеПомеченныхОбъектов",
+        "mdoRefRu": "Обработка.УдалениеПомеченныхОбъектов"
+      },
+      {
+        "type": "DATA_PROCESSOR",
+        "mdoRef": "DataProcessor.НастройкиПользователей",
+        "mdoRefRu": "Обработка.НастройкиПользователей"
+      },
+      {
+        "type": "CATALOG",
+        "mdoRef": "Catalog.Пользователи",
+        "mdoRefRu": "Справочник.Пользователи"
+      },
+      {
+        "type": "CATALOG",
+        "mdoRef": "Catalog.ГруппыДоступа",
+        "mdoRefRu": "Справочник.ГруппыДоступа"
+      },
+      {
+        "type": "CATALOG",
+        "mdoRef": "Catalog.ГруппыПользователей",
+        "mdoRefRu": "Справочник.ГруппыПользователей"
+      },
+      {
+        "type": "CATALOG",
+        "mdoRef": "Catalog.ВнешниеПользователи",
+        "mdoRefRu": "Справочник.ВнешниеПользователи"
+      },
+      {
+        "type": "CATALOG",
+        "mdoRef": "Catalog.ГруппыВнешнихПользователей",
+        "mdoRefRu": "Справочник.ГруппыВнешнихПользователей"
+      },
+      {
+        "type": "CATALOG",
+        "mdoRef": "Catalog.ТомаХраненияФайлов",
+        "mdoRefRu": "Справочник.ТомаХраненияФайлов"
+      },
+      {
+        "type": "CATALOG",
+        "mdoRef": "Catalog.ВидыКонтактнойИнформации",
+        "mdoRefRu": "Справочник.ВидыКонтактнойИнформации"
+      },
+      {
+        "type": "CATALOG",
+        "mdoRef": "Catalog.НаборыДополнительныхРеквизитовИСведений",
+        "mdoRefRu": "Справочник.НаборыДополнительныхРеквизитовИСведений"
+      },
+      {
+        "type": "INFORMATION_REGISTER",
+        "mdoRef": "InformationRegister.ПользовательскиеМакетыПечати",
+        "mdoRefRu": "РегистрСведений.ПользовательскиеМакетыПечати"
+      },
+      {
+        "type": "CATALOG",
+        "mdoRef": "Catalog.УчетныеЗаписиЭлектроннойПочты",
+        "mdoRefRu": "Справочник.УчетныеЗаписиЭлектроннойПочты"
+      },
+      {
+        "type": "CATALOG",
+        "mdoRef": "Catalog.ПрофилиГруппДоступа",
+        "mdoRefRu": "Справочник.ПрофилиГруппДоступа"
+      },
+      {
+        "type": "CATALOG",
+        "mdoRef": "Catalog.ДополнительныеОтчетыИОбработки",
+        "mdoRefRu": "Справочник.ДополнительныеОтчетыИОбработки"
+      },
+      {
+        "type": "COMMON_FORM",
+        "mdoRef": "CommonForm.ОписаниеИзмененийПрограммы",
+        "mdoRefRu": "ОбщаяФорма.ОписаниеИзмененийПрограммы"
+      },
+      {
+        "type": "INFORMATION_REGISTER",
+        "mdoRef": "InformationRegister.ИсполнителиЗадач",
+        "mdoRefRu": "РегистрСведений.ИсполнителиЗадач"
+      },
+      {
+        "type": "DATA_PROCESSOR",
+        "mdoRef": "DataProcessor.УстановкаОбновлений",
+        "mdoRefRu": "Обработка.УстановкаОбновлений"
+      },
+      {
+        "type": "DATA_PROCESSOR",
+        "mdoRef": "DataProcessor.АвтоматическоеИзвлечениеТекстов",
+        "mdoRefRu": "Обработка.АвтоматическоеИзвлечениеТекстов"
+      },
+      {
+        "type": "DATA_PROCESSOR",
+        "mdoRef": "DataProcessor.УправлениеИтогамиИАгрегатами",
+        "mdoRefRu": "Обработка.УправлениеИтогамиИАгрегатами"
+      },
+      {
+        "type": "COMMON_COMMAND",
+        "mdoRef": "CommonCommand.НастройкиСинхронизацииДанных",
+        "mdoRefRu": "ОбщаяКоманда.НастройкиСинхронизацииДанных"
+      },
+      {
+        "type": "CATALOG",
+        "mdoRef": "Catalog.СценарииОбменовДанными",
+        "mdoRefRu": "Справочник.СценарииОбменовДанными"
+      },
+      {
+        "type": "CATALOG",
+        "mdoRef": "Catalog.ВариантыОтчетов",
+        "mdoRefRu": "Справочник.ВариантыОтчетов"
+      },
+      {
+        "type": "INFORMATION_REGISTER",
+        "mdoRef": "InformationRegister.ДатыЗапретаИзменения",
+        "mdoRefRu": "РегистрСведений.ДатыЗапретаИзменения"
+      },
+      {
+        "type": "DATA_PROCESSOR",
+        "mdoRef": "DataProcessor.РезервноеКопированиеИБ",
+        "mdoRefRu": "Обработка.РезервноеКопированиеИБ"
+      },
+      {
+        "type": "DATA_PROCESSOR",
+        "mdoRef": "DataProcessor.НастройкаРезервногоКопированияИБ",
+        "mdoRefRu": "Обработка.НастройкаРезервногоКопированияИБ"
+      },
+      {
+        "type": "DATA_PROCESSOR",
+        "mdoRef": "DataProcessor.ЗащитаПерсональныхДанных",
+        "mdoRefRu": "Обработка.ЗащитаПерсональныхДанных"
+      },
+      {
+        "type": "COMMON_PICTURE",
+        "mdoRef": "CommonPicture.РазделАдминистрирование48",
+        "mdoRefRu": "ОбщаяКартинка.РазделАдминистрирование48"
+      },
+      {
+        "type": "CATALOG",
+        "mdoRef": "Catalog.РассылкиОтчетов",
+        "mdoRefRu": "Справочник.РассылкиОтчетов"
+      },
+      {
+        "type": "COMMON_COMMAND",
+        "mdoRef": "CommonCommand.АвтономнаяРаботаВМоделиСервиса",
+        "mdoRefRu": "ОбщаяКоманда.АвтономнаяРаботаВМоделиСервиса"
+      },
+      {
+        "type": "COMMON_COMMAND",
+        "mdoRef": "CommonCommand.АвтономнаяРабота",
+        "mdoRefRu": "ОбщаяКоманда.АвтономнаяРабота"
+      },
+      {
+        "type": "DATA_PROCESSOR",
+        "mdoRef": "DataProcessor.ИнформацияПриЗапуске",
+        "mdoRefRu": "Обработка.ИнформацияПриЗапуске"
+      },
+      {
+        "type": "COMMON_COMMAND",
+        "mdoRef": "CommonCommand.НастройкиСинхронизацииДанныхВМоделиСервиса",
+        "mdoRefRu": "ОбщаяКоманда.НастройкиСинхронизацииДанныхВМоделиСервиса"
+      },
+      {
+        "type": "DATA_PROCESSOR",
+        "mdoRef": "DataProcessor.ПанельАдминистрированияБСП",
+        "mdoRefRu": "Обработка.ПанельАдминистрированияБСП"
+      },
+      {
+        "type": "COMMON_FORM",
+        "mdoRef": "CommonForm.ПараметрыПроксиСервера",
+        "mdoRefRu": "ОбщаяФорма.ПараметрыПроксиСервера"
+      },
+      {
+        "type": "INFORMATION_REGISTER",
+        "mdoRef": "InformationRegister.НомераОтсканированныхФайлов",
+        "mdoRefRu": "РегистрСведений.НомераОтсканированныхФайлов"
+      },
+      {
+        "type": "CATALOG",
+        "mdoRef": "Catalog.Валюты",
+        "mdoRefRu": "Справочник.Валюты"
+      },
+      {
+        "type": "DATA_PROCESSOR",
+        "mdoRef": "DataProcessor.ОценкаПроизводительности",
+        "mdoRefRu": "Обработка.ОценкаПроизводительности"
+      },
+      {
+        "type": "COMMON_FORM",
+        "mdoRef": "CommonForm.НастройкаОтправкиSMS",
+        "mdoRefRu": "ОбщаяФорма.НастройкаОтправкиSMS"
+      },
+      {
+        "type": "COMMON_FORM",
+        "mdoRef": "CommonForm.НастройкиРегистрацииСобытийДоступаКПерсональнымДанным",
+        "mdoRefRu": "ОбщаяФорма.НастройкиРегистрацииСобытийДоступаКПерсональнымДанным"
+      },
+      {
+        "type": "DATA_PROCESSOR",
+        "mdoRef": "DataProcessor.ЗагрузкаКурсовВалют",
+        "mdoRefRu": "Обработка.ЗагрузкаКурсовВалют"
+      },
+      {
+        "type": "CATALOG",
+        "mdoRef": "Catalog.КлассификаторБанков",
+        "mdoRefRu": "Справочник.КлассификаторБанков"
+      },
+      {
+        "type": "COMMON_COMMAND",
+        "mdoRef": "CommonCommand.ДобавитьПользователейСервиса",
+        "mdoRefRu": "ОбщаяКоманда.ДобавитьПользователейСервиса"
+      },
+      {
+        "type": "INFORMATION_REGISTER",
+        "mdoRef": "InformationRegister.ВерсииПодсистемОбластейДанных",
+        "mdoRefRu": "РегистрСведений.ВерсииПодсистемОбластейДанных"
+      },
+      {
+        "type": "REPORT",
+        "mdoRef": "Report.ДатыЗапретаЗагрузки",
+        "mdoRefRu": "Отчет.ДатыЗапретаЗагрузки"
+      },
+      {
+        "type": "REPORT",
+        "mdoRef": "Report.ДатыЗапретаИзменения",
+        "mdoRefRu": "Отчет.ДатыЗапретаИзменения"
+      },
+      {
+        "type": "DATA_PROCESSOR",
+        "mdoRef": "DataProcessor.ГрупповоеИзменениеРеквизитов",
+        "mdoRefRu": "Обработка.ГрупповоеИзменениеРеквизитов"
+      },
+      {
+        "type": "DATA_PROCESSOR",
+        "mdoRef": "DataProcessor.РезультатыОбновленияПрограммы",
+        "mdoRefRu": "Обработка.РезультатыОбновленияПрограммы"
+      },
+      {
+        "type": "CATALOG",
+        "mdoRef": "Catalog.КлючевыеОперации",
+        "mdoRefRu": "Справочник.КлючевыеОперации"
+      },
+      {
+        "type": "DATA_PROCESSOR",
+        "mdoRef": "DataProcessor.УниверсальныйОбменДаннымиXML",
+        "mdoRefRu": "Обработка.УниверсальныйОбменДаннымиXML"
+      },
+      {
+        "type": "COMMON_COMMAND",
+        "mdoRef": "CommonCommand.ПанельОтчетовАдминистрирование",
+        "mdoRefRu": "ОбщаяКоманда.ПанельОтчетовАдминистрирование"
+      },
+      {
+        "type": "DATA_PROCESSOR",
+        "mdoRef": "DataProcessor.ЗагрузкаДанныхИзФайла",
+        "mdoRefRu": "Обработка.ЗагрузкаДанныхИзФайла"
+      },
+      {
+        "type": "COMMON_COMMAND",
+        "mdoRef": "CommonCommand.ДополнительныеОбработкиАдминистрирование",
+        "mdoRefRu": "ОбщаяКоманда.ДополнительныеОбработкиАдминистрирование"
+      },
+      {
+        "type": "COMMON_COMMAND",
+        "mdoRef": "CommonCommand.ДополнительныеОтчетыАдминистрирование",
+        "mdoRefRu": "ОбщаяКоманда.ДополнительныеОтчетыАдминистрирование"
+      },
+      {
+        "type": "INFORMATION_REGISTER",
+        "mdoRef": "InformationRegister.НастройкиВерсионированияОбъектов",
+        "mdoRefRu": "РегистрСведений.НастройкиВерсионированияОбъектов"
+      },
+      {
+        "type": "DATA_PROCESSOR",
+        "mdoRef": "DataProcessor.СдвигГраницыИтогов",
+        "mdoRefRu": "Обработка.СдвигГраницыИтогов"
+      },
+      {
+        "type": "DATA_PROCESSOR",
+        "mdoRef": "DataProcessor.ПереносФайлов",
+        "mdoRefRu": "Обработка.ПереносФайлов"
+      },
+      {
+        "type": "REPORT",
+        "mdoRef": "Report.ОбъемНенужныхФайлов",
+        "mdoRefRu": "Отчет.ОбъемНенужныхФайлов"
+      },
+      {
+        "type": "DATA_PROCESSOR",
+        "mdoRef": "DataProcessor.ПоискИУдалениеДублей",
+        "mdoRefRu": "Обработка.ПоискИУдалениеДублей"
+      },
+      {
+        "type": "INFORMATION_REGISTER",
+        "mdoRef": "InformationRegister.ПравилаДляОбменаДанными",
+        "mdoRefRu": "РегистрСведений.ПравилаДляОбменаДанными"
+      },
+      {
+        "type": "REPORT",
+        "mdoRef": "Report.ПрогрессОтложенногоОбновления",
+        "mdoRefRu": "Отчет.ПрогрессОтложенногоОбновления"
+      },
+      {
+        "type": "COMMON_FORM",
+        "mdoRef": "CommonForm.НастройкиЭлектроннойПодписиИШифрования",
+        "mdoRefRu": "ОбщаяФорма.НастройкиЭлектроннойПодписиИШифрования"
+      },
+      {
+        "type": "REPORT",
+        "mdoRef": "Report.УниверсальныйОтчет",
+        "mdoRefRu": "Отчет.УниверсальныйОтчет"
+      },
+      {
+        "type": "COMMON_FORM",
+        "mdoRef": "CommonForm.НастройкаДоступаКСервисуMorpher",
+        "mdoRefRu": "ОбщаяФорма.НастройкаДоступаКСервисуMorpher"
+      },
+      {
+        "type": "COMMON_FORM",
+        "mdoRef": "CommonForm.НастройкаКомандПечати",
+        "mdoRefRu": "ОбщаяФорма.НастройкаКомандПечати"
+      },
+      {
+        "type": "COMMON_COMMAND",
+        "mdoRef": "CommonCommand.ПредупрежденияПриСинхронизацииДанных",
+        "mdoRefRu": "ОбщаяКоманда.ПредупрежденияПриСинхронизацииДанных"
+      },
+      {
+        "type": "COMMON_FORM",
+        "mdoRef": "CommonForm.Расширения",
+        "mdoRefRu": "ОбщаяФорма.Расширения"
+      },
+      {
+        "type": "INFORMATION_REGISTER",
+        "mdoRef": "InformationRegister.НастройкиОчисткиФайлов",
+        "mdoRefRu": "РегистрСведений.НастройкиОчисткиФайлов"
+      },
+      {
+        "type": "COMMON_COMMAND",
+        "mdoRef": "CommonCommand.ВремяВПриложении",
+        "mdoRefRu": "ОбщаяКоманда.ВремяВПриложении"
+      },
+      {
+        "type": "COMMON_FORM",
+        "mdoRef": "CommonForm.НастройкиВходаПользователей",
+        "mdoRefRu": "ОбщаяФорма.НастройкиВходаПользователей"
+      },
+      {
+        "type": "DATA_PROCESSOR",
+        "mdoRef": "DataProcessor.ВыгрузкаЗагрузкаEnterpriseData",
+        "mdoRefRu": "Обработка.ВыгрузкаЗагрузкаEnterpriseData"
+      },
+      {
+        "type": "CATALOG",
+        "mdoRef": "Catalog.ПрофилиКлючевыхОпераций",
+        "mdoRefRu": "Справочник.ПрофилиКлючевыхОпераций"
+      },
+      {
+        "type": "REPORT",
+        "mdoRef": "Report.ОценкаПроизводительности",
+        "mdoRefRu": "Отчет.ОценкаПроизводительности"
+      },
+      {
+        "type": "DATA_PROCESSOR",
+        "mdoRef": "DataProcessor.ПодключениеОбсуждений",
+        "mdoRefRu": "Обработка.ПодключениеОбсуждений"
+      },
+      {
+        "type": "DATA_PROCESSOR",
+        "mdoRef": "DataProcessor.НастройкиЦентраМониторинга",
+        "mdoRefRu": "Обработка.НастройкиЦентраМониторинга"
+      },
+      {
+        "type": "CATALOG",
+        "mdoRef": "Catalog.ПравилаПроверкиУчета",
+        "mdoRefRu": "Справочник.ПравилаПроверкиУчета"
+      },
+      {
+        "type": "REPORT",
+        "mdoRef": "Report.ИспользуемыеВнешниеРесурсы",
+        "mdoRefRu": "Отчет.ИспользуемыеВнешниеРесурсы"
+      },
+      {
+        "type": "REPORT",
+        "mdoRef": "Report.РезультатыПроверкиУчета",
+        "mdoRefRu": "Отчет.РезультатыПроверкиУчета"
+      },
+      {
+        "type": "INFORMATION_REGISTER",
+        "mdoRef": "InformationRegister.АдресныеОбъекты",
+        "mdoRefRu": "РегистрСведений.АдресныеОбъекты"
+      },
+      {
+        "type": "COMMON_FORM",
+        "mdoRef": "CommonForm.УстановленныеИсправления",
+        "mdoRefRu": "ОбщаяФорма.УстановленныеИсправления"
+      },
+      {
+        "type": "DATA_PROCESSOR",
+        "mdoRef": "DataProcessor.НастройкаСтандартногоИнтерфейсаOData",
+        "mdoRefRu": "Обработка.НастройкаСтандартногоИнтерфейсаOData"
+      },
+      {
+        "type": "CATALOG",
+        "mdoRef": "Catalog.ВнешниеКомпоненты",
+        "mdoRefRu": "Справочник.ВнешниеКомпоненты"
+      },
+      {
+        "type": "CATALOG",
+        "mdoRef": "Catalog.ШаблоныСообщений",
+        "mdoRefRu": "Справочник.ШаблоныСообщений"
+      },
+      {
+        "type": "CATALOG",
+        "mdoRef": "Catalog.СостоянияОригиналовПервичныхДокументов",
+        "mdoRefRu": "Справочник.СостоянияОригиналовПервичныхДокументов"
+      },
+      {
+        "type": "COMMON_FORM",
+        "mdoRef": "CommonForm.ВосстановлениеПаролей",
+        "mdoRefRu": "ОбщаяФорма.ВосстановлениеПаролей"
+      },
+      {
+        "type": "REPORT",
+        "mdoRef": "Report.ПродлениеСрокаДействияЭлектронныхПодписей",
+        "mdoRefRu": "Отчет.ПродлениеСрокаДействияЭлектронныхПодписей"
+      },
+      {
+        "type": "COMMON_FORM",
+        "mdoRef": "CommonForm.РазрешенныеНеаккредитованныеУЦ",
+        "mdoRefRu": "ОбщаяФорма.РазрешенныеНеаккредитованныеУЦ"
+      },
+      {
+        "type": "REPORT",
+        "mdoRef": "Report.ДлительностьОтложенногоОбновления",
+        "mdoRefRu": "Отчет.ДлительностьОтложенногоОбновления"
+      },
+      {
+        "type": "COMMON_FORM",
+        "mdoRef": "CommonForm.НастройкиРегистрацииСобытийДоступаКДанным",
+        "mdoRefRu": "ОбщаяФорма.НастройкиРегистрацииСобытийДоступаКДанным"
+      },
+      {
+        "type": "REPORT",
+        "mdoRef": "Report.СертификатыЭлектроннойПодписи",
+        "mdoRefRu": "Отчет.СертификатыЭлектроннойПодписи"
+      }
+    ],
+    []
+  ],
+  "description": "Администрирование",
+  "explanation": {
+    "content": [
+      {
+        "default": {
+          "tag": 2
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+          "langKey": "ru",
+          "value": "Администрирование, настройка, сервисные функции"
+        }
+      }
+    ]
+  },
+  "includeHelpInContents": true,
+  "includeInCommandInterface": true,
+  "mdoReference": {
+    "type": "SUBSYSTEM",
+    "mdoRef": "Subsystem.Администрирование",
+    "mdoRefRu": "Подсистема.Администрирование"
+  },
+  "mdoType": "SUBSYSTEM",
+  "name": "Администрирование",
+  "objectBelonging": "OWN",
+  "parentSubsystem": {
+    "type": "UNKNOWN",
+    "mdoRef": "",
+    "mdoRefRu": ""
+  },
+  "possibleRights": [
+    {
+      "default": {
+        "tag": 4
+      },
+      "int": 1,
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "VIEW"
+    }
+  ],
+  "subsystems": [
+    {
+      "comment": "",
+      "content": [
+        [
+          {
+            "type": "REPORT",
+            "mdoRef": "Report.АнализПравДоступа",
+            "mdoRefRu": "Отчет.АнализПравДоступа"
+          },
+          {
+            "type": "REPORT",
+            "mdoRef": "Report.ИзменениеУчастниковГруппПользователей",
+            "mdoRefRu": "Отчет.ИзменениеУчастниковГруппПользователей"
+          },
+          {
+            "type": "REPORT",
+            "mdoRef": "Report.ИзменениеУчетныхЗаписей",
+            "mdoRefRu": "Отчет.ИзменениеУчетныхЗаписей"
+          },
+          {
+            "type": "REPORT",
+            "mdoRef": "Report.ПользователиПоПодразделениям",
+            "mdoRefRu": "Отчет.ПользователиПоПодразделениям"
+          },
+          {
+            "type": "REPORT",
+            "mdoRef": "Report.ПраваРолей",
+            "mdoRefRu": "Отчет.ПраваРолей"
+          },
+          {
+            "type": "REPORT",
+            "mdoRef": "Report.СведенияОПользователях",
+            "mdoRefRu": "Отчет.СведенияОПользователях"
+          },
+          {
+            "type": "REPORT",
+            "mdoRef": "Report.УчастникиГруппДоступа",
+            "mdoRefRu": "Отчет.УчастникиГруппДоступа"
+          },
+          {
+            "type": "REPORT",
+            "mdoRef": "Report.УчастникиГруппПользователей",
+            "mdoRefRu": "Отчет.УчастникиГруппПользователей"
+          },
+          {
+            "type": "REPORT",
+            "mdoRef": "Report.ИзменениеУчастниковГруппДоступа",
+            "mdoRefRu": "Отчет.ИзменениеУчастниковГруппДоступа"
+          },
+          {
+            "type": "REPORT",
+            "mdoRef": "Report.ИзменениеРазрешенныхЗначенийГруппДоступа",
+            "mdoRefRu": "Отчет.ИзменениеРазрешенныхЗначенийГруппДоступа"
+          },
+          {
+            "type": "REPORT",
+            "mdoRef": "Report.ИзменениеРолейПрофилей",
+            "mdoRefRu": "Отчет.ИзменениеРолейПрофилей"
+          }
+        ],
+        []
+      ],
+      "description": "Контроль работы пользователей",
+      "explanation": {
+        "content": []
+      },
+      "includeHelpInContents": true,
+      "includeInCommandInterface": true,
+      "mdoReference": {
+        "type": "SUBSYSTEM",
+        "mdoRef": "Subsystem.Администрирование.Subsystem.КонтрольРаботыПользователей",
+        "mdoRefRu": "Подсистема.Администрирование.Подсистема.КонтрольРаботыПользователей"
+      },
+      "mdoType": "SUBSYSTEM",
+      "name": "КонтрольРаботыПользователей",
+      "objectBelonging": "OWN",
+      "parentSubsystem": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.Subsystem/mdoReference"
+      },
+      "possibleRights": [],
+      "subsystems": [],
+      "supportVariant": "NOT_EDITABLE",
+      "synonym": {
+        "content": [
+          {
+            "default": {
+              "tag": 2
+            },
+            "int": 1,
+            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+              "langKey": "ru",
+              "value": "Контроль работы пользователей"
+            }
+          }
+        ]
+      },
+      "uuid": "fa04bf1e-69c0-4998-a939-039fcaba83c8"
+    }
+  ],
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "content": [
+      {
+        "default": {
+          "tag": 2
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+          "langKey": "ru",
+          "value": "Администрирование"
+        }
+      }
+    ]
+  },
+  "uuid": "9233322b-dfdb-4c66-91fe-1299292d40a5"
+}}

--- a/src/test/resources/fixtures/ssl_3_2/Tasks.ЗадачаИсполнителя.json
+++ b/src/test/resources/fixtures/ssl_3_2/Tasks.ЗадачаИсполнителя.json
@@ -1,0 +1,6091 @@
+{"com.github._1c_syntax.bsl.mdo.Task": {
+  "addressingAttributes": [
+    [
+      {
+        "uuid": "0408002c-9255-43a2-8022-82f02ee0e8f4",
+        "name": "ДополнительныйОбъектАдресации",
+        "mdoReference": {
+          "type": "TASK_ADDRESSING_ATTRIBUTE",
+          "mdoRef": "Task.ЗадачаИсполнителя.AddressingAttribute.ДополнительныйОбъектАдресации",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.РеквизитАдресации.ДополнительныйОбъектАдресации"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Дополнительный объект адресации"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "type": "TASK",
+          "mdoRef": "Task.ЗадачаИсполнителя",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "Характеристика.ОбъектыАдресацииЗадач",
+                  "nameEn": "Characteristic.ОбъектыАдресацииЗадач"
+                },
+                "variant": "METADATA",
+                "kind": "CHART_OF_CHARACTERISTIC_TYPES"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 0
+            }
+          ]
+        },
+        "format": {
+          "content": []
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "toolTip": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Дополнительный объект адресации, если задача адресована роли исполнителя"
+              }
+            }
+          ]
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false,
+        "choiceForm": {
+          "type": "UNKNOWN",
+          "mdoRef": "",
+          "mdoRefRu": ""
+        }
+      },
+      {
+        "uuid": "88f44c9b-216d-4d7e-bc88-1e6b253ed01e",
+        "name": "Исполнитель",
+        "mdoReference": {
+          "type": "TASK_ADDRESSING_ATTRIBUTE",
+          "mdoRef": "Task.ЗадачаИсполнителя.AddressingAttribute.Исполнитель",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.РеквизитАдресации.Исполнитель"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Исполнитель"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 2,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "СправочникСсылка.ВнешниеПользователи",
+                  "nameEn": "CatalogRef.ВнешниеПользователи"
+                },
+                "variant": "METADATA",
+                "kind": "CATALOG"
+              },
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "СправочникСсылка.Пользователи",
+                  "nameEn": "CatalogRef.Пользователи"
+                },
+                "variant": "METADATA",
+                "kind": "CATALOG"
+              }
+            }
+          ],
+          "composite": true,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "toolTip": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Пользователь, которому поручено выполнение задачи"
+              }
+            }
+          ]
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false,
+        "choiceForm": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/choiceForm"
+        }
+      },
+      {
+        "uuid": "1851afd4-5324-45c1-b754-54e65943f945",
+        "name": "ОсновнойОбъектАдресации",
+        "mdoReference": {
+          "type": "TASK_ADDRESSING_ATTRIBUTE",
+          "mdoRef": "Task.ЗадачаИсполнителя.AddressingAttribute.ОсновнойОбъектАдресации",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.РеквизитАдресации.ОсновнойОбъектАдресации"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Основной объект адресации"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "toolTip": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Основной объект адресации, если задача адресована роли исполнителя"
+              }
+            }
+          ]
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false,
+        "choiceForm": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/choiceForm"
+        }
+      },
+      {
+        "uuid": "bc5eca9b-32d8-44e0-a127-8ad1f47d7957",
+        "name": "РольИсполнителя",
+        "mdoReference": {
+          "type": "TASK_ADDRESSING_ATTRIBUTE",
+          "mdoRef": "Task.ЗадачаИсполнителя.AddressingAttribute.РольИсполнителя",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.РеквизитАдресации.РольИсполнителя"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Роль исполнителя"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "СправочникСсылка.РолиИсполнителей",
+                  "nameEn": "CatalogRef.РолиИсполнителей"
+                },
+                "variant": "METADATA",
+                "kind": "CATALOG"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "toolTip": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Роль исполнителя, которой адресована задача"
+              }
+            }
+          ]
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false,
+        "choiceForm": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/choiceForm"
+        }
+      }
+    ],
+    []
+  ],
+  "attributes": [
+    [
+      {
+        "uuid": "3ad08f4a-6202-4099-b6cc-bc116e6731a0",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Task.ЗадачаИсполнителя.StandardAttribute.Executed",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.СтандартныйРеквизит.Выполнена"
+        },
+        "comment": "Задача выполнена",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Выполнена"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "BOOLEAN"
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "fullName": {
+          "nameRu": "Выполнена",
+          "nameEn": "Executed"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "3ad08f4a-6202-4099-b6cc-bc116e6731a0",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Task.ЗадачаИсполнителя.StandardAttribute.Description",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.СтандартныйРеквизит.Наименование"
+        },
+        "comment": "Краткое описание задачи",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Задача"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                "length": 150,
+                "allowedLength": 0,
+                "description": {}
+              }
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "Наименование",
+          "nameEn": "Description"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "3ad08f4a-6202-4099-b6cc-bc116e6731a0",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Task.ЗадачаИсполнителя.StandardAttribute.RoutePoint",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.СтандартныйРеквизит.ТочкаМаршрута"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [],
+          "composite": false,
+          "qualifiers": []
+        },
+        "fullName": {
+          "nameRu": "ТочкаМаршрута",
+          "nameEn": "RoutePoint"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "3ad08f4a-6202-4099-b6cc-bc116e6731a0",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Task.ЗадачаИсполнителя.StandardAttribute.BusinessProcess",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.СтандартныйРеквизит.БизнесПроцесс"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[3]/type"
+        },
+        "fullName": {
+          "nameRu": "БизнесПроцесс",
+          "nameEn": "BusinessProcess"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "3ad08f4a-6202-4099-b6cc-bc116e6731a0",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Task.ЗадачаИсполнителя.StandardAttribute.Ref",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.СтандартныйРеквизит.Ссылка"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "ЗадачаСсылка.ЗадачаИсполнителя",
+                  "nameEn": "TaskRef.ЗадачаИсполнителя"
+                },
+                "variant": "METADATA",
+                "kind": "TASK"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "fullName": {
+          "nameRu": "Ссылка",
+          "nameEn": "Ref"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "3ad08f4a-6202-4099-b6cc-bc116e6731a0",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Task.ЗадачаИсполнителя.StandardAttribute.DeletionMark",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.СтандартныйРеквизит.ПометкаУдаления"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+        },
+        "fullName": {
+          "nameRu": "ПометкаУдаления",
+          "nameEn": "DeletionMark"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "3ad08f4a-6202-4099-b6cc-bc116e6731a0",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Task.ЗадачаИсполнителя.StandardAttribute.Date",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.СтандартныйРеквизит.Дата"
+        },
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Записана"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "DATE"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.DateQualifiers": {
+                "dateFractions": 2,
+                "description": {
+                  "value": {
+                    "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                    "nameRu": "КвалификаторыДаты (ДатаВремя)",
+                    "nameEn": "DateQualifiers (DateTime)"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "Дата",
+          "nameEn": "Date"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "3ad08f4a-6202-4099-b6cc-bc116e6731a0",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Task.ЗадачаИсполнителя.StandardAttribute.Number",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.СтандартныйРеквизит.Номер"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                "length": 14,
+                "allowedLength": 1,
+                "description": {}
+              }
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "Номер",
+          "nameEn": "Number"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "fd96c8ab-602a-4735-b168-52b501e80351",
+        "name": "Автор",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Task.ЗадачаИсполнителя.Attribute.Автор",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.Реквизит.Автор"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Автор бизнес-процесса, который сформировал задачу",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Автор"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute[2]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "b1dc619d-8d91-4f7a-aa50-1d07ff9aebdc",
+        "name": "Важность",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Task.ЗадачаИсполнителя.Attribute.Важность",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.Реквизит.Важность"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Для упорядочивания исполнителем своих задач по приоритету",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Важность"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "ПеречислениеСсылка.ВариантыВажностиЗадачи",
+                  "nameEn": "EnumRef.ВариантыВажностиЗадачи"
+                },
+                "variant": "METADATA",
+                "kind": "ENUM"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": true
+      },
+      {
+        "uuid": "370f0c75-d2c5-4be5-a633-4bcc77998ece",
+        "name": "ГруппаИсполнителейЗадач",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Task.ЗадачаИсполнителя.Attribute.ГруппаИсполнителейЗадач",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.Реквизит.ГруппаИсполнителейЗадач"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Группа исполнителей задач"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "СправочникСсылка.ГруппыИсполнителейЗадач",
+                  "nameEn": "CatalogRef.ГруппыИсполнителейЗадач"
+                },
+                "variant": "METADATA",
+                "kind": "CATALOG"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "f80b505f-b4ff-45fb-bd88-74b274ae9d2b",
+        "name": "ДатаИсполнения",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Task.ЗадачаИсполнителя.Attribute.ДатаИсполнения",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.Реквизит.ДатаИсполнения"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Дата и время фактического выполнения задачи",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[7]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "2139532c-f6cb-4393-936e-cc912e5adca9",
+        "name": "ДатаНачала",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Task.ЗадачаИсполнителя.Attribute.ДатаНачала",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.Реквизит.ДатаНачала"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Для упорядочивания исполнителем своих задач",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Дата начала"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[7]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "755c3eca-4956-4a44-9b38-c11dae00b87f",
+        "name": "ДатаПринятияКИсполнению",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Task.ЗадачаИсполнителя.Attribute.ДатаПринятияКИсполнению",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.Реквизит.ДатаПринятияКИсполнению"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Дата принятия к исполнению"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[7]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "f57c558c-2c94-4b9d-8697-448d0548ab1a",
+        "name": "Описание",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Task.ЗадачаИсполнителя.Attribute.Описание",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.Реквизит.Описание"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Описание постановки задачи для исполнителя",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Описание"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                "length": 0,
+                "allowedLength": 0,
+                "description": {
+                  "value": {
+                    "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                    "nameRu": "КвалификаторыСтроки (0, Переменная)",
+                    "nameEn": "StringQualifiers (0, Variable)"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": true,
+        "extendedEdit": true,
+        "fillFromFillingValue": true
+      },
+      {
+        "uuid": "a310c09f-4d3a-4d3a-9ad5-7a5735a33a1d",
+        "name": "Предмет",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Task.ЗадачаИсполнителя.Attribute.Предмет",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.Реквизит.Предмет"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Предмет задачи",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Предмет"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 4,
+              "com.github._1c_syntax.bsl.types.value.MDOValueType": "CATALOG_REF",
+              "com.github._1c_syntax.bsl.types.value.MDOValueType": "CHART_OF_CHARACTERISTIC_TYPES_REF",
+              "com.github._1c_syntax.bsl.types.value.MDOValueType": "DOCUMENT_REF",
+              "com.github._1c_syntax.bsl.types.value.MDOValueType": "TASK_REF"
+            }
+          ],
+          "composite": true,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "c32db021-eca1-4b67-aa85-3d6e28c51b53",
+        "name": "ПредметСтрокой",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Task.ЗадачаИсполнителя.Attribute.ПредметСтрокой",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.Реквизит.ПредметСтрокой"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Строковое представление предмета",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[8]/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                "length": 500,
+                "allowedLength": 0,
+                "description": {}
+              }
+            }
+          ]
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "e9ed0ee4-3fbe-4093-9078-cb265ed6842c",
+        "name": "ПринятаКИсполнению",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Task.ЗадачаИсполнителя.Attribute.ПринятаКИсполнению",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.Реквизит.ПринятаКИсполнению"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Принята к исполнению"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "02466dcf-02a1-4853-814f-a913a9baba45",
+        "name": "РезультатВыполнения",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Task.ЗадачаИсполнителя.Attribute.РезультатВыполнения",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.Реквизит.РезультатВыполнения"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Описание результата выполнения",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Результат выполнения"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[7]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": true,
+        "extendedEdit": true,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "c4a40dc9-b619-4219-9d9a-e11f49a14fb1",
+        "name": "СостояниеБизнесПроцесса",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Task.ЗадачаИсполнителя.Attribute.СостояниеБизнесПроцесса",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.Реквизит.СостояниеБизнесПроцесса"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Состояние бизнес процесса"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "ПеречислениеСсылка.СостоянияБизнесПроцессов",
+                  "nameEn": "EnumRef.СостоянияБизнесПроцессов"
+                },
+                "variant": "METADATA",
+                "kind": "ENUM"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "62b75eb2-42e1-4484-a77f-b676dd36f3d4",
+        "name": "СрокИсполнения",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Task.ЗадачаИсполнителя.Attribute.СрокИсполнения",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.Реквизит.СрокИсполнения"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Плановый срок исполнения задачи",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Срок"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[7]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "5e28e22a-dd6e-4703-92bd-13f5cb0dc023",
+        "name": "АвторСтрокой",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Task.ЗадачаИсполнителя.Attribute.АвторСтрокой",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.Реквизит.АвторСтрокой"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Автор строкой"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[2]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      }
+    ],
+    []
+  ],
+  "commands": [
+    [
+      {
+        "uuid": "6e5307ea-8fbf-4177-bcc8-f163a6ce1b40",
+        "name": "ВсеЗадачи",
+        "mdoReference": {
+          "type": "COMMAND",
+          "mdoRef": "Task.ЗадачаИсполнителя.Command.ВсеЗадачи",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.Команда.ВсеЗадачи"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Все задачи"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "CommandModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/Tasks/ЗадачаИсполнителя/Commands/ВсеЗадачи/Ext/CommandModule.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        }
+      },
+      {
+        "uuid": "0fa77ef7-a836-4459-9bca-6010d0bdfc7f",
+        "name": "Выполнено",
+        "mdoReference": {
+          "type": "COMMAND",
+          "mdoRef": "Task.ЗадачаИсполнителя.Command.Выполнено",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.Команда.Выполнено"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Выполнено"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "CommandModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/Tasks/ЗадачаИсполнителя/Commands/Выполнено/Ext/CommandModule.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[2]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        }
+      },
+      {
+        "uuid": "c322dc4a-30f3-4d23-9824-4a01c496408d",
+        "name": "МоиЗадачи",
+        "mdoReference": {
+          "type": "COMMAND",
+          "mdoRef": "Task.ЗадачаИсполнителя.Command.МоиЗадачи",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.Команда.МоиЗадачи"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Мои задачи"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "CommandModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/Tasks/ЗадачаИсполнителя/Commands/МоиЗадачи/Ext/CommandModule.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[3]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        }
+      },
+      {
+        "uuid": "dcff004c-1b61-4a19-b977-ea21bf688614",
+        "name": "Перенаправить",
+        "mdoReference": {
+          "type": "COMMAND",
+          "mdoRef": "Task.ЗадачаИсполнителя.Command.Перенаправить",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.Команда.Перенаправить"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Перенаправить..."
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "CommandModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/Tasks/ЗадачаИсполнителя/Commands/Перенаправить/Ext/CommandModule.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[4]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        }
+      }
+    ],
+    []
+  ],
+  "comment": "",
+  "description": "Задача",
+  "explanation": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+  },
+  "forms": [
+    [
+      {
+        "uuid": "856510ee-74f5-44e9-a3c0-1c60cfb7a787",
+        "name": "Дополнительно",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "Task.ЗадачаИсполнителя.Form.Дополнительно",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.Форма.Дополнительно"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Дополнительно"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/Tasks/ЗадачаИсполнителя/Forms/Дополнительно/Ext/Form/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/synonym"
+          },
+          "handlers": [
+            {
+              "event": "OnCreateAtServer",
+              "name": "ПриСозданииНаСервере"
+            }
+          ],
+          "items": [
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 99,
+                "name": "Документ",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Документ"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 41,
+                      "name": "Наименование",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "Объект.Description",
+                      "items": []
+                    },
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 63,
+                      "name": "ГруппаРезультат",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Результат выполнения задачи"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "CHECK_BOX_FIELD",
+                            "id": 64,
+                            "name": "Выполнена",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                            },
+                            "dataPath": "Объект.Executed",
+                            "items": []
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 66,
+                            "name": "ДатаИсполнения",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                            },
+                            "dataPath": "Объект.ДатаИсполнения",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 51,
+                      "name": "ГруппаБизнесПроцесс",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Бизнес-процесс"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 52,
+                            "name": "БизнесПроцесс",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                            },
+                            "dataPath": "Объект.BusinessProcess",
+                            "items": []
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 54,
+                            "name": "ТочкаМаршрута",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                            },
+                            "dataPath": "Объект.RoutePoint",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 69,
+                      "name": "ГруппаАдресация",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Задача адресована"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 27,
+                            "name": "Исполнитель",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                            },
+                            "dataPath": "Объект.Исполнитель",
+                            "items": []
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 29,
+                            "name": "РольИсполнителя",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                            },
+                            "dataPath": "Объект.РольИсполнителя",
+                            "items": []
+                          },
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 92,
+                            "name": "ГруппаУточнение",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Уточнение"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "LABEL_DECORATION",
+                                  "id": 96,
+                                  "name": "Отступ",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "USUAL_GROUP",
+                                  "id": 94,
+                                  "name": "ГруппаОбъектыАдресации",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Объекты адресации"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "INPUT_FIELD",
+                                        "id": 31,
+                                        "name": "ОсновнойОбъектАдресации",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                        },
+                                        "dataPath": "Объект.ОсновнойОбъектАдресации",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "INPUT_FIELD",
+                                        "id": 33,
+                                        "name": "ДополнительныйОбъектАдресации",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                        },
+                                        "dataPath": "Объект.ДополнительныйОбъектАдресации",
+                                        "items": []
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                }
+                              ],
+                              []
+                            ]
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 56,
+                      "name": "ГруппаВходящие",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Входящие"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 57,
+                            "name": "Дата",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                            },
+                            "dataPath": "Объект.Date",
+                            "items": []
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 71,
+                            "name": "СрокИсполнения",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                            },
+                            "dataPath": "Объект.СрокИсполнения",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 45,
+                "name": "ГруппаСправа",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Справа"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  {
+                    "type": "INPUT_FIELD",
+                    "id": 43,
+                    "name": "Номер",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                    },
+                    "dataPath": "Объект.Number",
+                    "items": []
+                  }
+                ]
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            {
+              "id": 1,
+              "name": "Объект",
+              "title": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+              },
+              "type": {
+                "types": [
+                  {
+                    "default": {
+                      "tag": 4
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                      "fullName": {
+                        "nameRu": "ЗадачаОбъект.ЗадачаИсполнителя",
+                        "nameEn": "TaskObject.ЗадачаИсполнителя"
+                      },
+                      "variant": "METADATA",
+                      "kind": "TASK"
+                    }
+                  }
+                ],
+                "composite": false,
+                "qualifiers": []
+              }
+            }
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "28b761c6-c286-4125-a4ed-da602e49950f",
+        "name": "ЗадачиПоБизнесПроцессу",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "Task.ЗадачаИсполнителя.Form.ЗадачиПоБизнесПроцессу",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.Форма.ЗадачиПоБизнесПроцессу"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Задачи"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/Tasks/ЗадачаИсполнителя/Forms/ЗадачиПоБизнесПроцессу/Ext/Form/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "content": [
+              {
+                "default": {
+                  "tag": 2
+                },
+                "int": 1,
+                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                  "langKey": "ru",
+                  "value": "Задачи бизнес-процесса"
+                }
+              }
+            ]
+          },
+          "handlers": [
+            [
+              {
+                "event": "NotificationProcessing",
+                "name": "ОбработкаОповещения"
+              },
+              {
+                "event": "OnLoadDataFromSettingsAtServer",
+                "name": "ПриЗагрузкеДанныхИзНастроекНаСервере"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler"
+              },
+              {
+                "event": "BeforeLoadDataFromSettingsAtServer",
+                "name": "ПриЗагрузкеДанныхИзНастроекНаСервере"
+              }
+            ],
+            []
+          ],
+          "items": [
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 85,
+                "name": "ГруппаПользовательскихНастроек",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Группа пользовательских настроек"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": []
+              },
+              {
+                "type": "COMMAND_BAR",
+                "id": 52,
+                "name": "КоманднаяПанельСписка",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Командная панель списка"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": []
+              },
+              {
+                "type": "TABLE",
+                "id": 1,
+                "name": "Список",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Список"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "Список",
+                "items": [
+                  [
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 6,
+                      "name": "Наименование",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "Список.Description",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 4,
+                      "name": "Номер",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Номер"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "Список.Number",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 8,
+                      "name": "Дата",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[7]/synonym"
+                      },
+                      "dataPath": "Список.Date",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 18,
+                      "name": "Исполнитель",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "Список.Исполнитель",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 23,
+                      "name": "Предмет",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "Список.Предмет",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 82,
+                      "name": "Ссылка",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "Список.Ref",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "TABLE",
+                "id": 25,
+                "name": "ДеревоЗадач",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Дерево задач"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "ДеревоЗадач",
+                "items": [
+                  [
+                    {
+                      "type": "PICTURE_FIELD",
+                      "id": 40,
+                      "name": "ДеревоЗадачВажность",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[2]/synonym"
+                      },
+                      "dataPath": "ДеревоЗадач.Важность",
+                      "items": []
+                    },
+                    {
+                      "type": "CHECK_BOX_FIELD",
+                      "id": 49,
+                      "name": "Выполнена",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "ДеревоЗадач.Выполнена",
+                      "items": []
+                    },
+                    {
+                      "type": "PICTURE_FIELD",
+                      "id": 42,
+                      "name": "ДеревоЗадачОстановлен",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Остановлен"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "ДеревоЗадач.Остановлен",
+                      "items": []
+                    },
+                    {
+                      "type": "COLUMN_GROUP",
+                      "id": 46,
+                      "name": "ТипИНаименование",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Тип и наименование"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "PICTURE_FIELD",
+                            "id": 44,
+                            "name": "ДеревоЗадачТип",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Тип"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "ДеревоЗадач.Тип",
+                            "items": []
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 30,
+                            "name": "ДеревоЗадачНаименование",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Наименование"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "ДеревоЗадач.Наименование",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 32,
+                      "name": "ДеревоЗадачИсполнитель",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute[2]/synonym"
+                      },
+                      "dataPath": "ДеревоЗадач.Исполнитель",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 47,
+                      "name": "СрокИсполнения",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Срок исполнения"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "ДеревоЗадач.СрокИсполнения",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "CHECK_BOX_FIELD",
+                "id": 21,
+                "name": "ПоказыватьВыполненные",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Показывать выполненные"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "ПоказыватьВыполненные",
+                "items": []
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "Список",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "DYNAMIC_LIST"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 2,
+                "name": "ПоказыватьВыполненные",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              },
+              {
+                "id": 3,
+                "name": "ДеревоЗадач",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "VALUE_TREE"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "4ac66a22-c736-4e06-a8aa-ef4a71788c65",
+        "name": "ЗадачиПоПредмету",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "Task.ЗадачаИсполнителя.Form.ЗадачиПоПредмету",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.Форма.ЗадачиПоПредмету"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Задачи по предмету"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/Tasks/ЗадачаИсполнителя/Forms/ЗадачиПоПредмету/Ext/Form/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/synonym"
+          },
+          "handlers": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[2]"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[4]"
+              }
+            ],
+            []
+          ],
+          "items": [
+            [
+              {
+                "type": "COMMAND_BAR",
+                "id": 130,
+                "name": "ГруппаПользовательскихНастроек",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "dataPath": "",
+                "items": []
+              },
+              {
+                "type": "COMMAND_BAR",
+                "id": 50,
+                "name": "КоманднаяПанельСписка",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "dataPath": "",
+                "items": [
+                  {
+                    "type": "BUTTON_GROUP",
+                    "id": 120,
+                    "name": "ГруппаПринятьКИсполнению",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Принять к исполнению"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "COMMAND_BAR_BUTTON",
+                          "id": 122,
+                          "name": "ПринятьКИсполнению",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "К исполнению"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": []
+                        },
+                        {
+                          "type": "COMMAND_BAR_BUTTON",
+                          "id": 124,
+                          "name": "ОтменитьПринятиеКИсполнению",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Обновить"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": []
+                        },
+                        {
+                          "type": "COMMAND_BAR_BUTTON",
+                          "id": 126,
+                          "name": "ЗадачаЗадачаИсполнителяВыполнено",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                          },
+                          "dataPath": "Items.Список.CurrentData.ОсновнойОбъектАдресации",
+                          "items": []
+                        },
+                        {
+                          "type": "COMMAND_BAR_BUTTON",
+                          "id": 128,
+                          "name": "ЗадачаЗадачаИсполнителяПеренаправить",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                          },
+                          "dataPath": "Items.Список.CurrentData.ОсновнойОбъектАдресации",
+                          "items": []
+                        }
+                      ],
+                      []
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "TABLE",
+                "id": 1,
+                "name": "Список",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                },
+                "dataPath": "Список",
+                "items": [
+                  [
+                    {
+                      "type": "COLUMN_GROUP",
+                      "id": 99,
+                      "name": "ГруппаВажность",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[2]/synonym"
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "PICTURE_FIELD",
+                            "id": 52,
+                            "name": "ВажностьКартинка",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[2]/synonym"
+                            },
+                            "dataPath": "Список.ВажностьКартинка",
+                            "items": []
+                          },
+                          {
+                            "type": "PICTURE_FIELD",
+                            "id": 56,
+                            "name": "Остановлена",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Остановлена"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "Список.Остановлена",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "COLUMN_GROUP",
+                      "id": 103,
+                      "name": "ГруппаОписание",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[7]/synonym"
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "COLUMN_GROUP",
+                            "id": 101,
+                            "name": "ГруппаНаименование",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 6,
+                                  "name": "Наименование",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[2]/synonym"
+                                  },
+                                  "dataPath": "Список.Description",
+                                  "items": []
+                                },
+                                {
+                                  "type": "LABEL_FIELD",
+                                  "id": 107,
+                                  "name": "Автор",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                  },
+                                  "dataPath": "Список.Автор",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          },
+                          {
+                            "type": "COLUMN_GROUP",
+                            "id": 105,
+                            "name": "ГруппаАвтор",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/synonym"
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 4,
+                                  "name": "Номер",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                  },
+                                  "dataPath": "Список.Number",
+                                  "items": []
+                                },
+                                {
+                                  "type": "LABEL_FIELD",
+                                  "id": 110,
+                                  "name": "Дата",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                  },
+                                  "dataPath": "Список.Date",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "COLUMN_GROUP",
+                      "id": 113,
+                      "name": "ГруппаИсполнение",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Исполнение"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "COLUMN_GROUP",
+                            "id": 64,
+                            "name": "ГруппаИсполнитель",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute[2]/synonym"
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 18,
+                                  "name": "Исполнитель",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                  },
+                                  "dataPath": "Список.Исполнитель",
+                                  "items": []
+                                },
+                                {
+                                  "type": "LABEL_FIELD",
+                                  "id": 58,
+                                  "name": "РольИсполнителя",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                  },
+                                  "dataPath": "Список.РольИсполнителя",
+                                  "items": []
+                                },
+                                {
+                                  "type": "LABEL_FIELD",
+                                  "id": 60,
+                                  "name": "ОсновнойОбъектАдресации",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                  },
+                                  "dataPath": "Список.ОсновнойОбъектАдресации",
+                                  "items": []
+                                },
+                                {
+                                  "type": "LABEL_FIELD",
+                                  "id": 62,
+                                  "name": "ДополнительныйОбъектАдресации",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                  },
+                                  "dataPath": "Список.ДополнительныйОбъектАдресации",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          },
+                          {
+                            "type": "COLUMN_GROUP",
+                            "id": 115,
+                            "name": "ГруппаСрокИсполнения",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[6]/title"
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "LABEL_FIELD",
+                                  "id": 23,
+                                  "name": "СрокИсполнения",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                  },
+                                  "dataPath": "Список.СрокИсполнения",
+                                  "items": []
+                                },
+                                {
+                                  "type": "CHECK_BOX_FIELD",
+                                  "id": 54,
+                                  "name": "ЗадачаВыполнена",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                  },
+                                  "dataPath": "Список.Executed",
+                                  "items": []
+                                },
+                                {
+                                  "type": "LABEL_FIELD",
+                                  "id": 117,
+                                  "name": "ДатаИсполнения",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                  },
+                                  "dataPath": "Список.ДатаИсполнения",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 96,
+                      "name": "Ссылка",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "Список.Ref",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "CHECK_BOX_FIELD",
+                "id": 21,
+                "name": "ПоказыватьВыполненные",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Показывать выполненные задачи"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "ПоказыватьВыполненные",
+                "items": []
+              },
+              {
+                "type": "TABLE",
+                "id": 25,
+                "name": "ДеревоЗадач",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                },
+                "dataPath": "ДеревоЗадач",
+                "items": [
+                  [
+                    {
+                      "type": "PICTURE_FIELD",
+                      "id": 28,
+                      "name": "ДеревоЗадачВажность",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[2]/synonym"
+                      },
+                      "dataPath": "ДеревоЗадач.Важность",
+                      "items": []
+                    },
+                    {
+                      "type": "CHECK_BOX_FIELD",
+                      "id": 30,
+                      "name": "Выполнена",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "ДеревоЗадач.Выполнена",
+                      "items": []
+                    },
+                    {
+                      "type": "PICTURE_FIELD",
+                      "id": 32,
+                      "name": "ДеревоЗадачОстановлен",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                      },
+                      "dataPath": "ДеревоЗадач.Остановлен",
+                      "items": []
+                    },
+                    {
+                      "type": "COLUMN_GROUP",
+                      "id": 34,
+                      "name": "ТипИНаименование",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "PICTURE_FIELD",
+                            "id": 35,
+                            "name": "ДеревоЗадачТип",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                            },
+                            "dataPath": "ДеревоЗадач.Тип",
+                            "items": []
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 37,
+                            "name": "ДеревоЗадачНаименование",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[2]/synonym"
+                            },
+                            "dataPath": "ДеревоЗадач.Наименование",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 39,
+                      "name": "ДеревоЗадачИсполнитель",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute[2]/synonym"
+                      },
+                      "dataPath": "ДеревоЗадач.Исполнитель",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 41,
+                      "name": "СрокИсполнения1",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[13]/synonym"
+                      },
+                      "dataPath": "ДеревоЗадач.СрокИсполнения",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "Список",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 2,
+                "name": "ПоказыватьВыполненные",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              },
+              {
+                "id": 3,
+                "name": "ДеревоЗадач",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "9cfe9281-8840-4077-824d-a2c9cbb0b730",
+        "name": "МоиЗадачи",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "Task.ЗадачаИсполнителя.Form.МоиЗадачи",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.Форма.МоиЗадачи"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[3]/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/Tasks/ЗадачаИсполнителя/Forms/МоиЗадачи/Ext/Form/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[3]/synonym"
+          },
+          "handlers": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler"
+              },
+              {
+                "event": "BeforeLoadDataFromSettingsAtServer",
+                "name": "ПередЗагрузкойДанныхИзНастроекНаСервере"
+              }
+            ],
+            []
+          ],
+          "items": [
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 126,
+                "name": "ГруппаПользовательскихНастроек",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "dataPath": "",
+                "items": []
+              },
+              {
+                "type": "COMMAND_BAR",
+                "id": 1,
+                "name": "ОсновнаяКоманднаяПанель",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Основная командная панель"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "POPUP",
+                      "id": 51,
+                      "name": "СгруппироватьПо",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Сгруппировать по"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "COMMAND_BAR_BUTTON",
+                            "id": 132,
+                            "name": "СписокСгруппироватьПоСроку",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[13]/synonym"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "COMMAND_BAR_BUTTON",
+                            "id": 52,
+                            "name": "СписокСгруппироватьПоВажности",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[2]/synonym"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "COMMAND_BAR_BUTTON",
+                            "id": 53,
+                            "name": "СписокСгруппироватьПоТочкеМаршрута",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Точка маршрута"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "COMMAND_BAR_BUTTON",
+                            "id": 61,
+                            "name": "СписокСгруппироватьПоАвтору",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/synonym"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "COMMAND_BAR_BUTTON",
+                            "id": 62,
+                            "name": "СписокСгруппироватьПоПредмету",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[8]/synonym"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "COMMAND_BAR_BUTTON",
+                            "id": 54,
+                            "name": "СписокСгруппироватьСгруппироватьПоБезГруппировки",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Без группировки"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "BUTTON_GROUP",
+                      "id": 140,
+                      "name": "ГруппаОткрыть",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Открыть"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "COMMAND_BAR_BUTTON",
+                            "id": 138,
+                            "name": "ФормаИзменить",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Открыть задачу"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "COMMAND_BAR_BUTTON",
+                            "id": 134,
+                            "name": "ОткрытьПредметЗадачи",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Открыть предмет задачи"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "COMMAND_BAR_BUTTON",
+                            "id": 136,
+                            "name": "ОткрытьБизнесПроцесс",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Открыть бизнес-процесс"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "BUTTON_GROUP",
+                      "id": 48,
+                      "name": "КоманднаяПанельСписка",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "COMMAND_BAR_BUTTON",
+                            "id": 128,
+                            "name": "ФормаНайти",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "COMMAND_BAR_BUTTON",
+                            "id": 130,
+                            "name": "ФормаОтменитьПоиск",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "COMMAND_BAR_BUTTON",
+                      "id": 80,
+                      "name": "ПринятьКИсполнению",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "COMMAND_BAR_BUTTON",
+                      "id": 82,
+                      "name": "ЗадачаЗадачаИсполнителяВыполнено",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "Items.Список.CurrentData.Ref",
+                      "items": []
+                    },
+                    {
+                      "type": "COMMAND_BAR_BUTTON",
+                      "id": 83,
+                      "name": "ЗадачаЗадачаИсполнителяПеренаправить",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "Items.Список.CurrentData.Ref",
+                      "items": []
+                    },
+                    {
+                      "type": "COMMAND_BAR_BUTTON",
+                      "id": 81,
+                      "name": "ОтменитьПринятиеКИсполнению",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Отменить принятие к исполнению"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "BUTTON_GROUP",
+                      "id": 8,
+                      "name": "КоманднаяПанельФормы",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Командная панель формы"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "COMMAND_BAR_BUTTON",
+                      "id": 65,
+                      "name": "Справка",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "TABLE",
+                "id": 9,
+                "name": "Список",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                },
+                "dataPath": "Список",
+                "items": [
+                  [
+                    {
+                      "type": "PICTURE_FIELD",
+                      "id": 24,
+                      "name": "Важность",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[2]/synonym"
+                      },
+                      "dataPath": "Список.ВажностьКартинка",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 57,
+                      "name": "Номер",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "Список.Number",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 16,
+                      "name": "Наименование",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "Список.Description",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 46,
+                      "name": "ДатаНачала",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[5]/synonym"
+                      },
+                      "dataPath": "Список.ДатаНачала",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 36,
+                      "name": "СрокИсполнения",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "Список.СрокИсполнения",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 40,
+                      "name": "Автор",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "Список.Автор",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 63,
+                      "name": "Предмет",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "Список.ПредметСтрокой",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 66,
+                      "name": "Дата",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[7]/synonym"
+                      },
+                      "dataPath": "Список.Date",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 123,
+                      "name": "Ссылка",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "Список.Ref",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "CHECK_BOX_FIELD",
+                "id": 38,
+                "name": "ПоказыватьВыполненные",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/title"
+                },
+                "dataPath": "ПоказыватьВыполненные",
+                "items": []
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "Список",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 2,
+                "name": "ПоказыватьВыполненные",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              },
+              {
+                "id": 3,
+                "name": "РежимГруппировки",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[7]/type"
+                }
+              },
+              {
+                "id": 4,
+                "name": "ПараметрыОтбораФормы",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[3]/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "76389fa9-b9e0-492e-9c93-24b5f3bf094c",
+        "name": "МоиЗадачиДляРабочегоСтола",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "Task.ЗадачаИсполнителя.Form.МоиЗадачиДляРабочегоСтола",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.Форма.МоиЗадачиДляРабочегоСтола"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[3]/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/Tasks/ЗадачаИсполнителя/Forms/МоиЗадачиДляРабочегоСтола/Ext/Form/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[5]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[3]/synonym"
+          },
+          "handlers": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[4]"
+              }
+            ],
+            []
+          ],
+          "items": [
+            {
+              "type": "TABLE",
+              "id": 9,
+              "name": "Список",
+              "title": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+              },
+              "dataPath": "Список",
+              "items": [
+                {
+                  "type": "COLUMN_GROUP",
+                  "id": 161,
+                  "name": "ГруппаКолонки",
+                  "title": {
+                    "content": [
+                      {
+                        "default": {
+                          "tag": 2
+                        },
+                        "int": 1,
+                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                          "langKey": "ru",
+                          "value": "Колонки"
+                        }
+                      }
+                    ]
+                  },
+                  "dataPath": "",
+                  "items": [
+                    [
+                      {
+                        "type": "COLUMN_GROUP",
+                        "id": 155,
+                        "name": "ЛеваяГруппа",
+                        "title": {
+                          "content": [
+                            {
+                              "default": {
+                                "tag": 2
+                              },
+                              "int": 1,
+                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                "langKey": "ru",
+                                "value": "Левая группа"
+                              }
+                            }
+                          ]
+                        },
+                        "dataPath": "",
+                        "items": [
+                          [
+                            {
+                              "type": "INPUT_FIELD",
+                              "id": 16,
+                              "name": "Наименование",
+                              "title": {
+                                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                              },
+                              "dataPath": "Список.Description",
+                              "items": []
+                            },
+                            {
+                              "type": "COLUMN_GROUP",
+                              "id": 153,
+                              "name": "ВажностьИАвтор",
+                              "title": {
+                                "content": [
+                                  {
+                                    "default": {
+                                      "tag": 2
+                                    },
+                                    "int": 1,
+                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                      "langKey": "ru",
+                                      "value": "Важность и автор"
+                                    }
+                                  }
+                                ]
+                              },
+                              "dataPath": "",
+                              "items": [
+                                [
+                                  {
+                                    "type": "PICTURE_FIELD",
+                                    "id": 24,
+                                    "name": "Важность",
+                                    "title": {
+                                      "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[2]/synonym"
+                                    },
+                                    "dataPath": "Список.ВажностьКартинка",
+                                    "items": []
+                                  },
+                                  {
+                                    "type": "INPUT_FIELD",
+                                    "id": 40,
+                                    "name": "Автор",
+                                    "title": {
+                                      "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                    },
+                                    "dataPath": "Список.Автор",
+                                    "items": []
+                                  }
+                                ],
+                                []
+                              ]
+                            }
+                          ],
+                          []
+                        ]
+                      },
+                      {
+                        "type": "COLUMN_GROUP",
+                        "id": 157,
+                        "name": "ПраваяГруппа",
+                        "title": {
+                          "content": [
+                            {
+                              "default": {
+                                "tag": 2
+                              },
+                              "int": 1,
+                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                "langKey": "ru",
+                                "value": "Правая группа"
+                              }
+                            }
+                          ]
+                        },
+                        "dataPath": "",
+                        "items": [
+                          [
+                            {
+                              "type": "LABEL_FIELD",
+                              "id": 65,
+                              "name": "Дата",
+                              "title": {
+                                "content": [
+                                  {
+                                    "default": {
+                                      "tag": 2
+                                    },
+                                    "int": 1,
+                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                      "langKey": "ru",
+                                      "value": "Записана / Срок"
+                                    }
+                                  }
+                                ]
+                              },
+                              "dataPath": "Список.Date",
+                              "items": []
+                            },
+                            {
+                              "type": "INPUT_FIELD",
+                              "id": 36,
+                              "name": "СрокИсполнения",
+                              "title": {
+                                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                              },
+                              "dataPath": "Список.СрокИсполнения",
+                              "items": []
+                            }
+                          ],
+                          []
+                        ]
+                      },
+                      {
+                        "type": "COLUMN_GROUP",
+                        "id": 159,
+                        "name": "ГруппаПрочее",
+                        "title": {
+                          "content": [
+                            {
+                              "default": {
+                                "tag": 2
+                              },
+                              "int": 1,
+                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                "langKey": "ru",
+                                "value": "Прочее"
+                              }
+                            }
+                          ]
+                        },
+                        "dataPath": "",
+                        "items": [
+                          [
+                            {
+                              "type": "INPUT_FIELD",
+                              "id": 46,
+                              "name": "ДатаНачала",
+                              "title": {
+                                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[5]/synonym"
+                              },
+                              "dataPath": "Список.ДатаНачала",
+                              "items": []
+                            },
+                            {
+                              "type": "LABEL_FIELD",
+                              "id": 57,
+                              "name": "Номер",
+                              "title": {
+                                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                              },
+                              "dataPath": "Список.Number",
+                              "items": []
+                            }
+                          ],
+                          []
+                        ]
+                      },
+                      {
+                        "type": "LABEL_FIELD",
+                        "id": 137,
+                        "name": "Ссылка",
+                        "title": {
+                          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                        },
+                        "dataPath": "Список.Ref",
+                        "items": []
+                      }
+                    ],
+                    []
+                  ]
+                }
+              ]
+            }
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "Список",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 2,
+                "name": "ПоказыватьВыполненные",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              },
+              {
+                "id": 3,
+                "name": "РежимГруппировки",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[7]/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "23e3de37-9315-45e6-bbfd-60aae28c25ae",
+        "name": "ПеренаправитьЗадачи",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "Task.ЗадачаИсполнителя.Form.ПеренаправитьЗадачи",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.Форма.ПеренаправитьЗадачи"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Перенаправить задачи"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/Tasks/ЗадачаИсполнителя/Forms/ПеренаправитьЗадачи/Ext/Form/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "content": [
+              {
+                "default": {
+                  "tag": 2
+                },
+                "int": 1,
+                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                  "langKey": "ru",
+                  "value": "Выбрать исполнителя"
+                }
+              }
+            ]
+          },
+          "handlers": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler"
+              },
+              {
+                "event": "FillCheckProcessingAtServer",
+                "name": "ОбработкаПроверкиЗаполненияНаСервере"
+              }
+            ],
+            []
+          ],
+          "items": [
+            [
+              {
+                "type": "LABEL_DECORATION",
+                "id": 5,
+                "name": "ДекорацияЗаголовок",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Выбранная задача"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": []
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 72,
+                "name": "Документ",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 11,
+                      "name": "ГруппаАдресация",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Адресация"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 12,
+                            "name": "ГруппаАдресацияИсполнитель",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Адресация исполнитель"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "RADIO_BUTTON_FIELD",
+                                  "id": 9,
+                                  "name": "ТипАдресацииИсполнитель",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Тип адресации"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "ТипАдресации",
+                                  "items": []
+                                },
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 1,
+                                  "name": "Исполнитель",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute[2]/synonym"
+                                  },
+                                  "dataPath": "Исполнитель",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          },
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 67,
+                            "name": "ГруппаАдресацияРоль",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Адресация роль"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "RADIO_BUTTON_FIELD",
+                                  "id": 69,
+                                  "name": "ТипАдресацииРоль",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                  },
+                                  "dataPath": "ТипАдресации",
+                                  "items": []
+                                },
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 13,
+                                  "name": "Роль",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Роль"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "Роль",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 60,
+                      "name": "ГруппаОбъектыАдресации",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "LABEL_DECORATION",
+                            "id": 62,
+                            "name": "Отступ",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 65,
+                            "name": "ОбъектыАдресации",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "USUAL_GROUP",
+                                  "id": 33,
+                                  "name": "ГруппаОдинОбъектАдресации",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Один объект адресации"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 34,
+                                      "name": "ОдинОсновнойОбъектАдресации",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute[3]/synonym"
+                                      },
+                                      "dataPath": "ОсновнойОбъектАдресации",
+                                      "items": []
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "USUAL_GROUP",
+                                  "id": 36,
+                                  "name": "ГруппаДваОбъектаАдресации",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Два объекта адресации"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "INPUT_FIELD",
+                                        "id": 37,
+                                        "name": "ОсновнойОбъектАдресации",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute[3]/synonym"
+                                        },
+                                        "dataPath": "ОсновнойОбъектАдресации",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "INPUT_FIELD",
+                                        "id": 39,
+                                        "name": "ДополнительныйОбъектАдресации",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Доп. объект адресации"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "ДополнительныйОбъектАдресации",
+                                        "items": []
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                }
+                              ],
+                              []
+                            ]
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 7,
+                      "name": "Комментарий",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Комментарий"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "Комментарий",
+                      "items": []
+                    },
+                    {
+                      "type": "CHECK_BOX_FIELD",
+                      "id": 41,
+                      "name": "ИгнорироватьПредупреждения",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Игнорировать предупреждения"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "ИгнорироватьПредупреждения",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "Исполнитель",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute[2]/synonym"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute[2]/type/types/java.util.CollSer/com.github._1c_syntax.bsl.types.value.CustomValueType[2]"
+                      }
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 2,
+                "name": "Комментарий",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[7]/type"
+                }
+              },
+              {
+                "id": 3,
+                "name": "ТипАдресации",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                        "precision": 1,
+                        "scale": 0,
+                        "nonNegative": false,
+                        "description": {}
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 4,
+                "name": "Роль",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute[4]/type"
+                }
+              },
+              {
+                "id": 5,
+                "name": "ИспользуетсяБезОбъектовАдресации",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              },
+              {
+                "id": 6,
+                "name": "ИспользуетсяСОбъектамиАдресации",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              },
+              {
+                "id": 7,
+                "name": "ОсновнойОбъектАдресации",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute[3]/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/type"
+                }
+              },
+              {
+                "id": 8,
+                "name": "ТипыДополнительногоОбъектаАдресации",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "TYPE_DESCRIPTION"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 9,
+                "name": "ТипыОсновногоОбъектаАдресации",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[8]/type"
+                }
+              },
+              {
+                "id": 10,
+                "name": "ДополнительныйОбъектАдресации",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/type"
+                }
+              },
+              {
+                "id": 11,
+                "name": "ИгнорироватьПредупреждения",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "a9957f43-8b6f-4d98-a2d8-77b78047494c",
+        "name": "ФормаЗадачи",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "Task.ЗадачаИсполнителя.Form.ФормаЗадачи",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.Форма.ФормаЗадачи"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Форма выполнения задачи по умолчанию",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Форма задачи"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/Tasks/ЗадачаИсполнителя/Forms/ФормаЗадачи/Ext/Form/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+          },
+          "handlers": [
+            [
+              {
+                "event": "AfterWrite",
+                "name": "ПослеЗаписи"
+              },
+              {
+                "event": "AfterWriteAtServer",
+                "name": "ПослеЗаписиНаСервере"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler"
+              },
+              {
+                "event": "OnReadAtServer",
+                "name": "ПриЧтенииНаСервере"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler"
+              },
+              {
+                "event": "OnWriteAtServer",
+                "name": "ПриЗаписиНаСервере"
+              }
+            ],
+            []
+          ],
+          "items": [
+            {
+              "type": "USUAL_GROUP",
+              "id": 170,
+              "name": "Документ",
+              "title": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+              },
+              "dataPath": "",
+              "items": [
+                [
+                  {
+                    "type": "USUAL_GROUP",
+                    "id": 93,
+                    "name": "ГруппаФормаВыполнения",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Форма выполнения"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "LABEL_DECORATION",
+                          "id": 94,
+                          "name": "ДекорацияТекст",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Выведены общие сведения о задаче.\nДля выполнения задачи необходимо перейти в специальную форму задачи."
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": []
+                        },
+                        {
+                          "type": "LABEL_DECORATION",
+                          "id": 97,
+                          "name": "ДекорацияОткрытьФормуЗадачи",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Перейти в форму для выполнения задачи"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": []
+                        }
+                      ],
+                      []
+                    ]
+                  },
+                  {
+                    "type": "USUAL_GROUP",
+                    "id": 99,
+                    "name": "ГруппаСостояние",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Состояние"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "",
+                    "items": []
+                  },
+                  {
+                    "type": "USUAL_GROUP",
+                    "id": 168,
+                    "name": "ГруппаЗадача",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[2]/synonym"
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 124,
+                          "name": "Шапка",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Шапка"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "USUAL_GROUP",
+                                "id": 83,
+                                "name": "ГруппаАвторИсполнитель",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Автор исполнитель"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 78,
+                                      "name": "Автор",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                      },
+                                      "dataPath": "Объект.Автор",
+                                      "items": []
+                                    },
+                                    {
+                                      "type": "LABEL_FIELD",
+                                      "id": 165,
+                                      "name": "АвторСтрокой",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/synonym"
+                                      },
+                                      "dataPath": "АвторСтрокой",
+                                      "items": []
+                                    },
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 20,
+                                      "name": "Исполнитель",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute[2]/synonym"
+                                      },
+                                      "dataPath": "Объект.Исполнитель",
+                                      "items": []
+                                    }
+                                  ],
+                                  []
+                                ]
+                              },
+                              {
+                                "type": "USUAL_GROUP",
+                                "id": 125,
+                                "name": "ГруппаДатаИСрок",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Дата и срок"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 113,
+                                      "name": "Дата",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                      },
+                                      "dataPath": "Объект.Date",
+                                      "items": []
+                                    },
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 12,
+                                      "name": "СрокИсполнения",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                      },
+                                      "dataPath": "Объект.СрокИсполнения",
+                                      "items": []
+                                    }
+                                  ],
+                                  []
+                                ]
+                              },
+                              {
+                                "type": "USUAL_GROUP",
+                                "id": 126,
+                                "name": "ГруппаНомерИВажность",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Номер и важность"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 115,
+                                      "name": "Номер",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                      },
+                                      "dataPath": "Объект.Number",
+                                      "items": []
+                                    },
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 16,
+                                      "name": "Важность",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                      },
+                                      "dataPath": "Объект.Важность",
+                                      "items": []
+                                    }
+                                  ],
+                                  []
+                                ]
+                              }
+                            ],
+                            []
+                          ]
+                        },
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 88,
+                          "name": "ГруппаПриоритет",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Приоритет"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 85,
+                                "name": "СрокНачалаИсполнения",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                },
+                                "dataPath": "Объект.ДатаНачала",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 110,
+                                "name": "СрокНачалаИсполненияВремя",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                },
+                                "dataPath": "Объект.ДатаНачала",
+                                "items": []
+                              }
+                            ],
+                            []
+                          ]
+                        },
+                        {
+                          "type": "INPUT_FIELD",
+                          "id": 117,
+                          "name": "Наименование",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                          },
+                          "dataPath": "Объект.Description",
+                          "items": []
+                        }
+                      ],
+                      []
+                    ]
+                  },
+                  {
+                    "type": "USUAL_GROUP",
+                    "id": 77,
+                    "name": "ГруппаСодержание",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Содержание"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "LABEL_FIELD",
+                          "id": 106,
+                          "name": "Предмет",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[8]/synonym"
+                          },
+                          "dataPath": "ПредметСтрокой",
+                          "items": []
+                        },
+                        {
+                          "type": "INPUT_FIELD",
+                          "id": 18,
+                          "name": "Описание",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                          },
+                          "dataPath": "Объект.Описание",
+                          "items": []
+                        }
+                      ],
+                      []
+                    ]
+                  },
+                  {
+                    "type": "USUAL_GROUP",
+                    "id": 27,
+                    "name": "ГруппаРезультат",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[11]/synonym"
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "USUAL_BUTTON",
+                          "id": 87,
+                          "name": "Выполнена",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                          },
+                          "dataPath": "",
+                          "items": []
+                        },
+                        {
+                          "type": "INPUT_FIELD",
+                          "id": 119,
+                          "name": "ДатаИсполнения",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Дата"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "Объект.ДатаИсполнения",
+                          "items": []
+                        },
+                        {
+                          "type": "INPUT_FIELD",
+                          "id": 121,
+                          "name": "ДатаИсполненияВремя",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                          },
+                          "dataPath": "Объект.ДатаИсполнения",
+                          "items": []
+                        }
+                      ],
+                      []
+                    ]
+                  }
+                ],
+                []
+              ]
+            }
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "Объект",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 2,
+                "name": "НачальныйПризнакВыполнения",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              },
+              {
+                "id": 5,
+                "name": "ПредметСтрокой",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[8]/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[7]/type"
+                }
+              },
+              {
+                "id": 6,
+                "name": "АвторСтрокой",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[7]/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "e470e15d-1b06-43cb-a9f9-ba489e2f596f",
+        "name": "ФормаСписка",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "Task.ЗадачаИсполнителя.Form.ФормаСписка",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.Форма.ФормаСписка"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Форма списка"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/Tasks/ЗадачаИсполнителя/Forms/ФормаСписка/Ext/Form/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[8]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+          },
+          "handlers": [
+            [
+              {
+                "event": "OnSaveDataInSettingsAtServer",
+                "name": "ПриСохраненииДанныхВНастройкахНаСервере"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler"
+              },
+              {
+                "event": "OnOpen",
+                "name": "ПриОткрытии"
+              },
+              {
+                "event": "NavigationProcessing",
+                "name": "ОбработкаПерехода"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[3]"
+              }
+            ],
+            []
+          ],
+          "items": [
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 54,
+                "name": "ГруппаЗаголовок",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Заголовок"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 55,
+                      "name": "СтрокаБизнесПроцесса",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                      },
+                      "dataPath": "СтрокаБизнесПроцесса",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 57,
+                      "name": "СтрокаЗадачи",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                      },
+                      "dataPath": "СтрокаЗадачи",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 43,
+                "name": "ГруппаОтбор",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Отбор"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 49,
+                      "name": "ПоказыватьЗадачи",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Показывать"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "ПоказыватьЗадачи",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 18,
+                      "name": "ПоАвтору",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/synonym"
+                      },
+                      "dataPath": "ПоАвтору",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 20,
+                      "name": "ПоИсполнителю",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute[2]/synonym"
+                      },
+                      "dataPath": "ПоИсполнителю",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 141,
+                "name": "ГруппаПользовательскихНастроек",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "dataPath": "",
+                "items": []
+              },
+              {
+                "type": "COMMAND_BAR",
+                "id": 47,
+                "name": "ОсновнаяКоманднаяПанель",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "COMMAND_BAR_BUTTON",
+                      "id": 155,
+                      "name": "Изменить",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "COMMAND_BAR_BUTTON",
+                      "id": 147,
+                      "name": "ОткрытьБизнесПроцесс",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "COMMAND_BAR_BUTTON",
+                      "id": 149,
+                      "name": "ОткрытьПредметЗадачи",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "BUTTON_GROUP",
+                      "id": 159,
+                      "name": "ГруппаПоиск",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Поиск"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "COMMAND_BAR_BUTTON",
+                            "id": 151,
+                            "name": "Найти",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "COMMAND_BAR_BUTTON",
+                            "id": 153,
+                            "name": "ОтменитьПоиск",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "BUTTON_GROUP",
+                      "id": 45,
+                      "name": "КоманднаяПанельСписка",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "BUTTON_GROUP",
+                      "id": 157,
+                      "name": "ГруппаПринятьКИсполнению",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "COMMAND_BAR_BUTTON",
+                            "id": 61,
+                            "name": "ПринятьКИсполнению",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "COMMAND_BAR_BUTTON",
+                            "id": 62,
+                            "name": "ОтменитьПринятиеКИсполнению",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[7]/title"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "COMMAND_BAR_BUTTON",
+                            "id": 76,
+                            "name": "ЗадачаЗадачаИсполнителяВыполнено",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                            },
+                            "dataPath": "Items.Список.CurrentData.Ref",
+                            "items": []
+                          },
+                          {
+                            "type": "COMMAND_BAR_BUTTON",
+                            "id": 77,
+                            "name": "ЗадачаЗадачаИсполнителяПеренаправить",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                            },
+                            "dataPath": "Items.Список.CurrentData.Ref",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "BUTTON_GROUP",
+                      "id": 46,
+                      "name": "КоманднаяПанельФормы",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[8]/title"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "COMMAND_BAR_BUTTON",
+                      "id": 139,
+                      "name": "Справка",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "TABLE",
+                "id": 1,
+                "name": "Список",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                },
+                "dataPath": "Список",
+                "items": [
+                  [
+                    {
+                      "type": "COLUMN_GROUP",
+                      "id": 161,
+                      "name": "ГруппаВажность",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[2]/synonym"
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "PICTURE_FIELD",
+                            "id": 81,
+                            "name": "ВажностьКартинка",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Важность (признак)"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "Список.ВажностьКартинка",
+                            "items": []
+                          },
+                          {
+                            "type": "PICTURE_FIELD",
+                            "id": 59,
+                            "name": "Остановлена",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                            },
+                            "dataPath": "Список.Остановлена",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "COLUMN_GROUP",
+                      "id": 85,
+                      "name": "ГруппаОписание",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Описание задачи"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "COLUMN_GROUP",
+                            "id": 165,
+                            "name": "ГруппаНаименование",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 6,
+                                  "name": "Наименование",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                  },
+                                  "dataPath": "Список.Description",
+                                  "items": []
+                                },
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 22,
+                                  "name": "Автор",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                  },
+                                  "dataPath": "Список.Автор",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          },
+                          {
+                            "type": "LABEL_FIELD",
+                            "id": 51,
+                            "name": "Предмет",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                            },
+                            "dataPath": "Список.ПредметСтрокой",
+                            "items": []
+                          },
+                          {
+                            "type": "COLUMN_GROUP",
+                            "id": 163,
+                            "name": "ГруппаАвтор",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/synonym"
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 8,
+                                  "name": "Дата",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[7]/synonym"
+                                  },
+                                  "dataPath": "Список.Date",
+                                  "items": []
+                                },
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 4,
+                                  "name": "Номер",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                  },
+                                  "dataPath": "Список.Number",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 83,
+                            "name": "Описание",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                            },
+                            "dataPath": "Список.Описание",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "COLUMN_GROUP",
+                      "id": 167,
+                      "name": "ГруппаИсполнение",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "COLUMN_GROUP",
+                            "id": 80,
+                            "name": "ГруппаИсполнитель",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute[2]/synonym"
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 24,
+                                  "name": "Исполнитель",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                  },
+                                  "dataPath": "Список.Исполнитель",
+                                  "items": []
+                                },
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 34,
+                                  "name": "РольИсполнителя",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                  },
+                                  "dataPath": "Список.РольИсполнителя",
+                                  "items": []
+                                },
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 40,
+                                  "name": "ОсновнойОбъектАдресации",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                  },
+                                  "dataPath": "Список.ОсновнойОбъектАдресации",
+                                  "items": []
+                                },
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 38,
+                                  "name": "ДополнительныйОбъектАдресации",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                  },
+                                  "dataPath": "Список.ДополнительныйОбъектАдресации",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          },
+                          {
+                            "type": "COLUMN_GROUP",
+                            "id": 169,
+                            "name": "ГруппаСрокИсполнения",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[6]/title"
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 30,
+                                  "name": "СрокИсполнения",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                  },
+                                  "dataPath": "Список.СрокИсполнения",
+                                  "items": []
+                                },
+                                {
+                                  "type": "CHECK_BOX_FIELD",
+                                  "id": 10,
+                                  "name": "Выполнена",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                  },
+                                  "dataPath": "Список.Executed",
+                                  "items": []
+                                },
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 32,
+                                  "name": "ДатаИсполнения",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                  },
+                                  "dataPath": "Список.ДатаИсполнения",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 134,
+                      "name": "Ссылка",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "Список.Ref",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "Список",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 2,
+                "name": "ПоАвтору",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 3,
+                "name": "ПоИсполнителю",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute[2]/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 4,
+                "name": "ПоказыватьЗадачи",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[8]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                        "precision": 1,
+                        "scale": 0,
+                        "nonNegative": true,
+                        "description": {}
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 5,
+                "name": "СтрокаБизнесПроцесса",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Строка бизнес процесса"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                        "length": 100,
+                        "allowedLength": 0,
+                        "description": {}
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 6,
+                "name": "СтрокаЗадачи",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Строка задачи"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[8]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      }
+    ],
+    []
+  ],
+  "mdoReference": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+  },
+  "mdoType": "TASK",
+  "moduleTypes": [
+    [
+      "ManagerModule",
+      [
+        "src/test/resources/ext/designer/ssl_3_2/src/cf/Tasks/ЗадачаИсполнителя/Ext/ManagerModule.bsl"
+      ]
+    ],
+    [
+      "ObjectModule",
+      [
+        "src/test/resources/ext/designer/ssl_3_2/src/cf/Tasks/ЗадачаИсполнителя/Ext/ObjectModule.bsl"
+      ]
+    ]
+  ],
+  "modules": [
+    {
+      "moduleType": "ManagerModule",
+      "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/Tasks/ЗадачаИсполнителя/Ext/ManagerModule.bsl",
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "isProtected": false
+    },
+    {
+      "moduleType": "ObjectModule",
+      "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/Tasks/ЗадачаИсполнителя/Ext/ObjectModule.bsl",
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "isProtected": false
+    }
+  ],
+  "name": "ЗадачаИсполнителя",
+  "objectBelonging": "OWN",
+  "possibleRights": [
+    {
+      "default": {
+        "tag": 4
+      },
+      "int": 24,
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INSERT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "DELETE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "VIEW",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "EDIT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INPUT_BY_STRING",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_DELETE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_INSERT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_SET_DELETION_MARK",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_CLEAR_DELETION_MARK",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_DELETE_MARKED",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_ACTIVATE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "EXECUTE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_EXECUTE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "VIEW_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ_DATA_HISTORY_OF_MISSING_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_OF_MISSING_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_SETTINGS",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_VERSION_COMMENT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "EDIT_DATA_HISTORY_VERSION_COMMENT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "SWITCH_TO_DATA_HISTORY_VERSION"
+    }
+  ],
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[2]/synonym"
+  },
+  "tabularSections": [],
+  "templates": [],
+  "uuid": "3ad08f4a-6202-4099-b6cc-bc116e6731a0"
+}}

--- a/src/test/resources/fixtures/ssl_3_2/Tasks.ЗадачаИсполнителя.json
+++ b/src/test/resources/fixtures/ssl_3_2/Tasks.ЗадачаИсполнителя.json
@@ -975,7 +975,7 @@
               "int": 1,
               "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                 "langKey": "ru",
-                "value": "Дата начала"
+                "value": "Дата начала исполнения"
               }
             }
           ]
@@ -1712,8 +1712,8 @@
             [
               {
                 "type": "USUAL_GROUP",
-                "id": 99,
-                "name": "Документ",
+                "id": 117,
+                "name": "Группа2",
                 "title": {
                   "content": [
                     {
@@ -1723,7 +1723,7 @@
                       "int": 1,
                       "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                         "langKey": "ru",
-                        "value": "Документ"
+                        "value": "Группа"
                       }
                     }
                   ]
@@ -1732,150 +1732,39 @@
                 "items": [
                   [
                     {
-                      "type": "INPUT_FIELD",
-                      "id": 41,
-                      "name": "Наименование",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                      },
-                      "dataPath": "Объект.Description",
-                      "items": []
-                    },
-                    {
                       "type": "USUAL_GROUP",
-                      "id": 63,
-                      "name": "ГруппаРезультат",
+                      "id": 119,
+                      "name": "Группа3",
                       "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Результат выполнения задачи"
-                            }
-                          }
-                        ]
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                       },
                       "dataPath": "",
                       "items": [
                         [
                           {
-                            "type": "CHECK_BOX_FIELD",
-                            "id": 64,
-                            "name": "Выполнена",
+                            "type": "LABEL_FIELD",
+                            "id": 41,
+                            "name": "Наименование",
                             "title": {
                               "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
                             },
-                            "dataPath": "Объект.Executed",
+                            "dataPath": "Объект.Description",
                             "items": []
                           },
                           {
-                            "type": "INPUT_FIELD",
-                            "id": 66,
-                            "name": "ДатаИсполнения",
+                            "type": "LABEL_FIELD",
+                            "id": 71,
+                            "name": "СрокИсполнения",
                             "title": {
                               "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
                             },
-                            "dataPath": "Объект.ДатаИсполнения",
-                            "items": []
-                          }
-                        ],
-                        []
-                      ]
-                    },
-                    {
-                      "type": "USUAL_GROUP",
-                      "id": 51,
-                      "name": "ГруппаБизнесПроцесс",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Бизнес-процесс"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "INPUT_FIELD",
-                            "id": 52,
-                            "name": "БизнесПроцесс",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                            },
-                            "dataPath": "Объект.BusinessProcess",
-                            "items": []
-                          },
-                          {
-                            "type": "INPUT_FIELD",
-                            "id": 54,
-                            "name": "ТочкаМаршрута",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                            },
-                            "dataPath": "Объект.RoutePoint",
-                            "items": []
-                          }
-                        ],
-                        []
-                      ]
-                    },
-                    {
-                      "type": "USUAL_GROUP",
-                      "id": 69,
-                      "name": "ГруппаАдресация",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Задача адресована"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "INPUT_FIELD",
-                            "id": 27,
-                            "name": "Исполнитель",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                            },
-                            "dataPath": "Объект.Исполнитель",
-                            "items": []
-                          },
-                          {
-                            "type": "INPUT_FIELD",
-                            "id": 29,
-                            "name": "РольИсполнителя",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                            },
-                            "dataPath": "Объект.РольИсполнителя",
+                            "dataPath": "Объект.СрокИсполнения",
                             "items": []
                           },
                           {
                             "type": "USUAL_GROUP",
-                            "id": 92,
-                            "name": "ГруппаУточнение",
+                            "id": 51,
+                            "name": "ГруппаБизнесПроцесс",
                             "title": {
                               "content": [
                                 {
@@ -1885,7 +1774,7 @@
                                   "int": 1,
                                   "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                                     "langKey": "ru",
-                                    "value": "Уточнение"
+                                    "value": "Бизнес-процесс"
                                   }
                                 }
                               ]
@@ -1894,59 +1783,69 @@
                             "items": [
                               [
                                 {
-                                  "type": "LABEL_DECORATION",
-                                  "id": 96,
-                                  "name": "Отступ",
+                                  "type": "LABEL_FIELD",
+                                  "id": 52,
+                                  "name": "БизнесПроцесс",
                                   "title": {
                                     "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
                                   },
-                                  "dataPath": "",
+                                  "dataPath": "Объект.BusinessProcess",
                                   "items": []
                                 },
                                 {
-                                  "type": "USUAL_GROUP",
-                                  "id": 94,
-                                  "name": "ГруппаОбъектыАдресации",
+                                  "type": "LABEL_FIELD",
+                                  "id": 54,
+                                  "name": "ТочкаМаршрута",
                                   "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Объекты адресации"
-                                        }
-                                      }
-                                    ]
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
                                   },
-                                  "dataPath": "",
-                                  "items": [
-                                    [
-                                      {
-                                        "type": "INPUT_FIELD",
-                                        "id": 31,
-                                        "name": "ОсновнойОбъектАдресации",
-                                        "title": {
-                                          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                        },
-                                        "dataPath": "Объект.ОсновнойОбъектАдресации",
-                                        "items": []
-                                      },
-                                      {
-                                        "type": "INPUT_FIELD",
-                                        "id": 33,
-                                        "name": "ДополнительныйОбъектАдресации",
-                                        "title": {
-                                          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                        },
-                                        "dataPath": "Объект.ДополнительныйОбъектАдресации",
-                                        "items": []
-                                      }
-                                    ],
-                                    []
-                                  ]
+                                  "dataPath": "Объект.RoutePoint",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          },
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 63,
+                            "name": "ГруппаРезультат",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Результат выполнения задачи"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "CHECK_BOX_FIELD",
+                                  "id": 64,
+                                  "name": "Выполнена",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                  },
+                                  "dataPath": "Объект.Executed",
+                                  "items": []
+                                },
+                                {
+                                  "type": "LABEL_FIELD",
+                                  "id": 66,
+                                  "name": "ДатаИсполнения",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                  },
+                                  "dataPath": "Объект.ДатаИсполнения",
+                                  "items": []
                                 }
                               ],
                               []
@@ -1958,27 +1857,26 @@
                     },
                     {
                       "type": "USUAL_GROUP",
-                      "id": 56,
-                      "name": "ГруппаВходящие",
+                      "id": 121,
+                      "name": "Группа4",
                       "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Входящие"
-                            }
-                          }
-                        ]
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                       },
                       "dataPath": "",
                       "items": [
                         [
                           {
-                            "type": "INPUT_FIELD",
+                            "type": "LABEL_FIELD",
+                            "id": 43,
+                            "name": "Номер",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                            },
+                            "dataPath": "Объект.Number",
+                            "items": []
+                          },
+                          {
+                            "type": "LABEL_FIELD",
                             "id": 57,
                             "name": "Дата",
                             "title": {
@@ -1988,14 +1886,119 @@
                             "items": []
                           },
                           {
-                            "type": "INPUT_FIELD",
-                            "id": 71,
-                            "name": "СрокИсполнения",
+                            "type": "USUAL_GROUP",
+                            "id": 69,
+                            "name": "ГруппаАдресация",
                             "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Задача адресована"
+                                  }
+                                }
+                              ]
                             },
-                            "dataPath": "Объект.СрокИсполнения",
-                            "items": []
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "LABEL_FIELD",
+                                  "id": 27,
+                                  "name": "Исполнитель",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                  },
+                                  "dataPath": "Объект.Исполнитель",
+                                  "items": []
+                                },
+                                {
+                                  "type": "USUAL_GROUP",
+                                  "id": 92,
+                                  "name": "ГруппаУточнение",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Уточнение"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "LABEL_FIELD",
+                                        "id": 29,
+                                        "name": "РольИсполнителя",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                        },
+                                        "dataPath": "Объект.РольИсполнителя",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "USUAL_GROUP",
+                                        "id": 113,
+                                        "name": "ГруппаОбъектАдресации",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Объект адресации"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": [
+                                          [
+                                            {
+                                              "type": "LABEL_FIELD",
+                                              "id": 31,
+                                              "name": "ОсновнойОбъектАдресации",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                              },
+                                              "dataPath": "Объект.ОсновнойОбъектАдресации",
+                                              "items": []
+                                            },
+                                            {
+                                              "type": "LABEL_FIELD",
+                                              "id": 33,
+                                              "name": "ДополнительныйОбъектАдресации",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                              },
+                                              "dataPath": "Объект.ДополнительныйОбъектАдресации",
+                                              "items": []
+                                            }
+                                          ],
+                                          []
+                                        ]
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                }
+                              ],
+                              []
+                            ]
                           }
                         ],
                         []
@@ -2024,18 +2027,38 @@
                   ]
                 },
                 "dataPath": "",
-                "items": [
-                  {
-                    "type": "INPUT_FIELD",
-                    "id": 43,
-                    "name": "Номер",
-                    "title": {
-                      "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                    },
-                    "dataPath": "Объект.Number",
-                    "items": []
-                  }
-                ]
+                "items": []
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 56,
+                "name": "ГруппаДаты",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Даты"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": []
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 115,
+                "name": "Группа1",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "dataPath": "",
+                "items": []
               }
             ],
             []
@@ -2170,27 +2193,6 @@
                       "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                         "langKey": "ru",
                         "value": "Группа пользовательских настроек"
-                      }
-                    }
-                  ]
-                },
-                "dataPath": "",
-                "items": []
-              },
-              {
-                "type": "COMMAND_BAR",
-                "id": 52,
-                "name": "КоманднаяПанельСписка",
-                "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Командная панель списка"
                       }
                     }
                   ]
@@ -2508,7 +2510,7 @@
                 "id": 2,
                 "name": "ПоказыватьВыполненные",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
@@ -2518,7 +2520,7 @@
                 "id": 3,
                 "name": "ДеревоЗадач",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
                 },
                 "type": {
                   "types": [
@@ -2611,8 +2613,8 @@
           "items": [
             [
               {
-                "type": "COMMAND_BAR",
-                "id": 130,
+                "type": "USUAL_GROUP",
+                "id": 181,
                 "name": "ГруппаПользовательскихНастроек",
                 "title": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
@@ -2621,244 +2623,29 @@
                 "items": []
               },
               {
-                "type": "COMMAND_BAR",
-                "id": 50,
-                "name": "КоманднаяПанельСписка",
-                "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                },
-                "dataPath": "",
-                "items": [
-                  {
-                    "type": "BUTTON_GROUP",
-                    "id": 120,
-                    "name": "ГруппаПринятьКИсполнению",
-                    "title": {
-                      "content": [
-                        {
-                          "default": {
-                            "tag": 2
-                          },
-                          "int": 1,
-                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                            "langKey": "ru",
-                            "value": "Принять к исполнению"
-                          }
-                        }
-                      ]
-                    },
-                    "dataPath": "",
-                    "items": [
-                      [
-                        {
-                          "type": "COMMAND_BAR_BUTTON",
-                          "id": 122,
-                          "name": "ПринятьКИсполнению",
-                          "title": {
-                            "content": [
-                              {
-                                "default": {
-                                  "tag": 2
-                                },
-                                "int": 1,
-                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                  "langKey": "ru",
-                                  "value": "К исполнению"
-                                }
-                              }
-                            ]
-                          },
-                          "dataPath": "",
-                          "items": []
-                        },
-                        {
-                          "type": "COMMAND_BAR_BUTTON",
-                          "id": 124,
-                          "name": "ОтменитьПринятиеКИсполнению",
-                          "title": {
-                            "content": [
-                              {
-                                "default": {
-                                  "tag": 2
-                                },
-                                "int": 1,
-                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                  "langKey": "ru",
-                                  "value": "Обновить"
-                                }
-                              }
-                            ]
-                          },
-                          "dataPath": "",
-                          "items": []
-                        },
-                        {
-                          "type": "COMMAND_BAR_BUTTON",
-                          "id": 126,
-                          "name": "ЗадачаЗадачаИсполнителяВыполнено",
-                          "title": {
-                            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                          },
-                          "dataPath": "Items.Список.CurrentData.ОсновнойОбъектАдресации",
-                          "items": []
-                        },
-                        {
-                          "type": "COMMAND_BAR_BUTTON",
-                          "id": 128,
-                          "name": "ЗадачаЗадачаИсполнителяПеренаправить",
-                          "title": {
-                            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                          },
-                          "dataPath": "Items.Список.CurrentData.ОсновнойОбъектАдресации",
-                          "items": []
-                        }
-                      ],
-                      []
-                    ]
-                  }
-                ]
-              },
-              {
                 "type": "TABLE",
                 "id": 1,
                 "name": "Список",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                 },
                 "dataPath": "Список",
                 "items": [
                   [
                     {
-                      "type": "COLUMN_GROUP",
-                      "id": 99,
-                      "name": "ГруппаВажность",
+                      "type": "PICTURE_FIELD",
+                      "id": 52,
+                      "name": "ВажностьКартинка",
                       "title": {
                         "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[2]/synonym"
                       },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "PICTURE_FIELD",
-                            "id": 52,
-                            "name": "ВажностьКартинка",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[2]/synonym"
-                            },
-                            "dataPath": "Список.ВажностьКартинка",
-                            "items": []
-                          },
-                          {
-                            "type": "PICTURE_FIELD",
-                            "id": 56,
-                            "name": "Остановлена",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Остановлена"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "Список.Остановлена",
-                            "items": []
-                          }
-                        ],
-                        []
-                      ]
+                      "dataPath": "Список.ВажностьКартинка",
+                      "items": []
                     },
                     {
-                      "type": "COLUMN_GROUP",
-                      "id": 103,
-                      "name": "ГруппаОписание",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[7]/synonym"
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "COLUMN_GROUP",
-                            "id": 101,
-                            "name": "ГруппаНаименование",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                            },
-                            "dataPath": "",
-                            "items": [
-                              [
-                                {
-                                  "type": "INPUT_FIELD",
-                                  "id": 6,
-                                  "name": "Наименование",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[2]/synonym"
-                                  },
-                                  "dataPath": "Список.Description",
-                                  "items": []
-                                },
-                                {
-                                  "type": "LABEL_FIELD",
-                                  "id": 107,
-                                  "name": "Автор",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                  },
-                                  "dataPath": "Список.Автор",
-                                  "items": []
-                                }
-                              ],
-                              []
-                            ]
-                          },
-                          {
-                            "type": "COLUMN_GROUP",
-                            "id": 105,
-                            "name": "ГруппаАвтор",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/synonym"
-                            },
-                            "dataPath": "",
-                            "items": [
-                              [
-                                {
-                                  "type": "INPUT_FIELD",
-                                  "id": 4,
-                                  "name": "Номер",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                                  },
-                                  "dataPath": "Список.Number",
-                                  "items": []
-                                },
-                                {
-                                  "type": "LABEL_FIELD",
-                                  "id": 110,
-                                  "name": "Дата",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                  },
-                                  "dataPath": "Список.Date",
-                                  "items": []
-                                }
-                              ],
-                              []
-                            ]
-                          }
-                        ],
-                        []
-                      ]
-                    },
-                    {
-                      "type": "COLUMN_GROUP",
-                      "id": 113,
-                      "name": "ГруппаИсполнение",
+                      "type": "PICTURE_FIELD",
+                      "id": 56,
+                      "name": "Остановлена",
                       "title": {
                         "content": [
                           {
@@ -2868,115 +2655,127 @@
                             "int": 1,
                             "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                               "langKey": "ru",
-                              "value": "Исполнение"
+                              "value": "Остановлена"
                             }
                           }
                         ]
+                      },
+                      "dataPath": "Список.Остановлена",
+                      "items": []
+                    },
+                    {
+                      "type": "CHECK_BOX_FIELD",
+                      "id": 54,
+                      "name": "ЗадачаВыполнена",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "Список.Executed",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 6,
+                      "name": "Наименование",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[2]/synonym"
+                      },
+                      "dataPath": "Список.Description",
+                      "items": []
+                    },
+                    {
+                      "type": "COLUMN_GROUP",
+                      "id": 64,
+                      "name": "ГруппаИсполнитель",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute[2]/synonym"
                       },
                       "dataPath": "",
                       "items": [
                         [
                           {
-                            "type": "COLUMN_GROUP",
-                            "id": 64,
-                            "name": "ГруппаИсполнитель",
+                            "type": "INPUT_FIELD",
+                            "id": 18,
+                            "name": "Исполнитель",
                             "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute[2]/synonym"
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
                             },
-                            "dataPath": "",
-                            "items": [
-                              [
-                                {
-                                  "type": "INPUT_FIELD",
-                                  "id": 18,
-                                  "name": "Исполнитель",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                  },
-                                  "dataPath": "Список.Исполнитель",
-                                  "items": []
-                                },
-                                {
-                                  "type": "LABEL_FIELD",
-                                  "id": 58,
-                                  "name": "РольИсполнителя",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                  },
-                                  "dataPath": "Список.РольИсполнителя",
-                                  "items": []
-                                },
-                                {
-                                  "type": "LABEL_FIELD",
-                                  "id": 60,
-                                  "name": "ОсновнойОбъектАдресации",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                  },
-                                  "dataPath": "Список.ОсновнойОбъектАдресации",
-                                  "items": []
-                                },
-                                {
-                                  "type": "LABEL_FIELD",
-                                  "id": 62,
-                                  "name": "ДополнительныйОбъектАдресации",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                  },
-                                  "dataPath": "Список.ДополнительныйОбъектАдресации",
-                                  "items": []
-                                }
-                              ],
-                              []
-                            ]
+                            "dataPath": "Список.Исполнитель",
+                            "items": []
                           },
                           {
-                            "type": "COLUMN_GROUP",
-                            "id": 115,
-                            "name": "ГруппаСрокИсполнения",
+                            "type": "LABEL_FIELD",
+                            "id": 58,
+                            "name": "РольИсполнителя",
                             "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[6]/title"
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
                             },
-                            "dataPath": "",
-                            "items": [
-                              [
-                                {
-                                  "type": "LABEL_FIELD",
-                                  "id": 23,
-                                  "name": "СрокИсполнения",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                  },
-                                  "dataPath": "Список.СрокИсполнения",
-                                  "items": []
-                                },
-                                {
-                                  "type": "CHECK_BOX_FIELD",
-                                  "id": 54,
-                                  "name": "ЗадачаВыполнена",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                  },
-                                  "dataPath": "Список.Executed",
-                                  "items": []
-                                },
-                                {
-                                  "type": "LABEL_FIELD",
-                                  "id": 117,
-                                  "name": "ДатаИсполнения",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                  },
-                                  "dataPath": "Список.ДатаИсполнения",
-                                  "items": []
-                                }
-                              ],
-                              []
-                            ]
+                            "dataPath": "Список.РольИсполнителя",
+                            "items": []
+                          },
+                          {
+                            "type": "LABEL_FIELD",
+                            "id": 60,
+                            "name": "ОсновнойОбъектАдресации",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                            },
+                            "dataPath": "Список.ОсновнойОбъектАдресации",
+                            "items": []
+                          },
+                          {
+                            "type": "LABEL_FIELD",
+                            "id": 62,
+                            "name": "ДополнительныйОбъектАдресации",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                            },
+                            "dataPath": "Список.ДополнительныйОбъектАдресации",
+                            "items": []
                           }
                         ],
                         []
                       ]
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 4,
+                      "name": "Номер",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                      },
+                      "dataPath": "Список.Number",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 23,
+                      "name": "СрокИсполнения",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "Список.СрокИсполнения",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 110,
+                      "name": "Дата",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "Список.Date",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 107,
+                      "name": "Автор",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "Список.Автор",
+                      "items": []
                     },
                     {
                       "type": "LABEL_FIELD",
@@ -2993,32 +2792,11 @@
                 ]
               },
               {
-                "type": "CHECK_BOX_FIELD",
-                "id": 21,
-                "name": "ПоказыватьВыполненные",
-                "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Показывать выполненные задачи"
-                      }
-                    }
-                  ]
-                },
-                "dataPath": "ПоказыватьВыполненные",
-                "items": []
-              },
-              {
                 "type": "TABLE",
                 "id": 25,
                 "name": "ДеревоЗадач",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
                 },
                 "dataPath": "ДеревоЗадач",
                 "items": [
@@ -3048,7 +2826,7 @@
                       "id": 32,
                       "name": "ДеревоЗадачОстановлен",
                       "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
                       },
                       "dataPath": "ДеревоЗадач.Остановлен",
                       "items": []
@@ -3058,7 +2836,7 @@
                       "id": 34,
                       "name": "ТипИНаименование",
                       "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
                       },
                       "dataPath": "",
                       "items": [
@@ -3068,7 +2846,7 @@
                             "id": 35,
                             "name": "ДеревоЗадачТип",
                             "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                             },
                             "dataPath": "ДеревоЗадач.Тип",
                             "items": []
@@ -3100,16 +2878,47 @@
                     {
                       "type": "INPUT_FIELD",
                       "id": 41,
-                      "name": "СрокИсполнения1",
+                      "name": "ДеревоСрокИсполнения",
                       "title": {
                         "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[13]/synonym"
                       },
                       "dataPath": "ДеревоЗадач.СрокИсполнения",
                       "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 187,
+                      "name": "ДеревоЗадачСсылка",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "ДеревоЗадач.Ссылка",
+                      "items": []
                     }
                   ],
                   []
                 ]
+              },
+              {
+                "type": "CHECK_BOX_FIELD",
+                "id": 21,
+                "name": "ПоказыватьВыполненные",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Показывать выполненные задачи"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "ПоказыватьВыполненные",
+                "items": []
               }
             ],
             []
@@ -3140,7 +2949,7 @@
                 "id": 3,
                 "name": "ДеревоЗадач",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
@@ -3211,7 +3020,7 @@
             [
               {
                 "type": "USUAL_GROUP",
-                "id": 126,
+                "id": 173,
                 "name": "ГруппаПользовательскихНастроек",
                 "title": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
@@ -3220,351 +3029,25 @@
                 "items": []
               },
               {
-                "type": "COMMAND_BAR",
-                "id": 1,
-                "name": "ОсновнаяКоманднаяПанель",
-                "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Основная командная панель"
-                      }
-                    }
-                  ]
-                },
-                "dataPath": "",
-                "items": [
-                  [
-                    {
-                      "type": "POPUP",
-                      "id": 51,
-                      "name": "СгруппироватьПо",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Сгруппировать по"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "COMMAND_BAR_BUTTON",
-                            "id": 132,
-                            "name": "СписокСгруппироватьПоСроку",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[13]/synonym"
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "COMMAND_BAR_BUTTON",
-                            "id": 52,
-                            "name": "СписокСгруппироватьПоВажности",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[2]/synonym"
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "COMMAND_BAR_BUTTON",
-                            "id": 53,
-                            "name": "СписокСгруппироватьПоТочкеМаршрута",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Точка маршрута"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "COMMAND_BAR_BUTTON",
-                            "id": 61,
-                            "name": "СписокСгруппироватьПоАвтору",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/synonym"
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "COMMAND_BAR_BUTTON",
-                            "id": 62,
-                            "name": "СписокСгруппироватьПоПредмету",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[8]/synonym"
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "COMMAND_BAR_BUTTON",
-                            "id": 54,
-                            "name": "СписокСгруппироватьСгруппироватьПоБезГруппировки",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Без группировки"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": []
-                          }
-                        ],
-                        []
-                      ]
-                    },
-                    {
-                      "type": "BUTTON_GROUP",
-                      "id": 140,
-                      "name": "ГруппаОткрыть",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Открыть"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "COMMAND_BAR_BUTTON",
-                            "id": 138,
-                            "name": "ФормаИзменить",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Открыть задачу"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "COMMAND_BAR_BUTTON",
-                            "id": 134,
-                            "name": "ОткрытьПредметЗадачи",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Открыть предмет задачи"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "COMMAND_BAR_BUTTON",
-                            "id": 136,
-                            "name": "ОткрытьБизнесПроцесс",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Открыть бизнес-процесс"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": []
-                          }
-                        ],
-                        []
-                      ]
-                    },
-                    {
-                      "type": "BUTTON_GROUP",
-                      "id": 48,
-                      "name": "КоманднаяПанельСписка",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "COMMAND_BAR_BUTTON",
-                            "id": 128,
-                            "name": "ФормаНайти",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "COMMAND_BAR_BUTTON",
-                            "id": 130,
-                            "name": "ФормаОтменитьПоиск",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                            },
-                            "dataPath": "",
-                            "items": []
-                          }
-                        ],
-                        []
-                      ]
-                    },
-                    {
-                      "type": "COMMAND_BAR_BUTTON",
-                      "id": 80,
-                      "name": "ПринятьКИсполнению",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "COMMAND_BAR_BUTTON",
-                      "id": 82,
-                      "name": "ЗадачаЗадачаИсполнителяВыполнено",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                      },
-                      "dataPath": "Items.Список.CurrentData.Ref",
-                      "items": []
-                    },
-                    {
-                      "type": "COMMAND_BAR_BUTTON",
-                      "id": 83,
-                      "name": "ЗадачаЗадачаИсполнителяПеренаправить",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                      },
-                      "dataPath": "Items.Список.CurrentData.Ref",
-                      "items": []
-                    },
-                    {
-                      "type": "COMMAND_BAR_BUTTON",
-                      "id": 81,
-                      "name": "ОтменитьПринятиеКИсполнению",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Отменить принятие к исполнению"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "BUTTON_GROUP",
-                      "id": 8,
-                      "name": "КоманднаяПанельФормы",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Командная панель формы"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "COMMAND_BAR_BUTTON",
-                      "id": 65,
-                      "name": "Справка",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    }
-                  ],
-                  []
-                ]
-              },
-              {
                 "type": "TABLE",
                 "id": 9,
                 "name": "Список",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                 },
                 "dataPath": "Список",
                 "items": [
                   [
+                    {
+                      "type": "CHECK_BOX_FIELD",
+                      "id": 168,
+                      "name": "ПринятаКИсполнению",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "Список.ПринятаКИсполнению",
+                      "items": []
+                    },
                     {
                       "type": "PICTURE_FIELD",
                       "id": 24,
@@ -3573,16 +3056,6 @@
                         "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[2]/synonym"
                       },
                       "dataPath": "Список.ВажностьКартинка",
-                      "items": []
-                    },
-                    {
-                      "type": "LABEL_FIELD",
-                      "id": 57,
-                      "name": "Номер",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                      },
-                      "dataPath": "Список.Number",
                       "items": []
                     },
                     {
@@ -3597,22 +3070,22 @@
                     },
                     {
                       "type": "INPUT_FIELD",
-                      "id": 46,
-                      "name": "ДатаНачала",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[5]/synonym"
-                      },
-                      "dataPath": "Список.ДатаНачала",
-                      "items": []
-                    },
-                    {
-                      "type": "INPUT_FIELD",
                       "id": 36,
                       "name": "СрокИсполнения",
                       "title": {
                         "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
                       },
                       "dataPath": "Список.СрокИсполнения",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 57,
+                      "name": "Номер",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "Список.Number",
                       "items": []
                     },
                     {
@@ -3633,6 +3106,27 @@
                         "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
                       },
                       "dataPath": "Список.ПредметСтрокой",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 46,
+                      "name": "ДатаНачала",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Дата начала"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "Список.ДатаНачала",
                       "items": []
                     },
                     {
@@ -3664,7 +3158,7 @@
                 "id": 38,
                 "name": "ПоказыватьВыполненные",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
                 },
                 "dataPath": "ПоказыватьВыполненные",
                 "items": []
@@ -3688,7 +3182,7 @@
                 "id": 2,
                 "name": "ПоказыватьВыполненные",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
@@ -3775,233 +3269,135 @@
             []
           ],
           "items": [
-            {
-              "type": "TABLE",
-              "id": 9,
-              "name": "Список",
-              "title": {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 232,
+                "name": "ГруппаПользовательскихНастроек",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "dataPath": "",
+                "items": []
               },
-              "dataPath": "Список",
-              "items": [
-                {
-                  "type": "COLUMN_GROUP",
-                  "id": 161,
-                  "name": "ГруппаКолонки",
-                  "title": {
-                    "content": [
-                      {
-                        "default": {
-                          "tag": 2
-                        },
-                        "int": 1,
-                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                          "langKey": "ru",
-                          "value": "Колонки"
+              {
+                "type": "TABLE",
+                "id": 9,
+                "name": "Список",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "dataPath": "Список",
+                "items": [
+                  {
+                    "type": "COLUMN_GROUP",
+                    "id": 161,
+                    "name": "ГруппаКолонки",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Колонки"
+                          }
                         }
-                      }
+                      ]
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "LABEL_FIELD",
+                          "id": 57,
+                          "name": "Номер",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                          },
+                          "dataPath": "Список.Number",
+                          "items": []
+                        },
+                        {
+                          "type": "PICTURE_FIELD",
+                          "id": 24,
+                          "name": "Важность",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[2]/synonym"
+                          },
+                          "dataPath": "Список.ВажностьКартинка",
+                          "items": []
+                        },
+                        {
+                          "type": "INPUT_FIELD",
+                          "id": 16,
+                          "name": "Наименование",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                          },
+                          "dataPath": "Список.Description",
+                          "items": []
+                        },
+                        {
+                          "type": "INPUT_FIELD",
+                          "id": 36,
+                          "name": "СрокИсполнения",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[13]/synonym"
+                          },
+                          "dataPath": "Список.СрокИсполнения",
+                          "items": []
+                        },
+                        {
+                          "type": "INPUT_FIELD",
+                          "id": 46,
+                          "name": "ДатаНачала",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[8]/title"
+                          },
+                          "dataPath": "Список.ДатаНачала",
+                          "items": []
+                        },
+                        {
+                          "type": "INPUT_FIELD",
+                          "id": 40,
+                          "name": "Автор",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                          },
+                          "dataPath": "Список.Автор",
+                          "items": []
+                        },
+                        {
+                          "type": "LABEL_FIELD",
+                          "id": 65,
+                          "name": "Дата",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[7]/synonym"
+                          },
+                          "dataPath": "Список.Date",
+                          "items": []
+                        },
+                        {
+                          "type": "LABEL_FIELD",
+                          "id": 137,
+                          "name": "Ссылка",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                          },
+                          "dataPath": "Список.Ref",
+                          "items": []
+                        }
+                      ],
+                      []
                     ]
-                  },
-                  "dataPath": "",
-                  "items": [
-                    [
-                      {
-                        "type": "COLUMN_GROUP",
-                        "id": 155,
-                        "name": "ЛеваяГруппа",
-                        "title": {
-                          "content": [
-                            {
-                              "default": {
-                                "tag": 2
-                              },
-                              "int": 1,
-                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                "langKey": "ru",
-                                "value": "Левая группа"
-                              }
-                            }
-                          ]
-                        },
-                        "dataPath": "",
-                        "items": [
-                          [
-                            {
-                              "type": "INPUT_FIELD",
-                              "id": 16,
-                              "name": "Наименование",
-                              "title": {
-                                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                              },
-                              "dataPath": "Список.Description",
-                              "items": []
-                            },
-                            {
-                              "type": "COLUMN_GROUP",
-                              "id": 153,
-                              "name": "ВажностьИАвтор",
-                              "title": {
-                                "content": [
-                                  {
-                                    "default": {
-                                      "tag": 2
-                                    },
-                                    "int": 1,
-                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                      "langKey": "ru",
-                                      "value": "Важность и автор"
-                                    }
-                                  }
-                                ]
-                              },
-                              "dataPath": "",
-                              "items": [
-                                [
-                                  {
-                                    "type": "PICTURE_FIELD",
-                                    "id": 24,
-                                    "name": "Важность",
-                                    "title": {
-                                      "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[2]/synonym"
-                                    },
-                                    "dataPath": "Список.ВажностьКартинка",
-                                    "items": []
-                                  },
-                                  {
-                                    "type": "INPUT_FIELD",
-                                    "id": 40,
-                                    "name": "Автор",
-                                    "title": {
-                                      "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                    },
-                                    "dataPath": "Список.Автор",
-                                    "items": []
-                                  }
-                                ],
-                                []
-                              ]
-                            }
-                          ],
-                          []
-                        ]
-                      },
-                      {
-                        "type": "COLUMN_GROUP",
-                        "id": 157,
-                        "name": "ПраваяГруппа",
-                        "title": {
-                          "content": [
-                            {
-                              "default": {
-                                "tag": 2
-                              },
-                              "int": 1,
-                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                "langKey": "ru",
-                                "value": "Правая группа"
-                              }
-                            }
-                          ]
-                        },
-                        "dataPath": "",
-                        "items": [
-                          [
-                            {
-                              "type": "LABEL_FIELD",
-                              "id": 65,
-                              "name": "Дата",
-                              "title": {
-                                "content": [
-                                  {
-                                    "default": {
-                                      "tag": 2
-                                    },
-                                    "int": 1,
-                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                      "langKey": "ru",
-                                      "value": "Записана / Срок"
-                                    }
-                                  }
-                                ]
-                              },
-                              "dataPath": "Список.Date",
-                              "items": []
-                            },
-                            {
-                              "type": "INPUT_FIELD",
-                              "id": 36,
-                              "name": "СрокИсполнения",
-                              "title": {
-                                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                              },
-                              "dataPath": "Список.СрокИсполнения",
-                              "items": []
-                            }
-                          ],
-                          []
-                        ]
-                      },
-                      {
-                        "type": "COLUMN_GROUP",
-                        "id": 159,
-                        "name": "ГруппаПрочее",
-                        "title": {
-                          "content": [
-                            {
-                              "default": {
-                                "tag": 2
-                              },
-                              "int": 1,
-                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                "langKey": "ru",
-                                "value": "Прочее"
-                              }
-                            }
-                          ]
-                        },
-                        "dataPath": "",
-                        "items": [
-                          [
-                            {
-                              "type": "INPUT_FIELD",
-                              "id": 46,
-                              "name": "ДатаНачала",
-                              "title": {
-                                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[5]/synonym"
-                              },
-                              "dataPath": "Список.ДатаНачала",
-                              "items": []
-                            },
-                            {
-                              "type": "LABEL_FIELD",
-                              "id": 57,
-                              "name": "Номер",
-                              "title": {
-                                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                              },
-                              "dataPath": "Список.Number",
-                              "items": []
-                            }
-                          ],
-                          []
-                        ]
-                      },
-                      {
-                        "type": "LABEL_FIELD",
-                        "id": 137,
-                        "name": "Ссылка",
-                        "title": {
-                          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                        },
-                        "dataPath": "Список.Ref",
-                        "items": []
-                      }
-                    ],
-                    []
-                  ]
-                }
-              ]
-            }
+                  }
+                ]
+              }
+            ],
+            []
           ],
           "attributes": [
             [
@@ -4143,7 +3539,18 @@
                 "id": 72,
                 "name": "Документ",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Документ"
+                      }
+                    }
+                  ]
                 },
                 "dataPath": "",
                 "items": [
@@ -4290,67 +3697,89 @@
                       "id": 60,
                       "name": "ГруппаОбъектыАдресации",
                       "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Объекты адресации"
+                            }
+                          }
+                        ]
                       },
                       "dataPath": "",
                       "items": [
                         [
                           {
-                            "type": "LABEL_DECORATION",
-                            "id": 62,
-                            "name": "Отступ",
+                            "type": "USUAL_GROUP",
+                            "id": 33,
+                            "name": "ГруппаОдинОбъектАдресации",
                             "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Один объект адресации"
+                                  }
+                                }
+                              ]
                             },
                             "dataPath": "",
-                            "items": []
+                            "items": [
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 34,
+                                "name": "ОдинОсновнойОбъектАдресации",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute[3]/synonym"
+                                },
+                                "dataPath": "ОсновнойОбъектАдресации",
+                                "items": []
+                              }
+                            ]
                           },
                           {
                             "type": "USUAL_GROUP",
-                            "id": 65,
-                            "name": "ОбъектыАдресации",
+                            "id": 36,
+                            "name": "ГруппаДваОбъектаАдресации",
                             "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Два объекта адресации"
+                                  }
+                                }
+                              ]
                             },
                             "dataPath": "",
                             "items": [
                               [
                                 {
-                                  "type": "USUAL_GROUP",
-                                  "id": 33,
-                                  "name": "ГруппаОдинОбъектАдресации",
+                                  "type": "INPUT_FIELD",
+                                  "id": 37,
+                                  "name": "ОсновнойОбъектАдресации",
                                   "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Один объект адресации"
-                                        }
-                                      }
-                                    ]
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute[3]/synonym"
                                   },
-                                  "dataPath": "",
-                                  "items": [
-                                    {
-                                      "type": "INPUT_FIELD",
-                                      "id": 34,
-                                      "name": "ОдинОсновнойОбъектАдресации",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute[3]/synonym"
-                                      },
-                                      "dataPath": "ОсновнойОбъектАдресации",
-                                      "items": []
-                                    }
-                                  ]
+                                  "dataPath": "ОсновнойОбъектАдресации",
+                                  "items": []
                                 },
                                 {
-                                  "type": "USUAL_GROUP",
-                                  "id": 36,
-                                  "name": "ГруппаДваОбъектаАдресации",
+                                  "type": "INPUT_FIELD",
+                                  "id": 39,
+                                  "name": "ДополнительныйОбъектАдресации",
                                   "title": {
                                     "content": [
                                       {
@@ -4360,48 +3789,13 @@
                                         "int": 1,
                                         "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                                           "langKey": "ru",
-                                          "value": "Два объекта адресации"
+                                          "value": "Доп. объект адресации"
                                         }
                                       }
                                     ]
                                   },
-                                  "dataPath": "",
-                                  "items": [
-                                    [
-                                      {
-                                        "type": "INPUT_FIELD",
-                                        "id": 37,
-                                        "name": "ОсновнойОбъектАдресации",
-                                        "title": {
-                                          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute[3]/synonym"
-                                        },
-                                        "dataPath": "ОсновнойОбъектАдресации",
-                                        "items": []
-                                      },
-                                      {
-                                        "type": "INPUT_FIELD",
-                                        "id": 39,
-                                        "name": "ДополнительныйОбъектАдресации",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Доп. объект адресации"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "ДополнительныйОбъектАдресации",
-                                        "items": []
-                                      }
-                                    ],
-                                    []
-                                  ]
+                                  "dataPath": "ДополнительныйОбъектАдресации",
+                                  "items": []
                                 }
                               ],
                               []
@@ -4601,7 +3995,7 @@
                 "id": 10,
                 "name": "ДополнительныйОбъектАдресации",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/type"
@@ -4702,447 +4096,342 @@
             []
           ],
           "items": [
-            {
-              "type": "USUAL_GROUP",
-              "id": 170,
-              "name": "Документ",
-              "title": {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 93,
+                "name": "ГруппаФормаВыполнения",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Форма выполнения"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "LABEL_DECORATION",
+                      "id": 94,
+                      "name": "ДекорацияТекст",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Выведены общие сведения о задаче.\nДля выполнения задачи необходимо перейти в специальную форму задачи."
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_DECORATION",
+                      "id": 97,
+                      "name": "ДекорацияОткрытьФормуЗадачи",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Перейти в форму для выполнения задачи"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
               },
-              "dataPath": "",
-              "items": [
-                [
-                  {
-                    "type": "USUAL_GROUP",
-                    "id": 93,
-                    "name": "ГруппаФормаВыполнения",
-                    "title": {
-                      "content": [
-                        {
-                          "default": {
-                            "tag": 2
-                          },
-                          "int": 1,
-                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                            "langKey": "ru",
-                            "value": "Форма выполнения"
+              {
+                "type": "USUAL_GROUP",
+                "id": 99,
+                "name": "ГруппаСостояние",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Состояние"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": []
+              },
+              {
+                "type": "PAGES",
+                "id": 198,
+                "name": "Страницы",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Страницы"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "PAGE",
+                      "id": 200,
+                      "name": "СтраницаОписаниеЗадачи",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Описание задачи"
+                            }
                           }
-                        }
-                      ]
-                    },
-                    "dataPath": "",
-                    "items": [
-                      [
-                        {
-                          "type": "LABEL_DECORATION",
-                          "id": 94,
-                          "name": "ДекорацияТекст",
-                          "title": {
-                            "content": [
-                              {
-                                "default": {
-                                  "tag": 2
-                                },
-                                "int": 1,
-                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                  "langKey": "ru",
-                                  "value": "Выведены общие сведения о задаче.\nДля выполнения задачи необходимо перейти в специальную форму задачи."
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 210,
+                            "name": "ГруппаНаименованиеИНомер",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Наименование и номер"
+                                  }
                                 }
-                              }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 117,
+                                  "name": "Наименование",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                  },
+                                  "dataPath": "Объект.Description",
+                                  "items": []
+                                },
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 115,
+                                  "name": "Номер",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                  },
+                                  "dataPath": "Объект.Number",
+                                  "items": []
+                                }
+                              ],
+                              []
                             ]
                           },
-                          "dataPath": "",
-                          "items": []
-                        },
-                        {
-                          "type": "LABEL_DECORATION",
-                          "id": 97,
-                          "name": "ДекорацияОткрытьФормуЗадачи",
-                          "title": {
-                            "content": [
-                              {
-                                "default": {
-                                  "tag": 2
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 18,
+                            "name": "Описание",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[7]/synonym"
+                            },
+                            "dataPath": "Объект.Описание",
+                            "items": []
+                          },
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 204,
+                            "name": "ГруппаВажность",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[2]/synonym"
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 20,
+                                  "name": "Исполнитель",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute[2]/synonym"
+                                  },
+                                  "dataPath": "Объект.Исполнитель",
+                                  "items": []
                                 },
-                                "int": 1,
-                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                  "langKey": "ru",
-                                  "value": "Перейти в форму для выполнения задачи"
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 12,
+                                  "name": "СрокИсполнения",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                  },
+                                  "dataPath": "Объект.СрокИсполнения",
+                                  "items": []
                                 }
-                              }
+                              ],
+                              []
                             ]
                           },
-                          "dataPath": "",
-                          "items": []
-                        }
-                      ],
-                      []
-                    ]
-                  },
-                  {
-                    "type": "USUAL_GROUP",
-                    "id": 99,
-                    "name": "ГруппаСостояние",
-                    "title": {
-                      "content": [
-                        {
-                          "default": {
-                            "tag": 2
-                          },
-                          "int": 1,
-                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                            "langKey": "ru",
-                            "value": "Состояние"
-                          }
-                        }
-                      ]
-                    },
-                    "dataPath": "",
-                    "items": []
-                  },
-                  {
-                    "type": "USUAL_GROUP",
-                    "id": 168,
-                    "name": "ГруппаЗадача",
-                    "title": {
-                      "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[2]/synonym"
-                    },
-                    "dataPath": "",
-                    "items": [
-                      [
-                        {
-                          "type": "USUAL_GROUP",
-                          "id": 124,
-                          "name": "Шапка",
-                          "title": {
-                            "content": [
-                              {
-                                "default": {
-                                  "tag": 2
-                                },
-                                "int": 1,
-                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                  "langKey": "ru",
-                                  "value": "Шапка"
-                                }
-                              }
-                            ]
-                          },
-                          "dataPath": "",
-                          "items": [
-                            [
-                              {
-                                "type": "USUAL_GROUP",
-                                "id": 83,
-                                "name": "ГруппаАвторИсполнитель",
-                                "title": {
-                                  "content": [
-                                    {
-                                      "default": {
-                                        "tag": 2
-                                      },
-                                      "int": 1,
-                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                        "langKey": "ru",
-                                        "value": "Автор исполнитель"
-                                      }
-                                    }
-                                  ]
-                                },
-                                "dataPath": "",
-                                "items": [
-                                  [
-                                    {
-                                      "type": "INPUT_FIELD",
-                                      "id": 78,
-                                      "name": "Автор",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                      },
-                                      "dataPath": "Объект.Автор",
-                                      "items": []
-                                    },
-                                    {
-                                      "type": "LABEL_FIELD",
-                                      "id": 165,
-                                      "name": "АвторСтрокой",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/synonym"
-                                      },
-                                      "dataPath": "АвторСтрокой",
-                                      "items": []
-                                    },
-                                    {
-                                      "type": "INPUT_FIELD",
-                                      "id": 20,
-                                      "name": "Исполнитель",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute[2]/synonym"
-                                      },
-                                      "dataPath": "Объект.Исполнитель",
-                                      "items": []
-                                    }
-                                  ],
-                                  []
-                                ]
-                              },
-                              {
-                                "type": "USUAL_GROUP",
-                                "id": 125,
-                                "name": "ГруппаДатаИСрок",
-                                "title": {
-                                  "content": [
-                                    {
-                                      "default": {
-                                        "tag": 2
-                                      },
-                                      "int": 1,
-                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                        "langKey": "ru",
-                                        "value": "Дата и срок"
-                                      }
-                                    }
-                                  ]
-                                },
-                                "dataPath": "",
-                                "items": [
-                                  [
-                                    {
-                                      "type": "INPUT_FIELD",
-                                      "id": 113,
-                                      "name": "Дата",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                      },
-                                      "dataPath": "Объект.Date",
-                                      "items": []
-                                    },
-                                    {
-                                      "type": "INPUT_FIELD",
-                                      "id": 12,
-                                      "name": "СрокИсполнения",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                      },
-                                      "dataPath": "Объект.СрокИсполнения",
-                                      "items": []
-                                    }
-                                  ],
-                                  []
-                                ]
-                              },
-                              {
-                                "type": "USUAL_GROUP",
-                                "id": 126,
-                                "name": "ГруппаНомерИВажность",
-                                "title": {
-                                  "content": [
-                                    {
-                                      "default": {
-                                        "tag": 2
-                                      },
-                                      "int": 1,
-                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                        "langKey": "ru",
-                                        "value": "Номер и важность"
-                                      }
-                                    }
-                                  ]
-                                },
-                                "dataPath": "",
-                                "items": [
-                                  [
-                                    {
-                                      "type": "INPUT_FIELD",
-                                      "id": 115,
-                                      "name": "Номер",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                      },
-                                      "dataPath": "Объект.Number",
-                                      "items": []
-                                    },
-                                    {
-                                      "type": "INPUT_FIELD",
-                                      "id": 16,
-                                      "name": "Важность",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                      },
-                                      "dataPath": "Объект.Важность",
-                                      "items": []
-                                    }
-                                  ],
-                                  []
-                                ]
-                              }
-                            ],
-                            []
-                          ]
-                        },
-                        {
-                          "type": "USUAL_GROUP",
-                          "id": 88,
-                          "name": "ГруппаПриоритет",
-                          "title": {
-                            "content": [
-                              {
-                                "default": {
-                                  "tag": 2
-                                },
-                                "int": 1,
-                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                  "langKey": "ru",
-                                  "value": "Приоритет"
-                                }
-                              }
-                            ]
-                          },
-                          "dataPath": "",
-                          "items": [
-                            [
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 186,
+                            "name": "ГруппаСрокИсполнения",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[6]/title"
+                            },
+                            "dataPath": "",
+                            "items": [
                               {
                                 "type": "INPUT_FIELD",
-                                "id": 85,
-                                "name": "СрокНачалаИсполнения",
+                                "id": 16,
+                                "name": "Важность",
                                 "title": {
                                   "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
                                 },
-                                "dataPath": "Объект.ДатаНачала",
+                                "dataPath": "Объект.Важность",
                                 "items": []
-                              },
-                              {
-                                "type": "INPUT_FIELD",
-                                "id": 110,
-                                "name": "СрокНачалаИсполненияВремя",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                },
-                                "dataPath": "Объект.ДатаНачала",
-                                "items": []
-                              }
-                            ],
-                            []
-                          ]
-                        },
-                        {
-                          "type": "INPUT_FIELD",
-                          "id": 117,
-                          "name": "Наименование",
-                          "title": {
-                            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                          },
-                          "dataPath": "Объект.Description",
-                          "items": []
-                        }
-                      ],
-                      []
-                    ]
-                  },
-                  {
-                    "type": "USUAL_GROUP",
-                    "id": 77,
-                    "name": "ГруппаСодержание",
-                    "title": {
-                      "content": [
-                        {
-                          "default": {
-                            "tag": 2
-                          },
-                          "int": 1,
-                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                            "langKey": "ru",
-                            "value": "Содержание"
-                          }
-                        }
-                      ]
-                    },
-                    "dataPath": "",
-                    "items": [
-                      [
-                        {
-                          "type": "LABEL_FIELD",
-                          "id": 106,
-                          "name": "Предмет",
-                          "title": {
-                            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[8]/synonym"
-                          },
-                          "dataPath": "ПредметСтрокой",
-                          "items": []
-                        },
-                        {
-                          "type": "INPUT_FIELD",
-                          "id": 18,
-                          "name": "Описание",
-                          "title": {
-                            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                          },
-                          "dataPath": "Объект.Описание",
-                          "items": []
-                        }
-                      ],
-                      []
-                    ]
-                  },
-                  {
-                    "type": "USUAL_GROUP",
-                    "id": 27,
-                    "name": "ГруппаРезультат",
-                    "title": {
-                      "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[11]/synonym"
-                    },
-                    "dataPath": "",
-                    "items": [
-                      [
-                        {
-                          "type": "USUAL_BUTTON",
-                          "id": 87,
-                          "name": "Выполнена",
-                          "title": {
-                            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                          },
-                          "dataPath": "",
-                          "items": []
-                        },
-                        {
-                          "type": "INPUT_FIELD",
-                          "id": 119,
-                          "name": "ДатаИсполнения",
-                          "title": {
-                            "content": [
-                              {
-                                "default": {
-                                  "tag": 2
-                                },
-                                "int": 1,
-                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                  "langKey": "ru",
-                                  "value": "Дата"
-                                }
                               }
                             ]
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "PAGE",
+                      "id": 202,
+                      "name": "СтраницаДополнительно",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/synonym"
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "LABEL_FIELD",
+                            "id": 106,
+                            "name": "Предмет",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[8]/synonym"
+                            },
+                            "dataPath": "ПредметСтрокой",
+                            "items": []
                           },
-                          "dataPath": "Объект.ДатаИсполнения",
-                          "items": []
-                        },
-                        {
-                          "type": "INPUT_FIELD",
-                          "id": 121,
-                          "name": "ДатаИсполненияВремя",
-                          "title": {
-                            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 119,
+                            "name": "ДатаИсполнения",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Дата выполнения"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "Объект.ДатаИсполнения",
+                            "items": []
                           },
-                          "dataPath": "Объект.ДатаИсполнения",
-                          "items": []
-                        }
-                      ],
-                      []
-                    ]
-                  }
-                ],
-                []
-              ]
-            }
+                          {
+                            "type": "LABEL_FIELD",
+                            "id": 113,
+                            "name": "Дата",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                            },
+                            "dataPath": "Объект.Date",
+                            "items": []
+                          },
+                          {
+                            "type": "LABEL_FIELD",
+                            "id": 85,
+                            "name": "СрокНачалаИсполнения",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                            },
+                            "dataPath": "Объект.ДатаПринятияКИсполнению",
+                            "items": []
+                          },
+                          {
+                            "type": "LABEL_FIELD",
+                            "id": 78,
+                            "name": "Автор",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                            },
+                            "dataPath": "Объект.Автор",
+                            "items": []
+                          },
+                          {
+                            "type": "LABEL_FIELD",
+                            "id": 165,
+                            "name": "АвторСтрокой",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/synonym"
+                            },
+                            "dataPath": "АвторСтрокой",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
           ],
           "attributes": [
             [
@@ -5154,16 +4443,6 @@
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
-                }
-              },
-              {
-                "id": 2,
-                "name": "НачальныйПризнакВыполнения",
-                "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                },
-                "type": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
                 }
               },
               {
@@ -5184,6 +4463,16 @@
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[7]/type"
+                }
+              },
+              {
+                "id": 2,
+                "name": "НачальныйПризнакВыполнения",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
                 }
               }
             ],
@@ -5273,6 +4562,16 @@
             [
               {
                 "type": "USUAL_GROUP",
+                "id": 203,
+                "name": "ГруппаПользовательскихНастроек",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "dataPath": "",
+                "items": []
+              },
+              {
+                "type": "USUAL_GROUP",
                 "id": 54,
                 "name": "ГруппаЗаголовок",
                 "title": {
@@ -5297,7 +4596,7 @@
                       "id": 55,
                       "name": "СтрокаБизнесПроцесса",
                       "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
                       },
                       "dataPath": "СтрокаБизнесПроцесса",
                       "items": []
@@ -5307,7 +4606,18 @@
                       "id": 57,
                       "name": "СтрокаЗадачи",
                       "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Точка маршрута"
+                            }
+                          }
+                        ]
                       },
                       "dataPath": "СтрокаЗадачи",
                       "items": []
@@ -5383,59 +4693,19 @@
                 ]
               },
               {
-                "type": "USUAL_GROUP",
-                "id": 141,
-                "name": "ГруппаПользовательскихНастроек",
+                "type": "TABLE",
+                "id": 1,
+                "name": "Список",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                 },
-                "dataPath": "",
-                "items": []
-              },
-              {
-                "type": "COMMAND_BAR",
-                "id": 47,
-                "name": "ОсновнаяКоманднаяПанель",
-                "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                },
-                "dataPath": "",
+                "dataPath": "Список",
                 "items": [
                   [
                     {
-                      "type": "COMMAND_BAR_BUTTON",
-                      "id": 155,
-                      "name": "Изменить",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "COMMAND_BAR_BUTTON",
-                      "id": 147,
-                      "name": "ОткрытьБизнесПроцесс",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "COMMAND_BAR_BUTTON",
-                      "id": 149,
-                      "name": "ОткрытьПредметЗадачи",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "BUTTON_GROUP",
-                      "id": 159,
-                      "name": "ГруппаПоиск",
+                      "type": "PICTURE_FIELD",
+                      "id": 81,
+                      "name": "ВажностьКартинка",
                       "title": {
                         "content": [
                           {
@@ -5445,150 +4715,68 @@
                             "int": 1,
                             "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                               "langKey": "ru",
-                              "value": "Поиск"
+                              "value": "Важность (признак)"
                             }
                           }
                         ]
                       },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "COMMAND_BAR_BUTTON",
-                            "id": 151,
-                            "name": "Найти",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "COMMAND_BAR_BUTTON",
-                            "id": 153,
-                            "name": "ОтменитьПоиск",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                            },
-                            "dataPath": "",
-                            "items": []
-                          }
-                        ],
-                        []
-                      ]
-                    },
-                    {
-                      "type": "BUTTON_GROUP",
-                      "id": 45,
-                      "name": "КоманднаяПанельСписка",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                      },
-                      "dataPath": "",
+                      "dataPath": "Список.ВажностьКартинка",
                       "items": []
                     },
                     {
-                      "type": "BUTTON_GROUP",
-                      "id": 157,
-                      "name": "ГруппаПринятьКИсполнению",
+                      "type": "PICTURE_FIELD",
+                      "id": 59,
+                      "name": "Остановлена",
                       "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                       },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "COMMAND_BAR_BUTTON",
-                            "id": 61,
-                            "name": "ПринятьКИсполнению",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "COMMAND_BAR_BUTTON",
-                            "id": 62,
-                            "name": "ОтменитьПринятиеКИсполнению",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[7]/title"
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "COMMAND_BAR_BUTTON",
-                            "id": 76,
-                            "name": "ЗадачаЗадачаИсполнителяВыполнено",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                            },
-                            "dataPath": "Items.Список.CurrentData.Ref",
-                            "items": []
-                          },
-                          {
-                            "type": "COMMAND_BAR_BUTTON",
-                            "id": 77,
-                            "name": "ЗадачаЗадачаИсполнителяПеренаправить",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                            },
-                            "dataPath": "Items.Список.CurrentData.Ref",
-                            "items": []
-                          }
-                        ],
-                        []
-                      ]
-                    },
-                    {
-                      "type": "BUTTON_GROUP",
-                      "id": 46,
-                      "name": "КоманднаяПанельФормы",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[8]/title"
-                      },
-                      "dataPath": "",
+                      "dataPath": "Список.Остановлена",
                       "items": []
                     },
                     {
-                      "type": "COMMAND_BAR_BUTTON",
-                      "id": 139,
-                      "name": "Справка",
+                      "type": "INPUT_FIELD",
+                      "id": 6,
+                      "name": "Наименование",
                       "title": {
                         "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
                       },
-                      "dataPath": "",
+                      "dataPath": "Список.Description",
                       "items": []
-                    }
-                  ],
-                  []
-                ]
-              },
-              {
-                "type": "TABLE",
-                "id": 1,
-                "name": "Список",
-                "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
-                },
-                "dataPath": "Список",
-                "items": [
-                  [
+                    },
                     {
                       "type": "COLUMN_GROUP",
-                      "id": 161,
-                      "name": "ГруппаВажность",
+                      "id": 169,
+                      "name": "ГруппаСрокИсполнения",
                       "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[2]/synonym"
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[6]/title"
                       },
                       "dataPath": "",
                       "items": [
                         [
                           {
-                            "type": "PICTURE_FIELD",
-                            "id": 81,
-                            "name": "ВажностьКартинка",
+                            "type": "INPUT_FIELD",
+                            "id": 30,
+                            "name": "СрокИсполнения",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[13]/synonym"
+                            },
+                            "dataPath": "Список.СрокИсполнения",
+                            "items": []
+                          },
+                          {
+                            "type": "CHECK_BOX_FIELD",
+                            "id": 10,
+                            "name": "Выполнена",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                            },
+                            "dataPath": "Список.Executed",
+                            "items": []
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 32,
+                            "name": "ДатаИсполнения",
                             "title": {
                               "content": [
                                 {
@@ -5598,22 +4786,12 @@
                                   "int": 1,
                                   "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                                     "langKey": "ru",
-                                    "value": "Важность (признак)"
+                                    "value": "Дата исполнения"
                                   }
                                 }
                               ]
                             },
-                            "dataPath": "Список.ВажностьКартинка",
-                            "items": []
-                          },
-                          {
-                            "type": "PICTURE_FIELD",
-                            "id": 59,
-                            "name": "Остановлена",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                            },
-                            "dataPath": "Список.Остановлена",
+                            "dataPath": "Список.ДатаИсполнения",
                             "items": []
                           }
                         ],
@@ -5622,111 +4800,52 @@
                     },
                     {
                       "type": "COLUMN_GROUP",
-                      "id": 85,
-                      "name": "ГруппаОписание",
+                      "id": 80,
+                      "name": "ГруппаИсполнитель",
                       "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Описание задачи"
-                            }
-                          }
-                        ]
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute[2]/synonym"
                       },
                       "dataPath": "",
                       "items": [
                         [
                           {
-                            "type": "COLUMN_GROUP",
-                            "id": 165,
-                            "name": "ГруппаНаименование",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                            },
-                            "dataPath": "",
-                            "items": [
-                              [
-                                {
-                                  "type": "INPUT_FIELD",
-                                  "id": 6,
-                                  "name": "Наименование",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                  },
-                                  "dataPath": "Список.Description",
-                                  "items": []
-                                },
-                                {
-                                  "type": "INPUT_FIELD",
-                                  "id": 22,
-                                  "name": "Автор",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                  },
-                                  "dataPath": "Список.Автор",
-                                  "items": []
-                                }
-                              ],
-                              []
-                            ]
-                          },
-                          {
-                            "type": "LABEL_FIELD",
-                            "id": 51,
-                            "name": "Предмет",
+                            "type": "INPUT_FIELD",
+                            "id": 24,
+                            "name": "Исполнитель",
                             "title": {
                               "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
                             },
-                            "dataPath": "Список.ПредметСтрокой",
+                            "dataPath": "Список.Исполнитель",
                             "items": []
-                          },
-                          {
-                            "type": "COLUMN_GROUP",
-                            "id": 163,
-                            "name": "ГруппаАвтор",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/synonym"
-                            },
-                            "dataPath": "",
-                            "items": [
-                              [
-                                {
-                                  "type": "INPUT_FIELD",
-                                  "id": 8,
-                                  "name": "Дата",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[7]/synonym"
-                                  },
-                                  "dataPath": "Список.Date",
-                                  "items": []
-                                },
-                                {
-                                  "type": "INPUT_FIELD",
-                                  "id": 4,
-                                  "name": "Номер",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                  },
-                                  "dataPath": "Список.Number",
-                                  "items": []
-                                }
-                              ],
-                              []
-                            ]
                           },
                           {
                             "type": "INPUT_FIELD",
-                            "id": 83,
-                            "name": "Описание",
+                            "id": 34,
+                            "name": "РольИсполнителя",
                             "title": {
                               "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
                             },
-                            "dataPath": "Список.Описание",
+                            "dataPath": "Список.РольИсполнителя",
+                            "items": []
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 40,
+                            "name": "ОсновнойОбъектАдресации",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                            },
+                            "dataPath": "Список.ОсновнойОбъектАдресации",
+                            "items": []
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 38,
+                            "name": "ДополнительныйОбъектАдресации",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                            },
+                            "dataPath": "Список.ДополнительныйОбъектАдресации",
                             "items": []
                           }
                         ],
@@ -5734,116 +4853,54 @@
                       ]
                     },
                     {
-                      "type": "COLUMN_GROUP",
-                      "id": 167,
-                      "name": "ГруппаИсполнение",
+                      "type": "LABEL_FIELD",
+                      "id": 51,
+                      "name": "Предмет",
                       "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
                       },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "COLUMN_GROUP",
-                            "id": 80,
-                            "name": "ГруппаИсполнитель",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute[2]/synonym"
-                            },
-                            "dataPath": "",
-                            "items": [
-                              [
-                                {
-                                  "type": "INPUT_FIELD",
-                                  "id": 24,
-                                  "name": "Исполнитель",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                  },
-                                  "dataPath": "Список.Исполнитель",
-                                  "items": []
-                                },
-                                {
-                                  "type": "INPUT_FIELD",
-                                  "id": 34,
-                                  "name": "РольИсполнителя",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                  },
-                                  "dataPath": "Список.РольИсполнителя",
-                                  "items": []
-                                },
-                                {
-                                  "type": "INPUT_FIELD",
-                                  "id": 40,
-                                  "name": "ОсновнойОбъектАдресации",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                  },
-                                  "dataPath": "Список.ОсновнойОбъектАдресации",
-                                  "items": []
-                                },
-                                {
-                                  "type": "INPUT_FIELD",
-                                  "id": 38,
-                                  "name": "ДополнительныйОбъектАдресации",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                  },
-                                  "dataPath": "Список.ДополнительныйОбъектАдресации",
-                                  "items": []
-                                }
-                              ],
-                              []
-                            ]
-                          },
-                          {
-                            "type": "COLUMN_GROUP",
-                            "id": 169,
-                            "name": "ГруппаСрокИсполнения",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[6]/title"
-                            },
-                            "dataPath": "",
-                            "items": [
-                              [
-                                {
-                                  "type": "INPUT_FIELD",
-                                  "id": 30,
-                                  "name": "СрокИсполнения",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                  },
-                                  "dataPath": "Список.СрокИсполнения",
-                                  "items": []
-                                },
-                                {
-                                  "type": "CHECK_BOX_FIELD",
-                                  "id": 10,
-                                  "name": "Выполнена",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                  },
-                                  "dataPath": "Список.Executed",
-                                  "items": []
-                                },
-                                {
-                                  "type": "INPUT_FIELD",
-                                  "id": 32,
-                                  "name": "ДатаИсполнения",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                  },
-                                  "dataPath": "Список.ДатаИсполнения",
-                                  "items": []
-                                }
-                              ],
-                              []
-                            ]
-                          }
-                        ],
-                        []
-                      ]
+                      "dataPath": "Список.ПредметСтрокой",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 22,
+                      "name": "Автор",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "Список.Автор",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 8,
+                      "name": "Дата",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[7]/synonym"
+                      },
+                      "dataPath": "Список.Date",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 4,
+                      "name": "Номер",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "Список.Number",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 83,
+                      "name": "Описание",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "Список.Описание",
+                      "items": []
                     },
                     {
                       "type": "LABEL_FIELD",
@@ -5898,7 +4955,7 @@
                 "id": 4,
                 "name": "ПоказыватьЗадачи",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[8]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[8]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "types": [

--- a/src/test/resources/fixtures/ssl_3_2/Tasks.ЗадачаИсполнителя_edt.json
+++ b/src/test/resources/fixtures/ssl_3_2/Tasks.ЗадачаИсполнителя_edt.json
@@ -975,7 +975,7 @@
               "int": 1,
               "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                 "langKey": "ru",
-                "value": "Дата начала"
+                "value": "Дата начала исполнения"
               }
             }
           ]
@@ -1712,8 +1712,8 @@
             [
               {
                 "type": "USUAL_GROUP",
-                "id": 99,
-                "name": "Документ",
+                "id": 117,
+                "name": "Группа2",
                 "title": {
                   "content": [
                     {
@@ -1723,7 +1723,7 @@
                       "int": 1,
                       "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                         "langKey": "ru",
-                        "value": "Документ"
+                        "value": "Группа"
                       }
                     }
                   ]
@@ -1732,150 +1732,39 @@
                 "items": [
                   [
                     {
-                      "type": "INPUT_FIELD",
-                      "id": 41,
-                      "name": "Наименование",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                      },
-                      "dataPath": "Объект.Description",
-                      "items": []
-                    },
-                    {
                       "type": "USUAL_GROUP",
-                      "id": 63,
-                      "name": "ГруппаРезультат",
+                      "id": 119,
+                      "name": "Группа3",
                       "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Результат выполнения задачи"
-                            }
-                          }
-                        ]
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                       },
                       "dataPath": "",
                       "items": [
                         [
                           {
-                            "type": "CHECK_BOX_FIELD",
-                            "id": 64,
-                            "name": "Выполнена",
+                            "type": "LABEL_FIELD",
+                            "id": 41,
+                            "name": "Наименование",
                             "title": {
                               "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
                             },
-                            "dataPath": "Объект.Executed",
+                            "dataPath": "Объект.Description",
                             "items": []
                           },
                           {
-                            "type": "INPUT_FIELD",
-                            "id": 66,
-                            "name": "ДатаИсполнения",
+                            "type": "LABEL_FIELD",
+                            "id": 71,
+                            "name": "СрокИсполнения",
                             "title": {
                               "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
                             },
-                            "dataPath": "Объект.ДатаИсполнения",
-                            "items": []
-                          }
-                        ],
-                        []
-                      ]
-                    },
-                    {
-                      "type": "USUAL_GROUP",
-                      "id": 51,
-                      "name": "ГруппаБизнесПроцесс",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Бизнес-процесс"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "INPUT_FIELD",
-                            "id": 52,
-                            "name": "БизнесПроцесс",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                            },
-                            "dataPath": "Объект.BusinessProcess",
-                            "items": []
-                          },
-                          {
-                            "type": "INPUT_FIELD",
-                            "id": 54,
-                            "name": "ТочкаМаршрута",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                            },
-                            "dataPath": "Объект.RoutePoint",
-                            "items": []
-                          }
-                        ],
-                        []
-                      ]
-                    },
-                    {
-                      "type": "USUAL_GROUP",
-                      "id": 69,
-                      "name": "ГруппаАдресация",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Задача адресована"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "INPUT_FIELD",
-                            "id": 27,
-                            "name": "Исполнитель",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                            },
-                            "dataPath": "Объект.Исполнитель",
-                            "items": []
-                          },
-                          {
-                            "type": "INPUT_FIELD",
-                            "id": 29,
-                            "name": "РольИсполнителя",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                            },
-                            "dataPath": "Объект.РольИсполнителя",
+                            "dataPath": "Объект.СрокИсполнения",
                             "items": []
                           },
                           {
                             "type": "USUAL_GROUP",
-                            "id": 92,
-                            "name": "ГруппаУточнение",
+                            "id": 51,
+                            "name": "ГруппаБизнесПроцесс",
                             "title": {
                               "content": [
                                 {
@@ -1885,7 +1774,7 @@
                                   "int": 1,
                                   "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                                     "langKey": "ru",
-                                    "value": "Уточнение"
+                                    "value": "Бизнес-процесс"
                                   }
                                 }
                               ]
@@ -1894,59 +1783,69 @@
                             "items": [
                               [
                                 {
-                                  "type": "LABEL",
-                                  "id": 96,
-                                  "name": "Отступ",
+                                  "type": "LABEL_FIELD",
+                                  "id": 52,
+                                  "name": "БизнесПроцесс",
                                   "title": {
                                     "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
                                   },
-                                  "dataPath": "",
+                                  "dataPath": "Объект.BusinessProcess",
                                   "items": []
                                 },
                                 {
-                                  "type": "USUAL_GROUP",
-                                  "id": 94,
-                                  "name": "ГруппаОбъектыАдресации",
+                                  "type": "LABEL_FIELD",
+                                  "id": 54,
+                                  "name": "ТочкаМаршрута",
                                   "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Объекты адресации"
-                                        }
-                                      }
-                                    ]
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
                                   },
-                                  "dataPath": "",
-                                  "items": [
-                                    [
-                                      {
-                                        "type": "INPUT_FIELD",
-                                        "id": 31,
-                                        "name": "ОсновнойОбъектАдресации",
-                                        "title": {
-                                          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                        },
-                                        "dataPath": "Объект.ОсновнойОбъектАдресации",
-                                        "items": []
-                                      },
-                                      {
-                                        "type": "INPUT_FIELD",
-                                        "id": 33,
-                                        "name": "ДополнительныйОбъектАдресации",
-                                        "title": {
-                                          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                        },
-                                        "dataPath": "Объект.ДополнительныйОбъектАдресации",
-                                        "items": []
-                                      }
-                                    ],
-                                    []
-                                  ]
+                                  "dataPath": "Объект.RoutePoint",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          },
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 63,
+                            "name": "ГруппаРезультат",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Результат выполнения задачи"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "CHECK_BOX_FIELD",
+                                  "id": 64,
+                                  "name": "Выполнена",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                  },
+                                  "dataPath": "Объект.Executed",
+                                  "items": []
+                                },
+                                {
+                                  "type": "LABEL_FIELD",
+                                  "id": 66,
+                                  "name": "ДатаИсполнения",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                  },
+                                  "dataPath": "Объект.ДатаИсполнения",
+                                  "items": []
                                 }
                               ],
                               []
@@ -1958,27 +1857,26 @@
                     },
                     {
                       "type": "USUAL_GROUP",
-                      "id": 56,
-                      "name": "ГруппаВходящие",
+                      "id": 121,
+                      "name": "Группа4",
                       "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Входящие"
-                            }
-                          }
-                        ]
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                       },
                       "dataPath": "",
                       "items": [
                         [
                           {
-                            "type": "INPUT_FIELD",
+                            "type": "LABEL_FIELD",
+                            "id": 43,
+                            "name": "Номер",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                            },
+                            "dataPath": "Объект.Number",
+                            "items": []
+                          },
+                          {
+                            "type": "LABEL_FIELD",
                             "id": 57,
                             "name": "Дата",
                             "title": {
@@ -1988,14 +1886,119 @@
                             "items": []
                           },
                           {
-                            "type": "INPUT_FIELD",
-                            "id": 71,
-                            "name": "СрокИсполнения",
+                            "type": "USUAL_GROUP",
+                            "id": 69,
+                            "name": "ГруппаАдресация",
                             "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Задача адресована"
+                                  }
+                                }
+                              ]
                             },
-                            "dataPath": "Объект.СрокИсполнения",
-                            "items": []
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "LABEL_FIELD",
+                                  "id": 27,
+                                  "name": "Исполнитель",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                  },
+                                  "dataPath": "Объект.Исполнитель",
+                                  "items": []
+                                },
+                                {
+                                  "type": "USUAL_GROUP",
+                                  "id": 92,
+                                  "name": "ГруппаУточнение",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Уточнение"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "LABEL_FIELD",
+                                        "id": 29,
+                                        "name": "РольИсполнителя",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                        },
+                                        "dataPath": "Объект.РольИсполнителя",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "USUAL_GROUP",
+                                        "id": 113,
+                                        "name": "ГруппаОбъектАдресации",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Объект адресации"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "",
+                                        "items": [
+                                          [
+                                            {
+                                              "type": "LABEL_FIELD",
+                                              "id": 31,
+                                              "name": "ОсновнойОбъектАдресации",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                              },
+                                              "dataPath": "Объект.ОсновнойОбъектАдресации",
+                                              "items": []
+                                            },
+                                            {
+                                              "type": "LABEL_FIELD",
+                                              "id": 33,
+                                              "name": "ДополнительныйОбъектАдресации",
+                                              "title": {
+                                                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                              },
+                                              "dataPath": "Объект.ДополнительныйОбъектАдресации",
+                                              "items": []
+                                            }
+                                          ],
+                                          []
+                                        ]
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                }
+                              ],
+                              []
+                            ]
                           }
                         ],
                         []
@@ -2024,18 +2027,38 @@
                   ]
                 },
                 "dataPath": "",
-                "items": [
-                  {
-                    "type": "INPUT_FIELD",
-                    "id": 43,
-                    "name": "Номер",
-                    "title": {
-                      "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                    },
-                    "dataPath": "Объект.Number",
-                    "items": []
-                  }
-                ]
+                "items": []
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 56,
+                "name": "ГруппаДаты",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Даты"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": []
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 115,
+                "name": "Группа1",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "dataPath": "",
+                "items": []
               }
             ],
             []
@@ -2170,27 +2193,6 @@
                       "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                         "langKey": "ru",
                         "value": "Группа пользовательских настроек"
-                      }
-                    }
-                  ]
-                },
-                "dataPath": "",
-                "items": []
-              },
-              {
-                "type": "COMMAND_BAR",
-                "id": 52,
-                "name": "КоманднаяПанельСписка",
-                "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Командная панель списка"
                       }
                     }
                   ]
@@ -2508,7 +2510,7 @@
                 "id": 2,
                 "name": "ПоказыватьВыполненные",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
@@ -2518,7 +2520,7 @@
                 "id": 3,
                 "name": "ДеревоЗадач",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
                 },
                 "type": {
                   "types": [
@@ -2611,8 +2613,8 @@
           "items": [
             [
               {
-                "type": "COMMAND_BAR",
-                "id": 130,
+                "type": "USUAL_GROUP",
+                "id": 181,
                 "name": "ГруппаПользовательскихНастроек",
                 "title": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
@@ -2621,244 +2623,29 @@
                 "items": []
               },
               {
-                "type": "COMMAND_BAR",
-                "id": 50,
-                "name": "КоманднаяПанельСписка",
-                "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                },
-                "dataPath": "",
-                "items": [
-                  {
-                    "type": "FORM_GROUP",
-                    "id": 120,
-                    "name": "ГруппаПринятьКИсполнению",
-                    "title": {
-                      "content": [
-                        {
-                          "default": {
-                            "tag": 2
-                          },
-                          "int": 1,
-                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                            "langKey": "ru",
-                            "value": "Принять к исполнению"
-                          }
-                        }
-                      ]
-                    },
-                    "dataPath": "",
-                    "items": [
-                      [
-                        {
-                          "type": "BUTTON",
-                          "id": 122,
-                          "name": "ПринятьКИсполнению",
-                          "title": {
-                            "content": [
-                              {
-                                "default": {
-                                  "tag": 2
-                                },
-                                "int": 1,
-                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                  "langKey": "ru",
-                                  "value": "К исполнению"
-                                }
-                              }
-                            ]
-                          },
-                          "dataPath": "",
-                          "items": []
-                        },
-                        {
-                          "type": "BUTTON",
-                          "id": 124,
-                          "name": "ОтменитьПринятиеКИсполнению",
-                          "title": {
-                            "content": [
-                              {
-                                "default": {
-                                  "tag": 2
-                                },
-                                "int": 1,
-                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                  "langKey": "ru",
-                                  "value": "Обновить"
-                                }
-                              }
-                            ]
-                          },
-                          "dataPath": "",
-                          "items": []
-                        },
-                        {
-                          "type": "BUTTON",
-                          "id": 126,
-                          "name": "ЗадачаЗадачаИсполнителяВыполнено",
-                          "title": {
-                            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                          },
-                          "dataPath": "Items.Список.CurrentData.ОсновнойОбъектАдресации",
-                          "items": []
-                        },
-                        {
-                          "type": "BUTTON",
-                          "id": 128,
-                          "name": "ЗадачаЗадачаИсполнителяПеренаправить",
-                          "title": {
-                            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                          },
-                          "dataPath": "Items.Список.CurrentData.ОсновнойОбъектАдресации",
-                          "items": []
-                        }
-                      ],
-                      []
-                    ]
-                  }
-                ]
-              },
-              {
                 "type": "TABLE",
                 "id": 1,
                 "name": "Список",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                 },
                 "dataPath": "Список",
                 "items": [
                   [
                     {
-                      "type": "COLUMN_GROUP",
-                      "id": 99,
-                      "name": "ГруппаВажность",
+                      "type": "PICTURE_FIELD",
+                      "id": 52,
+                      "name": "ВажностьКартинка",
                       "title": {
                         "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[2]/synonym"
                       },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "PICTURE_FIELD",
-                            "id": 52,
-                            "name": "ВажностьКартинка",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[2]/synonym"
-                            },
-                            "dataPath": "Список.ВажностьКартинка",
-                            "items": []
-                          },
-                          {
-                            "type": "PICTURE_FIELD",
-                            "id": 56,
-                            "name": "Остановлена",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Остановлена"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "Список.Остановлена",
-                            "items": []
-                          }
-                        ],
-                        []
-                      ]
+                      "dataPath": "Список.ВажностьКартинка",
+                      "items": []
                     },
                     {
-                      "type": "COLUMN_GROUP",
-                      "id": 103,
-                      "name": "ГруппаОписание",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[7]/synonym"
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "COLUMN_GROUP",
-                            "id": 101,
-                            "name": "ГруппаНаименование",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                            },
-                            "dataPath": "",
-                            "items": [
-                              [
-                                {
-                                  "type": "INPUT_FIELD",
-                                  "id": 6,
-                                  "name": "Наименование",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[2]/synonym"
-                                  },
-                                  "dataPath": "Список.Description",
-                                  "items": []
-                                },
-                                {
-                                  "type": "LABEL_FIELD",
-                                  "id": 107,
-                                  "name": "Автор",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                  },
-                                  "dataPath": "Список.Автор",
-                                  "items": []
-                                }
-                              ],
-                              []
-                            ]
-                          },
-                          {
-                            "type": "COLUMN_GROUP",
-                            "id": 105,
-                            "name": "ГруппаАвтор",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/synonym"
-                            },
-                            "dataPath": "",
-                            "items": [
-                              [
-                                {
-                                  "type": "INPUT_FIELD",
-                                  "id": 4,
-                                  "name": "Номер",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                                  },
-                                  "dataPath": "Список.Number",
-                                  "items": []
-                                },
-                                {
-                                  "type": "LABEL_FIELD",
-                                  "id": 110,
-                                  "name": "Дата",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                  },
-                                  "dataPath": "Список.Date",
-                                  "items": []
-                                }
-                              ],
-                              []
-                            ]
-                          }
-                        ],
-                        []
-                      ]
-                    },
-                    {
-                      "type": "COLUMN_GROUP",
-                      "id": 113,
-                      "name": "ГруппаИсполнение",
+                      "type": "PICTURE_FIELD",
+                      "id": 56,
+                      "name": "Остановлена",
                       "title": {
                         "content": [
                           {
@@ -2868,115 +2655,127 @@
                             "int": 1,
                             "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                               "langKey": "ru",
-                              "value": "Исполнение"
+                              "value": "Остановлена"
                             }
                           }
                         ]
+                      },
+                      "dataPath": "Список.Остановлена",
+                      "items": []
+                    },
+                    {
+                      "type": "CHECK_BOX_FIELD",
+                      "id": 54,
+                      "name": "ЗадачаВыполнена",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "Список.Executed",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 6,
+                      "name": "Наименование",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[2]/synonym"
+                      },
+                      "dataPath": "Список.Description",
+                      "items": []
+                    },
+                    {
+                      "type": "COLUMN_GROUP",
+                      "id": 64,
+                      "name": "ГруппаИсполнитель",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute[2]/synonym"
                       },
                       "dataPath": "",
                       "items": [
                         [
                           {
-                            "type": "COLUMN_GROUP",
-                            "id": 64,
-                            "name": "ГруппаИсполнитель",
+                            "type": "INPUT_FIELD",
+                            "id": 18,
+                            "name": "Исполнитель",
                             "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute[2]/synonym"
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
                             },
-                            "dataPath": "",
-                            "items": [
-                              [
-                                {
-                                  "type": "INPUT_FIELD",
-                                  "id": 18,
-                                  "name": "Исполнитель",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                  },
-                                  "dataPath": "Список.Исполнитель",
-                                  "items": []
-                                },
-                                {
-                                  "type": "LABEL_FIELD",
-                                  "id": 58,
-                                  "name": "РольИсполнителя",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                  },
-                                  "dataPath": "Список.РольИсполнителя",
-                                  "items": []
-                                },
-                                {
-                                  "type": "LABEL_FIELD",
-                                  "id": 60,
-                                  "name": "ОсновнойОбъектАдресации",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                  },
-                                  "dataPath": "Список.ОсновнойОбъектАдресации",
-                                  "items": []
-                                },
-                                {
-                                  "type": "LABEL_FIELD",
-                                  "id": 62,
-                                  "name": "ДополнительныйОбъектАдресации",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                  },
-                                  "dataPath": "Список.ДополнительныйОбъектАдресации",
-                                  "items": []
-                                }
-                              ],
-                              []
-                            ]
+                            "dataPath": "Список.Исполнитель",
+                            "items": []
                           },
                           {
-                            "type": "COLUMN_GROUP",
-                            "id": 115,
-                            "name": "ГруппаСрокИсполнения",
+                            "type": "LABEL_FIELD",
+                            "id": 58,
+                            "name": "РольИсполнителя",
                             "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[6]/title"
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
                             },
-                            "dataPath": "",
-                            "items": [
-                              [
-                                {
-                                  "type": "LABEL_FIELD",
-                                  "id": 23,
-                                  "name": "СрокИсполнения",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                  },
-                                  "dataPath": "Список.СрокИсполнения",
-                                  "items": []
-                                },
-                                {
-                                  "type": "CHECK_BOX_FIELD",
-                                  "id": 54,
-                                  "name": "ЗадачаВыполнена",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                  },
-                                  "dataPath": "Список.Executed",
-                                  "items": []
-                                },
-                                {
-                                  "type": "LABEL_FIELD",
-                                  "id": 117,
-                                  "name": "ДатаИсполнения",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                  },
-                                  "dataPath": "Список.ДатаИсполнения",
-                                  "items": []
-                                }
-                              ],
-                              []
-                            ]
+                            "dataPath": "Список.РольИсполнителя",
+                            "items": []
+                          },
+                          {
+                            "type": "LABEL_FIELD",
+                            "id": 60,
+                            "name": "ОсновнойОбъектАдресации",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                            },
+                            "dataPath": "Список.ОсновнойОбъектАдресации",
+                            "items": []
+                          },
+                          {
+                            "type": "LABEL_FIELD",
+                            "id": 62,
+                            "name": "ДополнительныйОбъектАдресации",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                            },
+                            "dataPath": "Список.ДополнительныйОбъектАдресации",
+                            "items": []
                           }
                         ],
                         []
                       ]
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 4,
+                      "name": "Номер",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                      },
+                      "dataPath": "Список.Number",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 23,
+                      "name": "СрокИсполнения",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "Список.СрокИсполнения",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 110,
+                      "name": "Дата",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "Список.Date",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 107,
+                      "name": "Автор",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "Список.Автор",
+                      "items": []
                     },
                     {
                       "type": "LABEL_FIELD",
@@ -2993,32 +2792,11 @@
                 ]
               },
               {
-                "type": "CHECK_BOX_FIELD",
-                "id": 21,
-                "name": "ПоказыватьВыполненные",
-                "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Показывать выполненные задачи"
-                      }
-                    }
-                  ]
-                },
-                "dataPath": "ПоказыватьВыполненные",
-                "items": []
-              },
-              {
                 "type": "TABLE",
                 "id": 25,
                 "name": "ДеревоЗадач",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
                 },
                 "dataPath": "ДеревоЗадач",
                 "items": [
@@ -3048,7 +2826,7 @@
                       "id": 32,
                       "name": "ДеревоЗадачОстановлен",
                       "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
                       },
                       "dataPath": "ДеревоЗадач.Остановлен",
                       "items": []
@@ -3058,7 +2836,7 @@
                       "id": 34,
                       "name": "ТипИНаименование",
                       "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
                       },
                       "dataPath": "",
                       "items": [
@@ -3068,7 +2846,7 @@
                             "id": 35,
                             "name": "ДеревоЗадачТип",
                             "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                             },
                             "dataPath": "ДеревоЗадач.Тип",
                             "items": []
@@ -3100,16 +2878,47 @@
                     {
                       "type": "INPUT_FIELD",
                       "id": 41,
-                      "name": "СрокИсполнения1",
+                      "name": "ДеревоСрокИсполнения",
                       "title": {
                         "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[13]/synonym"
                       },
                       "dataPath": "ДеревоЗадач.СрокИсполнения",
                       "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 187,
+                      "name": "ДеревоЗадачСсылка",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "ДеревоЗадач.Ссылка",
+                      "items": []
                     }
                   ],
                   []
                 ]
+              },
+              {
+                "type": "CHECK_BOX_FIELD",
+                "id": 21,
+                "name": "ПоказыватьВыполненные",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Показывать выполненные задачи"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "ПоказыватьВыполненные",
+                "items": []
               }
             ],
             []
@@ -3140,7 +2949,7 @@
                 "id": 3,
                 "name": "ДеревоЗадач",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
@@ -3211,7 +3020,7 @@
             [
               {
                 "type": "USUAL_GROUP",
-                "id": 126,
+                "id": 173,
                 "name": "ГруппаПользовательскихНастроек",
                 "title": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
@@ -3220,351 +3029,25 @@
                 "items": []
               },
               {
-                "type": "COMMAND_BAR",
-                "id": 1,
-                "name": "ОсновнаяКоманднаяПанель",
-                "title": {
-                  "content": [
-                    {
-                      "default": {
-                        "tag": 2
-                      },
-                      "int": 1,
-                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                        "langKey": "ru",
-                        "value": "Основная командная панель"
-                      }
-                    }
-                  ]
-                },
-                "dataPath": "",
-                "items": [
-                  [
-                    {
-                      "type": "POPUP",
-                      "id": 51,
-                      "name": "СгруппироватьПо",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Сгруппировать по"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "BUTTON",
-                            "id": 132,
-                            "name": "СписокСгруппироватьПоСроку",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[13]/synonym"
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "BUTTON",
-                            "id": 52,
-                            "name": "СписокСгруппироватьПоВажности",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[2]/synonym"
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "BUTTON",
-                            "id": 53,
-                            "name": "СписокСгруппироватьПоТочкеМаршрута",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Точка маршрута"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "BUTTON",
-                            "id": 61,
-                            "name": "СписокСгруппироватьПоАвтору",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/synonym"
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "BUTTON",
-                            "id": 62,
-                            "name": "СписокСгруппироватьПоПредмету",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[8]/synonym"
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "BUTTON",
-                            "id": 54,
-                            "name": "СписокСгруппироватьСгруппироватьПоБезГруппировки",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Без группировки"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": []
-                          }
-                        ],
-                        []
-                      ]
-                    },
-                    {
-                      "type": "FORM_GROUP",
-                      "id": 140,
-                      "name": "ГруппаОткрыть",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Открыть"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "BUTTON",
-                            "id": 138,
-                            "name": "ФормаИзменить",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Открыть задачу"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "BUTTON",
-                            "id": 134,
-                            "name": "ОткрытьПредметЗадачи",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Открыть предмет задачи"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "BUTTON",
-                            "id": 136,
-                            "name": "ОткрытьБизнесПроцесс",
-                            "title": {
-                              "content": [
-                                {
-                                  "default": {
-                                    "tag": 2
-                                  },
-                                  "int": 1,
-                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                    "langKey": "ru",
-                                    "value": "Открыть бизнес-процесс"
-                                  }
-                                }
-                              ]
-                            },
-                            "dataPath": "",
-                            "items": []
-                          }
-                        ],
-                        []
-                      ]
-                    },
-                    {
-                      "type": "FORM_GROUP",
-                      "id": 48,
-                      "name": "КоманднаяПанельСписка",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                      },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "BUTTON",
-                            "id": 128,
-                            "name": "ФормаНайти",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "BUTTON",
-                            "id": 130,
-                            "name": "ФормаОтменитьПоиск",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                            },
-                            "dataPath": "",
-                            "items": []
-                          }
-                        ],
-                        []
-                      ]
-                    },
-                    {
-                      "type": "BUTTON",
-                      "id": 80,
-                      "name": "ПринятьКИсполнению",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "BUTTON",
-                      "id": 82,
-                      "name": "ЗадачаЗадачаИсполнителяВыполнено",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                      },
-                      "dataPath": "Items.Список.CurrentData.Ref",
-                      "items": []
-                    },
-                    {
-                      "type": "BUTTON",
-                      "id": 83,
-                      "name": "ЗадачаЗадачаИсполнителяПеренаправить",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                      },
-                      "dataPath": "Items.Список.CurrentData.Ref",
-                      "items": []
-                    },
-                    {
-                      "type": "BUTTON",
-                      "id": 81,
-                      "name": "ОтменитьПринятиеКИсполнению",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Отменить принятие к исполнению"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "FORM_GROUP",
-                      "id": 8,
-                      "name": "КоманднаяПанельФормы",
-                      "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Командная панель формы"
-                            }
-                          }
-                        ]
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "BUTTON",
-                      "id": 65,
-                      "name": "Справка",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    }
-                  ],
-                  []
-                ]
-              },
-              {
                 "type": "TABLE",
                 "id": 9,
                 "name": "Список",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                 },
                 "dataPath": "Список",
                 "items": [
                   [
+                    {
+                      "type": "CHECK_BOX_FIELD",
+                      "id": 168,
+                      "name": "ПринятаКИсполнению",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "Список.ПринятаКИсполнению",
+                      "items": []
+                    },
                     {
                       "type": "PICTURE_FIELD",
                       "id": 24,
@@ -3573,16 +3056,6 @@
                         "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[2]/synonym"
                       },
                       "dataPath": "Список.ВажностьКартинка",
-                      "items": []
-                    },
-                    {
-                      "type": "LABEL_FIELD",
-                      "id": 57,
-                      "name": "Номер",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                      },
-                      "dataPath": "Список.Number",
                       "items": []
                     },
                     {
@@ -3597,22 +3070,22 @@
                     },
                     {
                       "type": "INPUT_FIELD",
-                      "id": 46,
-                      "name": "ДатаНачала",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[5]/synonym"
-                      },
-                      "dataPath": "Список.ДатаНачала",
-                      "items": []
-                    },
-                    {
-                      "type": "INPUT_FIELD",
                       "id": 36,
                       "name": "СрокИсполнения",
                       "title": {
                         "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
                       },
                       "dataPath": "Список.СрокИсполнения",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 57,
+                      "name": "Номер",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "Список.Number",
                       "items": []
                     },
                     {
@@ -3633,6 +3106,27 @@
                         "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
                       },
                       "dataPath": "Список.ПредметСтрокой",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 46,
+                      "name": "ДатаНачала",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Дата начала"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "Список.ДатаНачала",
                       "items": []
                     },
                     {
@@ -3664,7 +3158,7 @@
                 "id": 38,
                 "name": "ПоказыватьВыполненные",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
                 },
                 "dataPath": "ПоказыватьВыполненные",
                 "items": []
@@ -3688,7 +3182,7 @@
                 "id": 2,
                 "name": "ПоказыватьВыполненные",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
@@ -3775,233 +3269,135 @@
             []
           ],
           "items": [
-            {
-              "type": "TABLE",
-              "id": 9,
-              "name": "Список",
-              "title": {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 232,
+                "name": "ГруппаПользовательскихНастроек",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "dataPath": "",
+                "items": []
               },
-              "dataPath": "Список",
-              "items": [
-                {
-                  "type": "COLUMN_GROUP",
-                  "id": 161,
-                  "name": "ГруппаКолонки",
-                  "title": {
-                    "content": [
-                      {
-                        "default": {
-                          "tag": 2
-                        },
-                        "int": 1,
-                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                          "langKey": "ru",
-                          "value": "Колонки"
+              {
+                "type": "TABLE",
+                "id": 9,
+                "name": "Список",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "dataPath": "Список",
+                "items": [
+                  {
+                    "type": "COLUMN_GROUP",
+                    "id": 161,
+                    "name": "ГруппаКолонки",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Колонки"
+                          }
                         }
-                      }
+                      ]
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "LABEL_FIELD",
+                          "id": 57,
+                          "name": "Номер",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                          },
+                          "dataPath": "Список.Number",
+                          "items": []
+                        },
+                        {
+                          "type": "PICTURE_FIELD",
+                          "id": 24,
+                          "name": "Важность",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[2]/synonym"
+                          },
+                          "dataPath": "Список.ВажностьКартинка",
+                          "items": []
+                        },
+                        {
+                          "type": "INPUT_FIELD",
+                          "id": 16,
+                          "name": "Наименование",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                          },
+                          "dataPath": "Список.Description",
+                          "items": []
+                        },
+                        {
+                          "type": "INPUT_FIELD",
+                          "id": 36,
+                          "name": "СрокИсполнения",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[13]/synonym"
+                          },
+                          "dataPath": "Список.СрокИсполнения",
+                          "items": []
+                        },
+                        {
+                          "type": "INPUT_FIELD",
+                          "id": 46,
+                          "name": "ДатаНачала",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[8]/title"
+                          },
+                          "dataPath": "Список.ДатаНачала",
+                          "items": []
+                        },
+                        {
+                          "type": "INPUT_FIELD",
+                          "id": 40,
+                          "name": "Автор",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                          },
+                          "dataPath": "Список.Автор",
+                          "items": []
+                        },
+                        {
+                          "type": "LABEL_FIELD",
+                          "id": 65,
+                          "name": "Дата",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[7]/synonym"
+                          },
+                          "dataPath": "Список.Date",
+                          "items": []
+                        },
+                        {
+                          "type": "LABEL_FIELD",
+                          "id": 137,
+                          "name": "Ссылка",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                          },
+                          "dataPath": "Список.Ref",
+                          "items": []
+                        }
+                      ],
+                      []
                     ]
-                  },
-                  "dataPath": "",
-                  "items": [
-                    [
-                      {
-                        "type": "COLUMN_GROUP",
-                        "id": 155,
-                        "name": "ЛеваяГруппа",
-                        "title": {
-                          "content": [
-                            {
-                              "default": {
-                                "tag": 2
-                              },
-                              "int": 1,
-                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                "langKey": "ru",
-                                "value": "Левая группа"
-                              }
-                            }
-                          ]
-                        },
-                        "dataPath": "",
-                        "items": [
-                          [
-                            {
-                              "type": "INPUT_FIELD",
-                              "id": 16,
-                              "name": "Наименование",
-                              "title": {
-                                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                              },
-                              "dataPath": "Список.Description",
-                              "items": []
-                            },
-                            {
-                              "type": "COLUMN_GROUP",
-                              "id": 153,
-                              "name": "ВажностьИАвтор",
-                              "title": {
-                                "content": [
-                                  {
-                                    "default": {
-                                      "tag": 2
-                                    },
-                                    "int": 1,
-                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                      "langKey": "ru",
-                                      "value": "Важность и автор"
-                                    }
-                                  }
-                                ]
-                              },
-                              "dataPath": "",
-                              "items": [
-                                [
-                                  {
-                                    "type": "PICTURE_FIELD",
-                                    "id": 24,
-                                    "name": "Важность",
-                                    "title": {
-                                      "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[2]/synonym"
-                                    },
-                                    "dataPath": "Список.ВажностьКартинка",
-                                    "items": []
-                                  },
-                                  {
-                                    "type": "INPUT_FIELD",
-                                    "id": 40,
-                                    "name": "Автор",
-                                    "title": {
-                                      "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                    },
-                                    "dataPath": "Список.Автор",
-                                    "items": []
-                                  }
-                                ],
-                                []
-                              ]
-                            }
-                          ],
-                          []
-                        ]
-                      },
-                      {
-                        "type": "COLUMN_GROUP",
-                        "id": 157,
-                        "name": "ПраваяГруппа",
-                        "title": {
-                          "content": [
-                            {
-                              "default": {
-                                "tag": 2
-                              },
-                              "int": 1,
-                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                "langKey": "ru",
-                                "value": "Правая группа"
-                              }
-                            }
-                          ]
-                        },
-                        "dataPath": "",
-                        "items": [
-                          [
-                            {
-                              "type": "LABEL_FIELD",
-                              "id": 65,
-                              "name": "Дата",
-                              "title": {
-                                "content": [
-                                  {
-                                    "default": {
-                                      "tag": 2
-                                    },
-                                    "int": 1,
-                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                      "langKey": "ru",
-                                      "value": "Записана / Срок"
-                                    }
-                                  }
-                                ]
-                              },
-                              "dataPath": "Список.Date",
-                              "items": []
-                            },
-                            {
-                              "type": "INPUT_FIELD",
-                              "id": 36,
-                              "name": "СрокИсполнения",
-                              "title": {
-                                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                              },
-                              "dataPath": "Список.СрокИсполнения",
-                              "items": []
-                            }
-                          ],
-                          []
-                        ]
-                      },
-                      {
-                        "type": "COLUMN_GROUP",
-                        "id": 159,
-                        "name": "ГруппаПрочее",
-                        "title": {
-                          "content": [
-                            {
-                              "default": {
-                                "tag": 2
-                              },
-                              "int": 1,
-                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                "langKey": "ru",
-                                "value": "Прочее"
-                              }
-                            }
-                          ]
-                        },
-                        "dataPath": "",
-                        "items": [
-                          [
-                            {
-                              "type": "INPUT_FIELD",
-                              "id": 46,
-                              "name": "ДатаНачала",
-                              "title": {
-                                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[5]/synonym"
-                              },
-                              "dataPath": "Список.ДатаНачала",
-                              "items": []
-                            },
-                            {
-                              "type": "LABEL_FIELD",
-                              "id": 57,
-                              "name": "Номер",
-                              "title": {
-                                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                              },
-                              "dataPath": "Список.Number",
-                              "items": []
-                            }
-                          ],
-                          []
-                        ]
-                      },
-                      {
-                        "type": "LABEL_FIELD",
-                        "id": 137,
-                        "name": "Ссылка",
-                        "title": {
-                          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                        },
-                        "dataPath": "Список.Ref",
-                        "items": []
-                      }
-                    ],
-                    []
-                  ]
-                }
-              ]
-            }
+                  }
+                ]
+              }
+            ],
+            []
           ],
           "attributes": [
             [
@@ -4143,7 +3539,18 @@
                 "id": 72,
                 "name": "Документ",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Документ"
+                      }
+                    }
+                  ]
                 },
                 "dataPath": "",
                 "items": [
@@ -4290,67 +3697,89 @@
                       "id": 60,
                       "name": "ГруппаОбъектыАдресации",
                       "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Объекты адресации"
+                            }
+                          }
+                        ]
                       },
                       "dataPath": "",
                       "items": [
                         [
                           {
-                            "type": "LABEL",
-                            "id": 62,
-                            "name": "Отступ",
+                            "type": "USUAL_GROUP",
+                            "id": 33,
+                            "name": "ГруппаОдинОбъектАдресации",
                             "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Один объект адресации"
+                                  }
+                                }
+                              ]
                             },
                             "dataPath": "",
-                            "items": []
+                            "items": [
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 34,
+                                "name": "ОдинОсновнойОбъектАдресации",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute[3]/synonym"
+                                },
+                                "dataPath": "ОсновнойОбъектАдресации",
+                                "items": []
+                              }
+                            ]
                           },
                           {
                             "type": "USUAL_GROUP",
-                            "id": 65,
-                            "name": "ОбъектыАдресации",
+                            "id": 36,
+                            "name": "ГруппаДваОбъектаАдресации",
                             "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Два объекта адресации"
+                                  }
+                                }
+                              ]
                             },
                             "dataPath": "",
                             "items": [
                               [
                                 {
-                                  "type": "USUAL_GROUP",
-                                  "id": 33,
-                                  "name": "ГруппаОдинОбъектАдресации",
+                                  "type": "INPUT_FIELD",
+                                  "id": 37,
+                                  "name": "ОсновнойОбъектАдресации",
                                   "title": {
-                                    "content": [
-                                      {
-                                        "default": {
-                                          "tag": 2
-                                        },
-                                        "int": 1,
-                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                          "langKey": "ru",
-                                          "value": "Один объект адресации"
-                                        }
-                                      }
-                                    ]
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute[3]/synonym"
                                   },
-                                  "dataPath": "",
-                                  "items": [
-                                    {
-                                      "type": "INPUT_FIELD",
-                                      "id": 34,
-                                      "name": "ОдинОсновнойОбъектАдресации",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute[3]/synonym"
-                                      },
-                                      "dataPath": "ОсновнойОбъектАдресации",
-                                      "items": []
-                                    }
-                                  ]
+                                  "dataPath": "ОсновнойОбъектАдресации",
+                                  "items": []
                                 },
                                 {
-                                  "type": "USUAL_GROUP",
-                                  "id": 36,
-                                  "name": "ГруппаДваОбъектаАдресации",
+                                  "type": "INPUT_FIELD",
+                                  "id": 39,
+                                  "name": "ДополнительныйОбъектАдресации",
                                   "title": {
                                     "content": [
                                       {
@@ -4360,48 +3789,13 @@
                                         "int": 1,
                                         "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                                           "langKey": "ru",
-                                          "value": "Два объекта адресации"
+                                          "value": "Доп. объект адресации"
                                         }
                                       }
                                     ]
                                   },
-                                  "dataPath": "",
-                                  "items": [
-                                    [
-                                      {
-                                        "type": "INPUT_FIELD",
-                                        "id": 37,
-                                        "name": "ОсновнойОбъектАдресации",
-                                        "title": {
-                                          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute[3]/synonym"
-                                        },
-                                        "dataPath": "ОсновнойОбъектАдресации",
-                                        "items": []
-                                      },
-                                      {
-                                        "type": "INPUT_FIELD",
-                                        "id": 39,
-                                        "name": "ДополнительныйОбъектАдресации",
-                                        "title": {
-                                          "content": [
-                                            {
-                                              "default": {
-                                                "tag": 2
-                                              },
-                                              "int": 1,
-                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                                "langKey": "ru",
-                                                "value": "Доп. объект адресации"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        "dataPath": "ДополнительныйОбъектАдресации",
-                                        "items": []
-                                      }
-                                    ],
-                                    []
-                                  ]
+                                  "dataPath": "ДополнительныйОбъектАдресации",
+                                  "items": []
                                 }
                               ],
                               []
@@ -4601,7 +3995,7 @@
                 "id": 10,
                 "name": "ДополнительныйОбъектАдресации",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/type"
@@ -4686,447 +4080,342 @@
             []
           ],
           "items": [
-            {
-              "type": "USUAL_GROUP",
-              "id": 170,
-              "name": "Документ",
-              "title": {
-                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 93,
+                "name": "ГруппаФормаВыполнения",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Форма выполнения"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "LABEL",
+                      "id": 94,
+                      "name": "ДекорацияТекст",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Выведены общие сведения о задаче.\nДля выполнения задачи необходимо перейти в специальную форму задачи."
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL",
+                      "id": 97,
+                      "name": "ДекорацияОткрытьФормуЗадачи",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Перейти в форму для выполнения задачи"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
               },
-              "dataPath": "",
-              "items": [
-                [
-                  {
-                    "type": "USUAL_GROUP",
-                    "id": 93,
-                    "name": "ГруппаФормаВыполнения",
-                    "title": {
-                      "content": [
-                        {
-                          "default": {
-                            "tag": 2
-                          },
-                          "int": 1,
-                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                            "langKey": "ru",
-                            "value": "Форма выполнения"
+              {
+                "type": "USUAL_GROUP",
+                "id": 99,
+                "name": "ГруппаСостояние",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Состояние"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": []
+              },
+              {
+                "type": "PAGES",
+                "id": 198,
+                "name": "Страницы",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Страницы"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "PAGE",
+                      "id": 200,
+                      "name": "СтраницаОписаниеЗадачи",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Описание задачи"
+                            }
                           }
-                        }
-                      ]
-                    },
-                    "dataPath": "",
-                    "items": [
-                      [
-                        {
-                          "type": "LABEL",
-                          "id": 94,
-                          "name": "ДекорацияТекст",
-                          "title": {
-                            "content": [
-                              {
-                                "default": {
-                                  "tag": 2
-                                },
-                                "int": 1,
-                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                  "langKey": "ru",
-                                  "value": "Выведены общие сведения о задаче.\nДля выполнения задачи необходимо перейти в специальную форму задачи."
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 210,
+                            "name": "ГруппаНаименованиеИНомер",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Наименование и номер"
+                                  }
                                 }
-                              }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 117,
+                                  "name": "Наименование",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                  },
+                                  "dataPath": "Объект.Description",
+                                  "items": []
+                                },
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 115,
+                                  "name": "Номер",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                  },
+                                  "dataPath": "Объект.Number",
+                                  "items": []
+                                }
+                              ],
+                              []
                             ]
                           },
-                          "dataPath": "",
-                          "items": []
-                        },
-                        {
-                          "type": "LABEL",
-                          "id": 97,
-                          "name": "ДекорацияОткрытьФормуЗадачи",
-                          "title": {
-                            "content": [
-                              {
-                                "default": {
-                                  "tag": 2
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 18,
+                            "name": "Описание",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[7]/synonym"
+                            },
+                            "dataPath": "Объект.Описание",
+                            "items": []
+                          },
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 204,
+                            "name": "ГруппаВажность",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[2]/synonym"
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 20,
+                                  "name": "Исполнитель",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute[2]/synonym"
+                                  },
+                                  "dataPath": "Объект.Исполнитель",
+                                  "items": []
                                 },
-                                "int": 1,
-                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                  "langKey": "ru",
-                                  "value": "Перейти в форму для выполнения задачи"
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 12,
+                                  "name": "СрокИсполнения",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                  },
+                                  "dataPath": "Объект.СрокИсполнения",
+                                  "items": []
                                 }
-                              }
+                              ],
+                              []
                             ]
                           },
-                          "dataPath": "",
-                          "items": []
-                        }
-                      ],
-                      []
-                    ]
-                  },
-                  {
-                    "type": "USUAL_GROUP",
-                    "id": 99,
-                    "name": "ГруппаСостояние",
-                    "title": {
-                      "content": [
-                        {
-                          "default": {
-                            "tag": 2
-                          },
-                          "int": 1,
-                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                            "langKey": "ru",
-                            "value": "Состояние"
-                          }
-                        }
-                      ]
-                    },
-                    "dataPath": "",
-                    "items": []
-                  },
-                  {
-                    "type": "USUAL_GROUP",
-                    "id": 168,
-                    "name": "ГруппаЗадача",
-                    "title": {
-                      "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[2]/synonym"
-                    },
-                    "dataPath": "",
-                    "items": [
-                      [
-                        {
-                          "type": "USUAL_GROUP",
-                          "id": 124,
-                          "name": "Шапка",
-                          "title": {
-                            "content": [
-                              {
-                                "default": {
-                                  "tag": 2
-                                },
-                                "int": 1,
-                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                  "langKey": "ru",
-                                  "value": "Шапка"
-                                }
-                              }
-                            ]
-                          },
-                          "dataPath": "",
-                          "items": [
-                            [
-                              {
-                                "type": "USUAL_GROUP",
-                                "id": 83,
-                                "name": "ГруппаАвторИсполнитель",
-                                "title": {
-                                  "content": [
-                                    {
-                                      "default": {
-                                        "tag": 2
-                                      },
-                                      "int": 1,
-                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                        "langKey": "ru",
-                                        "value": "Автор исполнитель"
-                                      }
-                                    }
-                                  ]
-                                },
-                                "dataPath": "",
-                                "items": [
-                                  [
-                                    {
-                                      "type": "INPUT_FIELD",
-                                      "id": 78,
-                                      "name": "Автор",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                      },
-                                      "dataPath": "Объект.Автор",
-                                      "items": []
-                                    },
-                                    {
-                                      "type": "LABEL_FIELD",
-                                      "id": 165,
-                                      "name": "АвторСтрокой",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/synonym"
-                                      },
-                                      "dataPath": "АвторСтрокой",
-                                      "items": []
-                                    },
-                                    {
-                                      "type": "INPUT_FIELD",
-                                      "id": 20,
-                                      "name": "Исполнитель",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute[2]/synonym"
-                                      },
-                                      "dataPath": "Объект.Исполнитель",
-                                      "items": []
-                                    }
-                                  ],
-                                  []
-                                ]
-                              },
-                              {
-                                "type": "USUAL_GROUP",
-                                "id": 125,
-                                "name": "ГруппаДатаИСрок",
-                                "title": {
-                                  "content": [
-                                    {
-                                      "default": {
-                                        "tag": 2
-                                      },
-                                      "int": 1,
-                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                        "langKey": "ru",
-                                        "value": "Дата и срок"
-                                      }
-                                    }
-                                  ]
-                                },
-                                "dataPath": "",
-                                "items": [
-                                  [
-                                    {
-                                      "type": "INPUT_FIELD",
-                                      "id": 113,
-                                      "name": "Дата",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                      },
-                                      "dataPath": "Объект.Date",
-                                      "items": []
-                                    },
-                                    {
-                                      "type": "INPUT_FIELD",
-                                      "id": 12,
-                                      "name": "СрокИсполнения",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                      },
-                                      "dataPath": "Объект.СрокИсполнения",
-                                      "items": []
-                                    }
-                                  ],
-                                  []
-                                ]
-                              },
-                              {
-                                "type": "USUAL_GROUP",
-                                "id": 126,
-                                "name": "ГруппаНомерИВажность",
-                                "title": {
-                                  "content": [
-                                    {
-                                      "default": {
-                                        "tag": 2
-                                      },
-                                      "int": 1,
-                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                        "langKey": "ru",
-                                        "value": "Номер и важность"
-                                      }
-                                    }
-                                  ]
-                                },
-                                "dataPath": "",
-                                "items": [
-                                  [
-                                    {
-                                      "type": "INPUT_FIELD",
-                                      "id": 115,
-                                      "name": "Номер",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                      },
-                                      "dataPath": "Объект.Number",
-                                      "items": []
-                                    },
-                                    {
-                                      "type": "INPUT_FIELD",
-                                      "id": 16,
-                                      "name": "Важность",
-                                      "title": {
-                                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                      },
-                                      "dataPath": "Объект.Важность",
-                                      "items": []
-                                    }
-                                  ],
-                                  []
-                                ]
-                              }
-                            ],
-                            []
-                          ]
-                        },
-                        {
-                          "type": "USUAL_GROUP",
-                          "id": 88,
-                          "name": "ГруппаПриоритет",
-                          "title": {
-                            "content": [
-                              {
-                                "default": {
-                                  "tag": 2
-                                },
-                                "int": 1,
-                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                  "langKey": "ru",
-                                  "value": "Приоритет"
-                                }
-                              }
-                            ]
-                          },
-                          "dataPath": "",
-                          "items": [
-                            [
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 186,
+                            "name": "ГруппаСрокИсполнения",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[6]/title"
+                            },
+                            "dataPath": "",
+                            "items": [
                               {
                                 "type": "INPUT_FIELD",
-                                "id": 85,
-                                "name": "СрокНачалаИсполнения",
+                                "id": 16,
+                                "name": "Важность",
                                 "title": {
                                   "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
                                 },
-                                "dataPath": "Объект.ДатаНачала",
+                                "dataPath": "Объект.Важность",
                                 "items": []
-                              },
-                              {
-                                "type": "INPUT_FIELD",
-                                "id": 110,
-                                "name": "СрокНачалаИсполненияВремя",
-                                "title": {
-                                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                },
-                                "dataPath": "Объект.ДатаНачала",
-                                "items": []
-                              }
-                            ],
-                            []
-                          ]
-                        },
-                        {
-                          "type": "INPUT_FIELD",
-                          "id": 117,
-                          "name": "Наименование",
-                          "title": {
-                            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                          },
-                          "dataPath": "Объект.Description",
-                          "items": []
-                        }
-                      ],
-                      []
-                    ]
-                  },
-                  {
-                    "type": "USUAL_GROUP",
-                    "id": 77,
-                    "name": "ГруппаСодержание",
-                    "title": {
-                      "content": [
-                        {
-                          "default": {
-                            "tag": 2
-                          },
-                          "int": 1,
-                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                            "langKey": "ru",
-                            "value": "Содержание"
-                          }
-                        }
-                      ]
-                    },
-                    "dataPath": "",
-                    "items": [
-                      [
-                        {
-                          "type": "LABEL_FIELD",
-                          "id": 106,
-                          "name": "Предмет",
-                          "title": {
-                            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[8]/synonym"
-                          },
-                          "dataPath": "ПредметСтрокой",
-                          "items": []
-                        },
-                        {
-                          "type": "INPUT_FIELD",
-                          "id": 18,
-                          "name": "Описание",
-                          "title": {
-                            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                          },
-                          "dataPath": "Объект.Описание",
-                          "items": []
-                        }
-                      ],
-                      []
-                    ]
-                  },
-                  {
-                    "type": "USUAL_GROUP",
-                    "id": 27,
-                    "name": "ГруппаРезультат",
-                    "title": {
-                      "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[11]/synonym"
-                    },
-                    "dataPath": "",
-                    "items": [
-                      [
-                        {
-                          "type": "USUAL_BUTTON",
-                          "id": 87,
-                          "name": "Выполнена",
-                          "title": {
-                            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
-                          },
-                          "dataPath": "",
-                          "items": []
-                        },
-                        {
-                          "type": "INPUT_FIELD",
-                          "id": 119,
-                          "name": "ДатаИсполнения",
-                          "title": {
-                            "content": [
-                              {
-                                "default": {
-                                  "tag": 2
-                                },
-                                "int": 1,
-                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                                  "langKey": "ru",
-                                  "value": "Дата"
-                                }
                               }
                             ]
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "PAGE",
+                      "id": 202,
+                      "name": "СтраницаДополнительно",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/synonym"
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "LABEL_FIELD",
+                            "id": 106,
+                            "name": "Предмет",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[8]/synonym"
+                            },
+                            "dataPath": "ПредметСтрокой",
+                            "items": []
                           },
-                          "dataPath": "Объект.ДатаИсполнения",
-                          "items": []
-                        },
-                        {
-                          "type": "INPUT_FIELD",
-                          "id": 121,
-                          "name": "ДатаИсполненияВремя",
-                          "title": {
-                            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 119,
+                            "name": "ДатаИсполнения",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Дата выполнения"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "Объект.ДатаИсполнения",
+                            "items": []
                           },
-                          "dataPath": "Объект.ДатаИсполнения",
-                          "items": []
-                        }
-                      ],
-                      []
-                    ]
-                  }
-                ],
-                []
-              ]
-            }
+                          {
+                            "type": "LABEL_FIELD",
+                            "id": 113,
+                            "name": "Дата",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                            },
+                            "dataPath": "Объект.Date",
+                            "items": []
+                          },
+                          {
+                            "type": "LABEL_FIELD",
+                            "id": 85,
+                            "name": "СрокНачалаИсполнения",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                            },
+                            "dataPath": "Объект.ДатаПринятияКИсполнению",
+                            "items": []
+                          },
+                          {
+                            "type": "LABEL_FIELD",
+                            "id": 78,
+                            "name": "Автор",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                            },
+                            "dataPath": "Объект.Автор",
+                            "items": []
+                          },
+                          {
+                            "type": "LABEL_FIELD",
+                            "id": 165,
+                            "name": "АвторСтрокой",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/synonym"
+                            },
+                            "dataPath": "АвторСтрокой",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
           ],
           "attributes": [
             [
@@ -5138,16 +4427,6 @@
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
-                }
-              },
-              {
-                "id": 2,
-                "name": "НачальныйПризнакВыполнения",
-                "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                },
-                "type": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
                 }
               },
               {
@@ -5168,6 +4447,16 @@
                 },
                 "type": {
                   "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[7]/type"
+                }
+              },
+              {
+                "id": 2,
+                "name": "НачальныйПризнакВыполнения",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
                 }
               }
             ],
@@ -5257,6 +4546,16 @@
             [
               {
                 "type": "USUAL_GROUP",
+                "id": 203,
+                "name": "ГруппаПользовательскихНастроек",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "dataPath": "",
+                "items": []
+              },
+              {
+                "type": "USUAL_GROUP",
                 "id": 54,
                 "name": "ГруппаЗаголовок",
                 "title": {
@@ -5281,7 +4580,7 @@
                       "id": 55,
                       "name": "СтрокаБизнесПроцесса",
                       "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
                       },
                       "dataPath": "СтрокаБизнесПроцесса",
                       "items": []
@@ -5291,7 +4590,18 @@
                       "id": 57,
                       "name": "СтрокаЗадачи",
                       "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Точка маршрута"
+                            }
+                          }
+                        ]
                       },
                       "dataPath": "СтрокаЗадачи",
                       "items": []
@@ -5367,59 +4677,19 @@
                 ]
               },
               {
-                "type": "USUAL_GROUP",
-                "id": 141,
-                "name": "ГруппаПользовательскихНастроек",
+                "type": "TABLE",
+                "id": 1,
+                "name": "Список",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                 },
-                "dataPath": "",
-                "items": []
-              },
-              {
-                "type": "COMMAND_BAR",
-                "id": 47,
-                "name": "ОсновнаяКоманднаяПанель",
-                "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                },
-                "dataPath": "",
+                "dataPath": "Список",
                 "items": [
                   [
                     {
-                      "type": "BUTTON",
-                      "id": 155,
-                      "name": "Изменить",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "BUTTON",
-                      "id": 147,
-                      "name": "ОткрытьБизнесПроцесс",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "BUTTON",
-                      "id": 149,
-                      "name": "ОткрытьПредметЗадачи",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                      },
-                      "dataPath": "",
-                      "items": []
-                    },
-                    {
-                      "type": "FORM_GROUP",
-                      "id": 159,
-                      "name": "ГруппаПоиск",
+                      "type": "PICTURE_FIELD",
+                      "id": 81,
+                      "name": "ВажностьКартинка",
                       "title": {
                         "content": [
                           {
@@ -5429,150 +4699,68 @@
                             "int": 1,
                             "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                               "langKey": "ru",
-                              "value": "Поиск"
+                              "value": "Важность (признак)"
                             }
                           }
                         ]
                       },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "BUTTON",
-                            "id": 151,
-                            "name": "Найти",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "BUTTON",
-                            "id": 153,
-                            "name": "ОтменитьПоиск",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                            },
-                            "dataPath": "",
-                            "items": []
-                          }
-                        ],
-                        []
-                      ]
-                    },
-                    {
-                      "type": "FORM_GROUP",
-                      "id": 45,
-                      "name": "КоманднаяПанельСписка",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                      },
-                      "dataPath": "",
+                      "dataPath": "Список.ВажностьКартинка",
                       "items": []
                     },
                     {
-                      "type": "FORM_GROUP",
-                      "id": 157,
-                      "name": "ГруппаПринятьКИсполнению",
+                      "type": "PICTURE_FIELD",
+                      "id": 59,
+                      "name": "Остановлена",
                       "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
                       },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "BUTTON",
-                            "id": 61,
-                            "name": "ПринятьКИсполнению",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "BUTTON",
-                            "id": 62,
-                            "name": "ОтменитьПринятиеКИсполнению",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[7]/title"
-                            },
-                            "dataPath": "",
-                            "items": []
-                          },
-                          {
-                            "type": "BUTTON",
-                            "id": 76,
-                            "name": "ЗадачаЗадачаИсполнителяВыполнено",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                            },
-                            "dataPath": "Items.Список.CurrentData.Ref",
-                            "items": []
-                          },
-                          {
-                            "type": "BUTTON",
-                            "id": 77,
-                            "name": "ЗадачаЗадачаИсполнителяПеренаправить",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                            },
-                            "dataPath": "Items.Список.CurrentData.Ref",
-                            "items": []
-                          }
-                        ],
-                        []
-                      ]
-                    },
-                    {
-                      "type": "FORM_GROUP",
-                      "id": 46,
-                      "name": "КоманднаяПанельФормы",
-                      "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[8]/title"
-                      },
-                      "dataPath": "",
+                      "dataPath": "Список.Остановлена",
                       "items": []
                     },
                     {
-                      "type": "BUTTON",
-                      "id": 139,
-                      "name": "Справка",
+                      "type": "INPUT_FIELD",
+                      "id": 6,
+                      "name": "Наименование",
                       "title": {
                         "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
                       },
-                      "dataPath": "",
+                      "dataPath": "Список.Description",
                       "items": []
-                    }
-                  ],
-                  []
-                ]
-              },
-              {
-                "type": "TABLE",
-                "id": 1,
-                "name": "Список",
-                "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
-                },
-                "dataPath": "Список",
-                "items": [
-                  [
+                    },
                     {
                       "type": "COLUMN_GROUP",
-                      "id": 161,
-                      "name": "ГруппаВажность",
+                      "id": 169,
+                      "name": "ГруппаСрокИсполнения",
                       "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[2]/synonym"
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[6]/title"
                       },
                       "dataPath": "",
                       "items": [
                         [
                           {
-                            "type": "PICTURE_FIELD",
-                            "id": 81,
-                            "name": "ВажностьКартинка",
+                            "type": "INPUT_FIELD",
+                            "id": 30,
+                            "name": "СрокИсполнения",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[13]/synonym"
+                            },
+                            "dataPath": "Список.СрокИсполнения",
+                            "items": []
+                          },
+                          {
+                            "type": "CHECK_BOX_FIELD",
+                            "id": 10,
+                            "name": "Выполнена",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                            },
+                            "dataPath": "Список.Executed",
+                            "items": []
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 32,
+                            "name": "ДатаИсполнения",
                             "title": {
                               "content": [
                                 {
@@ -5582,22 +4770,12 @@
                                   "int": 1,
                                   "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
                                     "langKey": "ru",
-                                    "value": "Важность (признак)"
+                                    "value": "Дата исполнения"
                                   }
                                 }
                               ]
                             },
-                            "dataPath": "Список.ВажностьКартинка",
-                            "items": []
-                          },
-                          {
-                            "type": "PICTURE_FIELD",
-                            "id": 59,
-                            "name": "Остановлена",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                            },
-                            "dataPath": "Список.Остановлена",
+                            "dataPath": "Список.ДатаИсполнения",
                             "items": []
                           }
                         ],
@@ -5606,111 +4784,52 @@
                     },
                     {
                       "type": "COLUMN_GROUP",
-                      "id": 85,
-                      "name": "ГруппаОписание",
+                      "id": 80,
+                      "name": "ГруппаИсполнитель",
                       "title": {
-                        "content": [
-                          {
-                            "default": {
-                              "tag": 2
-                            },
-                            "int": 1,
-                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
-                              "langKey": "ru",
-                              "value": "Описание задачи"
-                            }
-                          }
-                        ]
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute[2]/synonym"
                       },
                       "dataPath": "",
                       "items": [
                         [
                           {
-                            "type": "COLUMN_GROUP",
-                            "id": 165,
-                            "name": "ГруппаНаименование",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
-                            },
-                            "dataPath": "",
-                            "items": [
-                              [
-                                {
-                                  "type": "INPUT_FIELD",
-                                  "id": 6,
-                                  "name": "Наименование",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                  },
-                                  "dataPath": "Список.Description",
-                                  "items": []
-                                },
-                                {
-                                  "type": "INPUT_FIELD",
-                                  "id": 22,
-                                  "name": "Автор",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                  },
-                                  "dataPath": "Список.Автор",
-                                  "items": []
-                                }
-                              ],
-                              []
-                            ]
-                          },
-                          {
-                            "type": "LABEL_FIELD",
-                            "id": 51,
-                            "name": "Предмет",
+                            "type": "INPUT_FIELD",
+                            "id": 24,
+                            "name": "Исполнитель",
                             "title": {
                               "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
                             },
-                            "dataPath": "Список.ПредметСтрокой",
+                            "dataPath": "Список.Исполнитель",
                             "items": []
-                          },
-                          {
-                            "type": "COLUMN_GROUP",
-                            "id": 163,
-                            "name": "ГруппаАвтор",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/synonym"
-                            },
-                            "dataPath": "",
-                            "items": [
-                              [
-                                {
-                                  "type": "INPUT_FIELD",
-                                  "id": 8,
-                                  "name": "Дата",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[7]/synonym"
-                                  },
-                                  "dataPath": "Список.Date",
-                                  "items": []
-                                },
-                                {
-                                  "type": "INPUT_FIELD",
-                                  "id": 4,
-                                  "name": "Номер",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                  },
-                                  "dataPath": "Список.Number",
-                                  "items": []
-                                }
-                              ],
-                              []
-                            ]
                           },
                           {
                             "type": "INPUT_FIELD",
-                            "id": 83,
-                            "name": "Описание",
+                            "id": 34,
+                            "name": "РольИсполнителя",
                             "title": {
                               "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
                             },
-                            "dataPath": "Список.Описание",
+                            "dataPath": "Список.РольИсполнителя",
+                            "items": []
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 40,
+                            "name": "ОсновнойОбъектАдресации",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                            },
+                            "dataPath": "Список.ОсновнойОбъектАдресации",
+                            "items": []
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 38,
+                            "name": "ДополнительныйОбъектАдресации",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                            },
+                            "dataPath": "Список.ДополнительныйОбъектАдресации",
                             "items": []
                           }
                         ],
@@ -5718,116 +4837,54 @@
                       ]
                     },
                     {
-                      "type": "COLUMN_GROUP",
-                      "id": 167,
-                      "name": "ГруппаИсполнение",
+                      "type": "LABEL_FIELD",
+                      "id": 51,
+                      "name": "Предмет",
                       "title": {
-                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
                       },
-                      "dataPath": "",
-                      "items": [
-                        [
-                          {
-                            "type": "COLUMN_GROUP",
-                            "id": 80,
-                            "name": "ГруппаИсполнитель",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute[2]/synonym"
-                            },
-                            "dataPath": "",
-                            "items": [
-                              [
-                                {
-                                  "type": "INPUT_FIELD",
-                                  "id": 24,
-                                  "name": "Исполнитель",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                  },
-                                  "dataPath": "Список.Исполнитель",
-                                  "items": []
-                                },
-                                {
-                                  "type": "INPUT_FIELD",
-                                  "id": 34,
-                                  "name": "РольИсполнителя",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                  },
-                                  "dataPath": "Список.РольИсполнителя",
-                                  "items": []
-                                },
-                                {
-                                  "type": "INPUT_FIELD",
-                                  "id": 40,
-                                  "name": "ОсновнойОбъектАдресации",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                  },
-                                  "dataPath": "Список.ОсновнойОбъектАдресации",
-                                  "items": []
-                                },
-                                {
-                                  "type": "INPUT_FIELD",
-                                  "id": 38,
-                                  "name": "ДополнительныйОбъектАдресации",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                  },
-                                  "dataPath": "Список.ДополнительныйОбъектАдресации",
-                                  "items": []
-                                }
-                              ],
-                              []
-                            ]
-                          },
-                          {
-                            "type": "COLUMN_GROUP",
-                            "id": 169,
-                            "name": "ГруппаСрокИсполнения",
-                            "title": {
-                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[6]/title"
-                            },
-                            "dataPath": "",
-                            "items": [
-                              [
-                                {
-                                  "type": "INPUT_FIELD",
-                                  "id": 30,
-                                  "name": "СрокИсполнения",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                  },
-                                  "dataPath": "Список.СрокИсполнения",
-                                  "items": []
-                                },
-                                {
-                                  "type": "CHECK_BOX_FIELD",
-                                  "id": 10,
-                                  "name": "Выполнена",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                  },
-                                  "dataPath": "Список.Executed",
-                                  "items": []
-                                },
-                                {
-                                  "type": "INPUT_FIELD",
-                                  "id": 32,
-                                  "name": "ДатаИсполнения",
-                                  "title": {
-                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
-                                  },
-                                  "dataPath": "Список.ДатаИсполнения",
-                                  "items": []
-                                }
-                              ],
-                              []
-                            ]
-                          }
-                        ],
-                        []
-                      ]
+                      "dataPath": "Список.ПредметСтрокой",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 22,
+                      "name": "Автор",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "Список.Автор",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 8,
+                      "name": "Дата",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[7]/synonym"
+                      },
+                      "dataPath": "Список.Date",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 4,
+                      "name": "Номер",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "Список.Number",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 83,
+                      "name": "Описание",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "Список.Описание",
+                      "items": []
                     },
                     {
                       "type": "LABEL_FIELD",
@@ -5882,7 +4939,7 @@
                 "id": 4,
                 "name": "ПоказыватьЗадачи",
                 "title": {
-                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[8]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[8]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
                 },
                 "type": {
                   "types": [

--- a/src/test/resources/fixtures/ssl_3_2/Tasks.ЗадачаИсполнителя_edt.json
+++ b/src/test/resources/fixtures/ssl_3_2/Tasks.ЗадачаИсполнителя_edt.json
@@ -1,0 +1,6075 @@
+{"com.github._1c_syntax.bsl.mdo.Task": {
+  "addressingAttributes": [
+    [
+      {
+        "uuid": "0408002c-9255-43a2-8022-82f02ee0e8f4",
+        "name": "ДополнительныйОбъектАдресации",
+        "mdoReference": {
+          "type": "TASK_ADDRESSING_ATTRIBUTE",
+          "mdoRef": "Task.ЗадачаИсполнителя.AddressingAttribute.ДополнительныйОбъектАдресации",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.РеквизитАдресации.ДополнительныйОбъектАдресации"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Дополнительный объект адресации"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "type": "TASK",
+          "mdoRef": "Task.ЗадачаИсполнителя",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "Характеристика.ОбъектыАдресацииЗадач",
+                  "nameEn": "Characteristic.ОбъектыАдресацииЗадач"
+                },
+                "variant": "METADATA",
+                "kind": "CHART_OF_CHARACTERISTIC_TYPES"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 0
+            }
+          ]
+        },
+        "format": {
+          "content": []
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "toolTip": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Дополнительный объект адресации, если задача адресована роли исполнителя"
+              }
+            }
+          ]
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false,
+        "choiceForm": {
+          "type": "UNKNOWN",
+          "mdoRef": "",
+          "mdoRefRu": ""
+        }
+      },
+      {
+        "uuid": "88f44c9b-216d-4d7e-bc88-1e6b253ed01e",
+        "name": "Исполнитель",
+        "mdoReference": {
+          "type": "TASK_ADDRESSING_ATTRIBUTE",
+          "mdoRef": "Task.ЗадачаИсполнителя.AddressingAttribute.Исполнитель",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.РеквизитАдресации.Исполнитель"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Исполнитель"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 2,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "СправочникСсылка.ВнешниеПользователи",
+                  "nameEn": "CatalogRef.ВнешниеПользователи"
+                },
+                "variant": "METADATA",
+                "kind": "CATALOG"
+              },
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "СправочникСсылка.Пользователи",
+                  "nameEn": "CatalogRef.Пользователи"
+                },
+                "variant": "METADATA",
+                "kind": "CATALOG"
+              }
+            }
+          ],
+          "composite": true,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "toolTip": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Пользователь, которому поручено выполнение задачи"
+              }
+            }
+          ]
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false,
+        "choiceForm": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/choiceForm"
+        }
+      },
+      {
+        "uuid": "1851afd4-5324-45c1-b754-54e65943f945",
+        "name": "ОсновнойОбъектАдресации",
+        "mdoReference": {
+          "type": "TASK_ADDRESSING_ATTRIBUTE",
+          "mdoRef": "Task.ЗадачаИсполнителя.AddressingAttribute.ОсновнойОбъектАдресации",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.РеквизитАдресации.ОсновнойОбъектАдресации"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Основной объект адресации"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "toolTip": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Основной объект адресации, если задача адресована роли исполнителя"
+              }
+            }
+          ]
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false,
+        "choiceForm": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/choiceForm"
+        }
+      },
+      {
+        "uuid": "bc5eca9b-32d8-44e0-a127-8ad1f47d7957",
+        "name": "РольИсполнителя",
+        "mdoReference": {
+          "type": "TASK_ADDRESSING_ATTRIBUTE",
+          "mdoRef": "Task.ЗадачаИсполнителя.AddressingAttribute.РольИсполнителя",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.РеквизитАдресации.РольИсполнителя"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Роль исполнителя"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "СправочникСсылка.РолиИсполнителей",
+                  "nameEn": "CatalogRef.РолиИсполнителей"
+                },
+                "variant": "METADATA",
+                "kind": "CATALOG"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "toolTip": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Роль исполнителя, которой адресована задача"
+              }
+            }
+          ]
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false,
+        "choiceForm": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/choiceForm"
+        }
+      }
+    ],
+    []
+  ],
+  "attributes": [
+    [
+      {
+        "uuid": "3ad08f4a-6202-4099-b6cc-bc116e6731a0",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Task.ЗадачаИсполнителя.StandardAttribute.Executed",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.СтандартныйРеквизит.Выполнена"
+        },
+        "comment": "Задача выполнена",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Выполнена"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "BOOLEAN"
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "fullName": {
+          "nameRu": "Выполнена",
+          "nameEn": "Executed"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "3ad08f4a-6202-4099-b6cc-bc116e6731a0",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Task.ЗадачаИсполнителя.StandardAttribute.Description",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.СтандартныйРеквизит.Наименование"
+        },
+        "comment": "Краткое описание задачи",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Задача"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                "length": 150,
+                "allowedLength": 0,
+                "description": {}
+              }
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "Наименование",
+          "nameEn": "Description"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "3ad08f4a-6202-4099-b6cc-bc116e6731a0",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Task.ЗадачаИсполнителя.StandardAttribute.RoutePoint",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.СтандартныйРеквизит.ТочкаМаршрута"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [],
+          "composite": false,
+          "qualifiers": []
+        },
+        "fullName": {
+          "nameRu": "ТочкаМаршрута",
+          "nameEn": "RoutePoint"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "3ad08f4a-6202-4099-b6cc-bc116e6731a0",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Task.ЗадачаИсполнителя.StandardAttribute.BusinessProcess",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.СтандартныйРеквизит.БизнесПроцесс"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[3]/type"
+        },
+        "fullName": {
+          "nameRu": "БизнесПроцесс",
+          "nameEn": "BusinessProcess"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "3ad08f4a-6202-4099-b6cc-bc116e6731a0",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Task.ЗадачаИсполнителя.StandardAttribute.Ref",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.СтандартныйРеквизит.Ссылка"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "ЗадачаСсылка.ЗадачаИсполнителя",
+                  "nameEn": "TaskRef.ЗадачаИсполнителя"
+                },
+                "variant": "METADATA",
+                "kind": "TASK"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "fullName": {
+          "nameRu": "Ссылка",
+          "nameEn": "Ref"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "3ad08f4a-6202-4099-b6cc-bc116e6731a0",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Task.ЗадачаИсполнителя.StandardAttribute.DeletionMark",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.СтандартныйРеквизит.ПометкаУдаления"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+        },
+        "fullName": {
+          "nameRu": "ПометкаУдаления",
+          "nameEn": "DeletionMark"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "3ad08f4a-6202-4099-b6cc-bc116e6731a0",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Task.ЗадачаИсполнителя.StandardAttribute.Date",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.СтандартныйРеквизит.Дата"
+        },
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Записана"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "DATE"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.DateQualifiers": {
+                "dateFractions": 2,
+                "description": {
+                  "value": {
+                    "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                    "nameRu": "КвалификаторыДаты (ДатаВремя)",
+                    "nameEn": "DateQualifiers (DateTime)"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "Дата",
+          "nameEn": "Date"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "3ad08f4a-6202-4099-b6cc-bc116e6731a0",
+        "mdoReference": {
+          "type": "STANDARD_ATTRIBUTE",
+          "mdoRef": "Task.ЗадачаИсполнителя.StandardAttribute.Number",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.СтандартныйРеквизит.Номер"
+        },
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "STANDARD",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                "length": 14,
+                "allowedLength": 0,
+                "description": {}
+              }
+            }
+          ]
+        },
+        "fullName": {
+          "nameRu": "Номер",
+          "nameEn": "Number"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "fd96c8ab-602a-4735-b168-52b501e80351",
+        "name": "Автор",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Task.ЗадачаИсполнителя.Attribute.Автор",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.Реквизит.Автор"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Автор бизнес-процесса, который сформировал задачу",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Автор"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute[2]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "b1dc619d-8d91-4f7a-aa50-1d07ff9aebdc",
+        "name": "Важность",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Task.ЗадачаИсполнителя.Attribute.Важность",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.Реквизит.Важность"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Для упорядочивания исполнителем своих задач по приоритету",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Важность"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "ПеречислениеСсылка.ВариантыВажностиЗадачи",
+                  "nameEn": "EnumRef.ВариантыВажностиЗадачи"
+                },
+                "variant": "METADATA",
+                "kind": "ENUM"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": true
+      },
+      {
+        "uuid": "370f0c75-d2c5-4be5-a633-4bcc77998ece",
+        "name": "ГруппаИсполнителейЗадач",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Task.ЗадачаИсполнителя.Attribute.ГруппаИсполнителейЗадач",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.Реквизит.ГруппаИсполнителейЗадач"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Группа исполнителей задач"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "СправочникСсылка.ГруппыИсполнителейЗадач",
+                  "nameEn": "CatalogRef.ГруппыИсполнителейЗадач"
+                },
+                "variant": "METADATA",
+                "kind": "CATALOG"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "f80b505f-b4ff-45fb-bd88-74b274ae9d2b",
+        "name": "ДатаИсполнения",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Task.ЗадачаИсполнителя.Attribute.ДатаИсполнения",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.Реквизит.ДатаИсполнения"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Дата и время фактического выполнения задачи",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[7]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "2139532c-f6cb-4393-936e-cc912e5adca9",
+        "name": "ДатаНачала",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Task.ЗадачаИсполнителя.Attribute.ДатаНачала",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.Реквизит.ДатаНачала"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Для упорядочивания исполнителем своих задач",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Дата начала"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[7]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "755c3eca-4956-4a44-9b38-c11dae00b87f",
+        "name": "ДатаПринятияКИсполнению",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Task.ЗадачаИсполнителя.Attribute.ДатаПринятияКИсполнению",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.Реквизит.ДатаПринятияКИсполнению"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Дата принятия к исполнению"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[7]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "f57c558c-2c94-4b9d-8697-448d0548ab1a",
+        "name": "Описание",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Task.ЗадачаИсполнителя.Attribute.Описание",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.Реквизит.Описание"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Описание постановки задачи для исполнителя",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Описание"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                "length": 0,
+                "allowedLength": 0,
+                "description": {
+                  "value": {
+                    "@class": "com.github._1c_syntax.bsl.types.MultiName",
+                    "nameRu": "КвалификаторыСтроки (0, Переменная)",
+                    "nameEn": "StringQualifiers (0, Variable)"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": true,
+        "extendedEdit": true,
+        "fillFromFillingValue": true
+      },
+      {
+        "uuid": "a310c09f-4d3a-4d3a-9ad5-7a5735a33a1d",
+        "name": "Предмет",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Task.ЗадачаИсполнителя.Attribute.Предмет",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.Реквизит.Предмет"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Предмет задачи",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Предмет"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 4,
+              "com.github._1c_syntax.bsl.types.value.MDOValueType": "CATALOG_REF",
+              "com.github._1c_syntax.bsl.types.value.MDOValueType": "CHART_OF_CHARACTERISTIC_TYPES_REF",
+              "com.github._1c_syntax.bsl.types.value.MDOValueType": "DOCUMENT_REF",
+              "com.github._1c_syntax.bsl.types.value.MDOValueType": "TASK_REF"
+            }
+          ],
+          "composite": true,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "c32db021-eca1-4b67-aa85-3d6e28c51b53",
+        "name": "ПредметСтрокой",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Task.ЗадачаИсполнителя.Attribute.ПредметСтрокой",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.Реквизит.ПредметСтрокой"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Строковое представление предмета",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[8]/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+            }
+          ],
+          "composite": false,
+          "qualifiers": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                "length": 500,
+                "allowedLength": 0,
+                "description": {}
+              }
+            }
+          ]
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "e9ed0ee4-3fbe-4093-9078-cb265ed6842c",
+        "name": "ПринятаКИсполнению",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Task.ЗадачаИсполнителя.Attribute.ПринятаКИсполнению",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.Реквизит.ПринятаКИсполнению"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Принята к исполнению"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "02466dcf-02a1-4853-814f-a913a9baba45",
+        "name": "РезультатВыполнения",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Task.ЗадачаИсполнителя.Attribute.РезультатВыполнения",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.Реквизит.РезультатВыполнения"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Описание результата выполнения",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Результат выполнения"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[7]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": true,
+        "extendedEdit": true,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "c4a40dc9-b619-4219-9d9a-e11f49a14fb1",
+        "name": "СостояниеБизнесПроцесса",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Task.ЗадачаИсполнителя.Attribute.СостояниеБизнесПроцесса",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.Реквизит.СостояниеБизнесПроцесса"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Состояние бизнес процесса"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "types": [
+            {
+              "default": {
+                "tag": 4
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                "fullName": {
+                  "nameRu": "ПеречислениеСсылка.СостоянияБизнесПроцессов",
+                  "nameEn": "EnumRef.СостоянияБизнесПроцессов"
+                },
+                "variant": "METADATA",
+                "kind": "ENUM"
+              }
+            }
+          ],
+          "composite": false,
+          "qualifiers": []
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "62b75eb2-42e1-4484-a77f-b676dd36f3d4",
+        "name": "СрокИсполнения",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Task.ЗадачаИсполнителя.Attribute.СрокИсполнения",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.Реквизит.СрокИсполнения"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Плановый срок исполнения задачи",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Срок"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[7]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      },
+      {
+        "uuid": "5e28e22a-dd6e-4703-92bd-13f5cb0dc023",
+        "name": "АвторСтрокой",
+        "mdoReference": {
+          "type": "ATTRIBUTE",
+          "mdoRef": "Task.ЗадачаИсполнителя.Attribute.АвторСтрокой",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.Реквизит.АвторСтрокой"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Автор строкой"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "passwordMode": false,
+        "kind": "CUSTOM",
+        "indexing": "DONT_INDEX",
+        "type": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[2]/type"
+        },
+        "format": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "editFormat": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+        },
+        "markNegatives": false,
+        "mask": "",
+        "multiLine": false,
+        "extendedEdit": false,
+        "fillFromFillingValue": false
+      }
+    ],
+    []
+  ],
+  "commands": [
+    [
+      {
+        "uuid": "6e5307ea-8fbf-4177-bcc8-f163a6ce1b40",
+        "name": "ВсеЗадачи",
+        "mdoReference": {
+          "type": "COMMAND",
+          "mdoRef": "Task.ЗадачаИсполнителя.Command.ВсеЗадачи",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.Команда.ВсеЗадачи"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Все задачи"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "CommandModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/Tasks/ЗадачаИсполнителя/Commands/ВсеЗадачи/CommandModule.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        }
+      },
+      {
+        "uuid": "0fa77ef7-a836-4459-9bca-6010d0bdfc7f",
+        "name": "Выполнено",
+        "mdoReference": {
+          "type": "COMMAND",
+          "mdoRef": "Task.ЗадачаИсполнителя.Command.Выполнено",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.Команда.Выполнено"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Выполнено"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "CommandModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/Tasks/ЗадачаИсполнителя/Commands/Выполнено/CommandModule.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[2]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        }
+      },
+      {
+        "uuid": "c322dc4a-30f3-4d23-9824-4a01c496408d",
+        "name": "МоиЗадачи",
+        "mdoReference": {
+          "type": "COMMAND",
+          "mdoRef": "Task.ЗадачаИсполнителя.Command.МоиЗадачи",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.Команда.МоиЗадачи"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Мои задачи"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "CommandModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/Tasks/ЗадачаИсполнителя/Commands/МоиЗадачи/CommandModule.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[3]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        }
+      },
+      {
+        "uuid": "dcff004c-1b61-4a19-b977-ea21bf688614",
+        "name": "Перенаправить",
+        "mdoReference": {
+          "type": "COMMAND",
+          "mdoRef": "Task.ЗадачаИсполнителя.Command.Перенаправить",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.Команда.Перенаправить"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Перенаправить..."
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "CommandModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/Tasks/ЗадачаИсполнителя/Commands/Перенаправить/CommandModule.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[4]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        }
+      }
+    ],
+    []
+  ],
+  "comment": "",
+  "description": "Задача",
+  "explanation": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+  },
+  "forms": [
+    [
+      {
+        "uuid": "856510ee-74f5-44e9-a3c0-1c60cfb7a787",
+        "name": "Дополнительно",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "Task.ЗадачаИсполнителя.Form.Дополнительно",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.Форма.Дополнительно"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Дополнительно"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/Tasks/ЗадачаИсполнителя/Forms/Дополнительно/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/synonym"
+          },
+          "handlers": [
+            {
+              "event": "OnCreateAtServer",
+              "name": "ПриСозданииНаСервере"
+            }
+          ],
+          "items": [
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 99,
+                "name": "Документ",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Документ"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 41,
+                      "name": "Наименование",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "Объект.Description",
+                      "items": []
+                    },
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 63,
+                      "name": "ГруппаРезультат",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Результат выполнения задачи"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "CHECK_BOX_FIELD",
+                            "id": 64,
+                            "name": "Выполнена",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                            },
+                            "dataPath": "Объект.Executed",
+                            "items": []
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 66,
+                            "name": "ДатаИсполнения",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                            },
+                            "dataPath": "Объект.ДатаИсполнения",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 51,
+                      "name": "ГруппаБизнесПроцесс",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Бизнес-процесс"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 52,
+                            "name": "БизнесПроцесс",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                            },
+                            "dataPath": "Объект.BusinessProcess",
+                            "items": []
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 54,
+                            "name": "ТочкаМаршрута",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                            },
+                            "dataPath": "Объект.RoutePoint",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 69,
+                      "name": "ГруппаАдресация",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Задача адресована"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 27,
+                            "name": "Исполнитель",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                            },
+                            "dataPath": "Объект.Исполнитель",
+                            "items": []
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 29,
+                            "name": "РольИсполнителя",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                            },
+                            "dataPath": "Объект.РольИсполнителя",
+                            "items": []
+                          },
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 92,
+                            "name": "ГруппаУточнение",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Уточнение"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "LABEL",
+                                  "id": 96,
+                                  "name": "Отступ",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                  },
+                                  "dataPath": "",
+                                  "items": []
+                                },
+                                {
+                                  "type": "USUAL_GROUP",
+                                  "id": 94,
+                                  "name": "ГруппаОбъектыАдресации",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Объекты адресации"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "INPUT_FIELD",
+                                        "id": 31,
+                                        "name": "ОсновнойОбъектАдресации",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                        },
+                                        "dataPath": "Объект.ОсновнойОбъектАдресации",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "INPUT_FIELD",
+                                        "id": 33,
+                                        "name": "ДополнительныйОбъектАдресации",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                        },
+                                        "dataPath": "Объект.ДополнительныйОбъектАдресации",
+                                        "items": []
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                }
+                              ],
+                              []
+                            ]
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 56,
+                      "name": "ГруппаВходящие",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Входящие"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 57,
+                            "name": "Дата",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                            },
+                            "dataPath": "Объект.Date",
+                            "items": []
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 71,
+                            "name": "СрокИсполнения",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                            },
+                            "dataPath": "Объект.СрокИсполнения",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 45,
+                "name": "ГруппаСправа",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Справа"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  {
+                    "type": "INPUT_FIELD",
+                    "id": 43,
+                    "name": "Номер",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                    },
+                    "dataPath": "Объект.Number",
+                    "items": []
+                  }
+                ]
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            {
+              "id": 1,
+              "name": "Объект",
+              "title": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+              },
+              "type": {
+                "types": [
+                  {
+                    "default": {
+                      "tag": 4
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                      "fullName": {
+                        "nameRu": "ЗадачаОбъект.ЗадачаИсполнителя",
+                        "nameEn": "TaskObject.ЗадачаИсполнителя"
+                      },
+                      "variant": "METADATA",
+                      "kind": "TASK"
+                    }
+                  }
+                ],
+                "composite": false,
+                "qualifiers": []
+              }
+            }
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "28b761c6-c286-4125-a4ed-da602e49950f",
+        "name": "ЗадачиПоБизнесПроцессу",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "Task.ЗадачаИсполнителя.Form.ЗадачиПоБизнесПроцессу",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.Форма.ЗадачиПоБизнесПроцессу"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Задачи"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/Tasks/ЗадачаИсполнителя/Forms/ЗадачиПоБизнесПроцессу/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "content": [
+              {
+                "default": {
+                  "tag": 2
+                },
+                "int": 1,
+                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                  "langKey": "ru",
+                  "value": "Задачи бизнес-процесса"
+                }
+              }
+            ]
+          },
+          "handlers": [
+            [
+              {
+                "event": "NotificationProcessing",
+                "name": "ОбработкаОповещения"
+              },
+              {
+                "event": "OnLoadDataFromSettingsAtServer",
+                "name": "ПриЗагрузкеДанныхИзНастроекНаСервере"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler"
+              },
+              {
+                "event": "BeforeLoadDataFromSettingsAtServer",
+                "name": "ПриЗагрузкеДанныхИзНастроекНаСервере"
+              }
+            ],
+            []
+          ],
+          "items": [
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 85,
+                "name": "ГруппаПользовательскихНастроек",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Группа пользовательских настроек"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": []
+              },
+              {
+                "type": "COMMAND_BAR",
+                "id": 52,
+                "name": "КоманднаяПанельСписка",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Командная панель списка"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": []
+              },
+              {
+                "type": "TABLE",
+                "id": 1,
+                "name": "Список",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Список"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "Список",
+                "items": [
+                  [
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 6,
+                      "name": "Наименование",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "Список.Description",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 4,
+                      "name": "Номер",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Номер"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "Список.Number",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 8,
+                      "name": "Дата",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[7]/synonym"
+                      },
+                      "dataPath": "Список.Date",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 18,
+                      "name": "Исполнитель",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "Список.Исполнитель",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 23,
+                      "name": "Предмет",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "Список.Предмет",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 82,
+                      "name": "Ссылка",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "Список.Ref",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "TABLE",
+                "id": 25,
+                "name": "ДеревоЗадач",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Дерево задач"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "ДеревоЗадач",
+                "items": [
+                  [
+                    {
+                      "type": "PICTURE_FIELD",
+                      "id": 40,
+                      "name": "ДеревоЗадачВажность",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[2]/synonym"
+                      },
+                      "dataPath": "ДеревоЗадач.Важность",
+                      "items": []
+                    },
+                    {
+                      "type": "CHECK_BOX_FIELD",
+                      "id": 49,
+                      "name": "Выполнена",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "ДеревоЗадач.Выполнена",
+                      "items": []
+                    },
+                    {
+                      "type": "PICTURE_FIELD",
+                      "id": 42,
+                      "name": "ДеревоЗадачОстановлен",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Остановлен"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "ДеревоЗадач.Остановлен",
+                      "items": []
+                    },
+                    {
+                      "type": "COLUMN_GROUP",
+                      "id": 46,
+                      "name": "ТипИНаименование",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Тип и наименование"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "PICTURE_FIELD",
+                            "id": 44,
+                            "name": "ДеревоЗадачТип",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Тип"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "ДеревоЗадач.Тип",
+                            "items": []
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 30,
+                            "name": "ДеревоЗадачНаименование",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Наименование"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "ДеревоЗадач.Наименование",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 32,
+                      "name": "ДеревоЗадачИсполнитель",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute[2]/synonym"
+                      },
+                      "dataPath": "ДеревоЗадач.Исполнитель",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 47,
+                      "name": "СрокИсполнения",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Срок исполнения"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "ДеревоЗадач.СрокИсполнения",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "CHECK_BOX_FIELD",
+                "id": 21,
+                "name": "ПоказыватьВыполненные",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Показывать выполненные"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "ПоказыватьВыполненные",
+                "items": []
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "Список",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "DYNAMIC_LIST"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 2,
+                "name": "ПоказыватьВыполненные",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              },
+              {
+                "id": 3,
+                "name": "ДеревоЗадач",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "VALUE_TREE"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "4ac66a22-c736-4e06-a8aa-ef4a71788c65",
+        "name": "ЗадачиПоПредмету",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "Task.ЗадачаИсполнителя.Form.ЗадачиПоПредмету",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.Форма.ЗадачиПоПредмету"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Задачи по предмету"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/Tasks/ЗадачаИсполнителя/Forms/ЗадачиПоПредмету/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/synonym"
+          },
+          "handlers": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[2]"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[4]"
+              }
+            ],
+            []
+          ],
+          "items": [
+            [
+              {
+                "type": "COMMAND_BAR",
+                "id": 130,
+                "name": "ГруппаПользовательскихНастроек",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "dataPath": "",
+                "items": []
+              },
+              {
+                "type": "COMMAND_BAR",
+                "id": 50,
+                "name": "КоманднаяПанельСписка",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "dataPath": "",
+                "items": [
+                  {
+                    "type": "FORM_GROUP",
+                    "id": 120,
+                    "name": "ГруппаПринятьКИсполнению",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Принять к исполнению"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "BUTTON",
+                          "id": 122,
+                          "name": "ПринятьКИсполнению",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "К исполнению"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": []
+                        },
+                        {
+                          "type": "BUTTON",
+                          "id": 124,
+                          "name": "ОтменитьПринятиеКИсполнению",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Обновить"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": []
+                        },
+                        {
+                          "type": "BUTTON",
+                          "id": 126,
+                          "name": "ЗадачаЗадачаИсполнителяВыполнено",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                          },
+                          "dataPath": "Items.Список.CurrentData.ОсновнойОбъектАдресации",
+                          "items": []
+                        },
+                        {
+                          "type": "BUTTON",
+                          "id": 128,
+                          "name": "ЗадачаЗадачаИсполнителяПеренаправить",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                          },
+                          "dataPath": "Items.Список.CurrentData.ОсновнойОбъектАдресации",
+                          "items": []
+                        }
+                      ],
+                      []
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "TABLE",
+                "id": 1,
+                "name": "Список",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                },
+                "dataPath": "Список",
+                "items": [
+                  [
+                    {
+                      "type": "COLUMN_GROUP",
+                      "id": 99,
+                      "name": "ГруппаВажность",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[2]/synonym"
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "PICTURE_FIELD",
+                            "id": 52,
+                            "name": "ВажностьКартинка",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[2]/synonym"
+                            },
+                            "dataPath": "Список.ВажностьКартинка",
+                            "items": []
+                          },
+                          {
+                            "type": "PICTURE_FIELD",
+                            "id": 56,
+                            "name": "Остановлена",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Остановлена"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "Список.Остановлена",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "COLUMN_GROUP",
+                      "id": 103,
+                      "name": "ГруппаОписание",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[7]/synonym"
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "COLUMN_GROUP",
+                            "id": 101,
+                            "name": "ГруппаНаименование",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 6,
+                                  "name": "Наименование",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[2]/synonym"
+                                  },
+                                  "dataPath": "Список.Description",
+                                  "items": []
+                                },
+                                {
+                                  "type": "LABEL_FIELD",
+                                  "id": 107,
+                                  "name": "Автор",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                  },
+                                  "dataPath": "Список.Автор",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          },
+                          {
+                            "type": "COLUMN_GROUP",
+                            "id": 105,
+                            "name": "ГруппаАвтор",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/synonym"
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 4,
+                                  "name": "Номер",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                                  },
+                                  "dataPath": "Список.Number",
+                                  "items": []
+                                },
+                                {
+                                  "type": "LABEL_FIELD",
+                                  "id": 110,
+                                  "name": "Дата",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                  },
+                                  "dataPath": "Список.Date",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "COLUMN_GROUP",
+                      "id": 113,
+                      "name": "ГруппаИсполнение",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Исполнение"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "COLUMN_GROUP",
+                            "id": 64,
+                            "name": "ГруппаИсполнитель",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute[2]/synonym"
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 18,
+                                  "name": "Исполнитель",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                  },
+                                  "dataPath": "Список.Исполнитель",
+                                  "items": []
+                                },
+                                {
+                                  "type": "LABEL_FIELD",
+                                  "id": 58,
+                                  "name": "РольИсполнителя",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                  },
+                                  "dataPath": "Список.РольИсполнителя",
+                                  "items": []
+                                },
+                                {
+                                  "type": "LABEL_FIELD",
+                                  "id": 60,
+                                  "name": "ОсновнойОбъектАдресации",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                  },
+                                  "dataPath": "Список.ОсновнойОбъектАдресации",
+                                  "items": []
+                                },
+                                {
+                                  "type": "LABEL_FIELD",
+                                  "id": 62,
+                                  "name": "ДополнительныйОбъектАдресации",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                  },
+                                  "dataPath": "Список.ДополнительныйОбъектАдресации",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          },
+                          {
+                            "type": "COLUMN_GROUP",
+                            "id": 115,
+                            "name": "ГруппаСрокИсполнения",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[6]/title"
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "LABEL_FIELD",
+                                  "id": 23,
+                                  "name": "СрокИсполнения",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                  },
+                                  "dataPath": "Список.СрокИсполнения",
+                                  "items": []
+                                },
+                                {
+                                  "type": "CHECK_BOX_FIELD",
+                                  "id": 54,
+                                  "name": "ЗадачаВыполнена",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                  },
+                                  "dataPath": "Список.Executed",
+                                  "items": []
+                                },
+                                {
+                                  "type": "LABEL_FIELD",
+                                  "id": 117,
+                                  "name": "ДатаИсполнения",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                  },
+                                  "dataPath": "Список.ДатаИсполнения",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 96,
+                      "name": "Ссылка",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "Список.Ref",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "CHECK_BOX_FIELD",
+                "id": 21,
+                "name": "ПоказыватьВыполненные",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Показывать выполненные задачи"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "ПоказыватьВыполненные",
+                "items": []
+              },
+              {
+                "type": "TABLE",
+                "id": 25,
+                "name": "ДеревоЗадач",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                },
+                "dataPath": "ДеревоЗадач",
+                "items": [
+                  [
+                    {
+                      "type": "PICTURE_FIELD",
+                      "id": 28,
+                      "name": "ДеревоЗадачВажность",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[2]/synonym"
+                      },
+                      "dataPath": "ДеревоЗадач.Важность",
+                      "items": []
+                    },
+                    {
+                      "type": "CHECK_BOX_FIELD",
+                      "id": 30,
+                      "name": "Выполнена",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                      },
+                      "dataPath": "ДеревоЗадач.Выполнена",
+                      "items": []
+                    },
+                    {
+                      "type": "PICTURE_FIELD",
+                      "id": 32,
+                      "name": "ДеревоЗадачОстановлен",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                      },
+                      "dataPath": "ДеревоЗадач.Остановлен",
+                      "items": []
+                    },
+                    {
+                      "type": "COLUMN_GROUP",
+                      "id": 34,
+                      "name": "ТипИНаименование",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "PICTURE_FIELD",
+                            "id": 35,
+                            "name": "ДеревоЗадачТип",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                            },
+                            "dataPath": "ДеревоЗадач.Тип",
+                            "items": []
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 37,
+                            "name": "ДеревоЗадачНаименование",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[2]/synonym"
+                            },
+                            "dataPath": "ДеревоЗадач.Наименование",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 39,
+                      "name": "ДеревоЗадачИсполнитель",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute[2]/synonym"
+                      },
+                      "dataPath": "ДеревоЗадач.Исполнитель",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 41,
+                      "name": "СрокИсполнения1",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[13]/synonym"
+                      },
+                      "dataPath": "ДеревоЗадач.СрокИсполнения",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "Список",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 2,
+                "name": "ПоказыватьВыполненные",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              },
+              {
+                "id": 3,
+                "name": "ДеревоЗадач",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[3]/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "9cfe9281-8840-4077-824d-a2c9cbb0b730",
+        "name": "МоиЗадачи",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "Task.ЗадачаИсполнителя.Form.МоиЗадачи",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.Форма.МоиЗадачи"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[3]/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/Tasks/ЗадачаИсполнителя/Forms/МоиЗадачи/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[3]/synonym"
+          },
+          "handlers": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler"
+              },
+              {
+                "event": "BeforeLoadDataFromSettingsAtServer",
+                "name": "ПередЗагрузкойДанныхИзНастроекНаСервере"
+              }
+            ],
+            []
+          ],
+          "items": [
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 126,
+                "name": "ГруппаПользовательскихНастроек",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "dataPath": "",
+                "items": []
+              },
+              {
+                "type": "COMMAND_BAR",
+                "id": 1,
+                "name": "ОсновнаяКоманднаяПанель",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Основная командная панель"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "POPUP",
+                      "id": 51,
+                      "name": "СгруппироватьПо",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Сгруппировать по"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "BUTTON",
+                            "id": 132,
+                            "name": "СписокСгруппироватьПоСроку",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[13]/synonym"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "BUTTON",
+                            "id": 52,
+                            "name": "СписокСгруппироватьПоВажности",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[2]/synonym"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "BUTTON",
+                            "id": 53,
+                            "name": "СписокСгруппироватьПоТочкеМаршрута",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Точка маршрута"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "BUTTON",
+                            "id": 61,
+                            "name": "СписокСгруппироватьПоАвтору",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/synonym"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "BUTTON",
+                            "id": 62,
+                            "name": "СписокСгруппироватьПоПредмету",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[8]/synonym"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "BUTTON",
+                            "id": 54,
+                            "name": "СписокСгруппироватьСгруппироватьПоБезГруппировки",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Без группировки"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "FORM_GROUP",
+                      "id": 140,
+                      "name": "ГруппаОткрыть",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Открыть"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "BUTTON",
+                            "id": 138,
+                            "name": "ФормаИзменить",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Открыть задачу"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "BUTTON",
+                            "id": 134,
+                            "name": "ОткрытьПредметЗадачи",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Открыть предмет задачи"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "BUTTON",
+                            "id": 136,
+                            "name": "ОткрытьБизнесПроцесс",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Открыть бизнес-процесс"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "FORM_GROUP",
+                      "id": 48,
+                      "name": "КоманднаяПанельСписка",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "BUTTON",
+                            "id": 128,
+                            "name": "ФормаНайти",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "BUTTON",
+                            "id": 130,
+                            "name": "ФормаОтменитьПоиск",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "BUTTON",
+                      "id": 80,
+                      "name": "ПринятьКИсполнению",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "BUTTON",
+                      "id": 82,
+                      "name": "ЗадачаЗадачаИсполнителяВыполнено",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "Items.Список.CurrentData.Ref",
+                      "items": []
+                    },
+                    {
+                      "type": "BUTTON",
+                      "id": 83,
+                      "name": "ЗадачаЗадачаИсполнителяПеренаправить",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "Items.Список.CurrentData.Ref",
+                      "items": []
+                    },
+                    {
+                      "type": "BUTTON",
+                      "id": 81,
+                      "name": "ОтменитьПринятиеКИсполнению",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Отменить принятие к исполнению"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "FORM_GROUP",
+                      "id": 8,
+                      "name": "КоманднаяПанельФормы",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Командная панель формы"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "BUTTON",
+                      "id": 65,
+                      "name": "Справка",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "TABLE",
+                "id": 9,
+                "name": "Список",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                },
+                "dataPath": "Список",
+                "items": [
+                  [
+                    {
+                      "type": "PICTURE_FIELD",
+                      "id": 24,
+                      "name": "Важность",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[2]/synonym"
+                      },
+                      "dataPath": "Список.ВажностьКартинка",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 57,
+                      "name": "Номер",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "Список.Number",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 16,
+                      "name": "Наименование",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "Список.Description",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 46,
+                      "name": "ДатаНачала",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[5]/synonym"
+                      },
+                      "dataPath": "Список.ДатаНачала",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 36,
+                      "name": "СрокИсполнения",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "Список.СрокИсполнения",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 40,
+                      "name": "Автор",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "Список.Автор",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 63,
+                      "name": "Предмет",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "Список.ПредметСтрокой",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 66,
+                      "name": "Дата",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[7]/synonym"
+                      },
+                      "dataPath": "Список.Date",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 123,
+                      "name": "Ссылка",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "Список.Ref",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "CHECK_BOX_FIELD",
+                "id": 38,
+                "name": "ПоказыватьВыполненные",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/title"
+                },
+                "dataPath": "ПоказыватьВыполненные",
+                "items": []
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "Список",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 2,
+                "name": "ПоказыватьВыполненные",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[5]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              },
+              {
+                "id": 3,
+                "name": "РежимГруппировки",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[7]/type"
+                }
+              },
+              {
+                "id": 4,
+                "name": "ПараметрыОтбораФормы",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[3]/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "76389fa9-b9e0-492e-9c93-24b5f3bf094c",
+        "name": "МоиЗадачиДляРабочегоСтола",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "Task.ЗадачаИсполнителя.Form.МоиЗадачиДляРабочегоСтола",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.Форма.МоиЗадачиДляРабочегоСтола"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[3]/synonym"
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/Tasks/ЗадачаИсполнителя/Forms/МоиЗадачиДляРабочегоСтола/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[5]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/commands/c/com.github._1c_syntax.bsl.mdo.children.ObjectCommand[3]/synonym"
+          },
+          "handlers": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[4]"
+              }
+            ],
+            []
+          ],
+          "items": [
+            {
+              "type": "TABLE",
+              "id": 9,
+              "name": "Список",
+              "title": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+              },
+              "dataPath": "Список",
+              "items": [
+                {
+                  "type": "COLUMN_GROUP",
+                  "id": 161,
+                  "name": "ГруппаКолонки",
+                  "title": {
+                    "content": [
+                      {
+                        "default": {
+                          "tag": 2
+                        },
+                        "int": 1,
+                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                          "langKey": "ru",
+                          "value": "Колонки"
+                        }
+                      }
+                    ]
+                  },
+                  "dataPath": "",
+                  "items": [
+                    [
+                      {
+                        "type": "COLUMN_GROUP",
+                        "id": 155,
+                        "name": "ЛеваяГруппа",
+                        "title": {
+                          "content": [
+                            {
+                              "default": {
+                                "tag": 2
+                              },
+                              "int": 1,
+                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                "langKey": "ru",
+                                "value": "Левая группа"
+                              }
+                            }
+                          ]
+                        },
+                        "dataPath": "",
+                        "items": [
+                          [
+                            {
+                              "type": "INPUT_FIELD",
+                              "id": 16,
+                              "name": "Наименование",
+                              "title": {
+                                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                              },
+                              "dataPath": "Список.Description",
+                              "items": []
+                            },
+                            {
+                              "type": "COLUMN_GROUP",
+                              "id": 153,
+                              "name": "ВажностьИАвтор",
+                              "title": {
+                                "content": [
+                                  {
+                                    "default": {
+                                      "tag": 2
+                                    },
+                                    "int": 1,
+                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                      "langKey": "ru",
+                                      "value": "Важность и автор"
+                                    }
+                                  }
+                                ]
+                              },
+                              "dataPath": "",
+                              "items": [
+                                [
+                                  {
+                                    "type": "PICTURE_FIELD",
+                                    "id": 24,
+                                    "name": "Важность",
+                                    "title": {
+                                      "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[2]/synonym"
+                                    },
+                                    "dataPath": "Список.ВажностьКартинка",
+                                    "items": []
+                                  },
+                                  {
+                                    "type": "INPUT_FIELD",
+                                    "id": 40,
+                                    "name": "Автор",
+                                    "title": {
+                                      "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                    },
+                                    "dataPath": "Список.Автор",
+                                    "items": []
+                                  }
+                                ],
+                                []
+                              ]
+                            }
+                          ],
+                          []
+                        ]
+                      },
+                      {
+                        "type": "COLUMN_GROUP",
+                        "id": 157,
+                        "name": "ПраваяГруппа",
+                        "title": {
+                          "content": [
+                            {
+                              "default": {
+                                "tag": 2
+                              },
+                              "int": 1,
+                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                "langKey": "ru",
+                                "value": "Правая группа"
+                              }
+                            }
+                          ]
+                        },
+                        "dataPath": "",
+                        "items": [
+                          [
+                            {
+                              "type": "LABEL_FIELD",
+                              "id": 65,
+                              "name": "Дата",
+                              "title": {
+                                "content": [
+                                  {
+                                    "default": {
+                                      "tag": 2
+                                    },
+                                    "int": 1,
+                                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                      "langKey": "ru",
+                                      "value": "Записана / Срок"
+                                    }
+                                  }
+                                ]
+                              },
+                              "dataPath": "Список.Date",
+                              "items": []
+                            },
+                            {
+                              "type": "INPUT_FIELD",
+                              "id": 36,
+                              "name": "СрокИсполнения",
+                              "title": {
+                                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                              },
+                              "dataPath": "Список.СрокИсполнения",
+                              "items": []
+                            }
+                          ],
+                          []
+                        ]
+                      },
+                      {
+                        "type": "COLUMN_GROUP",
+                        "id": 159,
+                        "name": "ГруппаПрочее",
+                        "title": {
+                          "content": [
+                            {
+                              "default": {
+                                "tag": 2
+                              },
+                              "int": 1,
+                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                "langKey": "ru",
+                                "value": "Прочее"
+                              }
+                            }
+                          ]
+                        },
+                        "dataPath": "",
+                        "items": [
+                          [
+                            {
+                              "type": "INPUT_FIELD",
+                              "id": 46,
+                              "name": "ДатаНачала",
+                              "title": {
+                                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[5]/synonym"
+                              },
+                              "dataPath": "Список.ДатаНачала",
+                              "items": []
+                            },
+                            {
+                              "type": "LABEL_FIELD",
+                              "id": 57,
+                              "name": "Номер",
+                              "title": {
+                                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                              },
+                              "dataPath": "Список.Number",
+                              "items": []
+                            }
+                          ],
+                          []
+                        ]
+                      },
+                      {
+                        "type": "LABEL_FIELD",
+                        "id": 137,
+                        "name": "Ссылка",
+                        "title": {
+                          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                        },
+                        "dataPath": "Список.Ref",
+                        "items": []
+                      }
+                    ],
+                    []
+                  ]
+                }
+              ]
+            }
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "Список",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 2,
+                "name": "ПоказыватьВыполненные",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              },
+              {
+                "id": 3,
+                "name": "РежимГруппировки",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[7]/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "23e3de37-9315-45e6-bbfd-60aae28c25ae",
+        "name": "ПеренаправитьЗадачи",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "Task.ЗадачаИсполнителя.Form.ПеренаправитьЗадачи",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.Форма.ПеренаправитьЗадачи"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Перенаправить задачи"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/Tasks/ЗадачаИсполнителя/Forms/ПеренаправитьЗадачи/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "content": [
+              {
+                "default": {
+                  "tag": 2
+                },
+                "int": 1,
+                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                  "langKey": "ru",
+                  "value": "Выбрать исполнителя"
+                }
+              }
+            ]
+          },
+          "handlers": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler"
+              },
+              {
+                "event": "FillCheckProcessingAtServer",
+                "name": "ОбработкаПроверкиЗаполненияНаСервере"
+              }
+            ],
+            []
+          ],
+          "items": [
+            [
+              {
+                "type": "LABEL",
+                "id": 5,
+                "name": "ДекорацияЗаголовок",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Выбранная задача"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": []
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 72,
+                "name": "Документ",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 11,
+                      "name": "ГруппаАдресация",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Адресация"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 12,
+                            "name": "ГруппаАдресацияИсполнитель",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Адресация исполнитель"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "RADIO_BUTTON_FIELD",
+                                  "id": 9,
+                                  "name": "ТипАдресацииИсполнитель",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Тип адресации"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "ТипАдресации",
+                                  "items": []
+                                },
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 1,
+                                  "name": "Исполнитель",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute[2]/synonym"
+                                  },
+                                  "dataPath": "Исполнитель",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          },
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 67,
+                            "name": "ГруппаАдресацияРоль",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Адресация роль"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "RADIO_BUTTON_FIELD",
+                                  "id": 69,
+                                  "name": "ТипАдресацииРоль",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                                  },
+                                  "dataPath": "ТипАдресации",
+                                  "items": []
+                                },
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 13,
+                                  "name": "Роль",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Роль"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "Роль",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "USUAL_GROUP",
+                      "id": 60,
+                      "name": "ГруппаОбъектыАдресации",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "LABEL",
+                            "id": 62,
+                            "name": "Отступ",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "USUAL_GROUP",
+                            "id": 65,
+                            "name": "ОбъектыАдресации",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "USUAL_GROUP",
+                                  "id": 33,
+                                  "name": "ГруппаОдинОбъектАдресации",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Один объект адресации"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 34,
+                                      "name": "ОдинОсновнойОбъектАдресации",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute[3]/synonym"
+                                      },
+                                      "dataPath": "ОсновнойОбъектАдресации",
+                                      "items": []
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "USUAL_GROUP",
+                                  "id": 36,
+                                  "name": "ГруппаДваОбъектаАдресации",
+                                  "title": {
+                                    "content": [
+                                      {
+                                        "default": {
+                                          "tag": 2
+                                        },
+                                        "int": 1,
+                                        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                          "langKey": "ru",
+                                          "value": "Два объекта адресации"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "dataPath": "",
+                                  "items": [
+                                    [
+                                      {
+                                        "type": "INPUT_FIELD",
+                                        "id": 37,
+                                        "name": "ОсновнойОбъектАдресации",
+                                        "title": {
+                                          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute[3]/synonym"
+                                        },
+                                        "dataPath": "ОсновнойОбъектАдресации",
+                                        "items": []
+                                      },
+                                      {
+                                        "type": "INPUT_FIELD",
+                                        "id": 39,
+                                        "name": "ДополнительныйОбъектАдресации",
+                                        "title": {
+                                          "content": [
+                                            {
+                                              "default": {
+                                                "tag": 2
+                                              },
+                                              "int": 1,
+                                              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                                "langKey": "ru",
+                                                "value": "Доп. объект адресации"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        "dataPath": "ДополнительныйОбъектАдресации",
+                                        "items": []
+                                      }
+                                    ],
+                                    []
+                                  ]
+                                }
+                              ],
+                              []
+                            ]
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 7,
+                      "name": "Комментарий",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Комментарий"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "Комментарий",
+                      "items": []
+                    },
+                    {
+                      "type": "CHECK_BOX_FIELD",
+                      "id": 41,
+                      "name": "ИгнорироватьПредупреждения",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Игнорировать предупреждения"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "ИгнорироватьПредупреждения",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "Исполнитель",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute[2]/synonym"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.CustomValueType": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute[2]/type/types/java.util.CollSer/com.github._1c_syntax.bsl.types.value.CustomValueType[2]"
+                      }
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 2,
+                "name": "Комментарий",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[7]/type"
+                }
+              },
+              {
+                "id": 3,
+                "name": "ТипАдресации",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                        "precision": 1,
+                        "scale": 0,
+                        "nonNegative": false,
+                        "description": {}
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 4,
+                "name": "Роль",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute[4]/type"
+                }
+              },
+              {
+                "id": 5,
+                "name": "ИспользуетсяБезОбъектовАдресации",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              },
+              {
+                "id": 6,
+                "name": "ИспользуетсяСОбъектамиАдресации",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              },
+              {
+                "id": 7,
+                "name": "ОсновнойОбъектАдресации",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute[3]/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/type"
+                }
+              },
+              {
+                "id": 8,
+                "name": "ТипыДополнительногоОбъектаАдресации",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.V8ValueType": "TYPE_DESCRIPTION"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": []
+                }
+              },
+              {
+                "id": 9,
+                "name": "ТипыОсновногоОбъектаАдресации",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[8]/type"
+                }
+              },
+              {
+                "id": 10,
+                "name": "ДополнительныйОбъектАдресации",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/type"
+                }
+              },
+              {
+                "id": 11,
+                "name": "ИгнорироватьПредупреждения",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/title"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "a9957f43-8b6f-4d98-a2d8-77b78047494c",
+        "name": "ФормаЗадачи",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "Task.ЗадачаИсполнителя.Form.ФормаЗадачи",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.Форма.ФормаЗадачи"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Форма выполнения задачи по умолчанию",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Форма задачи"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/Tasks/ЗадачаИсполнителя/Forms/ФормаЗадачи/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[7]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+          },
+          "handlers": [
+            [
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler"
+              }
+            ],
+            []
+          ],
+          "items": [
+            {
+              "type": "USUAL_GROUP",
+              "id": 170,
+              "name": "Документ",
+              "title": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+              },
+              "dataPath": "",
+              "items": [
+                [
+                  {
+                    "type": "USUAL_GROUP",
+                    "id": 93,
+                    "name": "ГруппаФормаВыполнения",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Форма выполнения"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "LABEL",
+                          "id": 94,
+                          "name": "ДекорацияТекст",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Выведены общие сведения о задаче.\nДля выполнения задачи необходимо перейти в специальную форму задачи."
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": []
+                        },
+                        {
+                          "type": "LABEL",
+                          "id": 97,
+                          "name": "ДекорацияОткрытьФормуЗадачи",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Перейти в форму для выполнения задачи"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": []
+                        }
+                      ],
+                      []
+                    ]
+                  },
+                  {
+                    "type": "USUAL_GROUP",
+                    "id": 99,
+                    "name": "ГруппаСостояние",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Состояние"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "",
+                    "items": []
+                  },
+                  {
+                    "type": "USUAL_GROUP",
+                    "id": 168,
+                    "name": "ГруппаЗадача",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[2]/synonym"
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 124,
+                          "name": "Шапка",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Шапка"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "USUAL_GROUP",
+                                "id": 83,
+                                "name": "ГруппаАвторИсполнитель",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Автор исполнитель"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 78,
+                                      "name": "Автор",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                      },
+                                      "dataPath": "Объект.Автор",
+                                      "items": []
+                                    },
+                                    {
+                                      "type": "LABEL_FIELD",
+                                      "id": 165,
+                                      "name": "АвторСтрокой",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/synonym"
+                                      },
+                                      "dataPath": "АвторСтрокой",
+                                      "items": []
+                                    },
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 20,
+                                      "name": "Исполнитель",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute[2]/synonym"
+                                      },
+                                      "dataPath": "Объект.Исполнитель",
+                                      "items": []
+                                    }
+                                  ],
+                                  []
+                                ]
+                              },
+                              {
+                                "type": "USUAL_GROUP",
+                                "id": 125,
+                                "name": "ГруппаДатаИСрок",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Дата и срок"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 113,
+                                      "name": "Дата",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                      },
+                                      "dataPath": "Объект.Date",
+                                      "items": []
+                                    },
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 12,
+                                      "name": "СрокИсполнения",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                      },
+                                      "dataPath": "Объект.СрокИсполнения",
+                                      "items": []
+                                    }
+                                  ],
+                                  []
+                                ]
+                              },
+                              {
+                                "type": "USUAL_GROUP",
+                                "id": 126,
+                                "name": "ГруппаНомерИВажность",
+                                "title": {
+                                  "content": [
+                                    {
+                                      "default": {
+                                        "tag": 2
+                                      },
+                                      "int": 1,
+                                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                        "langKey": "ru",
+                                        "value": "Номер и важность"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "dataPath": "",
+                                "items": [
+                                  [
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 115,
+                                      "name": "Номер",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                      },
+                                      "dataPath": "Объект.Number",
+                                      "items": []
+                                    },
+                                    {
+                                      "type": "INPUT_FIELD",
+                                      "id": 16,
+                                      "name": "Важность",
+                                      "title": {
+                                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                      },
+                                      "dataPath": "Объект.Важность",
+                                      "items": []
+                                    }
+                                  ],
+                                  []
+                                ]
+                              }
+                            ],
+                            []
+                          ]
+                        },
+                        {
+                          "type": "USUAL_GROUP",
+                          "id": 88,
+                          "name": "ГруппаПриоритет",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Приоритет"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "",
+                          "items": [
+                            [
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 85,
+                                "name": "СрокНачалаИсполнения",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                },
+                                "dataPath": "Объект.ДатаНачала",
+                                "items": []
+                              },
+                              {
+                                "type": "INPUT_FIELD",
+                                "id": 110,
+                                "name": "СрокНачалаИсполненияВремя",
+                                "title": {
+                                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                },
+                                "dataPath": "Объект.ДатаНачала",
+                                "items": []
+                              }
+                            ],
+                            []
+                          ]
+                        },
+                        {
+                          "type": "INPUT_FIELD",
+                          "id": 117,
+                          "name": "Наименование",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                          },
+                          "dataPath": "Объект.Description",
+                          "items": []
+                        }
+                      ],
+                      []
+                    ]
+                  },
+                  {
+                    "type": "USUAL_GROUP",
+                    "id": 77,
+                    "name": "ГруппаСодержание",
+                    "title": {
+                      "content": [
+                        {
+                          "default": {
+                            "tag": 2
+                          },
+                          "int": 1,
+                          "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                            "langKey": "ru",
+                            "value": "Содержание"
+                          }
+                        }
+                      ]
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "LABEL_FIELD",
+                          "id": 106,
+                          "name": "Предмет",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[8]/synonym"
+                          },
+                          "dataPath": "ПредметСтрокой",
+                          "items": []
+                        },
+                        {
+                          "type": "INPUT_FIELD",
+                          "id": 18,
+                          "name": "Описание",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                          },
+                          "dataPath": "Объект.Описание",
+                          "items": []
+                        }
+                      ],
+                      []
+                    ]
+                  },
+                  {
+                    "type": "USUAL_GROUP",
+                    "id": 27,
+                    "name": "ГруппаРезультат",
+                    "title": {
+                      "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[11]/synonym"
+                    },
+                    "dataPath": "",
+                    "items": [
+                      [
+                        {
+                          "type": "USUAL_BUTTON",
+                          "id": 87,
+                          "name": "Выполнена",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/synonym"
+                          },
+                          "dataPath": "",
+                          "items": []
+                        },
+                        {
+                          "type": "INPUT_FIELD",
+                          "id": 119,
+                          "name": "ДатаИсполнения",
+                          "title": {
+                            "content": [
+                              {
+                                "default": {
+                                  "tag": 2
+                                },
+                                "int": 1,
+                                "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                  "langKey": "ru",
+                                  "value": "Дата"
+                                }
+                              }
+                            ]
+                          },
+                          "dataPath": "Объект.ДатаИсполнения",
+                          "items": []
+                        },
+                        {
+                          "type": "INPUT_FIELD",
+                          "id": 121,
+                          "name": "ДатаИсполненияВремя",
+                          "title": {
+                            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                          },
+                          "dataPath": "Объект.ДатаИсполнения",
+                          "items": []
+                        }
+                      ],
+                      []
+                    ]
+                  }
+                ],
+                []
+              ]
+            }
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "Объект",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/attributes/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 2,
+                "name": "НачальныйПризнакВыполнения",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute/type"
+                }
+              },
+              {
+                "id": 5,
+                "name": "ПредметСтрокой",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[8]/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[7]/type"
+                }
+              },
+              {
+                "id": 6,
+                "name": "АвторСтрокой",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[7]/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "e470e15d-1b06-43cb-a9f9-ba489e2f596f",
+        "name": "ФормаСписка",
+        "mdoReference": {
+          "type": "FORM",
+          "mdoRef": "Task.ЗадачаИсполнителя.Form.ФормаСписка",
+          "mdoRefRu": "Задача.ЗадачаИсполнителя.Форма.ФормаСписка"
+        },
+        "objectBelonging": "OWN",
+        "comment": "",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Форма списка"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "modules": [
+          {
+            "moduleType": "FormModule",
+            "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/Tasks/ЗадачаИсполнителя/Forms/ФормаСписка/Module.bsl",
+            "owner": {
+              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[8]/mdoReference"
+            },
+            "supportVariant": "NOT_EDITABLE",
+            "isProtected": false
+          }
+        ],
+        "formType": "MANAGED",
+        "data": {
+          "@class": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+          "title": {
+            "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+          },
+          "handlers": [
+            [
+              {
+                "event": "OnSaveDataInSettingsAtServer",
+                "name": "ПриСохраненииДанныхВНастройкахНаСервере"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler"
+              },
+              {
+                "event": "OnOpen",
+                "name": "ПриОткрытии"
+              },
+              {
+                "event": "NavigationProcessing",
+                "name": "ОбработкаПерехода"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/handlers/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler"
+              },
+              {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/handlers/c/com.github._1c_syntax.bsl.mdo.storage.form.FormHandler[3]"
+              }
+            ],
+            []
+          ],
+          "items": [
+            [
+              {
+                "type": "USUAL_GROUP",
+                "id": 54,
+                "name": "ГруппаЗаголовок",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Заголовок"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 55,
+                      "name": "СтрокаБизнесПроцесса",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                      },
+                      "dataPath": "СтрокаБизнесПроцесса",
+                      "items": []
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 57,
+                      "name": "СтрокаЗадачи",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                      },
+                      "dataPath": "СтрокаЗадачи",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 43,
+                "name": "ГруппаОтбор",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Отбор"
+                      }
+                    }
+                  ]
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 49,
+                      "name": "ПоказыватьЗадачи",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Показывать"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "ПоказыватьЗадачи",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 18,
+                      "name": "ПоАвтору",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/synonym"
+                      },
+                      "dataPath": "ПоАвтору",
+                      "items": []
+                    },
+                    {
+                      "type": "INPUT_FIELD",
+                      "id": 20,
+                      "name": "ПоИсполнителю",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute[2]/synonym"
+                      },
+                      "dataPath": "ПоИсполнителю",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "USUAL_GROUP",
+                "id": 141,
+                "name": "ГруппаПользовательскихНастроек",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "dataPath": "",
+                "items": []
+              },
+              {
+                "type": "COMMAND_BAR",
+                "id": 47,
+                "name": "ОсновнаяКоманднаяПанель",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                },
+                "dataPath": "",
+                "items": [
+                  [
+                    {
+                      "type": "BUTTON",
+                      "id": 155,
+                      "name": "Изменить",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "BUTTON",
+                      "id": 147,
+                      "name": "ОткрытьБизнесПроцесс",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "BUTTON",
+                      "id": 149,
+                      "name": "ОткрытьПредметЗадачи",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "FORM_GROUP",
+                      "id": 159,
+                      "name": "ГруппаПоиск",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Поиск"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "BUTTON",
+                            "id": 151,
+                            "name": "Найти",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "BUTTON",
+                            "id": 153,
+                            "name": "ОтменитьПоиск",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "FORM_GROUP",
+                      "id": 45,
+                      "name": "КоманднаяПанельСписка",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "FORM_GROUP",
+                      "id": 157,
+                      "name": "ГруппаПринятьКИсполнению",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "BUTTON",
+                            "id": 61,
+                            "name": "ПринятьКИсполнению",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "BUTTON",
+                            "id": 62,
+                            "name": "ОтменитьПринятиеКИсполнению",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[7]/title"
+                            },
+                            "dataPath": "",
+                            "items": []
+                          },
+                          {
+                            "type": "BUTTON",
+                            "id": 76,
+                            "name": "ЗадачаЗадачаИсполнителяВыполнено",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                            },
+                            "dataPath": "Items.Список.CurrentData.Ref",
+                            "items": []
+                          },
+                          {
+                            "type": "BUTTON",
+                            "id": 77,
+                            "name": "ЗадачаЗадачаИсполнителяПеренаправить",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                            },
+                            "dataPath": "Items.Список.CurrentData.Ref",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "FORM_GROUP",
+                      "id": 46,
+                      "name": "КоманднаяПанельФормы",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[4]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[8]/title"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    },
+                    {
+                      "type": "BUTTON",
+                      "id": 139,
+                      "name": "Справка",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              },
+              {
+                "type": "TABLE",
+                "id": 1,
+                "name": "Список",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                },
+                "dataPath": "Список",
+                "items": [
+                  [
+                    {
+                      "type": "COLUMN_GROUP",
+                      "id": 161,
+                      "name": "ГруппаВажность",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute[2]/synonym"
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "PICTURE_FIELD",
+                            "id": 81,
+                            "name": "ВажностьКартинка",
+                            "title": {
+                              "content": [
+                                {
+                                  "default": {
+                                    "tag": 2
+                                  },
+                                  "int": 1,
+                                  "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                                    "langKey": "ru",
+                                    "value": "Важность (признак)"
+                                  }
+                                }
+                              ]
+                            },
+                            "dataPath": "Список.ВажностьКартинка",
+                            "items": []
+                          },
+                          {
+                            "type": "PICTURE_FIELD",
+                            "id": 59,
+                            "name": "Остановлена",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                            },
+                            "dataPath": "Список.Остановлена",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "COLUMN_GROUP",
+                      "id": 85,
+                      "name": "ГруппаОписание",
+                      "title": {
+                        "content": [
+                          {
+                            "default": {
+                              "tag": 2
+                            },
+                            "int": 1,
+                            "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                              "langKey": "ru",
+                              "value": "Описание задачи"
+                            }
+                          }
+                        ]
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "COLUMN_GROUP",
+                            "id": 165,
+                            "name": "ГруппаНаименование",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/title"
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 6,
+                                  "name": "Наименование",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                  },
+                                  "dataPath": "Список.Description",
+                                  "items": []
+                                },
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 22,
+                                  "name": "Автор",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                  },
+                                  "dataPath": "Список.Автор",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          },
+                          {
+                            "type": "LABEL_FIELD",
+                            "id": 51,
+                            "name": "Предмет",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                            },
+                            "dataPath": "Список.ПредметСтрокой",
+                            "items": []
+                          },
+                          {
+                            "type": "COLUMN_GROUP",
+                            "id": 163,
+                            "name": "ГруппаАвтор",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/synonym"
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 8,
+                                  "name": "Дата",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[7]/synonym"
+                                  },
+                                  "dataPath": "Список.Date",
+                                  "items": []
+                                },
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 4,
+                                  "name": "Номер",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                  },
+                                  "dataPath": "Список.Number",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          },
+                          {
+                            "type": "INPUT_FIELD",
+                            "id": 83,
+                            "name": "Описание",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                            },
+                            "dataPath": "Список.Описание",
+                            "items": []
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "COLUMN_GROUP",
+                      "id": 167,
+                      "name": "ГруппаИсполнение",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[3]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[3]/title"
+                      },
+                      "dataPath": "",
+                      "items": [
+                        [
+                          {
+                            "type": "COLUMN_GROUP",
+                            "id": 80,
+                            "name": "ГруппаИсполнитель",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute[2]/synonym"
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 24,
+                                  "name": "Исполнитель",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                  },
+                                  "dataPath": "Список.Исполнитель",
+                                  "items": []
+                                },
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 34,
+                                  "name": "РольИсполнителя",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                  },
+                                  "dataPath": "Список.РольИсполнителя",
+                                  "items": []
+                                },
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 40,
+                                  "name": "ОсновнойОбъектАдресации",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                  },
+                                  "dataPath": "Список.ОсновнойОбъектАдресации",
+                                  "items": []
+                                },
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 38,
+                                  "name": "ДополнительныйОбъектАдресации",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                  },
+                                  "dataPath": "Список.ДополнительныйОбъектАдресации",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          },
+                          {
+                            "type": "COLUMN_GROUP",
+                            "id": 169,
+                            "name": "ГруппаСрокИсполнения",
+                            "title": {
+                              "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[4]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[6]/title"
+                            },
+                            "dataPath": "",
+                            "items": [
+                              [
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 30,
+                                  "name": "СрокИсполнения",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                  },
+                                  "dataPath": "Список.СрокИсполнения",
+                                  "items": []
+                                },
+                                {
+                                  "type": "CHECK_BOX_FIELD",
+                                  "id": 10,
+                                  "name": "Выполнена",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                  },
+                                  "dataPath": "Список.Executed",
+                                  "items": []
+                                },
+                                {
+                                  "type": "INPUT_FIELD",
+                                  "id": 32,
+                                  "name": "ДатаИсполнения",
+                                  "title": {
+                                    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                                  },
+                                  "dataPath": "Список.ДатаИсполнения",
+                                  "items": []
+                                }
+                              ],
+                              []
+                            ]
+                          }
+                        ],
+                        []
+                      ]
+                    },
+                    {
+                      "type": "LABEL_FIELD",
+                      "id": 134,
+                      "name": "Ссылка",
+                      "title": {
+                        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                      },
+                      "dataPath": "Список.Ref",
+                      "items": []
+                    }
+                  ],
+                  []
+                ]
+              }
+            ],
+            []
+          ],
+          "attributes": [
+            [
+              {
+                "id": 1,
+                "name": "Список",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/format"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[2]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 2,
+                "name": "ПоАвтору",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 3,
+                "name": "ПоИсполнителю",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute[2]/synonym"
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[6]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute/type"
+                }
+              },
+              {
+                "id": 4,
+                "name": "ПоказыватьЗадачи",
+                "title": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[8]/data/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem[2]/items/c/com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem/title"
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "NUMBER"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.qualifiers.NumberQualifiers": {
+                        "precision": 1,
+                        "scale": 0,
+                        "nonNegative": true,
+                        "description": {}
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 5,
+                "name": "СтрокаБизнесПроцесса",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Строка бизнес процесса"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "types": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.value.PrimitiveValueType": "STRING"
+                    }
+                  ],
+                  "composite": false,
+                  "qualifiers": [
+                    {
+                      "default": {
+                        "tag": 4
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.qualifiers.StringQualifiers": {
+                        "length": 100,
+                        "allowedLength": 0,
+                        "description": {}
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": 6,
+                "name": "СтрокаЗадачи",
+                "title": {
+                  "content": [
+                    {
+                      "default": {
+                        "tag": 2
+                      },
+                      "int": 1,
+                      "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                        "langKey": "ru",
+                        "value": "Строка задачи"
+                      }
+                    }
+                  ]
+                },
+                "type": {
+                  "@reference": "/com.github._1c_syntax.bsl.mdo.Task/forms/c/com.github._1c_syntax.bsl.mdo.children.ObjectForm[8]/data/attributes/c/com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute[5]/type"
+                }
+              }
+            ],
+            []
+          ]
+        },
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+        },
+        "usePurposes": [
+          [
+            "PLATFORM_APPLICATION",
+            "MOBILE_PLATFORM_APPLICATION"
+          ],
+          []
+        ]
+      }
+    ],
+    []
+  ],
+  "mdoReference": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+  },
+  "mdoType": "TASK",
+  "moduleTypes": [
+    [
+      "ManagerModule",
+      [
+        "src/test/resources/ext/edt/ssl_3_2/configuration/src/Tasks/ЗадачаИсполнителя/ManagerModule.bsl"
+      ]
+    ],
+    [
+      "ObjectModule",
+      [
+        "src/test/resources/ext/edt/ssl_3_2/configuration/src/Tasks/ЗадачаИсполнителя/ObjectModule.bsl"
+      ]
+    ]
+  ],
+  "modules": [
+    {
+      "moduleType": "ManagerModule",
+      "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/Tasks/ЗадачаИсполнителя/ManagerModule.bsl",
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "isProtected": false
+    },
+    {
+      "moduleType": "ObjectModule",
+      "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/Tasks/ЗадачаИсполнителя/ObjectModule.bsl",
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.Task/addressingAttributes/c/com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute/owner"
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "isProtected": false
+    }
+  ],
+  "name": "ЗадачаИсполнителя",
+  "objectBelonging": "OWN",
+  "possibleRights": [
+    {
+      "default": {
+        "tag": 4
+      },
+      "int": 24,
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INSERT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "DELETE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "VIEW",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "EDIT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INPUT_BY_STRING",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_DELETE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_INSERT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_SET_DELETION_MARK",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_CLEAR_DELETION_MARK",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_DELETE_MARKED",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_ACTIVATE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "EXECUTE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "INTERACTIVE_EXECUTE",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "VIEW_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "READ_DATA_HISTORY_OF_MISSING_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_OF_MISSING_DATA",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_SETTINGS",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "UPDATE_DATA_HISTORY_VERSION_COMMENT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "EDIT_DATA_HISTORY_VERSION_COMMENT",
+      "com.github._1c_syntax.bsl.mdo.support.RoleRight": "SWITCH_TO_DATA_HISTORY_VERSION"
+    }
+  ],
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "@reference": "/com.github._1c_syntax.bsl.mdo.Task/attributes/c/com.github._1c_syntax.bsl.mdo.children.StandardAttribute[2]/synonym"
+  },
+  "tabularSections": [],
+  "templates": [],
+  "uuid": "3ad08f4a-6202-4099-b6cc-bc116e6731a0"
+}}

--- a/src/test/resources/fixtures/ssl_3_2/WebServices.EnterpriseDataExchange_1_0_1_1.json
+++ b/src/test/resources/fixtures/ssl_3_2/WebServices.EnterpriseDataExchange_1_0_1_1.json
@@ -1,0 +1,1033 @@
+{"com.github._1c_syntax.bsl.mdo.WebService": {
+  "comment": "",
+  "description": "Enterprise Data Exchange 1.0.1.1",
+  "descriptorFileName": "EnterpriseDataExchange_1_0_1_1.1cws",
+  "mdoReference": {
+    "type": "WEB_SERVICE",
+    "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1",
+    "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1"
+  },
+  "mdoType": "WEB_SERVICE",
+  "moduleTypes": [
+    [
+      "WEBServiceModule",
+      [
+        "src/test/resources/ext/designer/ssl_3_2/src/cf/WebServices/EnterpriseDataExchange_1_0_1_1/Ext/Module.bsl"
+      ]
+    ]
+  ],
+  "modules": [
+    {
+      "moduleType": "WEBServiceModule",
+      "uri": "src/test/resources/ext/designer/ssl_3_2/src/cf/WebServices/EnterpriseDataExchange_1_0_1_1/Ext/Module.bsl",
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/mdoReference"
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "isProtected": false
+    }
+  ],
+  "name": "EnterpriseDataExchange_1_0_1_1",
+  "namespace": "http://www.1c.ru/SSL/EnterpriseDataExchange_1_0_1_1",
+  "objectBelonging": "OWN",
+  "operations": [
+    [
+      {
+        "uuid": "e6fe7103-4dfa-4302-a58e-ccd7fac19c9d",
+        "name": "Ping",
+        "mdoReference": {
+          "type": "WS_OPERATION",
+          "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.Ping",
+          "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.Ping"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Проверка соединения с информационной базой",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Ping"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/mdoReference"
+        },
+        "procedureName": "Ping",
+        "nillable": true,
+        "transactioned": false,
+        "dataLockControlMode": "MANAGED",
+        "parameters": []
+      },
+      {
+        "uuid": "bb3a9973-67ce-479e-8668-c2f3bb20301e",
+        "name": "TestConnection",
+        "mdoReference": {
+          "type": "WS_OPERATION",
+          "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.TestConnection",
+          "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.TestConnection"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Проверка подключения к информационной базе",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Test connection"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/mdoReference"
+        },
+        "procedureName": "ПроверкаПодключения",
+        "nillable": false,
+        "transactioned": false,
+        "dataLockControlMode": "MANAGED",
+        "parameters": [
+          [
+            {
+              "uuid": "e5250dfe-dda2-4547-9b9e-2470ea1be1ab",
+              "name": "ExchangePlanName",
+              "mdoReference": {
+                "type": "WS_OPERATION_PARAMETER",
+                "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.TestConnection.Parameter.ExchangePlanName",
+                "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.TestConnection.Параметр.ExchangePlanName"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "content": [
+                  {
+                    "default": {
+                      "tag": 2
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                      "langKey": "ru",
+                      "value": "Exchange plan name"
+                    }
+                  }
+                ]
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[2]/mdoReference"
+              },
+              "nillable": false,
+              "transferDirection": "IN"
+            },
+            {
+              "uuid": "2c3fccc6-c4c0-49ec-bfc2-05ce05f27ea9",
+              "name": "PeerCode",
+              "mdoReference": {
+                "type": "WS_OPERATION_PARAMETER",
+                "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.TestConnection.Parameter.PeerCode",
+                "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.TestConnection.Параметр.PeerCode"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "content": [
+                  {
+                    "default": {
+                      "tag": 2
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                      "langKey": "ru",
+                      "value": "Peer code"
+                    }
+                  }
+                ]
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[2]/mdoReference"
+              },
+              "nillable": false,
+              "transferDirection": "IN"
+            },
+            {
+              "uuid": "37169451-1464-4f24-8ca6-802963ffb636",
+              "name": "ErrorMessage",
+              "mdoReference": {
+                "type": "WS_OPERATION_PARAMETER",
+                "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.TestConnection.Parameter.ErrorMessage",
+                "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.TestConnection.Параметр.ErrorMessage"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "content": [
+                  {
+                    "default": {
+                      "tag": 2
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                      "langKey": "ru",
+                      "value": "Error message"
+                    }
+                  }
+                ]
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[2]/mdoReference"
+              },
+              "nillable": true,
+              "transferDirection": "OUT"
+            }
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "c3a958b1-590f-4418-a74f-5982b478cf52",
+        "name": "PrepareDataForGetting",
+        "mdoReference": {
+          "type": "WS_OPERATION",
+          "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.PrepareDataForGetting",
+          "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.PrepareDataForGetting"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Выгрузить данные из информационной базы, согласно настроек узла плана обмена и подготовить их для отправки",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Prepare data for getting"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/mdoReference"
+        },
+        "procedureName": "ПодготовитьДанныеКПолучению",
+        "nillable": true,
+        "transactioned": false,
+        "dataLockControlMode": "MANAGED",
+        "parameters": [
+          [
+            {
+              "uuid": "ef0e618d-0942-460a-ac65-9aca2fed976e",
+              "name": "ExchangePlanName",
+              "mdoReference": {
+                "type": "WS_OPERATION_PARAMETER",
+                "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.PrepareDataForGetting.Parameter.ExchangePlanName",
+                "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.PrepareDataForGetting.Параметр.ExchangePlanName"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[2]/parameters/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperationParameter/synonym"
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[3]/mdoReference"
+              },
+              "nillable": false,
+              "transferDirection": "IN"
+            },
+            {
+              "uuid": "fd1ed7ec-d848-41cd-8ce3-2e5a682abcf0",
+              "name": "PeerCode",
+              "mdoReference": {
+                "type": "WS_OPERATION_PARAMETER",
+                "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.PrepareDataForGetting.Parameter.PeerCode",
+                "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.PrepareDataForGetting.Параметр.PeerCode"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[2]/parameters/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperationParameter[2]/synonym"
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[3]/mdoReference"
+              },
+              "nillable": false,
+              "transferDirection": "IN"
+            },
+            {
+              "uuid": "2ac8bd69-9fbf-4f15-b58d-397d9e903532",
+              "name": "PartSize",
+              "mdoReference": {
+                "type": "WS_OPERATION_PARAMETER",
+                "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.PrepareDataForGetting.Parameter.PartSize",
+                "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.PrepareDataForGetting.Параметр.PartSize"
+              },
+              "objectBelonging": "OWN",
+              "comment": "В КБ, 0 не разделять",
+              "synonym": {
+                "content": [
+                  {
+                    "default": {
+                      "tag": 2
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                      "langKey": "ru",
+                      "value": "Part size"
+                    }
+                  }
+                ]
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[3]/mdoReference"
+              },
+              "nillable": false,
+              "transferDirection": "IN"
+            },
+            {
+              "uuid": "2ff35814-7eaa-4ae5-bbac-f46bebb36c9d",
+              "name": "OperationID",
+              "mdoReference": {
+                "type": "WS_OPERATION_PARAMETER",
+                "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.PrepareDataForGetting.Parameter.OperationID",
+                "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.PrepareDataForGetting.Параметр.OperationID"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "content": [
+                  {
+                    "default": {
+                      "tag": 2
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                      "langKey": "ru",
+                      "value": "Operation ID"
+                    }
+                  }
+                ]
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[3]/mdoReference"
+              },
+              "nillable": true,
+              "transferDirection": "OUT"
+            },
+            {
+              "uuid": "5b460b92-2c74-4f59-88b2-18d9aac42c04",
+              "name": "ErrorMessage",
+              "mdoReference": {
+                "type": "WS_OPERATION_PARAMETER",
+                "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.PrepareDataForGetting.Parameter.ErrorMessage",
+                "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.PrepareDataForGetting.Параметр.ErrorMessage"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[2]/parameters/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperationParameter[3]/synonym"
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[3]/mdoReference"
+              },
+              "nillable": true,
+              "transferDirection": "OUT"
+            }
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "db05d35b-5f53-4c27-ba80-b477b9a98299",
+        "name": "PrepareDataActionResult",
+        "mdoReference": {
+          "type": "WS_OPERATION",
+          "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.PrepareDataActionResult",
+          "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.PrepareDataActionResult"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Получить результат выполнения операции подготовки данных для выгрузки из информационной базы",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Prepare data action result"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/mdoReference"
+        },
+        "procedureName": "ПолучитьРезультатПодготовкиДанныхКВыгрузке",
+        "nillable": false,
+        "transactioned": false,
+        "dataLockControlMode": "MANAGED",
+        "parameters": [
+          [
+            {
+              "uuid": "fa872ae1-b699-46fe-9d6a-e42e1388752b",
+              "name": "OperationID",
+              "mdoReference": {
+                "type": "WS_OPERATION_PARAMETER",
+                "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.PrepareDataActionResult.Parameter.OperationID",
+                "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.PrepareDataActionResult.Параметр.OperationID"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[3]/parameters/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperationParameter[4]/synonym"
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[4]/mdoReference"
+              },
+              "nillable": false,
+              "transferDirection": "IN"
+            },
+            {
+              "uuid": "1acf34e6-c428-4130-82f0-5160dfcc0858",
+              "name": "ErrorMessage",
+              "mdoReference": {
+                "type": "WS_OPERATION_PARAMETER",
+                "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.PrepareDataActionResult.Parameter.ErrorMessage",
+                "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.PrepareDataActionResult.Параметр.ErrorMessage"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[2]/parameters/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperationParameter[3]/synonym"
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[4]/mdoReference"
+              },
+              "nillable": true,
+              "transferDirection": "OUT"
+            }
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "57046262-b9ce-4670-9cf5-6db9e58dd0d5",
+        "name": "GetDataPart",
+        "mdoReference": {
+          "type": "WS_OPERATION",
+          "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.GetDataPart",
+          "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.GetDataPart"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Получить часть сформированного файла с данными, из временного хранилища",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Get data part"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/mdoReference"
+        },
+        "procedureName": "ВыгрузитьЧастьФайла",
+        "nillable": true,
+        "transactioned": false,
+        "dataLockControlMode": "MANAGED",
+        "parameters": [
+          [
+            {
+              "uuid": "a9824176-36d5-4be5-9984-f4312ff48515",
+              "name": "FileID",
+              "mdoReference": {
+                "type": "WS_OPERATION_PARAMETER",
+                "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.GetDataPart.Parameter.FileID",
+                "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.GetDataPart.Параметр.FileID"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "content": [
+                  {
+                    "default": {
+                      "tag": 2
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                      "langKey": "ru",
+                      "value": "File ID"
+                    }
+                  }
+                ]
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[5]/mdoReference"
+              },
+              "nillable": false,
+              "transferDirection": "IN"
+            },
+            {
+              "uuid": "8e980ca0-1627-45e8-bd27-5dd1ac199459",
+              "name": "PartNumber",
+              "mdoReference": {
+                "type": "WS_OPERATION_PARAMETER",
+                "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.GetDataPart.Parameter.PartNumber",
+                "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.GetDataPart.Параметр.PartNumber"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "content": [
+                  {
+                    "default": {
+                      "tag": 2
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                      "langKey": "ru",
+                      "value": "Part number"
+                    }
+                  }
+                ]
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[5]/mdoReference"
+              },
+              "nillable": false,
+              "transferDirection": "IN"
+            },
+            {
+              "uuid": "8b653beb-af9f-4f39-b691-ae14f80b7cd6",
+              "name": "ErrorMessage",
+              "mdoReference": {
+                "type": "WS_OPERATION_PARAMETER",
+                "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.GetDataPart.Parameter.ErrorMessage",
+                "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.GetDataPart.Параметр.ErrorMessage"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[2]/parameters/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperationParameter[3]/synonym"
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[5]/mdoReference"
+              },
+              "nillable": true,
+              "transferDirection": "OUT"
+            }
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "77559c11-713f-454d-aff4-56649e1350e9",
+        "name": "ConfirmGettingFile",
+        "mdoReference": {
+          "type": "WS_OPERATION",
+          "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.ConfirmGettingFile",
+          "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.ConfirmGettingFile"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Подтвердить получение файла",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Confirm getting file"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/mdoReference"
+        },
+        "procedureName": "ПодтвердитьПолучениеДанных",
+        "nillable": true,
+        "transactioned": false,
+        "dataLockControlMode": "MANAGED",
+        "parameters": [
+          [
+            {
+              "uuid": "0c965703-c1d0-48b7-80f9-b8d869ff98f5",
+              "name": "FileID",
+              "mdoReference": {
+                "type": "WS_OPERATION_PARAMETER",
+                "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.ConfirmGettingFile.Parameter.FileID",
+                "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.ConfirmGettingFile.Параметр.FileID"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[5]/parameters/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperationParameter/synonym"
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[6]/mdoReference"
+              },
+              "nillable": false,
+              "transferDirection": "IN"
+            },
+            {
+              "uuid": "51f8d5ff-aec5-4c0a-ad02-df8c6cb1b4ad",
+              "name": "ClearDataPool",
+              "mdoReference": {
+                "type": "WS_OPERATION_PARAMETER",
+                "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.ConfirmGettingFile.Parameter.ClearDataPool",
+                "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.ConfirmGettingFile.Параметр.ClearDataPool"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "content": [
+                  {
+                    "default": {
+                      "tag": 2
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                      "langKey": "ru",
+                      "value": "Clear data pool"
+                    }
+                  }
+                ]
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[6]/mdoReference"
+              },
+              "nillable": false,
+              "transferDirection": "IN"
+            },
+            {
+              "uuid": "7ba42162-557b-4e34-8aca-0cdee8cb2452",
+              "name": "ErrorMessage",
+              "mdoReference": {
+                "type": "WS_OPERATION_PARAMETER",
+                "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.ConfirmGettingFile.Parameter.ErrorMessage",
+                "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.ConfirmGettingFile.Параметр.ErrorMessage"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[2]/parameters/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperationParameter[3]/synonym"
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[6]/mdoReference"
+              },
+              "nillable": true,
+              "transferDirection": "OUT"
+            }
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "eee99b8e-29b6-4b7a-81f1-3d91d740c0d7",
+        "name": "PutFilePart",
+        "mdoReference": {
+          "type": "WS_OPERATION",
+          "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.PutFilePart",
+          "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.PutFilePart"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Поместить часть файла с данными во временное хранилище",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Put file part"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/mdoReference"
+        },
+        "procedureName": "ЗагрузитьЧастьФайла",
+        "nillable": true,
+        "transactioned": false,
+        "dataLockControlMode": "MANAGED",
+        "parameters": [
+          [
+            {
+              "uuid": "ad4f2d1f-1e6f-4f6a-8061-202c0e42a8e4",
+              "name": "FileID",
+              "mdoReference": {
+                "type": "WS_OPERATION_PARAMETER",
+                "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.PutFilePart.Parameter.FileID",
+                "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.PutFilePart.Параметр.FileID"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[5]/parameters/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperationParameter/synonym"
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[7]/mdoReference"
+              },
+              "nillable": false,
+              "transferDirection": "IN"
+            },
+            {
+              "uuid": "dd577924-c6cb-4aa9-9db5-366d8958d00f",
+              "name": "PartNumber",
+              "mdoReference": {
+                "type": "WS_OPERATION_PARAMETER",
+                "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.PutFilePart.Parameter.PartNumber",
+                "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.PutFilePart.Параметр.PartNumber"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[5]/parameters/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperationParameter[2]/synonym"
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[7]/mdoReference"
+              },
+              "nillable": true,
+              "transferDirection": "IN"
+            },
+            {
+              "uuid": "8ed8f72e-404a-4be4-a44d-ddebbad5f411",
+              "name": "PartData",
+              "mdoReference": {
+                "type": "WS_OPERATION_PARAMETER",
+                "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.PutFilePart.Parameter.PartData",
+                "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.PutFilePart.Параметр.PartData"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "content": [
+                  {
+                    "default": {
+                      "tag": 2
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                      "langKey": "ru",
+                      "value": "Part data"
+                    }
+                  }
+                ]
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[7]/mdoReference"
+              },
+              "nillable": false,
+              "transferDirection": "IN"
+            },
+            {
+              "uuid": "e919bc4c-86e6-44f6-be27-5a729b63d042",
+              "name": "ErrorMessage",
+              "mdoReference": {
+                "type": "WS_OPERATION_PARAMETER",
+                "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.PutFilePart.Parameter.ErrorMessage",
+                "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.PutFilePart.Параметр.ErrorMessage"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[2]/parameters/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperationParameter[3]/synonym"
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[7]/mdoReference"
+              },
+              "nillable": true,
+              "transferDirection": "OUT"
+            }
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "ec580e4f-1518-4923-a10e-bc1da8688b37",
+        "name": "PutData",
+        "mdoReference": {
+          "type": "WS_OPERATION",
+          "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.PutData",
+          "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.PutData"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Поместить данные в информационную базу",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Put data"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/mdoReference"
+        },
+        "procedureName": "ЗагрузитьДанныеВИнформационнуюБазу",
+        "nillable": true,
+        "transactioned": false,
+        "dataLockControlMode": "MANAGED",
+        "parameters": [
+          [
+            {
+              "uuid": "91c3902a-314f-4d40-8bcc-8dd131fed2f4",
+              "name": "ExchangePlanName",
+              "mdoReference": {
+                "type": "WS_OPERATION_PARAMETER",
+                "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.PutData.Parameter.ExchangePlanName",
+                "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.PutData.Параметр.ExchangePlanName"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[2]/parameters/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperationParameter/synonym"
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[8]/mdoReference"
+              },
+              "nillable": false,
+              "transferDirection": "IN"
+            },
+            {
+              "uuid": "ae2b21c5-9349-49e8-9627-26f05c21f43a",
+              "name": "PeerCode",
+              "mdoReference": {
+                "type": "WS_OPERATION_PARAMETER",
+                "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.PutData.Parameter.PeerCode",
+                "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.PutData.Параметр.PeerCode"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[2]/parameters/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperationParameter[2]/synonym"
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[8]/mdoReference"
+              },
+              "nillable": false,
+              "transferDirection": "IN"
+            },
+            {
+              "uuid": "7e4c0b74-e807-4aa9-ad69-3c85b147bb61",
+              "name": "FileID",
+              "mdoReference": {
+                "type": "WS_OPERATION_PARAMETER",
+                "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.PutData.Parameter.FileID",
+                "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.PutData.Параметр.FileID"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[5]/parameters/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperationParameter/synonym"
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[8]/mdoReference"
+              },
+              "nillable": false,
+              "transferDirection": "IN"
+            },
+            {
+              "uuid": "917a19d7-73db-4247-b892-397598d67879",
+              "name": "OperationID",
+              "mdoReference": {
+                "type": "WS_OPERATION_PARAMETER",
+                "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.PutData.Parameter.OperationID",
+                "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.PutData.Параметр.OperationID"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[3]/parameters/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperationParameter[4]/synonym"
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[8]/mdoReference"
+              },
+              "nillable": true,
+              "transferDirection": "OUT"
+            },
+            {
+              "uuid": "1f866dc3-a4bc-4e8d-96a3-a26ee073926f",
+              "name": "ErrorMessage",
+              "mdoReference": {
+                "type": "WS_OPERATION_PARAMETER",
+                "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.PutData.Parameter.ErrorMessage",
+                "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.PutData.Параметр.ErrorMessage"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[2]/parameters/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperationParameter[3]/synonym"
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[8]/mdoReference"
+              },
+              "nillable": true,
+              "transferDirection": "OUT"
+            }
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "d8066600-c669-449d-a187-fdd3af8f7afa",
+        "name": "PutDataActionResult",
+        "mdoReference": {
+          "type": "WS_OPERATION",
+          "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.PutDataActionResult",
+          "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.PutDataActionResult"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Получить результат выполнения операции помещения данных в информационную базу",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Put data action result"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/mdoReference"
+        },
+        "procedureName": "ПолучитьРезультатЗагрузкиДанных",
+        "nillable": false,
+        "transactioned": false,
+        "dataLockControlMode": "MANAGED",
+        "parameters": [
+          [
+            {
+              "uuid": "dadf86a6-c118-4827-b1b9-6cfee731242f",
+              "name": "OperationID",
+              "mdoReference": {
+                "type": "WS_OPERATION_PARAMETER",
+                "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.PutDataActionResult.Parameter.OperationID",
+                "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.PutDataActionResult.Параметр.OperationID"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[3]/parameters/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperationParameter[4]/synonym"
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[9]/mdoReference"
+              },
+              "nillable": false,
+              "transferDirection": "IN"
+            },
+            {
+              "uuid": "45bf7b20-f048-491a-a989-e50bea13d028",
+              "name": "ErrorMessage",
+              "mdoReference": {
+                "type": "WS_OPERATION_PARAMETER",
+                "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.PutDataActionResult.Parameter.ErrorMessage",
+                "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.PutDataActionResult.Параметр.ErrorMessage"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[2]/parameters/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperationParameter[3]/synonym"
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[9]/mdoReference"
+              },
+              "nillable": true,
+              "transferDirection": "OUT"
+            }
+          ],
+          []
+        ]
+      }
+    ],
+    []
+  ],
+  "reuseSessions": "DONT_USE",
+  "sessionMaxAge": 20,
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "content": [
+      {
+        "default": {
+          "tag": 2
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+          "langKey": "ru",
+          "value": "Enterprise Data Exchange 1.0.1.1"
+        }
+      }
+    ]
+  },
+  "uuid": "cb3a5c5b-7bdc-4e12-96f1-11b1213b6853"
+}}

--- a/src/test/resources/fixtures/ssl_3_2/WebServices.EnterpriseDataExchange_1_0_1_1_edt.json
+++ b/src/test/resources/fixtures/ssl_3_2/WebServices.EnterpriseDataExchange_1_0_1_1_edt.json
@@ -1,0 +1,1033 @@
+{"com.github._1c_syntax.bsl.mdo.WebService": {
+  "comment": "",
+  "description": "Enterprise Data Exchange 1.0.1.1",
+  "descriptorFileName": "EnterpriseDataExchange_1_0_1_1.1cws",
+  "mdoReference": {
+    "type": "WEB_SERVICE",
+    "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1",
+    "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1"
+  },
+  "mdoType": "WEB_SERVICE",
+  "moduleTypes": [
+    [
+      "WEBServiceModule",
+      [
+        "src/test/resources/ext/edt/ssl_3_2/configuration/src/WebServices/EnterpriseDataExchange_1_0_1_1/Module.bsl"
+      ]
+    ]
+  ],
+  "modules": [
+    {
+      "moduleType": "WEBServiceModule",
+      "uri": "src/test/resources/ext/edt/ssl_3_2/configuration/src/WebServices/EnterpriseDataExchange_1_0_1_1/Module.bsl",
+      "owner": {
+        "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/mdoReference"
+      },
+      "supportVariant": "NOT_EDITABLE",
+      "isProtected": false
+    }
+  ],
+  "name": "EnterpriseDataExchange_1_0_1_1",
+  "namespace": "http://www.1c.ru/SSL/EnterpriseDataExchange_1_0_1_1",
+  "objectBelonging": "OWN",
+  "operations": [
+    [
+      {
+        "uuid": "e6fe7103-4dfa-4302-a58e-ccd7fac19c9d",
+        "name": "Ping",
+        "mdoReference": {
+          "type": "WS_OPERATION",
+          "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.Ping",
+          "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.Ping"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Проверка соединения с информационной базой",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Ping"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/mdoReference"
+        },
+        "procedureName": "Ping",
+        "nillable": true,
+        "transactioned": false,
+        "dataLockControlMode": "MANAGED",
+        "parameters": []
+      },
+      {
+        "uuid": "bb3a9973-67ce-479e-8668-c2f3bb20301e",
+        "name": "TestConnection",
+        "mdoReference": {
+          "type": "WS_OPERATION",
+          "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.TestConnection",
+          "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.TestConnection"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Проверка подключения к информационной базе",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Test connection"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/mdoReference"
+        },
+        "procedureName": "ПроверкаПодключения",
+        "nillable": false,
+        "transactioned": false,
+        "dataLockControlMode": "MANAGED",
+        "parameters": [
+          [
+            {
+              "uuid": "e5250dfe-dda2-4547-9b9e-2470ea1be1ab",
+              "name": "ExchangePlanName",
+              "mdoReference": {
+                "type": "WS_OPERATION_PARAMETER",
+                "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.TestConnection.Parameter.ExchangePlanName",
+                "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.TestConnection.Параметр.ExchangePlanName"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "content": [
+                  {
+                    "default": {
+                      "tag": 2
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                      "langKey": "ru",
+                      "value": "Exchange plan name"
+                    }
+                  }
+                ]
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[2]/mdoReference"
+              },
+              "nillable": false,
+              "transferDirection": "IN"
+            },
+            {
+              "uuid": "2c3fccc6-c4c0-49ec-bfc2-05ce05f27ea9",
+              "name": "PeerCode",
+              "mdoReference": {
+                "type": "WS_OPERATION_PARAMETER",
+                "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.TestConnection.Parameter.PeerCode",
+                "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.TestConnection.Параметр.PeerCode"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "content": [
+                  {
+                    "default": {
+                      "tag": 2
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                      "langKey": "ru",
+                      "value": "Peer code"
+                    }
+                  }
+                ]
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[2]/mdoReference"
+              },
+              "nillable": false,
+              "transferDirection": "IN"
+            },
+            {
+              "uuid": "37169451-1464-4f24-8ca6-802963ffb636",
+              "name": "ErrorMessage",
+              "mdoReference": {
+                "type": "WS_OPERATION_PARAMETER",
+                "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.TestConnection.Parameter.ErrorMessage",
+                "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.TestConnection.Параметр.ErrorMessage"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "content": [
+                  {
+                    "default": {
+                      "tag": 2
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                      "langKey": "ru",
+                      "value": "Error message"
+                    }
+                  }
+                ]
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[2]/mdoReference"
+              },
+              "nillable": true,
+              "transferDirection": "OUT"
+            }
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "c3a958b1-590f-4418-a74f-5982b478cf52",
+        "name": "PrepareDataForGetting",
+        "mdoReference": {
+          "type": "WS_OPERATION",
+          "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.PrepareDataForGetting",
+          "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.PrepareDataForGetting"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Выгрузить данные из информационной базы, согласно настроек узла плана обмена и подготовить их для отправки",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Prepare data for getting"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/mdoReference"
+        },
+        "procedureName": "ПодготовитьДанныеКПолучению",
+        "nillable": true,
+        "transactioned": false,
+        "dataLockControlMode": "MANAGED",
+        "parameters": [
+          [
+            {
+              "uuid": "ef0e618d-0942-460a-ac65-9aca2fed976e",
+              "name": "ExchangePlanName",
+              "mdoReference": {
+                "type": "WS_OPERATION_PARAMETER",
+                "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.PrepareDataForGetting.Parameter.ExchangePlanName",
+                "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.PrepareDataForGetting.Параметр.ExchangePlanName"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[2]/parameters/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperationParameter/synonym"
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[3]/mdoReference"
+              },
+              "nillable": false,
+              "transferDirection": "IN"
+            },
+            {
+              "uuid": "fd1ed7ec-d848-41cd-8ce3-2e5a682abcf0",
+              "name": "PeerCode",
+              "mdoReference": {
+                "type": "WS_OPERATION_PARAMETER",
+                "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.PrepareDataForGetting.Parameter.PeerCode",
+                "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.PrepareDataForGetting.Параметр.PeerCode"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[2]/parameters/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperationParameter[2]/synonym"
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[3]/mdoReference"
+              },
+              "nillable": false,
+              "transferDirection": "IN"
+            },
+            {
+              "uuid": "2ac8bd69-9fbf-4f15-b58d-397d9e903532",
+              "name": "PartSize",
+              "mdoReference": {
+                "type": "WS_OPERATION_PARAMETER",
+                "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.PrepareDataForGetting.Parameter.PartSize",
+                "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.PrepareDataForGetting.Параметр.PartSize"
+              },
+              "objectBelonging": "OWN",
+              "comment": "В КБ, 0 не разделять",
+              "synonym": {
+                "content": [
+                  {
+                    "default": {
+                      "tag": 2
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                      "langKey": "ru",
+                      "value": "Part size"
+                    }
+                  }
+                ]
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[3]/mdoReference"
+              },
+              "nillable": false,
+              "transferDirection": "IN"
+            },
+            {
+              "uuid": "2ff35814-7eaa-4ae5-bbac-f46bebb36c9d",
+              "name": "OperationID",
+              "mdoReference": {
+                "type": "WS_OPERATION_PARAMETER",
+                "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.PrepareDataForGetting.Parameter.OperationID",
+                "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.PrepareDataForGetting.Параметр.OperationID"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "content": [
+                  {
+                    "default": {
+                      "tag": 2
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                      "langKey": "ru",
+                      "value": "Operation ID"
+                    }
+                  }
+                ]
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[3]/mdoReference"
+              },
+              "nillable": true,
+              "transferDirection": "OUT"
+            },
+            {
+              "uuid": "5b460b92-2c74-4f59-88b2-18d9aac42c04",
+              "name": "ErrorMessage",
+              "mdoReference": {
+                "type": "WS_OPERATION_PARAMETER",
+                "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.PrepareDataForGetting.Parameter.ErrorMessage",
+                "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.PrepareDataForGetting.Параметр.ErrorMessage"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[2]/parameters/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperationParameter[3]/synonym"
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[3]/mdoReference"
+              },
+              "nillable": true,
+              "transferDirection": "OUT"
+            }
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "db05d35b-5f53-4c27-ba80-b477b9a98299",
+        "name": "PrepareDataActionResult",
+        "mdoReference": {
+          "type": "WS_OPERATION",
+          "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.PrepareDataActionResult",
+          "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.PrepareDataActionResult"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Получить результат выполнения операции подготовки данных для выгрузки из информационной базы",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Prepare data action result"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/mdoReference"
+        },
+        "procedureName": "ПолучитьРезультатПодготовкиДанныхКВыгрузке",
+        "nillable": false,
+        "transactioned": false,
+        "dataLockControlMode": "MANAGED",
+        "parameters": [
+          [
+            {
+              "uuid": "fa872ae1-b699-46fe-9d6a-e42e1388752b",
+              "name": "OperationID",
+              "mdoReference": {
+                "type": "WS_OPERATION_PARAMETER",
+                "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.PrepareDataActionResult.Parameter.OperationID",
+                "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.PrepareDataActionResult.Параметр.OperationID"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[3]/parameters/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperationParameter[4]/synonym"
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[4]/mdoReference"
+              },
+              "nillable": false,
+              "transferDirection": "IN"
+            },
+            {
+              "uuid": "1acf34e6-c428-4130-82f0-5160dfcc0858",
+              "name": "ErrorMessage",
+              "mdoReference": {
+                "type": "WS_OPERATION_PARAMETER",
+                "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.PrepareDataActionResult.Parameter.ErrorMessage",
+                "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.PrepareDataActionResult.Параметр.ErrorMessage"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[2]/parameters/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperationParameter[3]/synonym"
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[4]/mdoReference"
+              },
+              "nillable": true,
+              "transferDirection": "OUT"
+            }
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "57046262-b9ce-4670-9cf5-6db9e58dd0d5",
+        "name": "GetDataPart",
+        "mdoReference": {
+          "type": "WS_OPERATION",
+          "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.GetDataPart",
+          "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.GetDataPart"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Получить часть сформированного файла с данными, из временного хранилища",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Get data part"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/mdoReference"
+        },
+        "procedureName": "ВыгрузитьЧастьФайла",
+        "nillable": true,
+        "transactioned": false,
+        "dataLockControlMode": "MANAGED",
+        "parameters": [
+          [
+            {
+              "uuid": "a9824176-36d5-4be5-9984-f4312ff48515",
+              "name": "FileID",
+              "mdoReference": {
+                "type": "WS_OPERATION_PARAMETER",
+                "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.GetDataPart.Parameter.FileID",
+                "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.GetDataPart.Параметр.FileID"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "content": [
+                  {
+                    "default": {
+                      "tag": 2
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                      "langKey": "ru",
+                      "value": "File ID"
+                    }
+                  }
+                ]
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[5]/mdoReference"
+              },
+              "nillable": false,
+              "transferDirection": "IN"
+            },
+            {
+              "uuid": "8e980ca0-1627-45e8-bd27-5dd1ac199459",
+              "name": "PartNumber",
+              "mdoReference": {
+                "type": "WS_OPERATION_PARAMETER",
+                "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.GetDataPart.Parameter.PartNumber",
+                "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.GetDataPart.Параметр.PartNumber"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "content": [
+                  {
+                    "default": {
+                      "tag": 2
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                      "langKey": "ru",
+                      "value": "Part number"
+                    }
+                  }
+                ]
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[5]/mdoReference"
+              },
+              "nillable": false,
+              "transferDirection": "IN"
+            },
+            {
+              "uuid": "8b653beb-af9f-4f39-b691-ae14f80b7cd6",
+              "name": "ErrorMessage",
+              "mdoReference": {
+                "type": "WS_OPERATION_PARAMETER",
+                "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.GetDataPart.Parameter.ErrorMessage",
+                "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.GetDataPart.Параметр.ErrorMessage"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[2]/parameters/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperationParameter[3]/synonym"
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[5]/mdoReference"
+              },
+              "nillable": true,
+              "transferDirection": "OUT"
+            }
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "77559c11-713f-454d-aff4-56649e1350e9",
+        "name": "ConfirmGettingFile",
+        "mdoReference": {
+          "type": "WS_OPERATION",
+          "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.ConfirmGettingFile",
+          "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.ConfirmGettingFile"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Подтвердить получение файла",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Confirm getting file"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/mdoReference"
+        },
+        "procedureName": "ПодтвердитьПолучениеДанных",
+        "nillable": true,
+        "transactioned": false,
+        "dataLockControlMode": "MANAGED",
+        "parameters": [
+          [
+            {
+              "uuid": "0c965703-c1d0-48b7-80f9-b8d869ff98f5",
+              "name": "FileID",
+              "mdoReference": {
+                "type": "WS_OPERATION_PARAMETER",
+                "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.ConfirmGettingFile.Parameter.FileID",
+                "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.ConfirmGettingFile.Параметр.FileID"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[5]/parameters/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperationParameter/synonym"
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[6]/mdoReference"
+              },
+              "nillable": false,
+              "transferDirection": "IN"
+            },
+            {
+              "uuid": "51f8d5ff-aec5-4c0a-ad02-df8c6cb1b4ad",
+              "name": "ClearDataPool",
+              "mdoReference": {
+                "type": "WS_OPERATION_PARAMETER",
+                "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.ConfirmGettingFile.Parameter.ClearDataPool",
+                "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.ConfirmGettingFile.Параметр.ClearDataPool"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "content": [
+                  {
+                    "default": {
+                      "tag": 2
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                      "langKey": "ru",
+                      "value": "Clear data pool"
+                    }
+                  }
+                ]
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[6]/mdoReference"
+              },
+              "nillable": false,
+              "transferDirection": "IN"
+            },
+            {
+              "uuid": "7ba42162-557b-4e34-8aca-0cdee8cb2452",
+              "name": "ErrorMessage",
+              "mdoReference": {
+                "type": "WS_OPERATION_PARAMETER",
+                "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.ConfirmGettingFile.Parameter.ErrorMessage",
+                "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.ConfirmGettingFile.Параметр.ErrorMessage"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[2]/parameters/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperationParameter[3]/synonym"
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[6]/mdoReference"
+              },
+              "nillable": true,
+              "transferDirection": "OUT"
+            }
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "eee99b8e-29b6-4b7a-81f1-3d91d740c0d7",
+        "name": "PutFilePart",
+        "mdoReference": {
+          "type": "WS_OPERATION",
+          "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.PutFilePart",
+          "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.PutFilePart"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Поместить часть файла с данными во временное хранилище",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Put file part"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/mdoReference"
+        },
+        "procedureName": "ЗагрузитьЧастьФайла",
+        "nillable": true,
+        "transactioned": false,
+        "dataLockControlMode": "MANAGED",
+        "parameters": [
+          [
+            {
+              "uuid": "ad4f2d1f-1e6f-4f6a-8061-202c0e42a8e4",
+              "name": "FileID",
+              "mdoReference": {
+                "type": "WS_OPERATION_PARAMETER",
+                "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.PutFilePart.Parameter.FileID",
+                "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.PutFilePart.Параметр.FileID"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[5]/parameters/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperationParameter/synonym"
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[7]/mdoReference"
+              },
+              "nillable": false,
+              "transferDirection": "IN"
+            },
+            {
+              "uuid": "dd577924-c6cb-4aa9-9db5-366d8958d00f",
+              "name": "PartNumber",
+              "mdoReference": {
+                "type": "WS_OPERATION_PARAMETER",
+                "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.PutFilePart.Parameter.PartNumber",
+                "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.PutFilePart.Параметр.PartNumber"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[5]/parameters/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperationParameter[2]/synonym"
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[7]/mdoReference"
+              },
+              "nillable": true,
+              "transferDirection": "IN"
+            },
+            {
+              "uuid": "8ed8f72e-404a-4be4-a44d-ddebbad5f411",
+              "name": "PartData",
+              "mdoReference": {
+                "type": "WS_OPERATION_PARAMETER",
+                "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.PutFilePart.Parameter.PartData",
+                "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.PutFilePart.Параметр.PartData"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "content": [
+                  {
+                    "default": {
+                      "tag": 2
+                    },
+                    "int": 1,
+                    "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                      "langKey": "ru",
+                      "value": "Part data"
+                    }
+                  }
+                ]
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[7]/mdoReference"
+              },
+              "nillable": false,
+              "transferDirection": "IN"
+            },
+            {
+              "uuid": "e919bc4c-86e6-44f6-be27-5a729b63d042",
+              "name": "ErrorMessage",
+              "mdoReference": {
+                "type": "WS_OPERATION_PARAMETER",
+                "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.PutFilePart.Parameter.ErrorMessage",
+                "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.PutFilePart.Параметр.ErrorMessage"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[2]/parameters/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperationParameter[3]/synonym"
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[7]/mdoReference"
+              },
+              "nillable": true,
+              "transferDirection": "OUT"
+            }
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "ec580e4f-1518-4923-a10e-bc1da8688b37",
+        "name": "PutData",
+        "mdoReference": {
+          "type": "WS_OPERATION",
+          "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.PutData",
+          "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.PutData"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Поместить данные в информационную базу",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Put data"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/mdoReference"
+        },
+        "procedureName": "ЗагрузитьДанныеВИнформационнуюБазу",
+        "nillable": true,
+        "transactioned": false,
+        "dataLockControlMode": "MANAGED",
+        "parameters": [
+          [
+            {
+              "uuid": "91c3902a-314f-4d40-8bcc-8dd131fed2f4",
+              "name": "ExchangePlanName",
+              "mdoReference": {
+                "type": "WS_OPERATION_PARAMETER",
+                "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.PutData.Parameter.ExchangePlanName",
+                "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.PutData.Параметр.ExchangePlanName"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[2]/parameters/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperationParameter/synonym"
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[8]/mdoReference"
+              },
+              "nillable": false,
+              "transferDirection": "IN"
+            },
+            {
+              "uuid": "ae2b21c5-9349-49e8-9627-26f05c21f43a",
+              "name": "PeerCode",
+              "mdoReference": {
+                "type": "WS_OPERATION_PARAMETER",
+                "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.PutData.Parameter.PeerCode",
+                "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.PutData.Параметр.PeerCode"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[2]/parameters/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperationParameter[2]/synonym"
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[8]/mdoReference"
+              },
+              "nillable": false,
+              "transferDirection": "IN"
+            },
+            {
+              "uuid": "7e4c0b74-e807-4aa9-ad69-3c85b147bb61",
+              "name": "FileID",
+              "mdoReference": {
+                "type": "WS_OPERATION_PARAMETER",
+                "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.PutData.Parameter.FileID",
+                "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.PutData.Параметр.FileID"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[5]/parameters/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperationParameter/synonym"
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[8]/mdoReference"
+              },
+              "nillable": false,
+              "transferDirection": "IN"
+            },
+            {
+              "uuid": "917a19d7-73db-4247-b892-397598d67879",
+              "name": "OperationID",
+              "mdoReference": {
+                "type": "WS_OPERATION_PARAMETER",
+                "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.PutData.Parameter.OperationID",
+                "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.PutData.Параметр.OperationID"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[3]/parameters/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperationParameter[4]/synonym"
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[8]/mdoReference"
+              },
+              "nillable": true,
+              "transferDirection": "OUT"
+            },
+            {
+              "uuid": "1f866dc3-a4bc-4e8d-96a3-a26ee073926f",
+              "name": "ErrorMessage",
+              "mdoReference": {
+                "type": "WS_OPERATION_PARAMETER",
+                "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.PutData.Parameter.ErrorMessage",
+                "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.PutData.Параметр.ErrorMessage"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[2]/parameters/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperationParameter[3]/synonym"
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[8]/mdoReference"
+              },
+              "nillable": true,
+              "transferDirection": "OUT"
+            }
+          ],
+          []
+        ]
+      },
+      {
+        "uuid": "d8066600-c669-449d-a187-fdd3af8f7afa",
+        "name": "PutDataActionResult",
+        "mdoReference": {
+          "type": "WS_OPERATION",
+          "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.PutDataActionResult",
+          "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.PutDataActionResult"
+        },
+        "objectBelonging": "OWN",
+        "comment": "Получить результат выполнения операции помещения данных в информационную базу",
+        "synonym": {
+          "content": [
+            {
+              "default": {
+                "tag": 2
+              },
+              "int": 1,
+              "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+                "langKey": "ru",
+                "value": "Put data action result"
+              }
+            }
+          ]
+        },
+        "supportVariant": "NOT_EDITABLE",
+        "owner": {
+          "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/mdoReference"
+        },
+        "procedureName": "ПолучитьРезультатЗагрузкиДанных",
+        "nillable": false,
+        "transactioned": false,
+        "dataLockControlMode": "MANAGED",
+        "parameters": [
+          [
+            {
+              "uuid": "dadf86a6-c118-4827-b1b9-6cfee731242f",
+              "name": "OperationID",
+              "mdoReference": {
+                "type": "WS_OPERATION_PARAMETER",
+                "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.PutDataActionResult.Parameter.OperationID",
+                "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.PutDataActionResult.Параметр.OperationID"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[3]/parameters/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperationParameter[4]/synonym"
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[9]/mdoReference"
+              },
+              "nillable": false,
+              "transferDirection": "IN"
+            },
+            {
+              "uuid": "45bf7b20-f048-491a-a989-e50bea13d028",
+              "name": "ErrorMessage",
+              "mdoReference": {
+                "type": "WS_OPERATION_PARAMETER",
+                "mdoRef": "WebService.EnterpriseDataExchange_1_0_1_1.Operation.PutDataActionResult.Parameter.ErrorMessage",
+                "mdoRefRu": "WebСервис.EnterpriseDataExchange_1_0_1_1.Операция.PutDataActionResult.Параметр.ErrorMessage"
+              },
+              "objectBelonging": "OWN",
+              "comment": "",
+              "synonym": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[2]/parameters/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperationParameter[3]/synonym"
+              },
+              "supportVariant": "NOT_EDITABLE",
+              "owner": {
+                "@reference": "/com.github._1c_syntax.bsl.mdo.WebService/operations/c/com.github._1c_syntax.bsl.mdo.children.WebServiceOperation[9]/mdoReference"
+              },
+              "nillable": true,
+              "transferDirection": "OUT"
+            }
+          ],
+          []
+        ]
+      }
+    ],
+    []
+  ],
+  "reuseSessions": "DONT_USE",
+  "sessionMaxAge": 20,
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "content": [
+      {
+        "default": {
+          "tag": 2
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+          "langKey": "ru",
+          "value": "Enterprise Data Exchange 1.0.1.1"
+        }
+      }
+    ]
+  },
+  "uuid": "cb3a5c5b-7bdc-4e12-96f1-11b1213b6853"
+}}

--- a/src/test/resources/fixtures/ssl_3_2/XDTOPackages.ApdexExport_1_0_0_4.json
+++ b/src/test/resources/fixtures/ssl_3_2/XDTOPackages.ApdexExport_1_0_0_4.json
@@ -1,0 +1,239 @@
+{"com.github._1c_syntax.bsl.mdo.XDTOPackage": {
+  "comment": "",
+  "data": {
+    "targetNamespace": "www.v8.1c.ru/ssl/performace-assessment/apdexExport/1.0.0.4",
+    "imports": [],
+    "valueTypes": [],
+    "objectTypes": [
+      [
+        {
+          "name": "Performance",
+          "base": "",
+          "properties": [
+            [
+              {
+                "name": "version",
+                "type": "xs:string",
+                "lowerBound": 0,
+                "upperBound": 0,
+                "nillable": false,
+                "form": "Attribute",
+                "typeDef": []
+              },
+              {
+                "name": "period",
+                "type": "xs:dateTime",
+                "lowerBound": 0,
+                "upperBound": 0,
+                "nillable": false,
+                "form": "Attribute",
+                "typeDef": []
+              },
+              {
+                "name": "keyOperation",
+                "type": "d3p1:KeyOperation",
+                "lowerBound": 0,
+                "upperBound": -1,
+                "nillable": false,
+                "form": "",
+                "typeDef": []
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": "KeyOperation",
+          "base": "",
+          "properties": [
+            [
+              {
+                "name": "uid",
+                "type": "xs:string",
+                "lowerBound": 0,
+                "upperBound": 0,
+                "nillable": false,
+                "form": "Attribute",
+                "typeDef": []
+              },
+              {
+                "name": "name",
+                "type": "xs:string",
+                "lowerBound": 0,
+                "upperBound": 0,
+                "nillable": false,
+                "form": "Attribute",
+                "typeDef": []
+              },
+              {
+                "name": "comment",
+                "type": "xs:string",
+                "lowerBound": 0,
+                "upperBound": 0,
+                "nillable": false,
+                "form": "Attribute",
+                "typeDef": []
+              },
+              {
+                "name": "priority",
+                "type": "xs:integer",
+                "lowerBound": 0,
+                "upperBound": 0,
+                "nillable": false,
+                "form": "Attribute",
+                "typeDef": []
+              },
+              {
+                "name": "targetValue",
+                "type": "xs:float",
+                "lowerBound": 0,
+                "upperBound": 0,
+                "nillable": false,
+                "form": "Attribute",
+                "typeDef": []
+              },
+              {
+                "name": "measurement",
+                "type": "d3p1:Measurement",
+                "lowerBound": 0,
+                "upperBound": -1,
+                "nillable": true,
+                "form": "",
+                "typeDef": []
+              },
+              {
+                "name": "nameFull",
+                "type": "xs:string",
+                "lowerBound": 0,
+                "upperBound": 0,
+                "nillable": false,
+                "form": "Attribute",
+                "typeDef": []
+              },
+              {
+                "name": "long",
+                "type": "xs:boolean",
+                "lowerBound": 0,
+                "upperBound": 0,
+                "nillable": false,
+                "form": "Attribute",
+                "typeDef": []
+              }
+            ],
+            []
+          ]
+        },
+        {
+          "name": "Measurement",
+          "base": "",
+          "properties": [
+            [
+              {
+                "name": "value",
+                "type": "xs:double",
+                "lowerBound": 0,
+                "upperBound": 0,
+                "nillable": false,
+                "form": "Attribute",
+                "typeDef": []
+              },
+              {
+                "name": "weight",
+                "type": "xs:double",
+                "lowerBound": 0,
+                "upperBound": 0,
+                "nillable": false,
+                "form": "Attribute",
+                "typeDef": []
+              },
+              {
+                "name": "tUtc",
+                "type": "xs:float",
+                "lowerBound": 0,
+                "upperBound": 0,
+                "nillable": false,
+                "form": "Attribute",
+                "typeDef": []
+              },
+              {
+                "name": "userName",
+                "type": "xs:string",
+                "lowerBound": 0,
+                "upperBound": 0,
+                "nillable": false,
+                "form": "Attribute",
+                "typeDef": []
+              },
+              {
+                "name": "tSaveUTC",
+                "type": "xs:dateTime",
+                "lowerBound": 0,
+                "upperBound": 0,
+                "nillable": false,
+                "form": "Attribute",
+                "typeDef": []
+              },
+              {
+                "name": "sessionNumber",
+                "type": "xs:integer",
+                "lowerBound": 0,
+                "upperBound": 0,
+                "nillable": false,
+                "form": "Attribute",
+                "typeDef": []
+              },
+              {
+                "name": "runningError",
+                "type": "xs:boolean",
+                "lowerBound": 0,
+                "upperBound": 0,
+                "nillable": false,
+                "form": "Attribute",
+                "typeDef": []
+              }
+            ],
+            []
+          ]
+        }
+      ],
+      []
+    ],
+    "properties": [
+      {
+        "name": "performance",
+        "type": "d2p1:Performance",
+        "lowerBound": 0,
+        "upperBound": 0,
+        "nillable": false,
+        "form": "",
+        "typeDef": []
+      }
+    ]
+  },
+  "description": "Apdex export 1 0 0 4",
+  "mdoReference": {
+    "type": "XDTO_PACKAGE",
+    "mdoRef": "XDTOPackage.ApdexExport_1_0_0_4",
+    "mdoRefRu": "ПакетXDTO.ApdexExport_1_0_0_4"
+  },
+  "mdoType": "XDTO_PACKAGE",
+  "name": "ApdexExport_1_0_0_4",
+  "namespace": "www.v8.1c.ru/ssl/performace-assessment/apdexExport/1.0.0.4",
+  "objectBelonging": "OWN",
+  "supportVariant": "NOT_EDITABLE",
+  "synonym": {
+    "content": [
+      {
+        "default": {
+          "tag": 2
+        },
+        "int": 1,
+        "com.github._1c_syntax.bsl.types.MultiLanguageString$Entry": {
+          "langKey": "ru",
+          "value": "Apdex export 1 0 0 4"
+        }
+      }
+    ]
+  },
+  "uuid": "5c45e96f-e245-4d16-9c47-836505582aef"
+}}


### PR DESCRIPTION
## Описание
<!--- ОБЯЗАТЕЛЬНО опишите внесенные изменения -->

1. Подключены фикстуры для 8.5
2. Обновлены фикстуры ssl 3.1
3. Исправлена ошибка чтения предопределенных

## Связанные задачи
<!--- Для каждого PR обязательно наличие связанной задачи (issue). -->
<!--- Необходимо указать ключи задач, предваряя их символом #, например -->
<!---Closes #123 -->
<!--  -->
<!-- ВНИМАНИЕ: Без ссылки на задачу пулл-реквест не будет принят! -->
<!--  -->
Closes: #584 

## Чеклист
<!--- Перед отправкой пройдите по списку и поставьте отметку для каждого выполненного действия -->
<!--- Если не понятно, что подразумевается - спросите в чате проекта https://t.me/bsl_language_server -->

### Общие

- [x] Ветка PR обновлена из develop
- [x] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [x] Изменения покрыты тестами
- [ ] Обязательные действия перед коммитом выполнены (запускал команду `gradlew precommit`)

## Дополнительно
<!--- Различная дополнительная информация, скриншоты и т.д. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for additional configuration content so more nested items are recognized.
  * Expanded support for a new SSL 3.2 example set across configuration and metadata handling.

* **Bug Fixes**
  * Improved handling of configuration and metadata cases that previously only worked for SSL 3.1.
  * Updated access and content counts to reflect the newer format accurately.

* **Tests**
  * Broadened test coverage for SSL 3.2 across many metadata types and reader scenarios.
  * Added new fixture-generation support for updating test resources more easily.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->