### PR TITLE
feat: чтение периодичности регистров сведений и расчета

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/mdo/CalculationRegister.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdo/CalculationRegister.java
@@ -27,6 +27,7 @@ import com.github._1c_syntax.bsl.mdo.children.ObjectForm;
 import com.github._1c_syntax.bsl.mdo.children.ObjectTemplate;
 import com.github._1c_syntax.bsl.mdo.children.Recalculation;
 import com.github._1c_syntax.bsl.mdo.children.Resource;
+import com.github._1c_syntax.bsl.mdo.support.CalculationRegisterPeriodicity;
 import com.github._1c_syntax.bsl.mdo.support.DefaultFormKind;
 import com.github._1c_syntax.bsl.mdo.support.ObjectBelonging;
 import com.github._1c_syntax.bsl.mdo.support.RoleRight;
@@ -101,6 +102,12 @@ public class CalculationRegister implements Register, AccessRightsOwner {
   /*
    * Свое
    */
+
+  /**
+   * Периодичность регистра расчета
+   */
+  @Default
+  CalculationRegisterPeriodicity periodicity = CalculationRegisterPeriodicity.MONTH;
 
   /**
    * Ссылка на форму списка по умолчанию

--- a/src/main/java/com/github/_1c_syntax/bsl/mdo/InformationRegister.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdo/InformationRegister.java
@@ -27,6 +27,7 @@ import com.github._1c_syntax.bsl.mdo.children.ObjectForm;
 import com.github._1c_syntax.bsl.mdo.children.ObjectTemplate;
 import com.github._1c_syntax.bsl.mdo.children.Resource;
 import com.github._1c_syntax.bsl.mdo.support.DefaultFormKind;
+import com.github._1c_syntax.bsl.mdo.support.InformationRegisterPeriodicity;
 import com.github._1c_syntax.bsl.mdo.support.ObjectBelonging;
 import com.github._1c_syntax.bsl.mdo.support.RoleRight;
 import com.github._1c_syntax.bsl.mdo.utils.LazyLoader;
@@ -101,6 +102,12 @@ public class InformationRegister implements Register, AccessRightsOwner {
   /*
    * Свое
    */
+
+  /**
+   * Периодичность регистра сведений
+   */
+  @Default
+  InformationRegisterPeriodicity informationRegisterPeriodicity = InformationRegisterPeriodicity.NONPERIODICAL;
 
   /**
    * Ссылка на форму списка по умолчанию

--- a/src/main/java/com/github/_1c_syntax/bsl/mdo/support/CalculationRegisterPeriodicity.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdo/support/CalculationRegisterPeriodicity.java
@@ -1,0 +1,63 @@
+/*
+ * This file is a part of MDClasses.
+ *
+ * Copyright (c) 2019 - 2026
+ * Tymko Oleg <olegtymko@yandex.ru>, Maximov Valery <maximovvalery@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * MDClasses is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * MDClasses is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with MDClasses.
+ */
+package com.github._1c_syntax.bsl.mdo.support;
+
+import com.github._1c_syntax.bsl.types.EnumWithName;
+import com.github._1c_syntax.bsl.types.MultiName;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Периодичность регистра расчета
+ */
+@ToString(of = "fullName")
+public enum CalculationRegisterPeriodicity implements EnumWithName {
+  DAY("Day", "День"),
+  MONTH("Month", "Месяц"),
+  QUARTER("Quarter", "Квартал"),
+  YEAR("Year", "Год"),
+  UNKNOWN("unknown", "неизвестный");
+
+  private static final Map<String, CalculationRegisterPeriodicity> KEYS = EnumWithName.computeKeys(values());
+
+  @Getter
+  @Accessors(fluent = true)
+  private final MultiName fullName;
+
+  CalculationRegisterPeriodicity(String nameEn, String nameRu) {
+    this.fullName = MultiName.create(nameEn, nameRu);
+  }
+
+  /**
+   * Ищет элемент перечисления по именам (рус, анг)
+   *
+   * @param string Имя искомого элемента
+   * @return Найденное значение, если не найден - то UNKNOWN
+   */
+  public static CalculationRegisterPeriodicity valueByName(String string) {
+    return KEYS.getOrDefault(string.toLowerCase(Locale.ROOT), UNKNOWN);
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/mdo/support/InformationRegisterPeriodicity.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdo/support/InformationRegisterPeriodicity.java
@@ -1,0 +1,66 @@
+/*
+ * This file is a part of MDClasses.
+ *
+ * Copyright (c) 2019 - 2026
+ * Tymko Oleg <olegtymko@yandex.ru>, Maximov Valery <maximovvalery@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * MDClasses is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * MDClasses is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with MDClasses.
+ */
+package com.github._1c_syntax.bsl.mdo.support;
+
+import com.github._1c_syntax.bsl.types.EnumWithName;
+import com.github._1c_syntax.bsl.types.MultiName;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Периодичность регистра сведений
+ */
+@ToString(of = "fullName")
+public enum InformationRegisterPeriodicity implements EnumWithName {
+  NONPERIODICAL("Nonperiodical", "Непериодический"),
+  RECORDER_POSITION("RecorderPosition", "ПоПозицииРегистратора"),
+  SECOND("Second", "Секунда"),
+  DAY("Day", "День"),
+  MONTH("Month", "Месяц"),
+  QUARTER("Quarter", "Квартал"),
+  YEAR("Year", "Год"),
+  UNKNOWN("unknown", "неизвестный");
+
+  private static final Map<String, InformationRegisterPeriodicity> KEYS = EnumWithName.computeKeys(values());
+
+  @Getter
+  @Accessors(fluent = true)
+  private final MultiName fullName;
+
+  InformationRegisterPeriodicity(String nameEn, String nameRu) {
+    this.fullName = MultiName.create(nameEn, nameRu);
+  }
+
+  /**
+   * Ищет элемент перечисления по именам (рус, анг)
+   *
+   * @param string Имя искомого элемента
+   * @return Найденное значение, если не найден - то UNKNOWN
+   */
+  public static InformationRegisterPeriodicity valueByName(String string) {
+    return KEYS.getOrDefault(string.toLowerCase(Locale.ROOT), UNKNOWN);
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/reader/common/xstream/ExtendXStream.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/reader/common/xstream/ExtendXStream.java
@@ -37,6 +37,7 @@ import com.github._1c_syntax.bsl.mdo.support.DataLockControlMode;
 import com.github._1c_syntax.bsl.mdo.support.DataSeparation;
 import com.github._1c_syntax.bsl.mdo.support.FormType;
 import com.github._1c_syntax.bsl.mdo.support.IndexingType;
+import com.github._1c_syntax.bsl.mdo.support.InformationRegisterPeriodicity;
 import com.github._1c_syntax.bsl.mdo.support.InterfaceCompatibilityMode;
 import com.github._1c_syntax.bsl.mdo.support.MessageDirection;
 import com.github._1c_syntax.bsl.mdo.support.ObjectBelonging;
@@ -266,6 +267,7 @@ public class ExtendXStream extends XStream {
     registerConverter(new EnumConverter<>(DataSeparation.class));
     registerConverter(new EnumConverter<>(FormType.class));
     registerConverter(new EnumConverter<>(IndexingType.class));
+    registerConverter(new EnumConverter<>(InformationRegisterPeriodicity.class));
     registerConverter(new EnumConverter<>(MessageDirection.class));
     registerConverter(new EnumConverter<>(ObjectBelonging.class));
     registerConverter(new EnumConverter<>(ReturnValueReuse.class));

--- a/src/main/java/com/github/_1c_syntax/bsl/reader/common/xstream/ExtendXStream.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/reader/common/xstream/ExtendXStream.java
@@ -31,6 +31,7 @@ import com.github._1c_syntax.bsl.mdo.storage.XdtoPackageData;
 import com.github._1c_syntax.bsl.mdo.storage.form.FormElementType;
 import com.github._1c_syntax.bsl.mdo.support.ApplicationRunMode;
 import com.github._1c_syntax.bsl.mdo.support.AutoRecordType;
+import com.github._1c_syntax.bsl.mdo.support.CalculationRegisterPeriodicity;
 import com.github._1c_syntax.bsl.mdo.support.CodeSeries;
 import com.github._1c_syntax.bsl.mdo.support.ConfigurationExtensionPurpose;
 import com.github._1c_syntax.bsl.mdo.support.DataLockControlMode;
@@ -262,6 +263,7 @@ public class ExtendXStream extends XStream {
 
     registerConverter(new EnumConverter<>(ApplicationRunMode.class));
     registerConverter(new EnumConverter<>(AutoRecordType.class));
+    registerConverter(new EnumConverter<>(CalculationRegisterPeriodicity.class));
     registerConverter(new EnumConverter<>(ConfigurationExtensionPurpose.class));
     registerConverter(new EnumConverter<>(DataLockControlMode.class));
     registerConverter(new EnumConverter<>(DataSeparation.class));

--- a/src/test/java/com/github/_1c_syntax/bsl/mdo/CalculationRegisterTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdo/CalculationRegisterTest.java
@@ -22,6 +22,7 @@
 package com.github._1c_syntax.bsl.mdo;
 
 import com.github._1c_syntax.bsl.mdo.children.RecalculationDimension;
+import com.github._1c_syntax.bsl.mdo.support.CalculationRegisterPeriodicity;
 import com.github._1c_syntax.bsl.test_utils.Fixtures;
 import com.github._1c_syntax.bsl.test_utils.assertions.Assertions;
 import com.github._1c_syntax.bsl.types.MDOType;
@@ -47,6 +48,9 @@ class CalculationRegisterTest {
 
     var calculationRegister = (CalculationRegister) mdo;
     assertThat(calculationRegister).isNotNull();
+
+    // --- Периодичность ---
+    assertThat(calculationRegister.getPeriodicity()).isEqualTo(CalculationRegisterPeriodicity.MONTH);
 
     // --- ModuleOwner ---
     assertThat(calculationRegister.getModuleTypes()).isEmpty();

--- a/src/test/java/com/github/_1c_syntax/bsl/mdo/InformationRegisterTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdo/InformationRegisterTest.java
@@ -21,6 +21,7 @@
  */
 package com.github._1c_syntax.bsl.mdo;
 
+import com.github._1c_syntax.bsl.mdo.support.InformationRegisterPeriodicity;
 import com.github._1c_syntax.bsl.test_utils.Fixtures;
 import com.github._1c_syntax.bsl.test_utils.assertions.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -32,16 +33,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 class InformationRegisterTest {
   @ParameterizedTest
   @CsvSource({
-    "true, mdclasses, InformationRegisters.РегистрСведений1",
-    "false, mdclasses, InformationRegisters.РегистрСведений1",
-    "true, ssl_3_1, InformationRegisters.ЭлектронныеПодписи",
-    "false, ssl_3_1, InformationRegisters.ЭлектронныеПодписи",
-    "true, ssl_3_2, InformationRegisters.ЭлектронныеПодписи",
-    "false, ssl_3_2, InformationRegisters.ЭлектронныеПодписи",
-    "true, ssl_3_1, InformationRegisters.СклоненияПредставленийОбъектов",
-    "false, ssl_3_1, InformationRegisters.СклоненияПредставленийОбъектов",
-    "true, ssl_3_2, InformationRegisters.СклоненияПредставленийОбъектов",
-    "false, ssl_3_2, InformationRegisters.СклоненияПредставленийОбъектов"
+    "true, mdclasses, InformationRegisters.РегистрСведений1, NONPERIODICAL",
+    "false, mdclasses, InformationRegisters.РегистрСведений1, NONPERIODICAL",
+    "true, ssl_3_1, InformationRegisters.ЭлектронныеПодписи, NONPERIODICAL",
+    "false, ssl_3_1, InformationRegisters.ЭлектронныеПодписи, NONPERIODICAL",
+    "true, ssl_3_2, InformationRegisters.ЭлектронныеПодписи, NONPERIODICAL",
+    "false, ssl_3_2, InformationRegisters.ЭлектронныеПодписи, NONPERIODICAL",
+    "true, ssl_3_1, InformationRegisters.СклоненияПредставленийОбъектов, NONPERIODICAL",
+    "false, ssl_3_1, InformationRegisters.СклоненияПредставленийОбъектов, NONPERIODICAL",
+    "true, ssl_3_2, InformationRegisters.СклоненияПредставленийОбъектов, NONPERIODICAL",
+    "false, ssl_3_2, InformationRegisters.СклоненияПредставленийОбъектов, NONPERIODICAL",
+    "true, ssl_3_2, InformationRegisters.КурсыВалют, DAY",
+    "false, ssl_3_2, InformationRegisters.КурсыВалют, DAY"
   })
   void test(ArgumentsAccessor argumentsAccessor) {
     var mdo = Fixtures.get(argumentsAccessor);
@@ -49,6 +52,10 @@ class InformationRegisterTest {
 
     var informationRegister = (InformationRegister) mdo;
     assertThat(informationRegister).isNotNull();
+
+    // --- Периодичность ---
+    var expectedPeriodicity = InformationRegisterPeriodicity.valueOf(argumentsAccessor.getString(3));
+    assertThat(informationRegister.getInformationRegisterPeriodicity()).isEqualTo(expectedPeriodicity);
 
     // --- ModuleOwner ---
     Assertions.assertThat(informationRegister.getAllModules(), false)

--- a/src/test/java/com/github/_1c_syntax/bsl/mdo/support/CalculationRegisterPeriodicityTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdo/support/CalculationRegisterPeriodicityTest.java
@@ -1,0 +1,52 @@
+/*
+ * This file is a part of MDClasses.
+ *
+ * Copyright (c) 2019 - 2026
+ * Tymko Oleg <olegtymko@yandex.ru>, Maximov Valery <maximovvalery@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * MDClasses is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * MDClasses is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with MDClasses.
+ */
+package com.github._1c_syntax.bsl.mdo.support;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CalculationRegisterPeriodicityTest {
+
+  @Test
+  void getByName() {
+    // англоязычные имена из формата конфигуратора / EDT
+    assertThat(CalculationRegisterPeriodicity.valueByName("Day"))
+      .isEqualTo(CalculationRegisterPeriodicity.DAY);
+    assertThat(CalculationRegisterPeriodicity.valueByName("month"))
+      .isEqualTo(CalculationRegisterPeriodicity.MONTH);
+    assertThat(CalculationRegisterPeriodicity.valueByName("Quarter"))
+      .isEqualTo(CalculationRegisterPeriodicity.QUARTER);
+    assertThat(CalculationRegisterPeriodicity.valueByName("Year"))
+      .isEqualTo(CalculationRegisterPeriodicity.YEAR);
+
+    // русскоязычные имена
+    assertThat(CalculationRegisterPeriodicity.valueByName("Квартал"))
+      .isEqualTo(CalculationRegisterPeriodicity.QUARTER);
+    assertThat(CalculationRegisterPeriodicity.valueByName("Год"))
+      .isEqualTo(CalculationRegisterPeriodicity.YEAR);
+
+    // неизвестное значение
+    assertThat(CalculationRegisterPeriodicity.valueByName("{sfdsfsd}"))
+      .isEqualTo(CalculationRegisterPeriodicity.UNKNOWN);
+  }
+}

--- a/src/test/java/com/github/_1c_syntax/bsl/mdo/support/InformationRegisterPeriodicityTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdo/support/InformationRegisterPeriodicityTest.java
@@ -1,0 +1,52 @@
+/*
+ * This file is a part of MDClasses.
+ *
+ * Copyright (c) 2019 - 2026
+ * Tymko Oleg <olegtymko@yandex.ru>, Maximov Valery <maximovvalery@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * MDClasses is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * MDClasses is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with MDClasses.
+ */
+package com.github._1c_syntax.bsl.mdo.support;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class InformationRegisterPeriodicityTest {
+
+  @Test
+  void getByName() {
+    // англоязычные имена из формата конфигуратора / EDT
+    assertThat(InformationRegisterPeriodicity.valueByName("Nonperiodical"))
+      .isEqualTo(InformationRegisterPeriodicity.NONPERIODICAL);
+    assertThat(InformationRegisterPeriodicity.valueByName("Second"))
+      .isEqualTo(InformationRegisterPeriodicity.SECOND);
+    assertThat(InformationRegisterPeriodicity.valueByName("day"))
+      .isEqualTo(InformationRegisterPeriodicity.DAY);
+    assertThat(InformationRegisterPeriodicity.valueByName("RecorderPosition"))
+      .isEqualTo(InformationRegisterPeriodicity.RECORDER_POSITION);
+
+    // русскоязычные имена
+    assertThat(InformationRegisterPeriodicity.valueByName("Месяц"))
+      .isEqualTo(InformationRegisterPeriodicity.MONTH);
+    assertThat(InformationRegisterPeriodicity.valueByName("Год"))
+      .isEqualTo(InformationRegisterPeriodicity.YEAR);
+
+    // неизвестное значение
+    assertThat(InformationRegisterPeriodicity.valueByName("{sfdsfsd}"))
+      .isEqualTo(InformationRegisterPeriodicity.UNKNOWN);
+  }
+}

--- a/src/test/java/com/github/_1c_syntax/bsl/test_utils/GenerateMdoFixtures.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/test_utils/GenerateMdoFixtures.java
@@ -1,0 +1,77 @@
+/*
+ * This file is a part of MDClasses.
+ *
+ * Copyright (c) 2019 - 2026
+ * Tymko Oleg <olegtymko@yandex.ru>, Maximov Valery <maximovvalery@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * MDClasses is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * MDClasses is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with MDClasses.
+ */
+package com.github._1c_syntax.bsl.test_utils;
+
+import lombok.SneakyThrows;
+import org.apache.commons.io.file.PathUtils;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Генератор JSON-фикстур для объектов MDO верхнего уровня.
+ * <p>
+ * Обходит уже существующие json-фикстуры верхнего уровня (файлы {@code <pack>/<mdoRef>.json}),
+ * перечитывает исходные MDO из формата конфигуратора и сохраняет их сериализацию поверх фикстуры.
+ * Используется для пересборки фикстур после изменения модели MDO.
+ */
+@Disabled
+class GenerateMdoFixtures {
+
+  private static final Path FIXTURES_BASE = Fixtures.FIXTURES_PATH;
+
+  @Test
+  @SneakyThrows
+  void generateAll() {
+    try (var packsStream = Files.list(FIXTURES_BASE)) {
+      packsStream.filter(Files::isDirectory).forEach(this::generateForPack);
+    }
+    System.out.println("Done. Regenerated top-level fixtures in " + FIXTURES_BASE);
+  }
+
+  @SneakyThrows
+  private void generateForPack(Path packDir) {
+    var pack = packDir.getFileName().toString();
+    try (var filesStream = Files.list(packDir)) {
+      filesStream
+        .filter(path -> path.toString().endsWith(".json"))
+        .filter(path -> {
+          var fileName = path.getFileName().toString();
+          return fileName.startsWith("InformationRegisters.") || fileName.equals("Configuration.json");
+        })
+        .forEach(fixtureFile -> regenerate(pack, fixtureFile));
+    }
+  }
+
+  private void regenerate(String pack, Path fixtureFile) {
+    var mdoRef = PathUtils.getBaseName(fixtureFile.getFileName());
+    var mdo = Fixtures.get(pack, mdoRef, false);
+    if (mdo == null) {
+      System.out.println("SKIP " + pack + "/" + mdoRef + " — source is null");
+      return;
+    }
+    Fixtures.write(mdo, fixtureFile);
+    System.out.println("  " + pack + "/" + mdoRef + ".json");
+  }
+}

--- a/src/test/java/com/github/_1c_syntax/bsl/test_utils/GenerateMdoFixtures.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/test_utils/GenerateMdoFixtures.java
@@ -22,9 +22,8 @@
 package com.github._1c_syntax.bsl.test_utils;
 
 import lombok.SneakyThrows;
+import lombok.experimental.UtilityClass;
 import org.apache.commons.io.file.PathUtils;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -35,36 +34,40 @@ import java.nio.file.Path;
  * Обходит уже существующие json-фикстуры верхнего уровня (файлы {@code <pack>/<mdoRef>.json}),
  * перечитывает исходные MDO из формата конфигуратора и сохраняет их сериализацию поверх фикстуры.
  * Используется для пересборки фикстур после изменения модели MDO.
+ * <p>
+ * Запускается вручную как обычное java-приложение (метод {@link #main(String[])}) с classpath тестов,
+ * например из IDE. В обычный прогон тестов не входит.
  */
-@Disabled
-class GenerateMdoFixtures {
+@UtilityClass
+public class GenerateMdoFixtures {
 
   private static final Path FIXTURES_BASE = Fixtures.FIXTURES_PATH;
 
-  @Test
   @SneakyThrows
-  void generateAll() {
+  public static void main(String[] args) {
     try (var packsStream = Files.list(FIXTURES_BASE)) {
-      packsStream.filter(Files::isDirectory).forEach(this::generateForPack);
+      packsStream.filter(Files::isDirectory).forEach(GenerateMdoFixtures::generateForPack);
     }
     System.out.println("Done. Regenerated top-level fixtures in " + FIXTURES_BASE);
   }
 
   @SneakyThrows
-  private void generateForPack(Path packDir) {
+  private static void generateForPack(Path packDir) {
     var pack = packDir.getFileName().toString();
     try (var filesStream = Files.list(packDir)) {
       filesStream
         .filter(path -> path.toString().endsWith(".json"))
         .filter(path -> {
           var fileName = path.getFileName().toString();
-          return fileName.startsWith("InformationRegisters.") || fileName.equals("Configuration.json");
+          return fileName.startsWith("InformationRegisters.")
+            || fileName.startsWith("CalculationRegisters.")
+            || fileName.equals("Configuration.json");
         })
         .forEach(fixtureFile -> regenerate(pack, fixtureFile));
     }
   }
 
-  private void regenerate(String pack, Path fixtureFile) {
+  private static void regenerate(String pack, Path fixtureFile) {
     var mdoRef = PathUtils.getBaseName(fixtureFile.getFileName());
     var mdo = Fixtures.get(pack, mdoRef, false);
     if (mdo == null) {

--- a/src/test/resources/fixtures/mdclasses/CalculationRegisters.РегистрРасчета1.json
+++ b/src/test/resources/fixtures/mdclasses/CalculationRegisters.РегистрРасчета1.json
@@ -77,6 +77,7 @@
    "@reference": "\/com.github._1c_syntax.bsl.mdo.CalculationRegister\/attributes\/com.github._1c_syntax.bsl.mdo.children.StandardAttribute\/synonym"
   },
   "name": "РегистрРасчета1",
+  "periodicity": "MONTH",
   "attributes": [
    {
     "owner": {

--- a/src/test/resources/fixtures/mdclasses/Configuration.json
+++ b/src/test/resources/fixtures/mdclasses/Configuration.json
@@ -1642,6 +1642,7 @@
      "@reference": "\/com.github._1c_syntax.bsl.mdclasses.Configuration\/accountingRegisters\/com.github._1c_syntax.bsl.mdo.AccountingRegister\/defaultListForm"
     },
     "name": "РегистрРасчета1",
+    "periodicity": "MONTH",
     "objectBelonging": "OWN",
     "comment": "",
     "attributes": [

--- a/src/test/resources/fixtures/mdclasses/InformationRegisters.РегистрСведений1.json
+++ b/src/test/resources/fixtures/mdclasses/InformationRegisters.РегистрСведений1.json
@@ -1,5 +1,39 @@
 {
  "com.github._1c_syntax.bsl.mdo.InformationRegister": {
+  "possibleRights": [
+   "EDIT",
+   "EDIT_DATA_HISTORY_VERSION_COMMENT",
+   "READ",
+   "READ_DATA_HISTORY",
+   "READ_DATA_HISTORY_OF_MISSING_DATA",
+   "SWITCH_TO_DATA_HISTORY_VERSION",
+   "TOTALS_CONTROL",
+   "UPDATE",
+   "UPDATE_DATA_HISTORY",
+   "UPDATE_DATA_HISTORY_OF_MISSING_DATA",
+   "UPDATE_DATA_HISTORY_SETTINGS",
+   "UPDATE_DATA_HISTORY_VERSION_COMMENT",
+   "VIEW",
+   "VIEW_DATA_HISTORY"
+  ],
+  "description": "РегистрСведений1",
+  "explanation": {
+   "@reference": "\/com.github._1c_syntax.bsl.mdo.InformationRegister\/attributes\/com.github._1c_syntax.bsl.mdo.children.StandardAttribute\/synonym"
+  },
+  "uuid": "184d9d78-9523-4cfa-9542-a7ba72efe4dd",
+  "mdoRef": "InformationRegister.РегистрСведений1",
+  "supportVariant": "NONE",
+  "informationRegisterPeriodicity": "NONPERIODICAL",
+  "auxiliaryListForm": {
+   "mdoRefRu": "",
+   "type": "UNKNOWN",
+   "mdoRef": ""
+  },
+  "synonym": {
+   "@reference": "\/com.github._1c_syntax.bsl.mdo.InformationRegister\/attributes\/com.github._1c_syntax.bsl.mdo.children.StandardAttribute\/synonym"
+  },
+  "objectBelonging": "OWN",
+  "commands": [],
   "mdoType": "INFORMATION_REGISTER",
   "defaultFormMap": [
    "AUX_LIST_FORM",
@@ -22,33 +56,11 @@
   "defaultListForm": {
    "@reference": "\/com.github._1c_syntax.bsl.mdo.InformationRegister\/auxiliaryListForm"
   },
-  "possibleRights": [
-   "EDIT",
-   "EDIT_DATA_HISTORY_VERSION_COMMENT",
-   "READ",
-   "READ_DATA_HISTORY",
-   "READ_DATA_HISTORY_OF_MISSING_DATA",
-   "SWITCH_TO_DATA_HISTORY_VERSION",
-   "TOTALS_CONTROL",
-   "UPDATE",
-   "UPDATE_DATA_HISTORY",
-   "UPDATE_DATA_HISTORY_OF_MISSING_DATA",
-   "UPDATE_DATA_HISTORY_SETTINGS",
-   "UPDATE_DATA_HISTORY_VERSION_COMMENT",
-   "VIEW",
-   "VIEW_DATA_HISTORY"
-  ],
   "templates": [],
-  "description": "РегистрСведений1",
   "resources": [],
-  "explanation": {
-   "@reference": "\/com.github._1c_syntax.bsl.mdo.InformationRegister\/attributes\/com.github._1c_syntax.bsl.mdo.children.StandardAttribute\/synonym"
-  },
   "mdoReference": {
    "@reference": "\/com.github._1c_syntax.bsl.mdo.InformationRegister\/attributes\/com.github._1c_syntax.bsl.mdo.children.StandardAttribute\/owner"
   },
-  "uuid": "184d9d78-9523-4cfa-9542-a7ba72efe4dd",
-  "mdoRef": "InformationRegister.РегистрСведений1",
   "modules": [
    {
     "owner": {
@@ -56,21 +68,11 @@
     },
     "isProtected": false,
     "moduleType": "RecordSetModule",
-    "uri": "src\/test\/resources\/mdclasses\/InformationRegisters\/РегистрСведени_1\/RecordSetModule.bsl",
     "supportVariant": "NONE"
    }
   ],
-  "supportVariant": "NONE",
   "auxiliaryRecordForm": {
    "@reference": "\/com.github._1c_syntax.bsl.mdo.InformationRegister\/auxiliaryListForm"
-  },
-  "auxiliaryListForm": {
-   "mdoRefRu": "",
-   "type": "UNKNOWN",
-   "mdoRef": ""
-  },
-  "synonym": {
-   "@reference": "\/com.github._1c_syntax.bsl.mdo.InformationRegister\/attributes\/com.github._1c_syntax.bsl.mdo.children.StandardAttribute\/synonym"
   },
   "name": "РегистрСведений1",
   "attributes": [
@@ -246,11 +248,9 @@
    }
   ],
   "comment": "",
-  "objectBelonging": "OWN",
   "defaultRecordForm": {
    "@reference": "\/com.github._1c_syntax.bsl.mdo.InformationRegister\/auxiliaryListForm"
   },
-  "commands": [],
   "forms": [],
   "dimensions": [
    {

--- a/src/test/resources/fixtures/mdclasses_3_18/Configuration.json
+++ b/src/test/resources/fixtures/mdclasses_3_18/Configuration.json
@@ -317,6 +317,7 @@
     },
     "modules": [],
     "supportVariant": "NONE",
+    "informationRegisterPeriodicity": "NONPERIODICAL",
     "auxiliaryRecordForm": {
      "@reference": "\/com.github._1c_syntax.bsl.mdclasses.Configuration\/chartsOfCharacteristicTypes\/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes\/defaultObjectForm"
     },

--- a/src/test/resources/fixtures/mdclasses_3_25/CalculationRegisters.РегистрРасчета1.json
+++ b/src/test/resources/fixtures/mdclasses_3_25/CalculationRegisters.РегистрРасчета1.json
@@ -105,6 +105,7 @@
    "@reference": "\/com.github._1c_syntax.bsl.mdo.CalculationRegister\/attributes\/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute\/synonym"
   },
   "name": "РегистрРасчета1",
+  "periodicity": "MONTH",
   "attributes": [
    {
     "owner": {

--- a/src/test/resources/fixtures/mdclasses_3_25/Configuration.json
+++ b/src/test/resources/fixtures/mdclasses_3_25/Configuration.json
@@ -1252,6 +1252,7 @@
      "@reference": "\/com.github._1c_syntax.bsl.mdclasses.Configuration\/accountingRegisters\/com.github._1c_syntax.bsl.mdo.AccountingRegister\/defaultListForm"
     },
     "name": "РегистрРасчета1",
+    "periodicity": "MONTH",
     "objectBelonging": "OWN",
     "comment": "",
     "attributes": [

--- a/src/test/resources/fixtures/mdclasses_3_27/Configuration.json
+++ b/src/test/resources/fixtures/mdclasses_3_27/Configuration.json
@@ -1260,6 +1260,7 @@
      "@reference": "\/com.github._1c_syntax.bsl.mdclasses.Configuration\/accountingRegisters\/com.github._1c_syntax.bsl.mdo.AccountingRegister\/defaultListForm"
     },
     "name": "РегистрРасчета1",
+    "periodicity": "MONTH",
     "objectBelonging": "OWN",
     "comment": "",
     "attributes": [

--- a/src/test/resources/fixtures/mdclasses_5_1/Configuration.json
+++ b/src/test/resources/fixtures/mdclasses_5_1/Configuration.json
@@ -349,6 +349,7 @@
     },
     "modules": [],
     "supportVariant": "NONE",
+    "informationRegisterPeriodicity": "NONPERIODICAL",
     "auxiliaryRecordForm": {
      "@reference": "\/com.github._1c_syntax.bsl.mdclasses.Configuration\/chartsOfCharacteristicTypes\/com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes\/defaultObjectForm"
     },

--- a/src/test/resources/fixtures/ssl_3_1/InformationRegisters.СклоненияПредставленийОбъектов.json
+++ b/src/test/resources/fixtures/ssl_3_1/InformationRegisters.СклоненияПредставленийОбъектов.json
@@ -237,6 +237,7 @@
   "mdoRef": "InformationRegister.СклоненияПредставленийОбъектов",
   "modules": [],
   "supportVariant": "NOT_EDITABLE",
+  "informationRegisterPeriodicity": "NONPERIODICAL",
   "auxiliaryRecordForm": {
    "@reference": "\/com.github._1c_syntax.bsl.mdo.InformationRegister\/auxiliaryListForm"
   },

--- a/src/test/resources/fixtures/ssl_3_1/InformationRegisters.ЭлектронныеПодписи.json
+++ b/src/test/resources/fixtures/ssl_3_1/InformationRegisters.ЭлектронныеПодписи.json
@@ -405,6 +405,7 @@
    }
   ],
   "supportVariant": "NOT_EDITABLE",
+  "informationRegisterPeriodicity": "NONPERIODICAL",
   "auxiliaryRecordForm": {
    "@reference": "\/com.github._1c_syntax.bsl.mdo.InformationRegister\/auxiliaryListForm"
   },

--- a/src/test/resources/fixtures/ssl_3_2/InformationRegisters.КурсыВалют.json
+++ b/src/test/resources/fixtures/ssl_3_2/InformationRegisters.КурсыВалют.json
@@ -1,0 +1,476 @@
+{
+ "com.github._1c_syntax.bsl.mdo.InformationRegister": {
+  "possibleRights": [
+   "EDIT",
+   "EDIT_DATA_HISTORY_VERSION_COMMENT",
+   "READ",
+   "READ_DATA_HISTORY",
+   "READ_DATA_HISTORY_OF_MISSING_DATA",
+   "SWITCH_TO_DATA_HISTORY_VERSION",
+   "TOTALS_CONTROL",
+   "UPDATE",
+   "UPDATE_DATA_HISTORY",
+   "UPDATE_DATA_HISTORY_OF_MISSING_DATA",
+   "UPDATE_DATA_HISTORY_SETTINGS",
+   "UPDATE_DATA_HISTORY_VERSION_COMMENT",
+   "VIEW",
+   "VIEW_DATA_HISTORY"
+  ],
+  "description": "Курсы валют",
+  "explanation": {
+   "@reference": "\/com.github._1c_syntax.bsl.mdo.InformationRegister\/attributes\/com.github._1c_syntax.bsl.mdo.children.StandardAttribute\/synonym"
+  },
+  "uuid": "105cd740-1f60-45e1-871c-adeecd291b0d",
+  "mdoRef": "InformationRegister.КурсыВалют",
+  "supportVariant": "NOT_EDITABLE",
+  "informationRegisterPeriodicity": "DAY",
+  "auxiliaryListForm": {
+   "mdoRefRu": "",
+   "type": "UNKNOWN",
+   "mdoRef": ""
+  },
+  "synonym": {
+   "content": [
+    {
+     "langKey": "ru",
+     "value": "Курсы валют"
+    }
+   ]
+  },
+  "objectBelonging": "OWN",
+  "commands": [],
+  "mdoType": "INFORMATION_REGISTER",
+  "defaultFormMap": [
+   "AUX_LIST_FORM",
+   {
+    "@reference": "\/com.github._1c_syntax.bsl.mdo.InformationRegister\/auxiliaryListForm"
+   },
+   "AUX_RECORD_FORM",
+   {
+    "@reference": "\/com.github._1c_syntax.bsl.mdo.InformationRegister\/auxiliaryListForm"
+   },
+   "LIST_FORM",
+   {
+    "mdoRefRu": "РегистрСведений.КурсыВалют.Форма.ФормаСписка",
+    "type": "FORM",
+    "mdoRef": "InformationRegister.КурсыВалют.Form.ФормаСписка"
+   },
+   "RECORD_FORM",
+   {
+    "mdoRefRu": "РегистрСведений.КурсыВалют.Форма.ФормаЗаписи",
+    "type": "FORM",
+    "mdoRef": "InformationRegister.КурсыВалют.Form.ФормаЗаписи"
+   }
+  ],
+  "defaultListForm": {
+   "@reference": "\/com.github._1c_syntax.bsl.mdo.InformationRegister\/defaultFormMap\/com.github._1c_syntax.bsl.types.MdoReference[3]"
+  },
+  "templates": [],
+  "resources": [
+   {
+    "owner": {
+     "@reference": "\/com.github._1c_syntax.bsl.mdo.InformationRegister\/attributes\/com.github._1c_syntax.bsl.mdo.children.StandardAttribute\/owner"
+    },
+    "synonym": {
+     "content": [
+      {
+       "langKey": "ru",
+       "value": "Кратность"
+      }
+     ]
+    },
+    "indexing": "DONT_INDEX",
+    "kind": "CUSTOM",
+    "passwordMode": false,
+    "name": "Кратность",
+    "objectBelonging": "OWN",
+    "comment": "",
+    "type": {
+     "types": [
+      "NUMBER"
+     ],
+     "composite": false,
+     "qualifiers": [
+      {
+       "precision": 10,
+       "nonNegative": true,
+       "scale": 0
+      }
+     ]
+    },
+    "uuid": "4bd1cae4-d5b5-444e-9cf5-67a969714293",
+    "mdoReference": {
+     "mdoRefRu": "РегистрСведений.КурсыВалют.Ресурс.Кратность",
+     "type": "RESOURCE",
+     "mdoRef": "InformationRegister.КурсыВалют.Resource.Кратность"
+    },
+    "supportVariant": "NOT_EDITABLE"
+   },
+   {
+    "owner": {
+     "@reference": "\/com.github._1c_syntax.bsl.mdo.InformationRegister\/attributes\/com.github._1c_syntax.bsl.mdo.children.StandardAttribute\/owner"
+    },
+    "synonym": {
+     "content": [
+      {
+       "langKey": "ru",
+       "value": "Курс"
+      }
+     ]
+    },
+    "indexing": "DONT_INDEX",
+    "kind": "CUSTOM",
+    "passwordMode": false,
+    "name": "Курс",
+    "objectBelonging": "OWN",
+    "comment": "",
+    "type": {
+     "types": [
+      {
+       "kind": "DEFINED_TYPE",
+       "variant": "METADATA",
+       "fullName": {
+        "nameRu": "ОпределяемыйТип.КурсВалюты",
+        "nameEn": "DefinedType.КурсВалюты"
+       }
+      }
+     ],
+     "composite": false,
+     "qualifiers": []
+    },
+    "uuid": "95aec7d2-179b-4ea3-a3df-3d737b713564",
+    "mdoReference": {
+     "mdoRefRu": "РегистрСведений.КурсыВалют.Ресурс.Курс",
+     "type": "RESOURCE",
+     "mdoRef": "InformationRegister.КурсыВалют.Resource.Курс"
+    },
+    "supportVariant": "NOT_EDITABLE"
+   }
+  ],
+  "mdoReference": {
+   "@reference": "\/com.github._1c_syntax.bsl.mdo.InformationRegister\/attributes\/com.github._1c_syntax.bsl.mdo.children.StandardAttribute\/owner"
+  },
+  "modules": [
+   {
+    "owner": {
+     "@reference": "\/com.github._1c_syntax.bsl.mdo.InformationRegister\/attributes\/com.github._1c_syntax.bsl.mdo.children.StandardAttribute\/owner"
+    },
+    "isProtected": false,
+    "moduleType": "ManagerModule",
+    "supportVariant": "NOT_EDITABLE"
+   },
+   {
+    "owner": {
+     "@reference": "\/com.github._1c_syntax.bsl.mdo.InformationRegister\/attributes\/com.github._1c_syntax.bsl.mdo.children.StandardAttribute\/owner"
+    },
+    "isProtected": false,
+    "moduleType": "RecordSetModule",
+    "supportVariant": "NOT_EDITABLE"
+   }
+  ],
+  "auxiliaryRecordForm": {
+   "@reference": "\/com.github._1c_syntax.bsl.mdo.InformationRegister\/auxiliaryListForm"
+  },
+  "name": "КурсыВалют",
+  "attributes": [
+   {
+    "owner": {
+     "mdoRefRu": "РегистрСведений.КурсыВалют",
+     "type": "INFORMATION_REGISTER",
+     "mdoRef": "InformationRegister.КурсыВалют"
+    },
+    "kind": "STANDARD",
+    "multiLine": false,
+    "format": {
+     "@reference": "\/com.github._1c_syntax.bsl.mdo.InformationRegister\/attributes\/com.github._1c_syntax.bsl.mdo.children.StandardAttribute\/synonym"
+    },
+    "fullName": {
+     "nameRu": "Активность",
+     "nameEn": "Active"
+    },
+    "editFormat": {
+     "@reference": "\/com.github._1c_syntax.bsl.mdo.InformationRegister\/attributes\/com.github._1c_syntax.bsl.mdo.children.StandardAttribute\/synonym"
+    },
+    "type": {
+     "types": [
+      "BOOLEAN"
+     ],
+     "composite": false,
+     "qualifiers": []
+    },
+    "uuid": "105cd740-1f60-45e1-871c-adeecd291b0d",
+    "mdoReference": {
+     "mdoRefRu": "РегистрСведений.КурсыВалют.СтандартныйРеквизит.Активность",
+     "type": "STANDARD_ATTRIBUTE",
+     "mdoRef": "InformationRegister.КурсыВалют.StandardAttribute.Active"
+    },
+    "supportVariant": "NOT_EDITABLE",
+    "fillFromFillingValue": false,
+    "synonym": {
+     "content": []
+    },
+    "passwordMode": false,
+    "comment": "",
+    "markNegatives": false,
+    "extendedEdit": false,
+    "mask": ""
+   },
+   {
+    "owner": {
+     "@reference": "\/com.github._1c_syntax.bsl.mdo.InformationRegister\/attributes\/com.github._1c_syntax.bsl.mdo.children.StandardAttribute\/owner"
+    },
+    "kind": "STANDARD",
+    "multiLine": false,
+    "format": {
+     "@reference": "\/com.github._1c_syntax.bsl.mdo.InformationRegister\/attributes\/com.github._1c_syntax.bsl.mdo.children.StandardAttribute\/synonym"
+    },
+    "fullName": {
+     "nameRu": "НомерСтроки",
+     "nameEn": "LineNumber"
+    },
+    "editFormat": {
+     "@reference": "\/com.github._1c_syntax.bsl.mdo.InformationRegister\/attributes\/com.github._1c_syntax.bsl.mdo.children.StandardAttribute\/synonym"
+    },
+    "type": {
+     "types": [
+      "NUMBER"
+     ],
+     "composite": false,
+     "qualifiers": [
+      {
+       "precision": 5,
+       "nonNegative": false,
+       "scale": 0
+      }
+     ]
+    },
+    "uuid": "105cd740-1f60-45e1-871c-adeecd291b0d",
+    "mdoReference": {
+     "mdoRefRu": "РегистрСведений.КурсыВалют.СтандартныйРеквизит.НомерСтроки",
+     "type": "STANDARD_ATTRIBUTE",
+     "mdoRef": "InformationRegister.КурсыВалют.StandardAttribute.LineNumber"
+    },
+    "supportVariant": "NOT_EDITABLE",
+    "fillFromFillingValue": false,
+    "synonym": {
+     "@reference": "\/com.github._1c_syntax.bsl.mdo.InformationRegister\/attributes\/com.github._1c_syntax.bsl.mdo.children.StandardAttribute\/synonym"
+    },
+    "passwordMode": false,
+    "comment": "",
+    "markNegatives": false,
+    "extendedEdit": false,
+    "mask": ""
+   },
+   {
+    "owner": {
+     "@reference": "\/com.github._1c_syntax.bsl.mdo.InformationRegister\/attributes\/com.github._1c_syntax.bsl.mdo.children.StandardAttribute\/owner"
+    },
+    "kind": "STANDARD",
+    "multiLine": false,
+    "format": {
+     "@reference": "\/com.github._1c_syntax.bsl.mdo.InformationRegister\/attributes\/com.github._1c_syntax.bsl.mdo.children.StandardAttribute\/synonym"
+    },
+    "fullName": {
+     "nameRu": "Период",
+     "nameEn": "Period"
+    },
+    "editFormat": {
+     "@reference": "\/com.github._1c_syntax.bsl.mdo.InformationRegister\/attributes\/com.github._1c_syntax.bsl.mdo.children.StandardAttribute\/synonym"
+    },
+    "type": {
+     "types": [
+      "DATE"
+     ],
+     "composite": false,
+     "qualifiers": [
+      {
+       "dateFractions": 2
+      }
+     ]
+    },
+    "uuid": "105cd740-1f60-45e1-871c-adeecd291b0d",
+    "mdoReference": {
+     "mdoRefRu": "РегистрСведений.КурсыВалют.СтандартныйРеквизит.Период",
+     "type": "STANDARD_ATTRIBUTE",
+     "mdoRef": "InformationRegister.КурсыВалют.StandardAttribute.Period"
+    },
+    "supportVariant": "NOT_EDITABLE",
+    "fillFromFillingValue": false,
+    "synonym": {
+     "content": [
+      {
+       "langKey": "ru",
+       "value": "Дата курса"
+      }
+     ]
+    },
+    "passwordMode": false,
+    "comment": "",
+    "markNegatives": false,
+    "extendedEdit": false,
+    "mask": ""
+   },
+   {
+    "owner": {
+     "@reference": "\/com.github._1c_syntax.bsl.mdo.InformationRegister\/attributes\/com.github._1c_syntax.bsl.mdo.children.StandardAttribute\/owner"
+    },
+    "kind": "STANDARD",
+    "multiLine": false,
+    "format": {
+     "@reference": "\/com.github._1c_syntax.bsl.mdo.InformationRegister\/attributes\/com.github._1c_syntax.bsl.mdo.children.StandardAttribute\/synonym"
+    },
+    "fullName": {
+     "nameRu": "Регистратор",
+     "nameEn": "Recorder"
+    },
+    "editFormat": {
+     "@reference": "\/com.github._1c_syntax.bsl.mdo.InformationRegister\/attributes\/com.github._1c_syntax.bsl.mdo.children.StandardAttribute\/synonym"
+    },
+    "type": {
+     "types": [],
+     "composite": false,
+     "qualifiers": []
+    },
+    "uuid": "105cd740-1f60-45e1-871c-adeecd291b0d",
+    "mdoReference": {
+     "mdoRefRu": "РегистрСведений.КурсыВалют.СтандартныйРеквизит.Регистратор",
+     "type": "STANDARD_ATTRIBUTE",
+     "mdoRef": "InformationRegister.КурсыВалют.StandardAttribute.Recorder"
+    },
+    "supportVariant": "NOT_EDITABLE",
+    "fillFromFillingValue": false,
+    "synonym": {
+     "@reference": "\/com.github._1c_syntax.bsl.mdo.InformationRegister\/attributes\/com.github._1c_syntax.bsl.mdo.children.StandardAttribute\/synonym"
+    },
+    "passwordMode": false,
+    "comment": "",
+    "markNegatives": false,
+    "extendedEdit": false,
+    "mask": ""
+   }
+  ],
+  "comment": "",
+  "defaultRecordForm": {
+   "@reference": "\/com.github._1c_syntax.bsl.mdo.InformationRegister\/defaultFormMap\/com.github._1c_syntax.bsl.types.MdoReference[4]"
+  },
+  "forms": [
+   {
+    "owner": {
+     "@reference": "\/com.github._1c_syntax.bsl.mdo.InformationRegister\/attributes\/com.github._1c_syntax.bsl.mdo.children.StandardAttribute\/owner"
+    },
+    "synonym": {
+     "content": [
+      {
+       "langKey": "ru",
+       "value": "Форма списка"
+      }
+     ]
+    },
+    "formType": "MANAGED",
+    "name": "ФормаСписка",
+    "objectBelonging": "OWN",
+    "comment": "",
+    "uuid": "a2f19cb2-9f2e-442b-b9f2-e5253c70871c",
+    "mdoReference": {
+     "@reference": "\/com.github._1c_syntax.bsl.mdo.InformationRegister\/defaultFormMap\/com.github._1c_syntax.bsl.types.MdoReference[3]"
+    },
+    "usePurposes": [
+     "MOBILE_PLATFORM_APPLICATION",
+     "PLATFORM_APPLICATION"
+    ],
+    "modules": [
+     {
+      "owner": {
+       "@reference": "\/com.github._1c_syntax.bsl.mdo.InformationRegister\/defaultFormMap\/com.github._1c_syntax.bsl.types.MdoReference[3]"
+      },
+      "isProtected": false,
+      "moduleType": "FormModule",
+      "supportVariant": "NOT_EDITABLE"
+     }
+    ],
+    "supportVariant": "NOT_EDITABLE"
+   },
+   {
+    "owner": {
+     "@reference": "\/com.github._1c_syntax.bsl.mdo.InformationRegister\/attributes\/com.github._1c_syntax.bsl.mdo.children.StandardAttribute\/owner"
+    },
+    "synonym": {
+     "content": [
+      {
+       "langKey": "ru",
+       "value": "Форма записи"
+      }
+     ]
+    },
+    "formType": "MANAGED",
+    "name": "ФормаЗаписи",
+    "objectBelonging": "OWN",
+    "comment": "",
+    "uuid": "f279a625-b88f-43b4-bce9-de1186fe7d7e",
+    "mdoReference": {
+     "@reference": "\/com.github._1c_syntax.bsl.mdo.InformationRegister\/defaultFormMap\/com.github._1c_syntax.bsl.types.MdoReference[4]"
+    },
+    "usePurposes": [
+     "MOBILE_PLATFORM_APPLICATION",
+     "PLATFORM_APPLICATION"
+    ],
+    "modules": [
+     {
+      "owner": {
+       "@reference": "\/com.github._1c_syntax.bsl.mdo.InformationRegister\/defaultFormMap\/com.github._1c_syntax.bsl.types.MdoReference[4]"
+      },
+      "isProtected": false,
+      "moduleType": "FormModule",
+      "supportVariant": "NOT_EDITABLE"
+     }
+    ],
+    "supportVariant": "NOT_EDITABLE"
+   }
+  ],
+  "dimensions": [
+   {
+    "owner": {
+     "@reference": "\/com.github._1c_syntax.bsl.mdo.InformationRegister\/attributes\/com.github._1c_syntax.bsl.mdo.children.StandardAttribute\/owner"
+    },
+    "indexing": "DONT_INDEX",
+    "kind": "CUSTOM",
+    "useInTotals": true,
+    "type": {
+     "types": [
+      {
+       "kind": "CATALOG",
+       "variant": "METADATA",
+       "fullName": {
+        "nameRu": "СправочникСсылка.Валюты",
+        "nameEn": "CatalogRef.Валюты"
+       }
+      }
+     ],
+     "composite": false,
+     "qualifiers": []
+    },
+    "uuid": "b1a330d7-9b88-44e9-aba6-41ce5e5e669c",
+    "mdoReference": {
+     "mdoRefRu": "РегистрСведений.КурсыВалют.Измерение.Валюта",
+     "type": "DIMENSION",
+     "mdoRef": "InformationRegister.КурсыВалют.Dimension.Валюта"
+    },
+    "supportVariant": "NOT_EDITABLE",
+    "master": true,
+    "synonym": {
+     "content": [
+      {
+       "langKey": "ru",
+       "value": "Валюта"
+      }
+     ]
+    },
+    "passwordMode": false,
+    "name": "Валюта",
+    "objectBelonging": "OWN",
+    "comment": "",
+    "denyIncompleteValues": true
+   }
+  ]
+ }
+}

--- a/src/test/resources/fixtures/ssl_3_2/InformationRegisters.СклоненияПредставленийОбъектов.json
+++ b/src/test/resources/fixtures/ssl_3_2/InformationRegisters.СклоненияПредставленийОбъектов.json
@@ -1,5 +1,44 @@
 {
  "com.github._1c_syntax.bsl.mdo.InformationRegister": {
+  "possibleRights": [
+   "EDIT",
+   "EDIT_DATA_HISTORY_VERSION_COMMENT",
+   "READ",
+   "READ_DATA_HISTORY",
+   "READ_DATA_HISTORY_OF_MISSING_DATA",
+   "SWITCH_TO_DATA_HISTORY_VERSION",
+   "TOTALS_CONTROL",
+   "UPDATE",
+   "UPDATE_DATA_HISTORY",
+   "UPDATE_DATA_HISTORY_OF_MISSING_DATA",
+   "UPDATE_DATA_HISTORY_SETTINGS",
+   "UPDATE_DATA_HISTORY_VERSION_COMMENT",
+   "VIEW",
+   "VIEW_DATA_HISTORY"
+  ],
+  "description": "Склонения представлений объектов",
+  "explanation": {
+   "@reference": "\/com.github._1c_syntax.bsl.mdo.InformationRegister\/attributes\/com.github._1c_syntax.bsl.mdo.children.StandardAttribute\/synonym"
+  },
+  "uuid": "7bf36370-3761-4fd5-bea5-90fa142a9d57",
+  "mdoRef": "InformationRegister.СклоненияПредставленийОбъектов",
+  "supportVariant": "NOT_EDITABLE",
+  "informationRegisterPeriodicity": "NONPERIODICAL",
+  "auxiliaryListForm": {
+   "mdoRefRu": "",
+   "type": "UNKNOWN",
+   "mdoRef": ""
+  },
+  "synonym": {
+   "content": [
+    {
+     "langKey": "ru",
+     "value": "Склонения представлений объектов"
+    }
+   ]
+  },
+  "objectBelonging": "OWN",
+  "commands": [],
   "mdoType": "INFORMATION_REGISTER",
   "defaultFormMap": [
    "AUX_LIST_FORM",
@@ -24,24 +63,7 @@
   "defaultListForm": {
    "@reference": "\/com.github._1c_syntax.bsl.mdo.InformationRegister\/auxiliaryListForm"
   },
-  "possibleRights": [
-   "EDIT",
-   "EDIT_DATA_HISTORY_VERSION_COMMENT",
-   "READ",
-   "READ_DATA_HISTORY",
-   "READ_DATA_HISTORY_OF_MISSING_DATA",
-   "SWITCH_TO_DATA_HISTORY_VERSION",
-   "TOTALS_CONTROL",
-   "UPDATE",
-   "UPDATE_DATA_HISTORY",
-   "UPDATE_DATA_HISTORY_OF_MISSING_DATA",
-   "UPDATE_DATA_HISTORY_SETTINGS",
-   "UPDATE_DATA_HISTORY_VERSION_COMMENT",
-   "VIEW",
-   "VIEW_DATA_HISTORY"
-  ],
   "templates": [],
-  "description": "Склонения представлений объектов",
   "resources": [
    {
     "owner": {
@@ -227,31 +249,12 @@
     "supportVariant": "NOT_EDITABLE"
    }
   ],
-  "explanation": {
-   "@reference": "\/com.github._1c_syntax.bsl.mdo.InformationRegister\/attributes\/com.github._1c_syntax.bsl.mdo.children.StandardAttribute\/synonym"
-  },
   "mdoReference": {
    "@reference": "\/com.github._1c_syntax.bsl.mdo.InformationRegister\/attributes\/com.github._1c_syntax.bsl.mdo.children.StandardAttribute\/owner"
   },
-  "uuid": "7bf36370-3761-4fd5-bea5-90fa142a9d57",
-  "mdoRef": "InformationRegister.СклоненияПредставленийОбъектов",
   "modules": [],
-  "supportVariant": "NOT_EDITABLE",
   "auxiliaryRecordForm": {
    "@reference": "\/com.github._1c_syntax.bsl.mdo.InformationRegister\/auxiliaryListForm"
-  },
-  "auxiliaryListForm": {
-   "mdoRefRu": "",
-   "type": "UNKNOWN",
-   "mdoRef": ""
-  },
-  "synonym": {
-   "content": [
-    {
-     "langKey": "ru",
-     "value": "Склонения представлений объектов"
-    }
-   ]
   },
   "name": "СклоненияПредставленийОбъектов",
   "attributes": [
@@ -427,11 +430,9 @@
    }
   ],
   "comment": "",
-  "objectBelonging": "OWN",
   "defaultRecordForm": {
    "@reference": "\/com.github._1c_syntax.bsl.mdo.InformationRegister\/defaultFormMap\/com.github._1c_syntax.bsl.types.MdoReference[4]"
   },
-  "commands": [],
   "forms": [
    {
     "owner": {
@@ -464,7 +465,6 @@
       },
       "isProtected": false,
       "moduleType": "FormModule",
-      "uri": "src\/test\/resources\/ssl_3_2\/InformationRegisters\/СклоненияПредставлени_Объектов\/Forms\/ФормаЗаписи\/Module.bsl",
       "supportVariant": "NOT_EDITABLE"
      }
     ],

--- a/src/test/resources/fixtures/ssl_3_2/InformationRegisters.ЭлектронныеПодписи.json
+++ b/src/test/resources/fixtures/ssl_3_2/InformationRegisters.ЭлектронныеПодписи.json
@@ -1,5 +1,44 @@
 {
  "com.github._1c_syntax.bsl.mdo.InformationRegister": {
+  "possibleRights": [
+   "EDIT",
+   "EDIT_DATA_HISTORY_VERSION_COMMENT",
+   "READ",
+   "READ_DATA_HISTORY",
+   "READ_DATA_HISTORY_OF_MISSING_DATA",
+   "SWITCH_TO_DATA_HISTORY_VERSION",
+   "TOTALS_CONTROL",
+   "UPDATE",
+   "UPDATE_DATA_HISTORY",
+   "UPDATE_DATA_HISTORY_OF_MISSING_DATA",
+   "UPDATE_DATA_HISTORY_SETTINGS",
+   "UPDATE_DATA_HISTORY_VERSION_COMMENT",
+   "VIEW",
+   "VIEW_DATA_HISTORY"
+  ],
+  "description": "Электронные подписи",
+  "explanation": {
+   "@reference": "\/com.github._1c_syntax.bsl.mdo.InformationRegister\/attributes\/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute\/format"
+  },
+  "uuid": "b50f3157-3c3a-4553-a16a-7fcd660e2824",
+  "mdoRef": "InformationRegister.ЭлектронныеПодписи",
+  "supportVariant": "NOT_EDITABLE",
+  "informationRegisterPeriodicity": "NONPERIODICAL",
+  "auxiliaryListForm": {
+   "mdoRefRu": "",
+   "type": "UNKNOWN",
+   "mdoRef": ""
+  },
+  "synonym": {
+   "content": [
+    {
+     "langKey": "ru",
+     "value": "Электронные подписи"
+    }
+   ]
+  },
+  "objectBelonging": "OWN",
+  "commands": [],
   "mdoType": "INFORMATION_REGISTER",
   "defaultFormMap": [
    "AUX_LIST_FORM",
@@ -22,24 +61,7 @@
   "defaultListForm": {
    "@reference": "\/com.github._1c_syntax.bsl.mdo.InformationRegister\/auxiliaryListForm"
   },
-  "possibleRights": [
-   "EDIT",
-   "EDIT_DATA_HISTORY_VERSION_COMMENT",
-   "READ",
-   "READ_DATA_HISTORY",
-   "READ_DATA_HISTORY_OF_MISSING_DATA",
-   "SWITCH_TO_DATA_HISTORY_VERSION",
-   "TOTALS_CONTROL",
-   "UPDATE",
-   "UPDATE_DATA_HISTORY",
-   "UPDATE_DATA_HISTORY_OF_MISSING_DATA",
-   "UPDATE_DATA_HISTORY_SETTINGS",
-   "UPDATE_DATA_HISTORY_VERSION_COMMENT",
-   "VIEW",
-   "VIEW_DATA_HISTORY"
-  ],
   "templates": [],
-  "description": "Электронные подписи",
   "resources": [
    {
     "owner": {
@@ -385,14 +407,9 @@
     "supportVariant": "NOT_EDITABLE"
    }
   ],
-  "explanation": {
-   "@reference": "\/com.github._1c_syntax.bsl.mdo.InformationRegister\/attributes\/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute\/format"
-  },
   "mdoReference": {
    "@reference": "\/com.github._1c_syntax.bsl.mdo.InformationRegister\/attributes\/com.github._1c_syntax.bsl.mdo.children.ObjectAttribute\/owner"
   },
-  "uuid": "b50f3157-3c3a-4553-a16a-7fcd660e2824",
-  "mdoRef": "InformationRegister.ЭлектронныеПодписи",
   "modules": [
    {
     "owner": {
@@ -400,26 +417,11 @@
     },
     "isProtected": false,
     "moduleType": "ManagerModule",
-    "uri": "src\/test\/resources\/ssl_3_2\/InformationRegisters\/ЭлектронныеПодписи\/ManagerModule.bsl",
     "supportVariant": "NOT_EDITABLE"
    }
   ],
-  "supportVariant": "NOT_EDITABLE",
   "auxiliaryRecordForm": {
    "@reference": "\/com.github._1c_syntax.bsl.mdo.InformationRegister\/auxiliaryListForm"
-  },
-  "auxiliaryListForm": {
-   "mdoRefRu": "",
-   "type": "UNKNOWN",
-   "mdoRef": ""
-  },
-  "synonym": {
-   "content": [
-    {
-     "langKey": "ru",
-     "value": "Электронные подписи"
-    }
-   ]
   },
   "name": "ЭлектронныеПодписи",
   "attributes": [
@@ -979,11 +981,9 @@
    }
   ],
   "comment": "",
-  "objectBelonging": "OWN",
   "defaultRecordForm": {
    "@reference": "\/com.github._1c_syntax.bsl.mdo.InformationRegister\/auxiliaryListForm"
   },
-  "commands": [],
   "forms": [
    {
     "owner": {
@@ -1018,7 +1018,6 @@
       },
       "isProtected": false,
       "moduleType": "FormModule",
-      "uri": "src\/test\/resources\/ssl_3_2\/InformationRegisters\/ЭлектронныеПодписи\/Forms\/ОбоснованиеДостоверностиПодписи\/Module.bsl",
       "supportVariant": "NOT_EDITABLE"
      }
     ],


### PR DESCRIPTION
## Описание

Добавлено чтение свойства **«Периодичность»** у регистров, где оно есть в модели 1С. Ранее оно не читалось ни из формата конфигуратора, ни из EDT.

Проверены все виды регистров:

| Тип регистра | «Периодичность» | Действие |
|---|---|---|
| Регистр сведений (`InformationRegister`) | есть | ✅ добавлено чтение |
| Регистр расчета (`CalculationRegister`) | есть | ✅ добавлено чтение |
| Регистр бухгалтерии (`AccountingRegister`) | нет (есть `PeriodAdjustmentLength` — иное) | — |
| Регистр накопления (`AccumulationRegister`) | нет (есть `RegisterType`) | — |

### Регистр сведений

- Перечисление `InformationRegisterPeriodicity` (`Nonperiodical`, `RecorderPosition`, `Second`, `Day`, `Month`, `Quarter`, `Year`, + `Unknown`).
- Поле `informationRegisterPeriodicity` в `InformationRegister`, по умолчанию `NONPERIODICAL`.
- Элементы: конфигуратор `<InformationRegisterPeriodicity>`, EDT `<informationRegisterPeriodicity>`.
- Пример периодического регистра в тестах — `КурсыВалют` (`DAY`).

### Регистр расчета

- Перечисление `CalculationRegisterPeriodicity` (`Day`, `Month`, `Quarter`, `Year`, + `Unknown`).
- Поле `periodicity` в `CalculationRegister`, по умолчанию `MONTH`.
- Элементы: конфигуратор `<Periodicity>`, EDT `<periodicity>`.

### Общее

- Регистрация `EnumConverter` для обоих перечислений в `ExtendXStream`.
- Юнит-тесты перечислений + проверки периодичности в `InformationRegisterTest` / `CalculationRegisterTest`.
- Обновлены затронутые фикстуры (top-level и встроенные в `Configuration`).
- Служебный генератор фикстур `GenerateMdoFixtures` (запуск через `main`, не входит в прогон тестов).

## Связанные задачи

Closes

## Чеклист

### Общие

- [x] Ветка PR обновлена из develop
- [x] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [x] Изменения покрыты тестами
- [ ] Обязательные действия перед коммитом выполнены (запускал команду `gradlew precommit`)

## Дополнительно

Проверено локально: `license`, юнит-тесты перечислений, `InformationRegisterTest`, `CalculationRegisterTest` и `FixtureComparisonTest` — зелёные для доступных пакетов `mdclasses*`/`ssl_3_2`. Пакеты `ssl_3_1` в этой среде недоступны как сабмодуль (проверены на CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
