### PR TITLE
perf(reader): кэш дескриптора сеттера в TransformationUtils

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/reader/common/TransformationUtils.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/reader/common/TransformationUtils.java
@@ -34,7 +34,6 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListMap;
@@ -48,6 +47,7 @@ public class TransformationUtils {
 
   private static final Map<String, Map<String, Optional<Method>>> METHODS = new ConcurrentHashMap<>();
   private static final Map<String, Map<String, Optional<Type>>> TYPES = new ConcurrentHashMap<>();
+  private static final Map<String, Map<String, Optional<SetterDescriptor>>> SETTERS = new ConcurrentHashMap<>();
   private static final String BUILD_METHOD_NAME = "build";
   private static final String BUILDER_METHOD_NAME = "builder";
   private static final String TO_BUILDER_METHOD_NAME = "toBuilder";
@@ -61,16 +61,13 @@ public class TransformationUtils {
    * @param value      Устанавливаемое значение
    */
   public void setValue(Object source, String methodName, @Nullable Object value) {
-    var method = getMethod(source.getClass(), methodName);
-    if (method != null && value != null) {
+    if (value == null) {
+      return;
+    }
+    var descriptor = getSetter(source.getClass(), methodName);
+    if (descriptor != null) {
       try {
-        var parameterType = method.getGenericParameterTypes()[0];
-        if (parameterType instanceof ParameterizedType && !(value instanceof List)) {
-          var singular = getMethod(source.getClass(), "add" + methodName);
-          Objects.requireNonNullElse(singular, method).invoke(source, value);
-        } else {
-          method.invoke(source, value);
-        }
+        descriptor.target(value).invoke(source, value);
       } catch (IllegalArgumentException | InvocationTargetException | IllegalAccessException e) {
         LOGGER.error(LOGGER_MESSAGE_PREF, source.getClass(), methodName, e);
       }
@@ -181,6 +178,56 @@ public class TransformationUtils {
         .filter(m -> methodName.equalsIgnoreCase(m.getName()))
         .findFirst())
       .orElse(null);
+  }
+
+  @Nullable
+  private SetterDescriptor getSetter(Class<?> clazz, String methodName) {
+    return SETTERS.computeIfAbsent(clazz.getName(),
+        k -> new ConcurrentSkipListMap<>(String.CASE_INSENSITIVE_ORDER))
+      .computeIfAbsent(methodName, k -> computeSetter(clazz, methodName))
+      .orElse(null);
+  }
+
+  private Optional<SetterDescriptor> computeSetter(Class<?> clazz, String methodName) {
+    var setter = getMethod(clazz, methodName);
+    if (setter == null) {
+      return Optional.empty();
+    }
+    var parameterized = setter.getGenericParameterTypes()[0] instanceof ParameterizedType;
+    var singularAdder = parameterized ? getMethod(clazz, "add" + methodName) : null;
+    return Optional.of(new SetterDescriptor(setter, parameterized, singularAdder));
+  }
+
+  /**
+   * Разобранный сеттер билдера, закэшированный по паре (класс, свойство).
+   * <p>
+   * Раньше {@code setValue} на каждый вызов заново вычислял тип параметра
+   * ({@code getGenericParameterTypes()} аллоцирует массив) и, для параметризованных
+   * свойств, склеивал имя {@code "add" + methodName} и делал повторный поиск метода.
+   * Дескриптор считает это один раз.
+   *
+   * @param setter        Метод-сеттер билдера.
+   * @param parameterized Признак того, что первый параметр — параметризованный тип
+   *                      (коллекция), для которого одиночное значение ставится через
+   *                      {@code singularAdder}.
+   * @param singularAdder Метод добавления одиночного значения ({@code add<Свойство>}) или
+   *                      {@code null}, если его нет либо свойство не параметризованное.
+   */
+  private record SetterDescriptor(Method setter, boolean parameterized, @Nullable Method singularAdder) {
+
+    /**
+     * Выбирает целевой метод под конкретное значение: для параметризованного свойства и
+     * одиночного (не {@link List}) значения — {@code singularAdder} (если есть), иначе сеттер.
+     *
+     * @param value Устанавливаемое значение.
+     * @return Метод для вызова через рефлексию.
+     */
+    private Method target(Object value) {
+      if (parameterized && singularAdder != null && !(value instanceof List)) {
+        return singularAdder;
+      }
+      return setter;
+    }
   }
 
   private static Optional<Type> computeFieldType(Object source, String methodName) {


### PR DESCRIPTION
## Описание

Профилирование чтения метаданных (mdclasses даёт ~42 % CPU при `analyze` большой конфигурации)
показало, что `TransformationUtils.setValue` на каждый XML-узел заново вычислял тип параметра
сеттера — `method.getGenericParameterTypes()` аллоцирует `Type[]` на каждый вызов — и, для
параметризованных свойств, склеивал `"add" + methodName` и делал повторный поиск метода.

Кэшируем разобранный сеттер в дескриптор `(setter, parameterized, singularAdder)` по паре
`(класс, свойство)`. `setValue` теперь только выбирает целевой метод и вызывает его — без повторной
интроспекции и аллокаций на каждый вызов. Поведение идентично.

### Замеры

JMH `MDClassesBenchmark.test_Designer_CreateConfiguration_SkipSupport_False`, направленный на
реальную конфигурацию (cpm, ~13k файлов) через `-Dbench.designer.path`, `-f 2 -wi 2 -i 5 -prof gc`
(один op = полное чтение конфигурации):

| метрика | before | after |
|---|---|---|
| gc.alloc.rate.norm | 5155.0 МБ/чтение ± 4.3 | **5078.1 МБ/чтение ± 6.1** |
| дельта аллокаций | — | **−77 МБ (−1.5 %)** |
| wall (avgt) | 13.57 с ± 3.2 | 12.59 с ± 3.6 (в пределах шума) |

Снижение аллокационной нагрузки чистое и стабильное (погрешность ±4–6 МБ при дельте 77 МБ). Wall —
в пределах шума (чтение 13k файлов + GC 5 ГБ/op), регрессии нет.

## Связанные задачи

<!-- Оптимизация выявлена профилированием чтения метаданных. Issue приложит мейнтейнер. -->
Closes

## Чеклист

### Общие

- [x] Ветка PR обновлена из develop
- [x] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [x] Изменения покрыты тестами (`TransformationUtilsTest`; интеграционные `MDOReaderTest` зелёные)
- [ ] Обязательные действия перед коммитом выполнены (`gradlew precommit`) — прогонял reader-тесты

## Дополнительно

Поведение `setValue` сохранено 1:1 (сеттер / одиночный `add`-метод для параметризованных свойств).