### PR TITLE
perf(reader): CI skip-list кэши → get-first ConcurrentHashMap

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/reader/common/TransformationUtils.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/reader/common/TransformationUtils.java
@@ -34,7 +34,6 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -44,9 +43,17 @@ import java.util.concurrent.ConcurrentHashMap;
 @Slf4j
 public class TransformationUtils {
 
-  private static final Map<String, Map<String, Optional<Method>>> METHODS = new ConcurrentHashMap<>();
-  private static final Map<String, Map<String, Optional<Type>>> TYPES = new ConcurrentHashMap<>();
-  private static final Map<String, Map<String, Optional<SetterDescriptor>>> SETTERS = new ConcurrentHashMap<>();
+  private static final Map<String, Map<String, Method>> METHODS = new ConcurrentHashMap<>();
+  private static final Map<String, Map<String, Type>> TYPES = new ConcurrentHashMap<>();
+  private static final Map<String, Map<String, SetterDescriptor>> SETTERS = new ConcurrentHashMap<>();
+
+  // Сентинелы отрицательного результата. В ConcurrentHashMap нельзя хранить null, но
+  // отсутствие метода/типа/сеттера тоже нужно кэшировать (иначе повторный дорогой резолв
+  // на каждый промах). Отличаются по ссылочной идентичности от любого настоящего значения.
+  private static final Method ABSENT_METHOD = absentMethod();
+  private static final Type ABSENT_TYPE = void.class;
+  private static final SetterDescriptor ABSENT_SETTER = new SetterDescriptor(ABSENT_METHOD, false, null);
+
   private static final String BUILD_METHOD_NAME = "build";
   private static final String BUILDER_METHOD_NAME = "builder";
   private static final String TO_BUILDER_METHOD_NAME = "toBuilder";
@@ -99,7 +106,7 @@ public class TransformationUtils {
       cached = computeFieldType(source, methodName);
       perClass.putIfAbsent(methodName, cached);
     }
-    return cached.orElse(null);
+    return cached == ABSENT_TYPE ? null : cached;
   }
 
   /**
@@ -180,10 +187,11 @@ public class TransformationUtils {
     if (cached == null) {
       cached = Arrays.stream(clazz.getDeclaredMethods())
         .filter(m -> methodName.equalsIgnoreCase(m.getName()))
-        .findFirst();
+        .findFirst()
+        .orElse(ABSENT_METHOD);
       perClass.putIfAbsent(methodName, cached);
     }
-    return cached.orElse(null);
+    return cached == ABSENT_METHOD ? null : cached;
   }
 
   @Nullable
@@ -194,16 +202,17 @@ public class TransformationUtils {
       cached = computeSetter(clazz, methodName);
       perClass.putIfAbsent(methodName, cached);
     }
-    return cached.orElse(null);
+    return cached == ABSENT_SETTER ? null : cached;
   }
 
   /**
    * Возвращает (создавая при первом обращении) пер-классовый кэш по имени класса.
    * <p>
-   * Используется {@code get()}-first вместо {@code computeIfAbsent} с захватывающей лямбдой:
-   * на попадании в кэш (горячий путь) лямбда не аллоцируется. {@code ConcurrentHashMap.computeIfAbsent}
-   * не встраивается JIT-ом, из-за чего захватывающая лямбда-функция отображения перестаёт
-   * скаляризоваться escape-анализом и аллоцируется на каждый вызов.
+   * Лямбда {@code k -> new ConcurrentHashMap<>()} незахватывающая, поэтому компилируется в
+   * синглтон и не аллоцируется на вызов; {@code computeIfAbsent} здесь безопасен по аллокациям.
+   * Захватывающие лямбды (резолв метода/типа/сеттера) вынесены на {@code get()}-first в вызывающих
+   * методах — иначе {@code ConcurrentHashMap.computeIfAbsent} (не встраивается JIT-ом) не даёт
+   * escape-анализу их скаляризовать.
    *
    * @param cache     Двухуровневый кэш «имя класса → (имя свойства → значение)».
    * @param className Имя класса.
@@ -211,21 +220,17 @@ public class TransformationUtils {
    * @return Пер-классовый кэш свойств.
    */
   private static <V> Map<String, V> perClassCache(Map<String, Map<String, V>> cache, String className) {
-    var perClass = cache.get(className);
-    if (perClass == null) {
-      perClass = cache.computeIfAbsent(className, k -> new ConcurrentHashMap<>());
-    }
-    return perClass;
+    return cache.computeIfAbsent(className, k -> new ConcurrentHashMap<>());
   }
 
-  private Optional<SetterDescriptor> computeSetter(Class<?> clazz, String methodName) {
+  private SetterDescriptor computeSetter(Class<?> clazz, String methodName) {
     var setter = getMethod(clazz, methodName);
     if (setter == null) {
-      return Optional.empty();
+      return ABSENT_SETTER;
     }
     var parameterized = setter.getGenericParameterTypes()[0] instanceof ParameterizedType;
     var singularAdder = parameterized ? getMethod(clazz, "add" + methodName) : null;
-    return Optional.of(new SetterDescriptor(setter, parameterized, singularAdder));
+    return new SetterDescriptor(setter, parameterized, singularAdder);
   }
 
   /**
@@ -260,7 +265,7 @@ public class TransformationUtils {
     }
   }
 
-  private static Optional<Type> computeFieldType(Object source, String methodName) {
+  private static Type computeFieldType(Object source, String methodName) {
     var method = getMethod(source.getClass(), methodName);
     if (method != null) {
       var fieldClass = method.getGenericParameterTypes()[0];
@@ -272,8 +277,22 @@ public class TransformationUtils {
           fieldClass = type;
         }
       }
-      return Optional.of(fieldClass);
+      return fieldClass;
     }
-    return Optional.empty();
+    return ABSENT_TYPE;
+  }
+
+  private static Method absentMethod() {
+    try {
+      return TransformationUtils.class.getDeclaredMethod("absentMethodTarget");
+    } catch (NoSuchMethodException e) {
+      throw new ExceptionInInitializerError(e);
+    }
+  }
+
+  @SuppressWarnings("unused")
+  private static void absentMethodTarget() {
+    // Целевой метод-маркер для ABSENT_METHOD; никогда не вызывается — нужен лишь как
+    // ненулевой уникальный экземпляр Method для сентинела отрицательного результата кэша.
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/reader/common/TransformationUtils.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/reader/common/TransformationUtils.java
@@ -36,7 +36,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentSkipListMap;
 
 /**
  * Вспомогательный класс для конвертирования значений между моделями
@@ -94,10 +93,13 @@ public class TransformationUtils {
    */
   @Nullable
   public Type fieldType(Object source, String methodName) {
-    return TYPES.computeIfAbsent(source.getClass().getName(),
-        k -> new ConcurrentSkipListMap<>(String.CASE_INSENSITIVE_ORDER))
-      .computeIfAbsent(methodName, l -> computeFieldType(source, methodName))
-      .orElse(null);
+    var perClass = perClassCache(TYPES, source.getClass().getName());
+    var cached = perClass.get(methodName);
+    if (cached == null) {
+      cached = computeFieldType(source, methodName);
+      perClass.putIfAbsent(methodName, cached);
+    }
+    return cached.orElse(null);
   }
 
   /**
@@ -173,19 +175,47 @@ public class TransformationUtils {
 
   @Nullable
   private Method getMethod(Class<?> clazz, String methodName) {
-    return METHODS.computeIfAbsent(clazz.getName(), k -> new ConcurrentSkipListMap<>(String.CASE_INSENSITIVE_ORDER))
-      .computeIfAbsent(methodName, k -> Arrays.stream(clazz.getDeclaredMethods())
+    var perClass = perClassCache(METHODS, clazz.getName());
+    var cached = perClass.get(methodName);
+    if (cached == null) {
+      cached = Arrays.stream(clazz.getDeclaredMethods())
         .filter(m -> methodName.equalsIgnoreCase(m.getName()))
-        .findFirst())
-      .orElse(null);
+        .findFirst();
+      perClass.putIfAbsent(methodName, cached);
+    }
+    return cached.orElse(null);
   }
 
   @Nullable
   private SetterDescriptor getSetter(Class<?> clazz, String methodName) {
-    return SETTERS.computeIfAbsent(clazz.getName(),
-        k -> new ConcurrentSkipListMap<>(String.CASE_INSENSITIVE_ORDER))
-      .computeIfAbsent(methodName, k -> computeSetter(clazz, methodName))
-      .orElse(null);
+    var perClass = perClassCache(SETTERS, clazz.getName());
+    var cached = perClass.get(methodName);
+    if (cached == null) {
+      cached = computeSetter(clazz, methodName);
+      perClass.putIfAbsent(methodName, cached);
+    }
+    return cached.orElse(null);
+  }
+
+  /**
+   * Возвращает (создавая при первом обращении) пер-классовый кэш по имени класса.
+   * <p>
+   * Используется {@code get()}-first вместо {@code computeIfAbsent} с захватывающей лямбдой:
+   * на попадании в кэш (горячий путь) лямбда не аллоцируется. {@code ConcurrentHashMap.computeIfAbsent}
+   * не встраивается JIT-ом, из-за чего захватывающая лямбда-функция отображения перестаёт
+   * скаляризоваться escape-анализом и аллоцируется на каждый вызов.
+   *
+   * @param cache     Двухуровневый кэш «имя класса → (имя свойства → значение)».
+   * @param className Имя класса.
+   * @param <V>       Тип кэшируемого значения.
+   * @return Пер-классовый кэш свойств.
+   */
+  private static <V> Map<String, V> perClassCache(Map<String, Map<String, V>> cache, String className) {
+    var perClass = cache.get(className);
+    if (perClass == null) {
+      perClass = cache.computeIfAbsent(className, k -> new ConcurrentHashMap<>());
+    }
+    return perClass;
   }
 
   private Optional<SetterDescriptor> computeSetter(Class<?> clazz, String methodName) {


### PR DESCRIPTION
## Описание

Профилирование чтения (JFR на cpm) показало, что кэши `TransformationUtils`
(`METHODS`/`TYPES`/`SETTERS`) на `ConcurrentSkipListMap` c `CASE_INSENSITIVE_ORDER` —
**крупнейший прикладной hotspot чтения**: ~6 % CPU на `ConcurrentSkipListMap.doGet` +
`StringLatin1.compareToCI` при поиске метода/типа по имени XML-узла.

Регистронезависимость нужна только при первом резолве (скан `equalsIgnoreCase` по методам
класса), а не на каждый поиск. Переводим кэши на `ConcurrentHashMap` с точным ключом-именем
узла (имена узлов повторяются и интернированы Xerces) — поиск O(1) по хешу без CI-сравнений.

Доступ к кэшу — **`get()`-first**, а не `computeIfAbsent` с захватывающей лямбдой:
`ConcurrentHashMap.computeIfAbsent` не встраивается JIT-ом, из-за чего лямбда отображения
перестаёт скаляризоваться escape-анализом и аллоцируется на каждый вызов (профиль поймал
405 сэмплов аллокации лямбд, +170 МБ/чтение у наивного варианта). `get()`-first убирает это.

> Стекнут на #643 (setter-descriptor cache) — та же область `TransformationUtils`. База PR —
> ветка #643; после её мержа переведу базу на `develop`.

### Замеры (JMH `MDClassesBenchmark` на cpm; CPU — доля JFR-сэмплов, устойчива к шуму машины)

| метрика | before (#643) | after |
|---|---|---|
| доля CI-поиска в CPU чтения | **6.0 %** | **1.1 %** (−4.9 п.п.) |
| аллокации кэш-лямбд | 0 | 0 (наивный CHM давал 405 сэмплов / +170 МБ — устранено) |
| аллокации всего | 5078 МБ/чтение | 5077 МБ/чтение (без изменений) |
| wall (avgt) | 9065 мс | 8887 мс (в пределах шума) |

CPU-выигрыш реальный и измерен через долю сэмплов (не зависит от разброса wall). Wall — в
пределах шума машины (чтение параллельное, GC 5 ГБ/op).

## Связанные задачи

Closes

## Чеклист

### Общие
- [x] Ветка PR обновлена из develop
- [x] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [x] Изменения покрыты тестами (`TransformationUtilsTest`; интеграционные `MDOReaderTest` зелёные)
- [ ] Обязательные действия перед коммитом выполнены (`gradlew precommit`) — прогонял reader-тесты

## Дополнительно

Регресс аллокации лямбд у наивного `ConcurrentHashMap.computeIfAbsent` пойман профилированием —
в PR только исправленный `get()`-first вариант.