### PR TITLE
perf(reader): lock-free ConcurrentQNameMap (снятие контеншена на synchronizedMap)

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/reader/common/xstream/ConcurrentQNameMap.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/reader/common/xstream/ConcurrentQNameMap.java
@@ -1,0 +1,61 @@
+/*
+ * This file is a part of MDClasses.
+ *
+ * Copyright (c) 2019 - 2026
+ * Tymko Oleg <olegtymko@yandex.ru>, Maximov Valery <maximovvalery@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * MDClasses is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * MDClasses is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with MDClasses.
+ */
+package com.github._1c_syntax.bsl.reader.common.xstream;
+
+import com.thoughtworks.xstream.io.xml.QNameMap;
+
+import javax.xml.namespace.QName;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * {@link QNameMap} с потокобезопасными картами без блокировок на чтении.
+ * <p>
+ * Штатный {@link QNameMap} хранит соответствия в {@code Collections.synchronizedMap}, а
+ * {@link #getJavaClassName(QName)} вызывается на каждый XML-элемент. При параллельном чтении
+ * (метаданные читаются {@code parallelStream}) все потоки сериализуются на мониторе этой общей
+ * карты — по профилю это заметная доля CPU. Здесь карты — {@link ConcurrentHashMap}, чтение
+ * которых свободно от блокировок; отображения регистрируются один раз до начала чтения.
+ */
+public class ConcurrentQNameMap extends QNameMap {
+
+  private final Map<QName, String> qnameToJava = new ConcurrentHashMap<>();
+  private final Map<String, QName> javaToQName = new ConcurrentHashMap<>();
+
+  @Override
+  public String getJavaClassName(QName qname) {
+    var answer = qnameToJava.get(qname);
+    return answer != null ? answer : qname.getLocalPart();
+  }
+
+  @Override
+  public QName getQName(String javaClassName) {
+    var answer = javaToQName.get(javaClassName);
+    return answer != null ? answer : new QName(getDefaultNamespace(), javaClassName, getDefaultPrefix());
+  }
+
+  @Override
+  public void registerMapping(QName qname, String javaClassName) {
+    javaToQName.put(javaClassName, qname);
+    qnameToJava.put(qname, javaClassName);
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/reader/common/xstream/ConcurrentQNameMap.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/reader/common/xstream/ConcurrentQNameMap.java
@@ -54,7 +54,7 @@ public class ConcurrentQNameMap extends QNameMap {
   }
 
   @Override
-  public void registerMapping(QName qname, String javaClassName) {
+  public synchronized void registerMapping(QName qname, String javaClassName) {
     javaToQName.put(javaClassName, qname);
     qnameToJava.put(qname, javaClassName);
   }

--- a/src/main/java/com/github/_1c_syntax/bsl/reader/designer/DesignerReader.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/reader/designer/DesignerReader.java
@@ -59,6 +59,7 @@ import com.github._1c_syntax.bsl.mdo.storage.PredefinedData;
 import com.github._1c_syntax.bsl.reader.MDReader;
 import com.github._1c_syntax.bsl.reader.common.context.AbstractReaderContext;
 import com.github._1c_syntax.bsl.reader.common.converter.DesignerRootWrapper;
+import com.github._1c_syntax.bsl.reader.common.xstream.ConcurrentQNameMap;
 import com.github._1c_syntax.bsl.reader.common.xstream.ExtendXStream;
 import com.github._1c_syntax.bsl.reader.designer.converter.DesignerConverter;
 import com.github._1c_syntax.bsl.reader.designer.converter.Unmarshaller;
@@ -71,7 +72,6 @@ import com.thoughtworks.xstream.converters.UnmarshallingContext;
 import com.thoughtworks.xstream.core.ClassLoaderReference;
 import com.thoughtworks.xstream.core.util.CompositeClassLoader;
 import com.thoughtworks.xstream.io.HierarchicalStreamReader;
-import com.thoughtworks.xstream.io.xml.QNameMap;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FilenameUtils;
@@ -239,7 +239,7 @@ public class DesignerReader implements MDReader {
   }
 
   private ExtendXStream createXMLMapper() {
-    var qNameMap = new QNameMap();
+    var qNameMap = new ConcurrentQNameMap();
     qNameMap.registerMapping(new QName("http://v8.1c.ru/8.3/xcf/logform", "Form"), ManagedFormData.class);
 
     var classLoaderReference = new ClassLoaderReference(new CompositeClassLoader());

--- a/src/test/java/com/github/_1c_syntax/bsl/reader/common/xstream/ConcurrentQNameMapTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/reader/common/xstream/ConcurrentQNameMapTest.java
@@ -1,0 +1,72 @@
+/*
+ * This file is a part of MDClasses.
+ *
+ * Copyright (c) 2019 - 2026
+ * Tymko Oleg <olegtymko@yandex.ru>, Maximov Valery <maximovvalery@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * MDClasses is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * MDClasses is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with MDClasses.
+ */
+package com.github._1c_syntax.bsl.reader.common.xstream;
+
+import org.junit.jupiter.api.Test;
+
+import javax.xml.namespace.QName;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ConcurrentQNameMapTest {
+
+  private static final QName FORM_QNAME = new QName("http://v8.1c.ru/8.3/xcf/logform", "Form");
+  private static final String FORM_CLASS = "com.github._1c_syntax.bsl.mdo.storage.form.ManagedFormData";
+
+  @Test
+  void mappedQNameResolvesToRegisteredClassAndBack() {
+    // given
+    var map = new ConcurrentQNameMap();
+
+    // when
+    map.registerMapping(FORM_QNAME, FORM_CLASS);
+
+    // then
+    assertThat(map.getJavaClassName(FORM_QNAME)).isEqualTo(FORM_CLASS);
+    assertThat(map.getQName(FORM_CLASS)).isEqualTo(FORM_QNAME);
+  }
+
+  @Test
+  void unmappedQNameFallsBackToLocalPart() {
+    // given
+    var map = new ConcurrentQNameMap();
+
+    // when
+    var javaClassName = map.getJavaClassName(new QName("http://ns", "Catalog"));
+
+    // then
+    assertThat(javaClassName).isEqualTo("Catalog");
+  }
+
+  @Test
+  void unmappedClassNameFallsBackToDefaultQName() {
+    // given
+    var map = new ConcurrentQNameMap();
+
+    // when
+    var qName = map.getQName("Catalog");
+
+    // then
+    assertThat(qName.getLocalPart()).isEqualTo("Catalog");
+    assertThat(qName.getNamespaceURI()).isEqualTo(map.getDefaultNamespace());
+  }
+}


### PR DESCRIPTION
## Описание

Профилирование чтения (JFR на cpm) показало, что `QNameMap.getJavaClassName` вызывается на
**каждый XML-элемент** и делает `get` по `Collections.synchronizedMap`. Метаданные читаются
параллельно (`parallelStream`), поэтому все потоки сериализуются на мониторе одной общей карты.

Вводим `ConcurrentQNameMap` — наследник `QNameMap` с картами на `ConcurrentHashMap` (чтение без
блокировок). Отображения регистрируются один раз до начала чтения, во время чтения карты только
читаются. Поведение не меняется.

### Замеры (JMH `MDClassesBenchmark` на cpm; CPU — доля JFR-сэмплов, устойчива к шуму машины)

Правильный объект профилирования — **стоимость самой операции поиска `getJavaClassName`
(inclusive)**, а не фрейм реализации: в новой версии `synchronizedMap` физически нет, поэтому
считать его сэмплы бессмысленно. Inclusive-метрика учитывает и новую стоимость `ConcurrentHashMap.get`:

| метрика | before (develop) | after |
|---|---|---|
| `getJavaClassName` (inclusive) в CPU чтения | 332/5609 = **5.9 %** | 83/8927 = **0.9 %** (−5 п.п.) |
| аллокации | 5154.6 МБ/чтение | 5157.9 МБ/чтение (без изменений) |

Т.е. вся операция поиска (включая `ConcurrentHashMap.get` в новой версии) подешевела ~5 п.п. —
за счёт снятия монитора/контеншена на общей `synchronizedMap`. Wall на тестовой машине имеет
разброс ~±35 %, поэтому по нему изменение ~5 % не разрешается; CPU меряем долей сэмплов.

## Связанные задачи

Closes

## Чеклист

### Общие
- [x] Ветка PR обновлена из develop
- [x] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [x] Изменения покрыты тестами (`ConcurrentQNameMapTest`; интеграционные `MDOReaderTest`/`MDMergerMergeTest` читают Designer-формы через это отображение)
- [ ] Обязательные действия перед коммитом выполнены (`gradlew precommit`) — прогонял reader-тесты

## Дополнительно

- `registerMapping` помечен `synchronized` под контракт родителя (Sonar S3551); вызывается только
  на этапе настройки, на горячий путь не влияет.
- Метрика исправлена по замечанию ревью: считаем `getJavaClassName` inclusive, а не сам
  `SynchronizedMap.get` (которого в новой версии нет).