### PR TITLE
Реализовано чтение дополнительных индексов объектов

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/mdo/AccountingRegister.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdo/AccountingRegister.java
@@ -26,6 +26,7 @@ import com.github._1c_syntax.bsl.mdo.children.ObjectCommand;
 import com.github._1c_syntax.bsl.mdo.children.ObjectForm;
 import com.github._1c_syntax.bsl.mdo.children.ObjectTemplate;
 import com.github._1c_syntax.bsl.mdo.children.Resource;
+import com.github._1c_syntax.bsl.mdo.storage.AdditionalIndex;
 import com.github._1c_syntax.bsl.mdo.support.DefaultFormKind;
 import com.github._1c_syntax.bsl.mdo.support.ObjectBelonging;
 import com.github._1c_syntax.bsl.mdo.support.UseMode;
@@ -93,6 +94,13 @@ public class AccountingRegister implements Register, AccessRightsOwner {
 
   @Singular
   List<ObjectTemplate> templates;
+
+  /**
+   * Дополнительные индексы
+   */
+  @Singular("addAdditionalIndex")
+  List<AdditionalIndex> additionalIndexes;
+
   @Getter(lazy = true)
   List<MD> children = LazyLoader.computeChildren(this);
 

--- a/src/main/java/com/github/_1c_syntax/bsl/mdo/AccumulationRegister.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdo/AccumulationRegister.java
@@ -26,6 +26,7 @@ import com.github._1c_syntax.bsl.mdo.children.ObjectCommand;
 import com.github._1c_syntax.bsl.mdo.children.ObjectForm;
 import com.github._1c_syntax.bsl.mdo.children.ObjectTemplate;
 import com.github._1c_syntax.bsl.mdo.children.Resource;
+import com.github._1c_syntax.bsl.mdo.storage.AdditionalIndex;
 import com.github._1c_syntax.bsl.mdo.support.DefaultFormKind;
 import com.github._1c_syntax.bsl.mdo.support.ObjectBelonging;
 import com.github._1c_syntax.bsl.mdo.support.UseMode;
@@ -95,6 +96,13 @@ public class AccumulationRegister implements Register, AccessRightsOwner {
 
   @Singular
   List<ObjectTemplate> templates;
+
+  /**
+   * Дополнительные индексы
+   */
+  @Singular("addAdditionalIndex")
+  List<AdditionalIndex> additionalIndexes;
+
   @Getter(lazy = true)
   List<MD> children = LazyLoader.computeChildren(this);
 

--- a/src/main/java/com/github/_1c_syntax/bsl/mdo/AttributeOwner.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdo/AttributeOwner.java
@@ -21,6 +21,7 @@
  */
 package com.github._1c_syntax.bsl.mdo;
 
+import com.github._1c_syntax.bsl.mdo.storage.AdditionalIndex;
 import java.util.Collections;
 import java.util.List;
 
@@ -45,5 +46,12 @@ public interface AttributeOwner extends ChildrenOwner {
    */
   default List<MD> getPlainStorageFields() {
     return getStorageFields();
+  }
+
+  /**
+   * Список дополнительных индексов объекта
+   */
+  default List<AdditionalIndex> getAdditionalIndexes() {
+    return Collections.emptyList();
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/mdo/BusinessProcess.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdo/BusinessProcess.java
@@ -24,6 +24,7 @@ package com.github._1c_syntax.bsl.mdo;
 import com.github._1c_syntax.bsl.mdo.children.ObjectCommand;
 import com.github._1c_syntax.bsl.mdo.children.ObjectForm;
 import com.github._1c_syntax.bsl.mdo.children.ObjectTemplate;
+import com.github._1c_syntax.bsl.mdo.storage.AdditionalIndex;
 import com.github._1c_syntax.bsl.mdo.support.ChoiceDataGetMode;
 import com.github._1c_syntax.bsl.mdo.support.ChoiceHistoryOnInputMode;
 import com.github._1c_syntax.bsl.mdo.support.DataLockControlMode;
@@ -103,6 +104,12 @@ public class BusinessProcess implements ReferenceObject, AccessRightsOwner {
 
   @Singular
   List<ObjectTemplate> templates;
+
+  /**
+   * Дополнительные индексы
+   */
+  @Singular("addAdditionalIndex")
+  List<AdditionalIndex> additionalIndexes;
 
   @Getter(lazy = true)
   List<MD> children = LazyLoader.computeChildren(this);

--- a/src/main/java/com/github/_1c_syntax/bsl/mdo/CalculationRegister.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdo/CalculationRegister.java
@@ -27,6 +27,7 @@ import com.github._1c_syntax.bsl.mdo.children.ObjectForm;
 import com.github._1c_syntax.bsl.mdo.children.ObjectTemplate;
 import com.github._1c_syntax.bsl.mdo.children.Recalculation;
 import com.github._1c_syntax.bsl.mdo.children.Resource;
+import com.github._1c_syntax.bsl.mdo.storage.AdditionalIndex;
 import com.github._1c_syntax.bsl.mdo.support.CalculationRegisterPeriodicity;
 import com.github._1c_syntax.bsl.mdo.support.DefaultFormKind;
 import com.github._1c_syntax.bsl.mdo.support.ObjectBelonging;
@@ -97,6 +98,13 @@ public class CalculationRegister implements Register, AccessRightsOwner {
 
   @Singular
   List<ObjectTemplate> templates;
+
+  /**
+   * Дополнительные индексы
+   */
+  @Singular("addAdditionalIndex")
+  List<AdditionalIndex> additionalIndexes;
+
   @Getter(lazy = true)
   List<MD> children = LazyLoader.computeChildren(this);
 

--- a/src/main/java/com/github/_1c_syntax/bsl/mdo/Catalog.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdo/Catalog.java
@@ -25,6 +25,7 @@ import com.github._1c_syntax.bsl.mdo.children.ObjectCommand;
 import com.github._1c_syntax.bsl.mdo.children.ObjectForm;
 import com.github._1c_syntax.bsl.mdo.children.ObjectTemplate;
 import com.github._1c_syntax.bsl.mdo.children.PredefinedValue;
+import com.github._1c_syntax.bsl.mdo.storage.AdditionalIndex;
 import com.github._1c_syntax.bsl.mdo.support.ChoiceDataGetMode;
 import com.github._1c_syntax.bsl.mdo.support.ChoiceHistoryOnInputMode;
 import com.github._1c_syntax.bsl.mdo.support.CodeSeries;
@@ -187,6 +188,12 @@ public class Catalog implements ReferenceObject, AccessRightsOwner, PredefinedDa
    */
   @Singular
   List<PredefinedValue> predefinedValues;
+
+  /**
+   * Дополнительные индексы
+   */
+  @Singular("addAdditionalIndex")
+  List<AdditionalIndex> additionalIndexes;
 
   /**
    * Пояснение

--- a/src/main/java/com/github/_1c_syntax/bsl/mdo/ChartOfAccounts.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdo/ChartOfAccounts.java
@@ -27,6 +27,7 @@ import com.github._1c_syntax.bsl.mdo.children.ObjectCommand;
 import com.github._1c_syntax.bsl.mdo.children.ObjectForm;
 import com.github._1c_syntax.bsl.mdo.children.ObjectTemplate;
 import com.github._1c_syntax.bsl.mdo.children.PredefinedValue;
+import com.github._1c_syntax.bsl.mdo.storage.AdditionalIndex;
 import com.github._1c_syntax.bsl.mdo.support.ChoiceDataGetMode;
 import com.github._1c_syntax.bsl.mdo.support.ChoiceHistoryOnInputMode;
 import com.github._1c_syntax.bsl.mdo.support.CodeSeries;
@@ -164,6 +165,12 @@ public class ChartOfAccounts implements ReferenceObject, AccessRightsOwner, Pred
    */
   @Singular
   List<PredefinedValue> predefinedValues;
+
+  /**
+   * Дополнительные индексы
+   */
+  @Singular("addAdditionalIndex")
+  List<AdditionalIndex> additionalIndexes;
 
   /**
    * Признаки учета

--- a/src/main/java/com/github/_1c_syntax/bsl/mdo/ChartOfCalculationTypes.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdo/ChartOfCalculationTypes.java
@@ -25,6 +25,7 @@ import com.github._1c_syntax.bsl.mdo.children.ObjectCommand;
 import com.github._1c_syntax.bsl.mdo.children.ObjectForm;
 import com.github._1c_syntax.bsl.mdo.children.ObjectTemplate;
 import com.github._1c_syntax.bsl.mdo.children.PredefinedValue;
+import com.github._1c_syntax.bsl.mdo.storage.AdditionalIndex;
 import com.github._1c_syntax.bsl.mdo.support.ChoiceDataGetMode;
 import com.github._1c_syntax.bsl.mdo.support.ChoiceHistoryOnInputMode;
 import com.github._1c_syntax.bsl.mdo.support.DataLockControlMode;
@@ -159,6 +160,12 @@ public class ChartOfCalculationTypes implements ReferenceObject, AccessRightsOwn
    */
   @Singular
   List<PredefinedValue> predefinedValues;
+
+  /**
+   * Дополнительные индексы
+   */
+  @Singular("addAdditionalIndex")
+  List<AdditionalIndex> additionalIndexes;
 
   /**
    * Пояснение

--- a/src/main/java/com/github/_1c_syntax/bsl/mdo/ChartOfCharacteristicTypes.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdo/ChartOfCharacteristicTypes.java
@@ -25,6 +25,7 @@ import com.github._1c_syntax.bsl.mdo.children.ObjectCommand;
 import com.github._1c_syntax.bsl.mdo.children.ObjectForm;
 import com.github._1c_syntax.bsl.mdo.children.ObjectTemplate;
 import com.github._1c_syntax.bsl.mdo.children.PredefinedValue;
+import com.github._1c_syntax.bsl.mdo.storage.AdditionalIndex;
 import com.github._1c_syntax.bsl.mdo.support.ChoiceDataGetMode;
 import com.github._1c_syntax.bsl.mdo.support.ChoiceHistoryOnInputMode;
 import com.github._1c_syntax.bsl.mdo.support.CodeSeries;
@@ -196,6 +197,12 @@ public class ChartOfCharacteristicTypes
    */
   @Singular
   List<PredefinedValue> predefinedValues;
+
+  /**
+   * Дополнительные индексы
+   */
+  @Singular("addAdditionalIndex")
+  List<AdditionalIndex> additionalIndexes;
 
   /**
    * Пояснение

--- a/src/main/java/com/github/_1c_syntax/bsl/mdo/Document.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdo/Document.java
@@ -24,6 +24,7 @@ package com.github._1c_syntax.bsl.mdo;
 import com.github._1c_syntax.bsl.mdo.children.ObjectCommand;
 import com.github._1c_syntax.bsl.mdo.children.ObjectForm;
 import com.github._1c_syntax.bsl.mdo.children.ObjectTemplate;
+import com.github._1c_syntax.bsl.mdo.storage.AdditionalIndex;
 import com.github._1c_syntax.bsl.mdo.support.ChoiceDataGetMode;
 import com.github._1c_syntax.bsl.mdo.support.ChoiceHistoryOnInputMode;
 import com.github._1c_syntax.bsl.mdo.support.DataLockControlMode;
@@ -160,6 +161,12 @@ public class Document implements ReferenceObject, AccessRightsOwner {
    */
   @Singular("addRegisterRecords")
   List<MdoReference> registerRecords;
+
+  /**
+   * Дополнительные индексы
+   */
+  @Singular("addAdditionalIndex")
+  List<AdditionalIndex> additionalIndexes;
 
   /**
    * Пояснение

--- a/src/main/java/com/github/_1c_syntax/bsl/mdo/DocumentJournal.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdo/DocumentJournal.java
@@ -25,6 +25,7 @@ import com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn;
 import com.github._1c_syntax.bsl.mdo.children.ObjectCommand;
 import com.github._1c_syntax.bsl.mdo.children.ObjectForm;
 import com.github._1c_syntax.bsl.mdo.children.ObjectTemplate;
+import com.github._1c_syntax.bsl.mdo.storage.AdditionalIndex;
 import com.github._1c_syntax.bsl.mdo.support.DefaultFormKind;
 import com.github._1c_syntax.bsl.mdo.support.ObjectBelonging;
 import com.github._1c_syntax.bsl.mdo.support.RoleRight;
@@ -97,6 +98,12 @@ public class DocumentJournal implements MDObject, ModuleOwner, CommandOwner, Att
 
   @Singular
   List<DocumentJournalColumn> columns;
+
+  /**
+   * Дополнительные индексы
+   */
+  @Singular("addAdditionalIndex")
+  List<AdditionalIndex> additionalIndexes;
 
   /*
    * FormOwner

--- a/src/main/java/com/github/_1c_syntax/bsl/mdo/ExchangePlan.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdo/ExchangePlan.java
@@ -25,6 +25,7 @@ import com.github._1c_syntax.bsl.mdo.children.ObjectCommand;
 import com.github._1c_syntax.bsl.mdo.children.ObjectForm;
 import com.github._1c_syntax.bsl.mdo.children.ObjectTemplate;
 import com.github._1c_syntax.bsl.mdo.children.PredefinedValue;
+import com.github._1c_syntax.bsl.mdo.storage.AdditionalIndex;
 import com.github._1c_syntax.bsl.mdo.support.AutoRecordType;
 import com.github._1c_syntax.bsl.mdo.support.ChoiceDataGetMode;
 import com.github._1c_syntax.bsl.mdo.support.ChoiceHistoryOnInputMode;
@@ -162,6 +163,12 @@ public class ExchangePlan implements ReferenceObject, AccessRightsOwner, Predefi
    */
   @Singular
   List<PredefinedValue> predefinedValues;
+
+  /**
+   * Дополнительные индексы
+   */
+  @Singular("addAdditionalIndex")
+  List<AdditionalIndex> additionalIndexes;
 
   /**
    * Распределенная информационная база

--- a/src/main/java/com/github/_1c_syntax/bsl/mdo/InformationRegister.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdo/InformationRegister.java
@@ -26,6 +26,7 @@ import com.github._1c_syntax.bsl.mdo.children.ObjectCommand;
 import com.github._1c_syntax.bsl.mdo.children.ObjectForm;
 import com.github._1c_syntax.bsl.mdo.children.ObjectTemplate;
 import com.github._1c_syntax.bsl.mdo.children.Resource;
+import com.github._1c_syntax.bsl.mdo.storage.AdditionalIndex;
 import com.github._1c_syntax.bsl.mdo.support.DefaultFormKind;
 import com.github._1c_syntax.bsl.mdo.support.InformationRegisterPeriodicity;
 import com.github._1c_syntax.bsl.mdo.support.ObjectBelonging;
@@ -96,6 +97,12 @@ public class InformationRegister implements Register, AccessRightsOwner {
 
   @Singular
   List<ObjectTemplate> templates;
+
+  /**
+   * Дополнительные индексы
+   */
+  @Singular("addAdditionalIndex")
+  List<AdditionalIndex> additionalIndexes;
 
   @Getter(lazy = true)
   List<MD> children = LazyLoader.computeChildren(this);

--- a/src/main/java/com/github/_1c_syntax/bsl/mdo/Sequence.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdo/Sequence.java
@@ -22,6 +22,7 @@
 package com.github._1c_syntax.bsl.mdo;
 
 import com.github._1c_syntax.bsl.mdo.children.Dimension;
+import com.github._1c_syntax.bsl.mdo.storage.AdditionalIndex;
 import com.github._1c_syntax.bsl.mdo.support.ObjectBelonging;
 import com.github._1c_syntax.bsl.mdo.support.RoleRight;
 import com.github._1c_syntax.bsl.support.SupportVariant;
@@ -86,6 +87,12 @@ public class Sequence implements MDObject, AttributeOwner, ModuleOwner, AccessRi
    */
   @Singular("addDocuments")
   List<MdoReference> documents;
+
+  /**
+   * Дополнительные индексы
+   */
+  @Singular("addAdditionalIndex")
+  List<AdditionalIndex> additionalIndexes;
 
   /*
    * Для AttributeOwner

--- a/src/main/java/com/github/_1c_syntax/bsl/mdo/Task.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdo/Task.java
@@ -25,6 +25,7 @@ import com.github._1c_syntax.bsl.mdo.children.ObjectCommand;
 import com.github._1c_syntax.bsl.mdo.children.ObjectForm;
 import com.github._1c_syntax.bsl.mdo.children.ObjectTemplate;
 import com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute;
+import com.github._1c_syntax.bsl.mdo.storage.AdditionalIndex;
 import com.github._1c_syntax.bsl.mdo.support.ChoiceDataGetMode;
 import com.github._1c_syntax.bsl.mdo.support.ChoiceHistoryOnInputMode;
 import com.github._1c_syntax.bsl.mdo.support.DataLockControlMode;
@@ -104,6 +105,12 @@ public class Task implements ReferenceObject, AccessRightsOwner {
 
   @Singular
   List<ObjectTemplate> templates;
+
+  /**
+   * Дополнительные индексы
+   */
+  @Singular("addAdditionalIndex")
+  List<AdditionalIndex> additionalIndexes;
 
   @Getter(lazy = true)
   List<MD> children = LazyLoader.computeChildren(this);

--- a/src/main/java/com/github/_1c_syntax/bsl/mdo/storage/AdditionalIndex.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/mdo/storage/AdditionalIndex.java
@@ -1,0 +1,64 @@
+/*
+ * This file is a part of MDClasses.
+ *
+ * Copyright (c) 2019 - 2026
+ * Tymko Oleg <olegtymko@yandex.ru>, Maximov Valery <maximovvalery@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * MDClasses is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * MDClasses is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with MDClasses.
+ */
+package com.github._1c_syntax.bsl.mdo.storage;
+
+import com.github._1c_syntax.bsl.types.MdoReference;
+import lombok.Builder;
+import lombok.Singular;
+import lombok.Value;
+
+import java.util.List;
+
+/**
+ * Данные дополнительного индекса таблицы
+ */
+@Value
+@Builder(toBuilder = true)
+public class AdditionalIndex {
+
+  /**
+   * Уникальный идентификатор
+   */
+  String uuid;
+
+  /**
+   * Имя индекса
+   */
+  String name;
+
+  /**
+   * Ссылка на таблицу
+   */
+  MdoReference table;
+
+  /**
+   * Список полей, входящих в индекс
+   */
+  @Singular("addIndexedField")
+  List<MdoReference> indexedFields;
+
+  /**
+   * Список дополнительных полей индекса
+   */
+  @Singular("addAdditionalField")
+  List<MdoReference> additionalFields;
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/reader/MDReader.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/reader/MDReader.java
@@ -25,8 +25,10 @@ import com.github._1c_syntax.bsl.mdclasses.ExternalSource;
 import com.github._1c_syntax.bsl.mdclasses.MDCReadSettings;
 import com.github._1c_syntax.bsl.mdclasses.MDClass;
 import com.github._1c_syntax.bsl.mdo.children.PredefinedValue;
+import com.github._1c_syntax.bsl.mdo.storage.AdditionalIndex;
 import com.github._1c_syntax.bsl.mdo.storage.FormData;
 import com.github._1c_syntax.bsl.reader.common.context.AbstractReaderContext;
+import com.github._1c_syntax.bsl.reader.common.converter.AdditionalIndexesWrapper;
 import com.github._1c_syntax.bsl.reader.common.xstream.ExtendXStream;
 import com.github._1c_syntax.bsl.types.ConfigurationSource;
 import com.github._1c_syntax.bsl.types.MDOType;
@@ -141,6 +143,18 @@ public interface MDReader {
    */
   default List<PredefinedValue> readPredefinedData(Path currentPath, String name, MDOType mdoType) {
     return Collections.emptyList();
+  }
+
+  /**
+   * Читает данные дополнительных индексов объекта.
+   *
+   * @param currentPath Путь к файлу объекта
+   * @param name        Имя объекта
+   * @param mdoType     Тип объекта
+   * @return Контейнер дополнительных индексов
+   */
+  default AdditionalIndexesWrapper readAdditionalIndexes(Path currentPath, String name, MDOType mdoType) {
+    return AdditionalIndexesWrapper.EMPTY;
   }
 
   /**

--- a/src/main/java/com/github/_1c_syntax/bsl/reader/common/context/MDReaderContext.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/reader/common/context/MDReaderContext.java
@@ -21,6 +21,7 @@
  */
 package com.github._1c_syntax.bsl.reader.common.context;
 
+import com.github._1c_syntax.bsl.mdo.Attribute;
 import com.github._1c_syntax.bsl.mdo.AttributeOwner;
 import com.github._1c_syntax.bsl.mdo.ChildrenOwner;
 import com.github._1c_syntax.bsl.mdo.Form;
@@ -33,11 +34,13 @@ import com.github._1c_syntax.bsl.mdo.children.ExternalDataSourceTableField;
 import com.github._1c_syntax.bsl.mdo.children.PredefinedValue;
 import com.github._1c_syntax.bsl.mdo.children.RecalculationDimension;
 import com.github._1c_syntax.bsl.mdo.children.StandardAttribute;
+import com.github._1c_syntax.bsl.mdo.storage.AdditionalIndex;
 import com.github._1c_syntax.bsl.mdo.support.TemplateType;
 import com.github._1c_syntax.bsl.reader.MDReader;
 import com.github._1c_syntax.bsl.reader.common.TransformationUtils;
 import com.github._1c_syntax.bsl.reader.common.context.std_attributes.StdAtrInfo;
 import com.github._1c_syntax.bsl.reader.common.context.std_attributes.StdAttributeFiller;
+import com.github._1c_syntax.bsl.reader.common.converter.AdditionalIndexesWrapper;
 import com.github._1c_syntax.bsl.reader.common.xstream.ExtendReaderWrapper;
 import com.github._1c_syntax.bsl.supconf.ParseSupportData;
 import com.github._1c_syntax.bsl.support.SupportVariant;
@@ -55,8 +58,10 @@ import org.jspecify.annotations.Nullable;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -99,6 +104,12 @@ public class MDReaderContext extends AbstractReaderContext {
    */
   @Nullable
   private StdAtrInfo stdAtrInfo;
+
+  /**
+   * Построенные атрибуты (стандартные + пользовательские), собранные при setValueChildren
+   */
+  @Nullable
+  private Map<String, MdoReference> builtAttributes;
 
   public MDReaderContext(HierarchicalStreamReader reader) {
     super(reader);
@@ -205,6 +216,10 @@ public class MDReaderContext extends AbstractReaderContext {
       setValueChildren();
     }
 
+    if (AttributeOwner.class.isAssignableFrom(realClass)) {
+      setupAdditionalIndexes();
+    }
+
     if (ModuleOwner.class.isAssignableFrom(realClass)) {
       setValueModules();
     }
@@ -257,16 +272,53 @@ public class MDReaderContext extends AbstractReaderContext {
   }
 
   private void setValueChildren() {
+    var allChildren = new HashMap<String, MdoReference>();
     childrenContexts.forEach((String collectionName, List<MDReaderContext> value) -> {
       var collection = value.parallelStream()
         .map((MDReaderContext childContext) -> {
           childContext.setOwner(mdoReference);
           return childContext.build();
         }).toList();
+      for (var obj : collection) {
+        if (obj instanceof Attribute attr) {
+          allChildren.put(attr.getName(), attr.getMdoReference());
+        }
+      }
       if (!collectionName.endsWith("s")) {
         collectionName += "s";
       }
       setValue(collectionName, collection);
     });
+    builtAttributes = allChildren;
+  }
+
+  private void setupAdditionalIndexes() {
+    var cached = getFromCache("additionalIndexes", Collections.emptyList());
+    if (!cached.isEmpty() || builtAttributes == null) {
+      return;
+    }
+
+    var raw = mdReader.readAdditionalIndexes(currentPath, name, mdoType);
+    if (raw == AdditionalIndexesWrapper.EMPTY || raw.getIndexes().isEmpty()) {
+      return;
+    }
+
+    var resolved = raw.getIndexes().stream().map((AdditionalIndexesWrapper.AdditionalIndexItem item) -> {
+      var tableRef = MdoReference.create(item.getTable());
+      return AdditionalIndex.builder()
+        .uuid(item.getId())
+        .name(item.getName())
+        .table(builtAttributes.getOrDefault(item.getTable(), tableRef))
+        .indexedFields(item.getIndexedFields().stream()
+          .map(fieldName -> builtAttributes.get(fieldName))
+          .filter(Objects::nonNull)
+          .toList())
+        .additionalFields(item.getAdditionalFields().stream()
+          .map(fieldName -> builtAttributes.get(fieldName))
+          .filter(Objects::nonNull)
+          .toList())
+        .build();
+    }).toList();
+    setValue("additionalIndexes", resolved);
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/reader/common/converter/AdditionalIndexesWrapper.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/reader/common/converter/AdditionalIndexesWrapper.java
@@ -34,7 +34,7 @@ import java.util.List;
 @Builder
 public class AdditionalIndexesWrapper {
 
-  public static AdditionalIndexesWrapper EMPTY = builder().build();
+  public static final AdditionalIndexesWrapper EMPTY = builder().build();
 
   @Singular
   List<AdditionalIndexItem> indexes;

--- a/src/main/java/com/github/_1c_syntax/bsl/reader/common/converter/AdditionalIndexesWrapper.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/reader/common/converter/AdditionalIndexesWrapper.java
@@ -1,0 +1,55 @@
+/*
+ * This file is a part of MDClasses.
+ *
+ * Copyright (c) 2019 - 2026
+ * Tymko Oleg <olegtymko@yandex.ru>, Maximov Valery <maximovvalery@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * MDClasses is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * MDClasses is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with MDClasses.
+ */
+package com.github._1c_syntax.bsl.reader.common.converter;
+
+import lombok.Builder;
+import lombok.Singular;
+import lombok.Value;
+
+import java.util.List;
+
+/**
+ * Контейнер данных дополнительных индексов из отдельного файла
+ */
+@Value
+@Builder
+public class AdditionalIndexesWrapper {
+
+  public static AdditionalIndexesWrapper EMPTY = builder().build();
+
+  @Singular
+  List<AdditionalIndexItem> indexes;
+
+  @Value
+  @Builder
+  public static class AdditionalIndexItem {
+    String id;
+    String name;
+    String table;
+
+    @Singular("indexedField")
+    List<String> indexedFields;
+
+    @Singular("additionalField")
+    List<String> additionalFields;
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/reader/common/xstream/ExtendXStream.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/reader/common/xstream/ExtendXStream.java
@@ -25,6 +25,7 @@ import com.github._1c_syntax.bsl.mdclasses.ConfigurationTree;
 import com.github._1c_syntax.bsl.mdclasses.ExternalDataProcessor;
 import com.github._1c_syntax.bsl.mdclasses.ExternalReport;
 import com.github._1c_syntax.bsl.mdo.MD;
+import com.github._1c_syntax.bsl.reader.common.converter.AdditionalIndexesWrapper;
 import com.github._1c_syntax.bsl.mdo.storage.DataCompositionSchema;
 import com.github._1c_syntax.bsl.mdo.storage.RoleData;
 import com.github._1c_syntax.bsl.mdo.storage.XdtoPackageData;
@@ -342,6 +343,7 @@ public class ExtendXStream extends XStream {
     alias("Configuration", ConfigurationTree.class);
     alias("ExternalDataProcessor", ExternalDataProcessor.class);
     alias("ExternalReport", ExternalReport.class);
+    alias("AdditionalIndexes", AdditionalIndexesWrapper.class);
   }
 
   @Nullable

--- a/src/main/java/com/github/_1c_syntax/bsl/reader/designer/DesignerReader.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/reader/designer/DesignerReader.java
@@ -55,13 +55,14 @@ import com.github._1c_syntax.bsl.mdo.children.WebServiceOperationParameter;
 import com.github._1c_syntax.bsl.mdo.storage.EmptyFormData;
 import com.github._1c_syntax.bsl.mdo.storage.FormData;
 import com.github._1c_syntax.bsl.mdo.storage.ManagedFormData;
-import com.github._1c_syntax.bsl.mdo.storage.PredefinedData;
 import com.github._1c_syntax.bsl.reader.MDReader;
 import com.github._1c_syntax.bsl.reader.common.context.AbstractReaderContext;
+import com.github._1c_syntax.bsl.reader.common.converter.AdditionalIndexesWrapper;
 import com.github._1c_syntax.bsl.reader.common.converter.DesignerRootWrapper;
 import com.github._1c_syntax.bsl.reader.common.xstream.ConcurrentQNameMap;
 import com.github._1c_syntax.bsl.reader.common.xstream.ExtendXStream;
 import com.github._1c_syntax.bsl.reader.designer.converter.DesignerConverter;
+import com.github._1c_syntax.bsl.reader.designer.converter.PredefinedDataWrapper;
 import com.github._1c_syntax.bsl.reader.designer.converter.Unmarshaller;
 import com.github._1c_syntax.bsl.supconf.ParseSupportData;
 import com.github._1c_syntax.bsl.types.ConfigurationSource;
@@ -189,10 +190,26 @@ public class DesignerReader implements MDReader {
       return Collections.emptyList();
     }
     var value = read(predefinedPath);
-    if (value instanceof PredefinedData predefinedData) {
-      return predefinedData.getItems();
+    if (value instanceof PredefinedDataWrapper predefinedDataWrapper) {
+      return predefinedDataWrapper.getItems();
     }
     return Collections.emptyList();
+  }
+
+  @Override
+  public AdditionalIndexesWrapper readAdditionalIndexes(Path currentPath, String name, MDOType mdoType) {
+    var additionalIndexesPath = Paths.get(currentPath.getParent().toString(),
+      name,
+      "Ext",
+      "AdditionalIndexes.xml");
+
+    if (additionalIndexesPath.toFile().exists()) {
+      var value = read(additionalIndexesPath);
+      if (value instanceof AdditionalIndexesWrapper data) {
+        return data;
+      }
+    }
+    return AdditionalIndexesWrapper.EMPTY;
   }
 
   @Override
@@ -273,7 +290,7 @@ public class DesignerReader implements MDReader {
     xStream.alias("Method", HTTPServiceMethod.class);
     xStream.alias("Operation", WebServiceOperation.class);
     xStream.alias("Parameter", WebServiceOperationParameter.class);
-    xStream.alias("PredefinedData", PredefinedData.class);
+    xStream.alias("PredefinedData", PredefinedDataWrapper.class);
     xStream.alias("Recalculation", Recalculation.class);
     xStream.alias("Resource", Resource.class);
     xStream.alias("Table", ExternalDataSourceTable.class);

--- a/src/main/java/com/github/_1c_syntax/bsl/reader/designer/converter/AdditionalIndexesConverter.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/reader/designer/converter/AdditionalIndexesConverter.java
@@ -1,0 +1,91 @@
+/*
+ * This file is a part of MDClasses.
+ *
+ * Copyright (c) 2019 - 2026
+ * Tymko Oleg <olegtymko@yandex.ru>, Maximov Valery <maximovvalery@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * MDClasses is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * MDClasses is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with MDClasses.
+ */
+package com.github._1c_syntax.bsl.reader.designer.converter;
+
+import com.github._1c_syntax.bsl.reader.common.converter.AdditionalIndexesWrapper;
+import com.github._1c_syntax.bsl.reader.common.converter.AdditionalIndexesWrapper.AdditionalIndexItem;
+import com.github._1c_syntax.bsl.reader.common.xstream.ReadConverter;
+import com.thoughtworks.xstream.converters.UnmarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+
+/**
+ * Читает файл дополнительных индексов {@code Ext/AdditionalIndexes.xml}
+ */
+@DesignerConverter
+public class AdditionalIndexesConverter implements ReadConverter {
+
+  private static final String INDEX_NODE = "AdditionalIndex";
+  private static final String NAME_NODE = "Name";
+  private static final String TABLE_NODE = "Table";
+  private static final String INDEXED_FIELDS_NODE = "IndexedFields";
+  private static final String ADDITIONAL_FIELDS_NODE = "AdditionalFields";
+  private static final String FIELD_NODE = "Field";
+
+  @Override
+  public Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context) {
+    var builder = AdditionalIndexesWrapper.builder();
+    while (reader.hasMoreChildren()) {
+      reader.moveDown();
+      if (INDEX_NODE.equals(reader.getNodeName())) {
+        String id = reader.getAttribute("id");
+        var itemBuilder = AdditionalIndexItem.builder().id(id);
+        while (reader.hasMoreChildren()) {
+          reader.moveDown();
+          String nodeName = reader.getNodeName();
+          switch (nodeName) {
+            case NAME_NODE -> itemBuilder.name(reader.getValue());
+            case TABLE_NODE -> itemBuilder.table(reader.getValue());
+            case INDEXED_FIELDS_NODE -> readFields(reader, itemBuilder, true);
+            case ADDITIONAL_FIELDS_NODE -> readFields(reader, itemBuilder, false);
+            default -> {
+            }
+          }
+          reader.moveUp();
+        }
+        builder.index(itemBuilder.build());
+      }
+      reader.moveUp();
+    }
+    return builder.build();
+  }
+
+  @Override
+  public boolean canConvert(Class type) {
+    return AdditionalIndexesWrapper.class.isAssignableFrom(type);
+  }
+
+  private void readFields(HierarchicalStreamReader reader,
+                          AdditionalIndexItem.AdditionalIndexItemBuilder itemBuilder,
+                          boolean indexed) {
+    while (reader.hasMoreChildren()) {
+      reader.moveDown();
+      if (FIELD_NODE.equals(reader.getNodeName())) {
+        if (indexed) {
+          itemBuilder.indexedField(reader.getValue());
+        } else {
+          itemBuilder.additionalField(reader.getValue());
+        }
+      }
+      reader.moveUp();
+    }
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/reader/designer/converter/PredefinedDataConverter.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/reader/designer/converter/PredefinedDataConverter.java
@@ -22,7 +22,6 @@
 package com.github._1c_syntax.bsl.reader.designer.converter;
 
 import com.github._1c_syntax.bsl.mdo.children.PredefinedValue;
-import com.github._1c_syntax.bsl.mdo.storage.PredefinedData;
 import com.github._1c_syntax.bsl.reader.common.xstream.ReadConverter;
 import com.thoughtworks.xstream.converters.UnmarshallingContext;
 import com.thoughtworks.xstream.io.HierarchicalStreamReader;
@@ -37,7 +36,7 @@ public class PredefinedDataConverter implements ReadConverter {
 
   @Override
   public Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context) {
-    var builder = PredefinedData.builder();
+    var builder = PredefinedDataWrapper.builder();
     while (reader.hasMoreChildren()) {
       reader.moveDown();
       if (ITEM_NODE.equals(reader.getNodeName())) {
@@ -50,6 +49,6 @@ public class PredefinedDataConverter implements ReadConverter {
 
   @Override
   public boolean canConvert(Class type) {
-    return PredefinedData.class.isAssignableFrom(type);
+    return PredefinedDataWrapper.class.isAssignableFrom(type);
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/reader/designer/converter/PredefinedDataWrapper.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/reader/designer/converter/PredefinedDataWrapper.java
@@ -19,7 +19,7 @@
  * You should have received a copy of the GNU Lesser General Public
  * License along with MDClasses.
  */
-package com.github._1c_syntax.bsl.mdo.storage;
+package com.github._1c_syntax.bsl.reader.designer.converter;
 
 import com.github._1c_syntax.bsl.mdo.children.PredefinedValue;
 import lombok.Builder;
@@ -33,10 +33,7 @@ import java.util.List;
  */
 @Value
 @Builder
-public class PredefinedData {
-
-  public static final PredefinedData EMPTY = PredefinedData.builder().build();
-
+public class PredefinedDataWrapper {
   /**
    * Предопределенные элементы верхнего уровня
    */

--- a/src/main/java/com/github/_1c_syntax/bsl/reader/edt/EDTReader.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/reader/edt/EDTReader.java
@@ -56,6 +56,7 @@ import com.github._1c_syntax.bsl.mdo.storage.FormData;
 import com.github._1c_syntax.bsl.mdo.storage.ManagedFormData;
 import com.github._1c_syntax.bsl.reader.MDReader;
 import com.github._1c_syntax.bsl.reader.common.context.AbstractReaderContext;
+import com.github._1c_syntax.bsl.reader.common.converter.AdditionalIndexesWrapper;
 import com.github._1c_syntax.bsl.reader.common.converter.DesignerRootWrapper;
 import com.github._1c_syntax.bsl.reader.common.xstream.ExtendXStream;
 import com.github._1c_syntax.bsl.reader.edt.converter.EDTConverter;
@@ -199,6 +200,18 @@ public class EDTReader implements MDReader {
       return EmptyFormData.EMPTY;
     }
     return (FormData) read(formDataPath);
+  }
+
+  @Override
+  public AdditionalIndexesWrapper readAdditionalIndexes(Path currentPath, String name, MDOType mdoType) {
+    var additionalIndexesPath = Paths.get(currentPath.getParent().toString(), "AdditionalIndexes.aindex");
+    if (additionalIndexesPath.toFile().exists()) {
+      var value = read(additionalIndexesPath);
+      if (value instanceof AdditionalIndexesWrapper data) {
+        return data;
+      }
+    }
+    return AdditionalIndexesWrapper.EMPTY;
   }
 
   @Override

--- a/src/main/java/com/github/_1c_syntax/bsl/reader/edt/converter/AdditionalIndexesConverter.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/reader/edt/converter/AdditionalIndexesConverter.java
@@ -1,0 +1,110 @@
+/*
+ * This file is a part of MDClasses.
+ *
+ * Copyright (c) 2019 - 2026
+ * Tymko Oleg <olegtymko@yandex.ru>, Maximov Valery <maximovvalery@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * MDClasses is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * MDClasses is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with MDClasses.
+ */
+package com.github._1c_syntax.bsl.reader.edt.converter;
+
+import com.github._1c_syntax.bsl.reader.common.converter.AdditionalIndexesWrapper;
+import com.github._1c_syntax.bsl.reader.common.converter.AdditionalIndexesWrapper.AdditionalIndexItem;
+import com.github._1c_syntax.bsl.reader.common.xstream.ReadConverter;
+import com.thoughtworks.xstream.converters.UnmarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Конвертер для чтения дополнительных индексов из файла {@code AdditionalIndexes.aindex}
+ */
+@EDTConverter
+public class AdditionalIndexesConverter implements ReadConverter {
+
+  private static final String INDEXES_NODE = "indexes";
+  private static final String ID_NODE = "id";
+  private static final String NAME_NODE = "name";
+  private static final String TABLE_NODE = "table";
+  private static final String INDEXED_FIELDS_NODE = "indexedFields";
+  private static final String ADDITIONAL_FIELDS_NODE = "additionalFields";
+  private static final String PATH_NODE = "path";
+
+  @Override
+  public Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context) {
+    var builder = AdditionalIndexesWrapper.builder();
+
+    while (reader.hasMoreChildren()) {
+      reader.moveDown();
+      if (INDEXES_NODE.equals(reader.getNodeName())) {
+        builder.index(readIndexItem(reader));
+      }
+      reader.moveUp();
+    }
+
+    return builder.build();
+  }
+
+  @Override
+  public boolean canConvert(Class type) {
+    return AdditionalIndexesWrapper.class.isAssignableFrom(type);
+  }
+
+  private AdditionalIndexItem readIndexItem(HierarchicalStreamReader reader) {
+    String id = "";
+    String name = "";
+    String table = "";
+    var indexedFields = new ArrayList<String>();
+    var additionalFields = new ArrayList<String>();
+
+    while (reader.hasMoreChildren()) {
+      reader.moveDown();
+      var nodeName = reader.getNodeName();
+      switch (nodeName) {
+        case ID_NODE -> id = reader.getValue();
+        case NAME_NODE -> name = reader.getValue();
+        case TABLE_NODE -> table = reader.getValue();
+        case INDEXED_FIELDS_NODE -> indexedFields.addAll(readPaths(reader));
+        case ADDITIONAL_FIELDS_NODE -> additionalFields.addAll(readPaths(reader));
+        default -> {
+          // пропуск неизвестных узлов
+        }
+      }
+      reader.moveUp();
+    }
+
+    return AdditionalIndexItem.builder()
+      .id(id)
+      .name(name)
+      .table(table)
+      .indexedFields(indexedFields)
+      .additionalFields(additionalFields)
+      .build();
+  }
+
+  private List<String> readPaths(HierarchicalStreamReader reader) {
+    var paths = new ArrayList<String>();
+    while (reader.hasMoreChildren()) {
+      reader.moveDown();
+      if (PATH_NODE.equals(reader.getNodeName())) {
+        paths.add(reader.getValue());
+      }
+      reader.moveUp();
+    }
+    return paths;
+  }
+}

--- a/src/test/java/com/github/_1c_syntax/bsl/mdo/CatalogTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/mdo/CatalogTest.java
@@ -21,6 +21,7 @@
  */
 package com.github._1c_syntax.bsl.mdo;
 
+import com.github._1c_syntax.bsl.mdo.storage.AdditionalIndex;
 import com.github._1c_syntax.bsl.test_utils.Fixtures;
 import com.github._1c_syntax.bsl.test_utils.assertions.Assertions;
 import com.github._1c_syntax.bsl.types.MdoReference;
@@ -166,5 +167,44 @@ class CatalogTest {
       .containsExactlyInAnyOrder(
         MdoReference.create("Document.ЭлектронноеПисьмоИсходящее")
       );
+  }
+
+  @ParameterizedTest
+  @CsvSource(
+    {
+      "true, mdclasses_3_27, Catalogs.Справочник1",
+      "false, mdclasses_3_27, Catalogs.Справочник1"
+    }
+  )
+  void testAdditionalIndexes(ArgumentsAccessor argumentsAccessor) {
+    var mdo = Fixtures.get(argumentsAccessor);
+    assertThat(mdo).isInstanceOf(Catalog.class);
+
+    var catalog = (Catalog) mdo;
+    assertThat(catalog).isNotNull();
+
+    assertThat(catalog.getAdditionalIndexes()).hasSize(2);
+
+    var index1 = catalog.getAdditionalIndexes().get(0);
+    assertThat(index1.getName()).isEqualTo("Индекс1");
+    assertThat(index1.getUuid()).isEqualTo("00000000-0000-0000-0000-000000000000");
+    assertThat(index1.getTable()).isEqualTo(MdoReference.create("Catalog.Справочник1"));
+    assertThat(index1.getIndexedFields()).hasSize(2);
+    assertThat(index1.getIndexedFields()).extracting(MdoReference::getMdoRef)
+      .containsExactly("Catalog.Справочник1.StandardAttribute.Code", "Catalog.Справочник1.Attribute.Реквизит1");
+    assertThat(index1.getAdditionalFields()).hasSize(2);
+    assertThat(index1.getAdditionalFields()).extracting(MdoReference::getMdoRef)
+      .containsExactly("Catalog.Справочник1.Attribute.Реквизит4", "Catalog.Справочник1.StandardAttribute.Predefined");
+
+    var index2 = catalog.getAdditionalIndexes().get(1);
+    assertThat(index2.getName()).isEqualTo("Индекс2");
+    assertThat(index2.getUuid()).isEqualTo("4bf0a294-aae4-4965-b9f7-b1eaf3b4d021");
+    assertThat(index2.getTable()).isEqualTo(MdoReference.create("Catalog.Справочник1"));
+    assertThat(index2.getIndexedFields()).hasSize(2);
+    assertThat(index2.getIndexedFields()).extracting(MdoReference::getMdoRef)
+      .containsExactly("Catalog.Справочник1.StandardAttribute.Ref", "Catalog.Справочник1.StandardAttribute.Code");
+    assertThat(index2.getAdditionalFields()).hasSize(1);
+    assertThat(index2.getAdditionalFields()).extracting(MdoReference::getMdoRef)
+      .containsExactly("Catalog.Справочник1.StandardAttribute.DeletionMark");
   }
 }

--- a/src/test/java/com/github/_1c_syntax/bsl/test_utils/Fixtures.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/test_utils/Fixtures.java
@@ -296,6 +296,7 @@ public class Fixtures {
             xstream.omitField(clazz, "allAttributes");
             xstream.omitField(clazz, "storageFields");
             xstream.omitField(clazz, "plainStorageFields");
+            xstream.omitField(clazz, "additionalIndexes");
           }
 
           if (Form.class.isAssignableFrom(clazz)) {


### PR DESCRIPTION
## Описание
<!--- ОБЯЗАТЕЛЬНО опишите внесенные изменения -->

Дополнительные индексы объектов метаданных
 - добавлено новое поле в MDO 
 - добален новый тип данных
 - реализовано чтение

## Связанные задачи
<!--- Для каждого PR обязательно наличие связанной задачи (issue). -->
<!--- Необходимо указать ключи задач, предваряя их символом #, например -->
<!---Closes #123 -->
<!--  -->
<!-- ВНИМАНИЕ: Без ссылки на задачу пулл-реквест не будет принят! -->
<!--  -->
Closes #654

## Чеклист
<!--- Перед отправкой пройдите по списку и поставьте отметку для каждого выполненного действия -->
<!--- Если не понятно, что подразумевается - спросите в чате проекта https://t.me/bsl_language_server -->

### Общие

- [x] Ветка PR обновлена из develop
- [x] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [x] Изменения покрыты тестами
- [x] Обязательные действия перед коммитом выполнены (запускал команду `gradlew precommit`)

## Дополнительно
<!--- Различная дополнительная информация, скриншоты и т.д. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for reading and exposing additional indexes across metadata objects.
  * Additional indexes now include names, table references, indexed fields, and supplementary fields.
  * Added support for loading additional-index definitions from Designer and EDT metadata sources.
* **Bug Fixes**
  * Improved predefined-data parsing compatibility through dedicated wrapper handling.
* **Tests**
  * Added coverage validating additional-index names, references, and field mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->